### PR TITLE
Expand measures parity catalogs and close conversion perf gaps

### DIFF
--- a/crates/casa-measures-data/src/lib.rs
+++ b/crates/casa-measures-data/src/lib.rs
@@ -22,11 +22,15 @@ use tar::Archive;
 mod interp;
 mod observatory;
 mod parser;
+mod source;
+mod spectral_line;
 
 #[cfg(feature = "update")]
 pub mod update;
 
 pub use observatory::{ObservatoryCatalog, ObservatoryEntry};
+pub use source::{SourceCatalog, SourceEntry};
+pub use spectral_line::{SpectralLineCatalog, SpectralLineEntry};
 
 const DEFAULT_MEASURES_ENV: &str = "CASA_RS_MEASURESPATH";
 const LEGACY_MEASURES_ENV: &str = "CASA_RS_DATA";
@@ -385,6 +389,9 @@ static STANDARD_MEASURES_ROOT: OnceLock<Result<(PathBuf, &'static str), String>>
 static STANDARD_EOP: OnceLock<Result<(EopTable, &'static str), String>> = OnceLock::new();
 static STANDARD_OBSERVATORIES: OnceLock<Result<(ObservatoryCatalog, &'static str), String>> =
     OnceLock::new();
+static STANDARD_SOURCES: OnceLock<Result<(SourceCatalog, &'static str), String>> = OnceLock::new();
+static STANDARD_SPECTRAL_LINES: OnceLock<Result<(SpectralLineCatalog, &'static str), String>> =
+    OnceLock::new();
 static STANDARD_TAI_UTC: OnceLock<Result<TaiUtcTable, String>> = OnceLock::new();
 static STANDARD_IGRF: OnceLock<Result<IgrfTable, String>> = OnceLock::new();
 static PACKAGED_PROVENANCE: OnceLock<Result<SnapshotProvenance, String>> = OnceLock::new();
@@ -455,6 +462,39 @@ pub fn try_load_observatories()
 pub fn load_observatories() -> (&'static ObservatoryCatalog, &'static str) {
     try_load_observatories()
         .unwrap_or_else(|error| panic!("failed to load standard observatory runtime: {error}"))
+}
+
+/// Load the standard runtime source catalog.
+pub fn try_load_sources() -> Result<(&'static SourceCatalog, &'static str), MeasuresDataError> {
+    match STANDARD_SOURCES
+        .get_or_init(|| load_standard_sources().map_err(|error| error.to_string()))
+    {
+        Ok((catalog, source)) => Ok((catalog, *source)),
+        Err(error) => Err(MeasuresDataError::TableRead(error.clone())),
+    }
+}
+
+/// Infallible compatibility wrapper for callers that expect a standard catalog.
+pub fn load_sources() -> (&'static SourceCatalog, &'static str) {
+    try_load_sources()
+        .unwrap_or_else(|error| panic!("failed to load standard source runtime: {error}"))
+}
+
+/// Load the standard runtime spectral-line catalog.
+pub fn try_load_spectral_lines()
+-> Result<(&'static SpectralLineCatalog, &'static str), MeasuresDataError> {
+    match STANDARD_SPECTRAL_LINES
+        .get_or_init(|| load_standard_spectral_lines().map_err(|error| error.to_string()))
+    {
+        Ok((catalog, source)) => Ok((catalog, *source)),
+        Err(error) => Err(MeasuresDataError::TableRead(error.clone())),
+    }
+}
+
+/// Infallible compatibility wrapper for callers that expect a standard catalog.
+pub fn load_spectral_lines() -> (&'static SpectralLineCatalog, &'static str) {
+    try_load_spectral_lines()
+        .unwrap_or_else(|error| panic!("failed to load standard spectral-line runtime: {error}"))
 }
 
 /// Compute `TAI-UTC` in seconds from the standard `geodetic/TAI_UTC` table.
@@ -663,6 +703,59 @@ fn load_standard_observatories() -> Result<(ObservatoryCatalog, &'static str), M
     Ok((ObservatoryCatalog::from_entries(entries), source))
 }
 
+fn load_standard_sources() -> Result<(SourceCatalog, &'static str), MeasuresDataError> {
+    let (root, source) = standard_measures_path()?;
+    let table = PlainTable::open(&root.join("ephemerides/Sources"))?;
+    let mjd = table.scalar_f64("MJD")?;
+    let name = table.scalar_string("Name")?;
+    let direction_type = table.scalar_string("Type")?;
+    let longitude_deg = table.scalar_f64("Long")?;
+    let latitude_deg = table.scalar_f64("Lat")?;
+    let source_col = table.scalar_string("Source")?;
+    let comment = table.scalar_string("Comment")?;
+
+    let mut entries = Vec::with_capacity(table.row_count());
+    for row in 0..table.row_count() {
+        entries.push(SourceEntry {
+            mjd: mjd[row],
+            name: name[row].clone(),
+            direction_type: direction_type[row].clone(),
+            longitude_deg: longitude_deg[row],
+            latitude_deg: latitude_deg[row],
+            source: source_col[row].clone(),
+            comment: comment[row].clone(),
+        });
+    }
+
+    Ok((SourceCatalog::from_entries(entries), source))
+}
+
+fn load_standard_spectral_lines() -> Result<(SpectralLineCatalog, &'static str), MeasuresDataError>
+{
+    let (root, source) = standard_measures_path()?;
+    let table = PlainTable::open(&root.join("ephemerides/Lines"))?;
+    let mjd = table.scalar_f64("MJD")?;
+    let name = table.scalar_string("Name")?;
+    let frequency_type = table.scalar_string("Type")?;
+    let frequency_ghz = table.scalar_f64("Freq")?;
+    let source_col = table.scalar_string("Source")?;
+    let comment = table.scalar_string("Comment")?;
+
+    let mut entries = Vec::with_capacity(table.row_count());
+    for row in 0..table.row_count() {
+        entries.push(SpectralLineEntry {
+            mjd: mjd[row],
+            name: name[row].clone(),
+            frequency_type: frequency_type[row].clone(),
+            frequency_ghz: frequency_ghz[row],
+            source: source_col[row].clone(),
+            comment: comment[row].clone(),
+        });
+    }
+
+    Ok((SpectralLineCatalog::from_entries(entries), source))
+}
+
 fn load_standard_tai_utc() -> Result<TaiUtcTable, MeasuresDataError> {
     let (root, _source) = standard_measures_path()?;
     let table = PlainTable::open(&root.join("geodetic/TAI_UTC"))?;
@@ -828,6 +921,27 @@ mod tests {
         let (catalog, source) = try_load_observatories().expect("observatories");
         assert!(catalog.entries().len() > 40);
         assert!(catalog.get("ALMA").is_some());
+        assert!(!source.is_empty());
+    }
+
+    #[test]
+    fn standard_source_catalog_loads() {
+        let (catalog, source) = try_load_sources().expect("sources");
+        assert!(catalog.entries().len() > 100);
+        let source_0002 = catalog.get("0002-478").expect("catalog source");
+        assert_eq!(source_0002.direction_type, "ICRS");
+        assert!((source_0002.longitude_rad() - 0.020_046_3).abs() < 1.0e-6);
+        assert!((source_0002.latitude_rad() - (-0.830_872)).abs() < 1.0e-6);
+        assert!(!source.is_empty());
+    }
+
+    #[test]
+    fn standard_spectral_line_catalog_loads() {
+        let (catalog, source) = try_load_spectral_lines().expect("lines");
+        assert!(catalog.entries().len() >= 18);
+        let hi = catalog.get("HI").expect("HI line");
+        assert_eq!(hi.frequency_type, "REST");
+        assert!((hi.frequency_hz() - 1.420_405_752e9).abs() < 5.0e3);
         assert!(!source.is_empty());
     }
 

--- a/crates/casa-measures-data/src/source.rs
+++ b/crates/casa-measures-data/src/source.rs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//! Source catalog data loaded from casacore `ephemerides/Sources`.
+
+use std::collections::HashMap;
+
+/// A single source row from casacore `ephemerides/Sources`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SourceEntry {
+    /// Table `MJD` column.
+    pub mjd: f64,
+    /// Table `Name` column.
+    pub name: String,
+    /// Table `Type` column.
+    pub direction_type: String,
+    /// Table `Long` column, in degrees.
+    pub longitude_deg: f64,
+    /// Table `Lat` column, in degrees.
+    pub latitude_deg: f64,
+    /// Table `Source` column.
+    pub source: String,
+    /// Table `Comment` column.
+    pub comment: String,
+}
+
+impl SourceEntry {
+    /// Return the longitude in radians.
+    pub fn longitude_rad(&self) -> f64 {
+        self.longitude_deg.to_radians()
+    }
+
+    /// Return the latitude in radians.
+    pub fn latitude_rad(&self) -> f64 {
+        self.latitude_deg.to_radians()
+    }
+}
+
+/// In-memory catalog of named-source metadata.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SourceCatalog {
+    entries: Vec<SourceEntry>,
+    by_name: HashMap<String, usize>,
+}
+
+impl SourceCatalog {
+    /// Build a catalog from explicitly provided entries.
+    pub fn from_entries(entries: Vec<SourceEntry>) -> Self {
+        let by_name = entries
+            .iter()
+            .enumerate()
+            .fold(HashMap::new(), |mut map, (index, entry)| {
+                map.entry(normalize_name(&entry.name)).or_insert(index);
+                map
+            });
+        Self { entries, by_name }
+    }
+
+    /// Return the packaged/runtime standard catalog.
+    pub fn bundled() -> &'static Self {
+        crate::load_sources().0
+    }
+
+    /// Iterate over the catalog entries in source order.
+    pub fn iter(&self) -> impl Iterator<Item = &SourceEntry> {
+        self.entries.iter()
+    }
+
+    /// Borrow all entries.
+    pub fn entries(&self) -> &[SourceEntry] {
+        &self.entries
+    }
+
+    /// Look up a source by case-insensitive name.
+    pub fn get(&self, name: &str) -> Option<&SourceEntry> {
+        self.by_name
+            .get(&normalize_name(name))
+            .and_then(|index| self.entries.get(*index))
+    }
+}
+
+fn normalize_name(name: &str) -> String {
+    name.trim().to_ascii_uppercase()
+}

--- a/crates/casa-measures-data/src/spectral_line.rs
+++ b/crates/casa-measures-data/src/spectral_line.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//! Spectral-line catalog data loaded from casacore `ephemerides/Lines`.
+
+use std::collections::HashMap;
+
+/// A single spectral-line row from casacore `ephemerides/Lines`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SpectralLineEntry {
+    /// Table `MJD` column.
+    pub mjd: f64,
+    /// Table `Name` column.
+    pub name: String,
+    /// Table `Type` column.
+    pub frequency_type: String,
+    /// Table `Freq` column, in GHz.
+    pub frequency_ghz: f64,
+    /// Table `Source` column.
+    pub source: String,
+    /// Table `Comment` column.
+    pub comment: String,
+}
+
+impl SpectralLineEntry {
+    /// Return the rest frequency in Hz.
+    pub fn frequency_hz(&self) -> f64 {
+        self.frequency_ghz * 1.0e9
+    }
+}
+
+/// In-memory catalog of named spectral-line metadata.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SpectralLineCatalog {
+    entries: Vec<SpectralLineEntry>,
+    by_name: HashMap<String, usize>,
+}
+
+impl SpectralLineCatalog {
+    /// Build a catalog from explicitly provided entries.
+    pub fn from_entries(entries: Vec<SpectralLineEntry>) -> Self {
+        let by_name = entries
+            .iter()
+            .enumerate()
+            .fold(HashMap::new(), |mut map, (index, entry)| {
+                map.entry(normalize_name(&entry.name)).or_insert(index);
+                map
+            });
+        Self { entries, by_name }
+    }
+
+    /// Return the packaged/runtime standard catalog.
+    pub fn bundled() -> &'static Self {
+        crate::load_spectral_lines().0
+    }
+
+    /// Iterate over the catalog entries in source order.
+    pub fn iter(&self) -> impl Iterator<Item = &SpectralLineEntry> {
+        self.entries.iter()
+    }
+
+    /// Borrow all entries.
+    pub fn entries(&self) -> &[SpectralLineEntry] {
+        &self.entries
+    }
+
+    /// Look up a spectral line by case-insensitive name.
+    pub fn get(&self, name: &str) -> Option<&SpectralLineEntry> {
+        self.by_name
+            .get(&normalize_name(name))
+            .and_then(|index| self.entries.get(*index))
+    }
+}
+
+fn normalize_name(name: &str) -> String {
+    name.trim().to_ascii_uppercase()
+}

--- a/crates/casa-test-support/src/cpp/casacore_cpp_measures_shim.cpp
+++ b/crates/casa-test-support/src/cpp/casacore_cpp_measures_shim.cpp
@@ -562,6 +562,22 @@ int measures_shim_riseset(
     }
 }
 
+int measures_shim_line_frequency(
+    const char* line_name,
+    double* freq_out_hz)
+{
+    try {
+        MFrequency line;
+        if (!MeasTable::Line(line, String(line_name))) {
+            return 1;
+        }
+        *freq_out_hz = line.getValue().getValue();
+        return 0;
+    } catch (...) {
+        return -1;
+    }
+}
+
 int measures_shim_earthmag_convert_xyz(
     double x_in, double y_in, double z_in,
     const char* ref_in, const char* ref_out,

--- a/crates/casa-test-support/src/cpp/casacore_cpp_taql.cpp
+++ b/crates/casa-test-support/src/cpp/casacore_cpp_taql.cpp
@@ -3,6 +3,7 @@
 // and execute TaQL queries via casacore's tableCommand().
 #include "casacore_cpp_common.h"
 
+#include <casacore/meas/MeasUDF/Register.h>
 #include <casacore/tables/TaQL/TableParse.h>
 #include <casacore/tables/TaQL/TaQLResult.h>
 #include <casacore/tables/Tables/TableColumn.h>
@@ -14,6 +15,7 @@
 #include <chrono>
 #include <sstream>
 #include <iomanip>
+#include <mutex>
 #include <vector>
 
 static casacore_shim::TerminateGuard g_terminate_guard_taql;
@@ -21,6 +23,8 @@ static casacore_shim::TerminateGuard g_terminate_guard_taql;
 namespace {
 
 using namespace casacore;
+
+std::once_flag g_meas_udf_register_once;
 
 // ── Simple fixture (50 rows) ──
 // Schema: id(Int32), name(String), ra(Double), dec(Double), flux(Double),
@@ -304,6 +308,7 @@ void query_impl(const std::string& table_path,
                 uint64_t& out_nrow,
                 uint64_t& out_ncol,
                 uint64_t& out_elapsed_ns) {
+    std::call_once(g_meas_udf_register_once, []() { register_meas(); });
     Table tab(table_path, Table::Old);
 
     // Replace $1 with the temp table

--- a/crates/casa-test-support/src/measures_interop.rs
+++ b/crates/casa-test-support/src/measures_interop.rs
@@ -125,6 +125,11 @@ unsafe extern "C" {
         set_out: *mut f64,
     ) -> i32;
 
+    fn measures_shim_line_frequency(
+        line_name: *const std::ffi::c_char,
+        freq_out_hz: *mut f64,
+    ) -> i32;
+
     fn measures_shim_earthmag_convert_xyz(
         x_in: f64,
         y_in: f64,
@@ -696,6 +701,21 @@ pub fn cpp_riseset(
         Ok((rise_out, set_out))
     } else {
         Err(format!("C++ riseset failed: rc={rc}"))
+    }
+}
+
+/// Resolve a named spectral line to its rest frequency using C++ casacore.
+#[cfg(has_casacore_cpp)]
+pub fn cpp_line_frequency(line_name: &str) -> Result<f64, String> {
+    let c_name = CString::new(line_name).unwrap();
+    let mut freq_out_hz = 0.0;
+
+    let rc = unsafe { measures_shim_line_frequency(c_name.as_ptr(), &mut freq_out_hz) };
+
+    if rc == 0 {
+        Ok(freq_out_hz)
+    } else {
+        Err(format!("C++ line_frequency failed: rc={rc}"))
     }
 }
 

--- a/crates/casa-test-support/tests/measures_interop.rs
+++ b/crates/casa-test-support/tests/measures_interop.rs
@@ -6,7 +6,7 @@ use casa_test_support::measures_interop::{
     cpp_direction_convert, cpp_direction_convert_iau2000a, cpp_doppler_convert, cpp_earth_velocity,
     cpp_eop_query, cpp_epoch_convert, cpp_epoch_convert_with_frame, cpp_epoch_to_record,
     cpp_frequency_convert, cpp_frequency_convert_with_rv, cpp_iau2000_precession_matrix,
-    cpp_position_convert, cpp_position_to_record, cpp_radvel_convert,
+    cpp_line_frequency, cpp_position_convert, cpp_position_to_record, cpp_radvel_convert,
 };
 use casa_types::measures::direction::{DirectionRef, MDirection};
 use casa_types::measures::doppler::{DopplerRef, MDoppler};
@@ -250,6 +250,18 @@ fn rc_doppler_beta_to_radio() {
         "Rust={}, C++={}",
         rust_radio.value(),
         cpp_radio
+    );
+}
+
+#[test]
+fn rc_catalog_line_hi_matches_cpp() {
+    let rust_line = MFrequency::from_line_name("HI").unwrap();
+    let cpp_line_hz = cpp_line_frequency("HI").unwrap();
+    assert!(
+        close(rust_line.hz(), cpp_line_hz, 1.0e-3),
+        "HI rest frequency: Rust={}, C++={}",
+        rust_line.hz(),
+        cpp_line_hz
     );
 }
 
@@ -2151,6 +2163,55 @@ fn eop_rv_bary_to_topo() {
     );
 }
 
+#[test]
+fn accepted_direction_divergence_routes_are_bounded() {
+    fn target_ref(name: &str) -> DirectionRef {
+        match name {
+            "APP" => DirectionRef::APP,
+            "HADEC" => DirectionRef::HADEC,
+            "AZEL" => DirectionRef::AZEL,
+            "ITRF" => DirectionRef::ITRF,
+            _ => unreachable!("unexpected route"),
+        }
+    }
+
+    let source = MDirection::from_angles(1.0, 0.5, DirectionRef::J2000);
+    let cases = [
+        ("IAU1976/1980", IauModel::Iau1976_1980, 0.01_f64),
+        ("IAU2006/2000A", IauModel::Iau2006_2000A, 0.03_f64),
+    ];
+    let routes = ["APP", "HADEC", "AZEL", "ITRF"];
+
+    for (model_name, model, max_sep_arcsec) in cases {
+        let frame = MeasFrame::new()
+            .with_epoch(MEpoch::from_mjd(J2000_MJD, EpochRef::UTC))
+            .with_position(MPosition::new_wgs84(VLA_LON, VLA_LAT, VLA_H))
+            .with_bundled_eop()
+            .with_iau_model(model);
+
+        for route in routes {
+            let rust_value = source.convert_to(target_ref(route), &frame).unwrap();
+            let (rust_lon, rust_lat) = rust_value.as_angles();
+            let (cpp_lon, cpp_lat) = match model {
+                IauModel::Iau1976_1980 => cpp_direction_convert(
+                    1.0, 0.5, "J2000", route, J2000_MJD, VLA_LON, VLA_LAT, VLA_H,
+                ),
+                IauModel::Iau2006_2000A => cpp_direction_convert_iau2000a(
+                    1.0, 0.5, "J2000", route, J2000_MJD, VLA_LON, VLA_LAT, VLA_H,
+                ),
+            }
+            .unwrap();
+
+            let sep = sep_arcsec(rust_lon, rust_lat, cpp_lon, cpp_lat);
+            eprintln!("{model_name} J2000->{route}: sep={sep:.6} arcsec");
+            assert!(
+                sep <= max_sep_arcsec,
+                "{model_name} J2000->{route}: sep={sep:.6} arcsec exceeds {max_sep_arcsec:.6}"
+            );
+        }
+    }
+}
+
 // --- Full pipeline integration test ---
 
 #[test]
@@ -2259,11 +2320,13 @@ fn diag_direction_chain_steps() {
 // polynomial series and internal decompositions. For IAU 2000A, the
 // precession/nutation matrices agree perfectly (verified in
 // diag_iau2000a_chain_steps: JMEAN and JTRUE match to 0.000"),
-// but the apparent-place (APP) step diverges by ~16 mas due to
-// differences in the aberration/deflection computations (Stumpff vs
-// VSOP87 velocity series, plus casacore applies full Sun gravitational
-// deflection that SOFA's ab() omits). This is direction-dependent and
-// larger than the ~1.5 mas deviation for IAU 1976/1980.
+// but the apparent-place (APP) step diverges by ~16 mas. Upstream
+// casacore PR #1464 records the same missing-frame-bias hypothesis for
+// casacore's shared IAU2000 JNAT<->APP helper, but that PR is not
+// independent confirmation because it was derived from the same line of
+// investigation. Until that lands upstream, keep the current residual
+// explicitly bounded here. The smaller ~1.5 mas residual still remains
+// from the expected aberration/deflection and velocity-series differences.
 //
 // Tolerance: 1e-7 rad ≈ 20 mas. See misc/casacore_vs_sofa_deviation.cpp
 // for a standalone C++ test quantifying this, and the corresponding

--- a/crates/casa-test-support/tests/measures_perf_vs_cpp.rs
+++ b/crates/casa-test-support/tests/measures_perf_vs_cpp.rs
@@ -1,5 +1,11 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 //! Performance comparison: Rust measures vs C++ casacore.
+//!
+//! The historical Phase 3 slow routes were:
+//! `UTC -> TAI`, `TT -> TDB`, `UT1 -> GAST`, `J2000 -> ITRF`, and `BARY -> GEO`.
+//! These benchmarks keep those paths reproducible in-tree. The named slow-route
+//! tests below now enforce a `<= 2x` regression threshold; if they fail, treat
+//! it as a frame-state reuse regression rather than an accepted algorithmic gap.
 #![cfg(has_casacore_cpp)]
 
 use casa_test_support::measures_interop::{
@@ -16,7 +22,7 @@ const J2000_MJD: f64 = 51544.5;
 const COUNT: i32 = 10_000;
 const ITERATIONS: i32 = 1;
 
-fn bench_epoch(ref_in: EpochRef, ref_out: EpochRef) {
+fn bench_epoch(ref_in: EpochRef, ref_out: EpochRef) -> f64 {
     let frame = MeasFrame::new();
     let ref_in_str = ref_in.as_str();
     let ref_out_str = ref_out.as_str();
@@ -44,6 +50,7 @@ fn bench_epoch(ref_in: EpochRef, ref_out: EpochRef) {
     if ratio > 2.0 {
         eprintln!("WARNING: Rust is >2x slower than C++ for {ref_in_str}→{ref_out_str}");
     }
+    ratio
 }
 
 fn bench_position(ref_in: PositionRef, ref_out: PositionRef) {
@@ -98,7 +105,11 @@ fn bench_position(ref_in: PositionRef, ref_out: PositionRef) {
 
 #[test]
 fn perf_epoch_utc_to_tai() {
-    bench_epoch(EpochRef::UTC, EpochRef::TAI);
+    let ratio = bench_epoch(EpochRef::UTC, EpochRef::TAI);
+    assert!(
+        ratio <= 2.0,
+        "UTC->TAI ratio {ratio:.2}x exceeds 2.0x threshold"
+    );
 }
 
 #[test]
@@ -108,7 +119,11 @@ fn perf_epoch_utc_to_tt() {
 
 #[test]
 fn perf_epoch_tt_to_tdb() {
-    bench_epoch(EpochRef::TT, EpochRef::TDB);
+    let ratio = bench_epoch(EpochRef::TT, EpochRef::TDB);
+    assert!(
+        ratio <= 2.0,
+        "TT->TDB ratio {ratio:.2}x exceeds 2.0x threshold"
+    );
 }
 
 #[test]
@@ -207,7 +222,7 @@ fn perf_doppler_beta_to_gamma() {
 // Direction perf tests
 // ---------------------------------------------------------------------------
 
-fn bench_direction(ref_in: DirectionRef, ref_out: DirectionRef, epoch_mjd: f64) {
+fn bench_direction(ref_in: DirectionRef, ref_out: DirectionRef, epoch_mjd: f64) -> f64 {
     let ref_in_str = ref_in.as_str();
     let ref_out_str = ref_out.as_str();
 
@@ -262,6 +277,7 @@ fn bench_direction(ref_in: DirectionRef, ref_out: DirectionRef, epoch_mjd: f64) 
     if ratio > 2.0 {
         eprintln!("WARNING: Rust is >2x slower than C++ for Direction {ref_in_str}→{ref_out_str}");
     }
+    ratio
 }
 
 #[test]
@@ -337,7 +353,7 @@ fn perf_frequency_bary_to_lgroup() {
 // Wave 5: Radial velocity perf tests
 // ---------------------------------------------------------------------------
 
-fn bench_radvel(ref_in: RadialVelocityRef, ref_out: RadialVelocityRef) {
+fn bench_radvel(ref_in: RadialVelocityRef, ref_out: RadialVelocityRef) -> f64 {
     let ref_in_str = ref_in.as_str();
     let ref_out_str = ref_out.as_str();
     let dir_lon = 0.185_948_8;
@@ -380,6 +396,7 @@ fn bench_radvel(ref_in: RadialVelocityRef, ref_out: RadialVelocityRef) {
     if ratio > 2.0 {
         eprintln!("WARNING: Rust is >2x slower than C++ for RadVel {ref_in_str}→{ref_out_str}");
     }
+    ratio
 }
 
 #[test]
@@ -389,7 +406,11 @@ fn perf_radvel_lsrk_to_bary() {
 
 #[test]
 fn perf_radvel_bary_to_geo() {
-    bench_radvel(RadialVelocityRef::BARY, RadialVelocityRef::GEO);
+    let ratio = bench_radvel(RadialVelocityRef::BARY, RadialVelocityRef::GEO);
+    assert!(
+        ratio <= 2.0,
+        "BARY->GEO ratio {ratio:.2}x exceeds 2.0x threshold"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -403,7 +424,11 @@ fn perf_direction_j2000_to_b1950() {
 
 #[test]
 fn perf_direction_j2000_to_itrf() {
-    bench_direction(DirectionRef::J2000, DirectionRef::ITRF, J2000_MJD);
+    let ratio = bench_direction(DirectionRef::J2000, DirectionRef::ITRF, J2000_MJD);
+    assert!(
+        ratio <= 2.0,
+        "J2000->ITRF ratio {ratio:.2}x exceeds 2.0x threshold"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -454,4 +479,8 @@ fn perf_epoch_ut1_to_gast() {
     if ratio > 2.0 {
         eprintln!("WARNING: Rust is >2x slower than C++ for Epoch UT1→GAST");
     }
+    assert!(
+        ratio <= 2.0,
+        "UT1->GAST ratio {ratio:.2}x exceeds 2.0x threshold"
+    );
 }

--- a/crates/casa-test-support/tests/taql_meas_column_interop.rs
+++ b/crates/casa-test-support/tests/taql_meas_column_interop.rs
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//! End-to-end TaQL interop for MEASINFO-backed columns.
+//!
+//! These tests exercise the remaining semantic gap between the current Rust
+//! `meas.*` TaQL UDF surface and casacore's TaQL integration:
+//!
+//! - Rust currently consumes explicit raw values plus reference strings.
+//! - C++ casacore TaQL can consume a `MEASINFO`-annotated column directly.
+//!
+//! The parity checks below compare those two calling models on the same
+//! persisted fixture tables.
+#![cfg(has_casacore_cpp)]
+
+use tempfile::TempDir;
+
+use casa_tables::table_measures::{MeasureType, TableMeasDesc};
+use casa_tables::{ColumnSchema, Table, TableOptions, TableSchema};
+use casa_test_support::table_measures_interop::{
+    cpp_create_direction_fixed, cpp_create_epoch_fixed,
+};
+use casa_test_support::taql_interop::{
+    CppTaqlQueryResult, TaqlQueryResult, cpp_taql_query, rust_taql_query,
+};
+use casa_types::{ArrayValue, PrimitiveType, RecordField, RecordValue, Value};
+
+const RUST_EPOCH_QUERY: &str = "SELECT meas.epoch('TAI', TIME[1], 'UTC') AS tai";
+const CPP_EPOCH_QUERY: &str = "using style python select meas.epoch('TAI', TIME)d as tai from $1";
+const RUST_DIRECTION_QUERY: &str = "SELECT meas.galactic(DIR[1], DIR[2], 'J2000') AS gal";
+const CPP_DIRECTION_QUERY: &str = "using style python select meas.galactic(DIR) as gal from $1";
+
+fn build_epoch_measure_fixture() -> Table {
+    let schema = TableSchema::new(vec![ColumnSchema::array_fixed(
+        "TIME",
+        PrimitiveType::Float64,
+        vec![1],
+    )])
+    .unwrap();
+
+    let mut table = Table::with_schema(schema);
+    TableMeasDesc::new_fixed("TIME", MeasureType::Epoch, "UTC")
+        .write(&mut table)
+        .unwrap();
+
+    for mjd in [51544.5_f64, 51545.0, 51546.5] {
+        table
+            .add_row(RecordValue::new(vec![RecordField::new(
+                "TIME",
+                Value::Array(ArrayValue::from_f64_vec(vec![mjd])),
+            )]))
+            .unwrap();
+    }
+
+    table
+}
+
+fn build_direction_measure_fixture() -> Table {
+    let schema = TableSchema::new(vec![ColumnSchema::array_fixed(
+        "DIR",
+        PrimitiveType::Float64,
+        vec![2],
+    )])
+    .unwrap();
+
+    let mut table = Table::with_schema(schema);
+    TableMeasDesc::new_fixed("DIR", MeasureType::Direction, "J2000")
+        .write(&mut table)
+        .unwrap();
+
+    for (lon, lat) in [(1.0_f64, 0.5_f64), (2.0, -0.3), (0.0, 1.5)] {
+        table
+            .add_row(RecordValue::new(vec![RecordField::new(
+                "DIR",
+                Value::Array(ArrayValue::from_f64_vec(vec![lon, lat])),
+            )]))
+            .unwrap();
+    }
+
+    table
+}
+
+fn assert_single_float_column_matches(
+    rust_result: &TaqlQueryResult,
+    cpp_result: &CppTaqlQueryResult,
+    tolerance: f64,
+) {
+    assert_eq!(rust_result.rows.len(), cpp_result.grid.rows.len());
+    assert_eq!(rust_result.rows.len(), 3);
+    for (row_index, (rust_row, cpp_row)) in rust_result
+        .rows
+        .iter()
+        .zip(cpp_result.grid.rows.iter())
+        .enumerate()
+    {
+        assert_eq!(rust_row.len(), 1);
+        assert_eq!(cpp_row.len(), 1);
+        let rust_value = rust_row[0].parse::<f64>().unwrap();
+        let cpp_value = cpp_row[0].parse::<f64>().unwrap();
+        assert!(
+            (rust_value - cpp_value).abs() <= tolerance,
+            "row {row_index}: Rust={rust_value}, C++={cpp_value}"
+        );
+    }
+}
+
+fn parse_float_array_cell(cell: &str) -> Vec<f64> {
+    cell.trim()
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(|part| part.parse::<f64>().unwrap())
+        .collect()
+}
+
+fn angle_diff_wrapped(lhs: f64, rhs: f64) -> f64 {
+    let two_pi = std::f64::consts::TAU;
+    let mut diff = (lhs - rhs).abs();
+    while diff > two_pi {
+        diff -= two_pi;
+    }
+    diff.min((two_pi - diff).abs())
+}
+
+fn assert_single_array_column_matches(
+    rust_result: &TaqlQueryResult,
+    cpp_result: &CppTaqlQueryResult,
+    tolerance: f64,
+) {
+    assert_eq!(rust_result.rows.len(), cpp_result.grid.rows.len());
+    for (row_index, (rust_row, cpp_row)) in rust_result
+        .rows
+        .iter()
+        .zip(cpp_result.grid.rows.iter())
+        .enumerate()
+    {
+        assert_eq!(rust_row.len(), 1);
+        assert_eq!(cpp_row.len(), 1);
+        let rust_values = parse_float_array_cell(&rust_row[0]);
+        let cpp_values = parse_float_array_cell(&cpp_row[0]);
+        assert_eq!(rust_values.len(), cpp_values.len());
+        for (value_index, (rust_value, cpp_value)) in
+            rust_values.iter().zip(cpp_values.iter()).enumerate()
+        {
+            let diff = if value_index == 0 {
+                angle_diff_wrapped(*rust_value, *cpp_value)
+            } else {
+                (rust_value - cpp_value).abs()
+            };
+            assert!(
+                diff <= tolerance,
+                "row {row_index}, value {value_index}: Rust={rust_value}, C++={cpp_value}"
+            );
+        }
+    }
+}
+
+#[test]
+fn rc_epoch_meas_column_matches_cpp_taql() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("rc_epoch.tab");
+
+    let mut rust_table = build_epoch_measure_fixture();
+    let rust_result = rust_taql_query(&mut rust_table, RUST_EPOCH_QUERY).unwrap();
+    rust_table.save(TableOptions::new(&path)).unwrap();
+
+    let cpp_result = cpp_taql_query(&path, CPP_EPOCH_QUERY).unwrap();
+    assert_single_float_column_matches(&rust_result, &cpp_result, 1.0e-9);
+}
+
+#[test]
+fn cr_epoch_meas_column_matches_cpp_taql() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("cr_epoch.tab");
+    cpp_create_epoch_fixed(path.to_str().unwrap()).unwrap();
+
+    let cpp_result = cpp_taql_query(&path, CPP_EPOCH_QUERY).unwrap();
+    let mut rust_table = Table::open(TableOptions::new(&path)).unwrap();
+    let rust_result = rust_taql_query(&mut rust_table, RUST_EPOCH_QUERY).unwrap();
+
+    assert_single_float_column_matches(&rust_result, &cpp_result, 1.0e-9);
+}
+
+#[test]
+fn rc_direction_meas_column_matches_cpp_taql() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("rc_direction.tab");
+
+    let mut rust_table = build_direction_measure_fixture();
+    let rust_result = rust_taql_query(&mut rust_table, RUST_DIRECTION_QUERY).unwrap();
+    rust_table.save(TableOptions::new(&path)).unwrap();
+
+    let cpp_result = cpp_taql_query(&path, CPP_DIRECTION_QUERY).unwrap();
+    assert_single_array_column_matches(&rust_result, &cpp_result, 5.0e-6);
+}
+
+#[test]
+fn cr_direction_meas_column_matches_cpp_taql() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("cr_direction.tab");
+    cpp_create_direction_fixed(path.to_str().unwrap()).unwrap();
+
+    let cpp_result = cpp_taql_query(&path, CPP_DIRECTION_QUERY).unwrap();
+    let mut rust_table = Table::open(TableOptions::new(&path)).unwrap();
+    let rust_result = rust_taql_query(&mut rust_table, RUST_DIRECTION_QUERY).unwrap();
+
+    assert_single_array_column_matches(&rust_result, &cpp_result, 5.0e-6);
+}

--- a/crates/casa-test-support/tests/taql_meas_interop.rs
+++ b/crates/casa-test-support/tests/taql_meas_interop.rs
@@ -376,6 +376,20 @@ fn named_source_fixed_direction_matches_cpp() {
 }
 
 #[test]
+fn named_source_catalog_direction_matches_cpp() {
+    let rust_result = eval_meas("meas.j2000", &[s("0002-478")]);
+    let (rust_lon, rust_lat) = extract_dir(&rust_result);
+
+    let (cpp_lon, cpp_lat) =
+        cpp_named_direction_convert("0002-478", "J2000", 0.0, 0.0, 0.0, 0.0).unwrap();
+
+    assert!(
+        close_angle(rust_lon, cpp_lon, 1e-11) && close(rust_lat, cpp_lat, 1e-11),
+        "dir 0002-478→J2000: Rust=({rust_lon},{rust_lat}), C++=({cpp_lon},{cpp_lat})"
+    );
+}
+
+#[test]
 fn named_source_sun_direction_matches_cpp() {
     let rust_result = eval_meas("meas.dir", &[s("ITRF"), s("SUN"), fl(J2000_MJD), s("VLA")]);
     let (rust_lon, rust_lat) = extract_dir(&rust_result);

--- a/crates/casa-types/src/measures/direction.rs
+++ b/crates/casa-types/src/measures/direction.rs
@@ -20,12 +20,22 @@
 //! This Rust implementation uses [`sofars`] (a Rust port of SOFA) instead of
 //! transliterating casacore's bespoke algorithms. Both implement the same IAU
 //! standards but with different polynomial series and internal decompositions.
-//! Measured deviations in J2000 → APP direction conversions:
+//! Accepted casacore-vs-SOFA divergence on the apparent-place branch:
 //!
 //! | IAU model | Typical deviation | Main contributors |
 //! |-----------|-------------------|-------------------|
 //! | 1976/1980 | ~1.5 mas | Sun deflection, velocity series |
 //! | 2000A | ~16 mas | Precession/nutation parameterization |
+//!
+//! The affected conversion paths are the ones that pass through apparent place:
+//! - `J2000 -> APP`
+//! - `J2000 -> HADEC`
+//! - `J2000 -> AZEL`
+//! - `J2000 -> ITRF`
+//!
+//! `HADEC`, `AZEL`, and `ITRF` inherit the same mismatch because their
+//! implementations transit the apparent-place branch before applying local
+//! sidereal-time, horizon, or terrestrial rotations.
 //!
 //! The IAU 1976/1980 deviation is dominated by:
 //! - **Sun gravitational deflection**: C++ casacore applies full light deflection
@@ -39,14 +49,17 @@
 //! Casacore uses (ζA, zA, θA) Euler angles with frame bias baked into the
 //! constant terms; SOFA uses (ψA, ωA, χA) Lieske 1977 angles with IAU 2000
 //! corrections from `pr00` and separate frame bias via `bi00`.
+//! Upstream casacore PR `#1464` records the same working hypothesis for the
+//! IAU2000 `JNAT <-> APP` helper: a missing `frameBias00()` step in the shared
+//! combined precession/nutation path. That PR is useful background, but not
+//! independent confirmation. If that fix lands upstream, the IAU2000A residual
+//! should collapse from ~16 mas to the same ~1.5 mas class as the older
+//! IAU 1976/1980 path.
 //!
 //! A test program comparing casacore and ERFA (SOFA) side-by-side is in
-//! `misc/casacore_vs_sofa_deviation.cpp`. An issue has been filed with the
-//! casacore C++ maintainers to clarify whether this is expected.
-//!
-//! Deferred: GitHub issue #14 tracks the remaining casacore vs SOFA deviation
-//! audit, including whether to match casacore exactly or document the
-//! expected divergence more explicitly.
+//! `misc/casacore_vs_sofa_deviation.cpp`. The Rust project treats the current
+//! mismatch as an accepted, regression-tested divergence rather than
+//! re-implementing casacore's bespoke pre-SOFA algorithms byte-for-byte.
 //!
 //! # Implemented routes
 //!
@@ -67,6 +80,8 @@ use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::str::FromStr;
 use std::sync::LazyLock;
+
+use casa_measures_data::SourceCatalog;
 
 use crate::quanta::MvAngle;
 use crate::quanta::{Quantity, Unit};
@@ -604,6 +619,26 @@ fn parse_named_direction(source_name: &str) -> Result<ParsedNamedDirection, Meas
 
     if let Some(parsed) = parse_solar_system_name(original, &upper)? {
         return Ok(parsed);
+    }
+
+    if let Some(entry) = SourceCatalog::bundled().get(original) {
+        let refer = DirectionRef::from_str(&entry.direction_type).map_err(|_| {
+            MeasureError::InvalidSourceName {
+                input: source_name.to_string(),
+                reason: format!(
+                    "unsupported direction type {:?} in ephemerides/Sources",
+                    entry.direction_type
+                ),
+            }
+        })?;
+        return Ok(ParsedNamedDirection {
+            kind: NamedDirectionKind::Fixed(MDirection::from_angles(
+                entry.longitude_rad(),
+                entry.latitude_rad(),
+                refer,
+            )),
+            rise_set_horizon_rad: 0.0,
+        });
     }
 
     let fixed = match upper.as_str() {
@@ -1404,7 +1439,7 @@ impl ConvCtx {
         if let Some(v) = *self.tt_jd.borrow() {
             return Ok(v);
         }
-        let v = compute_tt_jd(frame)?;
+        let v = frame.cached_tt_jd(|| compute_tt_jd(frame))?;
         *self.tt_jd.borrow_mut() = Some(v);
         Ok(v)
     }
@@ -1413,7 +1448,7 @@ impl ConvCtx {
         if let Some(v) = *self.ut1_jd.borrow() {
             return Ok(v);
         }
-        let v = compute_ut1_jd(frame)?;
+        let v = frame.cached_ut1_jd(|| compute_ut1_jd(frame))?;
         *self.ut1_jd.borrow_mut() = Some(v);
         Ok(v)
     }
@@ -1422,7 +1457,7 @@ impl ConvCtx {
         if let Some(v) = *self.gast.borrow() {
             return Ok(v);
         }
-        let v = compute_gast(frame, self)?;
+        let v = frame.cached_gast(|| compute_gast(frame, self))?;
         *self.gast.borrow_mut() = Some(v);
         Ok(v)
     }
@@ -1431,11 +1466,13 @@ impl ConvCtx {
         if let Some(v) = *self.precession.borrow() {
             return Ok(v);
         }
-        let (tt1, tt2) = self.get_tt_jd(frame)?;
-        let v = match frame.iau_model() {
-            IauModel::Iau1976_1980 => sofars::pnp::pmat76(tt1, tt2),
-            IauModel::Iau2006_2000A => sofars::pnp::pmat00(tt1, tt2),
-        };
+        let v = frame.cached_precession(|| {
+            let (tt1, tt2) = self.get_tt_jd(frame)?;
+            Ok(match frame.iau_model() {
+                IauModel::Iau1976_1980 => sofars::pnp::pmat76(tt1, tt2),
+                IauModel::Iau2006_2000A => sofars::pnp::pmat00(tt1, tt2),
+            })
+        })?;
         *self.precession.borrow_mut() = Some(v);
         Ok(v)
     }
@@ -1444,11 +1481,13 @@ impl ConvCtx {
         if let Some(v) = *self.nutation.borrow() {
             return Ok(v);
         }
-        let (tt1, tt2) = self.get_tt_jd(frame)?;
-        let v = match frame.iau_model() {
-            IauModel::Iau1976_1980 => sofars::pnp::nutm80(tt1, tt2),
-            IauModel::Iau2006_2000A => sofars::pnp::num00a(tt1, tt2),
-        };
+        let v = frame.cached_nutation(|| {
+            let (tt1, tt2) = self.get_tt_jd(frame)?;
+            Ok(match frame.iau_model() {
+                IauModel::Iau1976_1980 => sofars::pnp::nutm80(tt1, tt2),
+                IauModel::Iau2006_2000A => sofars::pnp::num00a(tt1, tt2),
+            })
+        })?;
         *self.nutation.borrow_mut() = Some(v);
         Ok(v)
     }
@@ -1457,11 +1496,13 @@ impl ConvCtx {
         if let Some(v) = *self.earth_vel.borrow() {
             return Ok(v);
         }
-        let (tt1, tt2) = self.get_tt_jd(frame)?;
-        let (pvh, pvb) =
-            sofars::eph::epv00(tt1, tt2).ok_or(MeasureError::SofarsError { code: -1 })?;
-        let sun_dist = sofars::vm::pm(pvh[0]);
-        let v = (pvb[1], sun_dist);
+        let v = frame.cached_earth_velocity_au_per_day(|| {
+            let (tt1, tt2) = self.get_tt_jd(frame)?;
+            let (pvh, pvb) =
+                sofars::eph::epv00(tt1, tt2).ok_or(MeasureError::SofarsError { code: -1 })?;
+            let sun_dist = sofars::vm::pm(pvh[0]);
+            Ok((pvb[1], sun_dist))
+        })?;
         *self.earth_vel.borrow_mut() = Some(v);
         Ok(v)
     }
@@ -2083,6 +2124,15 @@ mod tests {
         let (lon, lat) = direction.as_angles();
         assert!(close(lon, 6.123_487_680_622_104, 1e-15));
         assert!(close(lat, 1.026_515_399_560_464_8, 1e-15));
+    }
+
+    #[test]
+    fn source_name_catalog_entry_uses_runtime_sources_table() {
+        let direction = MDirection::from_source_name("0002-478", &MeasFrame::new()).unwrap();
+        assert_eq!(direction.refer(), DirectionRef::ICRS);
+        let (lon, lat) = direction.as_angles();
+        assert!(close(lon, 0.020_046_3, 1e-6));
+        assert!(close(lat, -0.830_872, 1e-6));
     }
 
     #[test]

--- a/crates/casa-types/src/measures/error.rs
+++ b/crates/casa-types/src/measures/error.rs
@@ -40,6 +40,11 @@ pub enum MeasureError {
         /// The original source-name input.
         input: String,
     },
+    /// An unknown spectral-line name was encountered.
+    UnknownLineName {
+        /// The original spectral-line input.
+        input: String,
+    },
     /// A unit does not match the expected dimension for a measure value.
     NonConformantUnit {
         /// The expected dimension (e.g. "time", "length").
@@ -86,6 +91,9 @@ impl fmt::Display for MeasureError {
             }
             Self::UnknownSourceName { input } => {
                 write!(f, "unknown source name: {input:?}")
+            }
+            Self::UnknownLineName { input } => {
+                write!(f, "unknown spectral line name: {input:?}")
             }
             Self::NonConformantUnit { expected, got } => {
                 write!(f, "non-conformant unit: expected {expected}, got {got:?}")
@@ -140,6 +148,12 @@ mod tests {
                     input: "NotARealSource".to_string(),
                 },
                 "unknown source name: \"NotARealSource\"",
+            ),
+            (
+                MeasureError::UnknownLineName {
+                    input: "NotARealLine".to_string(),
+                },
+                "unknown spectral line name: \"NotARealLine\"",
             ),
             (
                 MeasureError::NonConformantUnit {

--- a/crates/casa-types/src/measures/frame.rs
+++ b/crates/casa-types/src/measures/frame.rs
@@ -8,12 +8,13 @@
 //! It mirrors C++ `MeasFrame` but stores only the subset of fields relevant to
 //! MEpoch, MPosition, MDirection, and MFrequency conversions.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use casa_measures_data::EopTable;
 
 use super::direction::MDirection;
 use super::epoch::MEpoch;
+use super::error::MeasureError;
 use super::position::MPosition;
 use super::radial_velocity::MRadialVelocity;
 
@@ -89,6 +90,32 @@ pub struct MeasFrame {
     dut1_seconds: Option<f64>,
     eop_table: Option<Arc<EopTable>>,
     iau_model: IauModel,
+    cache: FrameCache,
+}
+
+/// Reusable derived state for repeated conversions against the same frame.
+///
+/// Casacore keeps comparable intermediate state inside its conversion engine.
+/// We keep the public builder immutable and hide the reusable state behind
+/// interior mutability so repeated conversions can reuse the same epoch/frame
+/// derivatives without recomputing them on every call.
+#[derive(Debug, Default)]
+struct FrameCache {
+    tt_jd: Mutex<Option<(f64, f64)>>,
+    ut1_jd: Mutex<Option<(f64, f64)>>,
+    gast: Mutex<Option<f64>>,
+    precession: Mutex<Option<[[f64; 3]; 3]>>,
+    nutation: Mutex<Option<[[f64; 3]; 3]>>,
+    earth_velocity_au_per_day: Mutex<Option<([f64; 3], f64)>>,
+    earth_velocity_ms: Mutex<Option<[f64; 3]>>,
+    observatory_velocity_ms: Mutex<Option<[f64; 3]>>,
+    direction_j2000: Mutex<Option<[f64; 3]>>,
+}
+
+impl Clone for FrameCache {
+    fn clone(&self) -> Self {
+        Self::default()
+    }
 }
 
 impl MeasFrame {
@@ -102,6 +129,7 @@ impl MeasFrame {
             dut1_seconds: None,
             eop_table: None,
             iau_model: IauModel::default(),
+            cache: FrameCache::default(),
         }
     }
 
@@ -249,6 +277,120 @@ impl MeasFrame {
         let eop = self.eop_table.as_ref()?;
         let vals = eop.interpolate(mjd)?;
         Some((vals.x_arcsec, vals.y_arcsec))
+    }
+
+    pub(crate) fn cached_tt_jd<F>(&self, compute: F) -> Result<(f64, f64), MeasureError>
+    where
+        F: FnOnce() -> Result<(f64, f64), MeasureError>,
+    {
+        if let Some(value) = *self.cache.tt_jd.lock().unwrap() {
+            return Ok(value);
+        }
+        let value = compute()?;
+        *self.cache.tt_jd.lock().unwrap() = Some(value);
+        Ok(value)
+    }
+
+    pub(crate) fn cached_ut1_jd<F>(&self, compute: F) -> Result<(f64, f64), MeasureError>
+    where
+        F: FnOnce() -> Result<(f64, f64), MeasureError>,
+    {
+        if let Some(value) = *self.cache.ut1_jd.lock().unwrap() {
+            return Ok(value);
+        }
+        let value = compute()?;
+        *self.cache.ut1_jd.lock().unwrap() = Some(value);
+        Ok(value)
+    }
+
+    pub(crate) fn cached_gast<F>(&self, compute: F) -> Result<f64, MeasureError>
+    where
+        F: FnOnce() -> Result<f64, MeasureError>,
+    {
+        if let Some(value) = *self.cache.gast.lock().unwrap() {
+            return Ok(value);
+        }
+        let value = compute()?;
+        *self.cache.gast.lock().unwrap() = Some(value);
+        Ok(value)
+    }
+
+    pub(crate) fn cached_precession<F>(&self, compute: F) -> Result<[[f64; 3]; 3], MeasureError>
+    where
+        F: FnOnce() -> Result<[[f64; 3]; 3], MeasureError>,
+    {
+        if let Some(value) = *self.cache.precession.lock().unwrap() {
+            return Ok(value);
+        }
+        let value = compute()?;
+        *self.cache.precession.lock().unwrap() = Some(value);
+        Ok(value)
+    }
+
+    pub(crate) fn cached_nutation<F>(&self, compute: F) -> Result<[[f64; 3]; 3], MeasureError>
+    where
+        F: FnOnce() -> Result<[[f64; 3]; 3], MeasureError>,
+    {
+        if let Some(value) = *self.cache.nutation.lock().unwrap() {
+            return Ok(value);
+        }
+        let value = compute()?;
+        *self.cache.nutation.lock().unwrap() = Some(value);
+        Ok(value)
+    }
+
+    pub(crate) fn cached_earth_velocity_au_per_day<F>(
+        &self,
+        compute: F,
+    ) -> Result<([f64; 3], f64), MeasureError>
+    where
+        F: FnOnce() -> Result<([f64; 3], f64), MeasureError>,
+    {
+        if let Some(value) = *self.cache.earth_velocity_au_per_day.lock().unwrap() {
+            return Ok(value);
+        }
+        let value = compute()?;
+        *self.cache.earth_velocity_au_per_day.lock().unwrap() = Some(value);
+        Ok(value)
+    }
+
+    pub(crate) fn cached_earth_velocity_ms<F>(&self, compute: F) -> Result<[f64; 3], MeasureError>
+    where
+        F: FnOnce() -> Result<[f64; 3], MeasureError>,
+    {
+        if let Some(value) = *self.cache.earth_velocity_ms.lock().unwrap() {
+            return Ok(value);
+        }
+        let value = compute()?;
+        *self.cache.earth_velocity_ms.lock().unwrap() = Some(value);
+        Ok(value)
+    }
+
+    pub(crate) fn cached_observatory_velocity_ms<F>(
+        &self,
+        compute: F,
+    ) -> Result<[f64; 3], MeasureError>
+    where
+        F: FnOnce() -> Result<[f64; 3], MeasureError>,
+    {
+        if let Some(value) = *self.cache.observatory_velocity_ms.lock().unwrap() {
+            return Ok(value);
+        }
+        let value = compute()?;
+        *self.cache.observatory_velocity_ms.lock().unwrap() = Some(value);
+        Ok(value)
+    }
+
+    pub(crate) fn cached_direction_j2000<F>(&self, compute: F) -> Result<[f64; 3], MeasureError>
+    where
+        F: FnOnce() -> Result<[f64; 3], MeasureError>,
+    {
+        if let Some(value) = *self.cache.direction_j2000.lock().unwrap() {
+            return Ok(value);
+        }
+        let value = compute()?;
+        *self.cache.direction_j2000.lock().unwrap() = Some(value);
+        Ok(value)
     }
 }
 

--- a/crates/casa-types/src/measures/frequency.rs
+++ b/crates/casa-types/src/measures/frequency.rs
@@ -26,6 +26,8 @@
 use std::fmt;
 use std::str::FromStr;
 
+use casa_measures_data::SpectralLineCatalog;
+
 use super::epoch::EpochRef;
 use super::error::MeasureError;
 use super::frame::MeasFrame;
@@ -197,6 +199,20 @@ impl MFrequency {
         Self { hz, refer }
     }
 
+    /// Resolves a casacore/CASA spectral-line name into a rest frequency.
+    ///
+    /// This mirrors C++ `MeasTable::Line`, using the runtime
+    /// `ephemerides/Lines` table bundled with or discovered by
+    /// `casa-measures-data`.
+    pub fn from_line_name(line_name: &str) -> Result<Self, MeasureError> {
+        let entry = SpectralLineCatalog::bundled()
+            .get(line_name)
+            .ok_or_else(|| MeasureError::UnknownLineName {
+                input: line_name.to_string(),
+            })?;
+        Ok(Self::new(entry.frequency_hz(), FrequencyRef::REST))
+    }
+
     /// Returns the frequency in Hz.
     pub fn hz(&self) -> f64 {
         self.hz
@@ -309,69 +325,76 @@ pub(super) fn compute_beta(velocity_ms: &[f64; 3], dir_j2000: &[f64; 3]) -> f64 
 
 /// Get direction in J2000 from the frame.
 pub(super) fn get_direction_j2000(frame: &MeasFrame) -> Result<[f64; 3], MeasureError> {
-    let dir = frame.direction().ok_or(MeasureError::MissingFrameData {
-        what: "direction (for velocity projection)",
-    })?;
-    dir.to_j2000(frame)
+    frame.cached_direction_j2000(|| {
+        let dir = frame.direction().ok_or(MeasureError::MissingFrameData {
+            what: "direction (for velocity projection)",
+        })?;
+        dir.to_j2000(frame)
+    })
 }
 
 /// Get Earth's barycentric velocity in m/s (J2000).
 pub(super) fn earth_velocity_ms(frame: &MeasFrame) -> Result<[f64; 3], MeasureError> {
-    let epoch = frame.epoch().ok_or(MeasureError::MissingFrameData {
-        what: "epoch (for Earth orbital velocity)",
-    })?;
-    let tt = if epoch.refer() == EpochRef::TT {
-        epoch.clone()
-    } else {
-        epoch.convert_to(EpochRef::TT, frame)?
-    };
-    let (tt1, tt2) = tt.value().as_jd_pair();
-    let (_pvh, pvb) = sofars::eph::epv00(tt1, tt2).ok_or(MeasureError::SofarsError { code: -1 })?;
-    // pvb[1] is Earth barycentric velocity in AU/day → convert to m/s
-    let au_to_m = 149_597_870_700.0_f64;
-    let day_to_s = 86400.0;
-    Ok([
-        pvb[1][0] * au_to_m / day_to_s,
-        pvb[1][1] * au_to_m / day_to_s,
-        pvb[1][2] * au_to_m / day_to_s,
-    ])
+    frame.cached_earth_velocity_ms(|| {
+        let epoch = frame.epoch().ok_or(MeasureError::MissingFrameData {
+            what: "epoch (for Earth orbital velocity)",
+        })?;
+        let tt = if epoch.refer() == EpochRef::TT {
+            epoch.clone()
+        } else {
+            epoch.convert_to(EpochRef::TT, frame)?
+        };
+        let (tt1, tt2) = tt.value().as_jd_pair();
+        let (_pvh, pvb) =
+            sofars::eph::epv00(tt1, tt2).ok_or(MeasureError::SofarsError { code: -1 })?;
+        // pvb[1] is Earth barycentric velocity in AU/day → convert to m/s
+        let au_to_m = 149_597_870_700.0_f64;
+        let day_to_s = 86400.0;
+        Ok([
+            pvb[1][0] * au_to_m / day_to_s,
+            pvb[1][1] * au_to_m / day_to_s,
+            pvb[1][2] * au_to_m / day_to_s,
+        ])
+    })
 }
 
 /// Get observatory velocity in m/s (J2000) from Earth rotation.
 pub(super) fn observatory_velocity_ms(frame: &MeasFrame) -> Result<[f64; 3], MeasureError> {
-    let pos = frame.position().ok_or(MeasureError::MissingFrameData {
-        what: "position (for diurnal velocity)",
-    })?;
-    let epoch = frame.epoch().ok_or(MeasureError::MissingFrameData {
-        what: "epoch (for Earth rotation angle)",
-    })?;
+    frame.cached_observatory_velocity_ms(|| {
+        let pos = frame.position().ok_or(MeasureError::MissingFrameData {
+            what: "position (for diurnal velocity)",
+        })?;
+        let epoch = frame.epoch().ok_or(MeasureError::MissingFrameData {
+            what: "epoch (for Earth rotation angle)",
+        })?;
 
-    // Get ITRF coordinates
-    let itrf = pos.as_itrf();
+        // Get ITRF coordinates
+        let itrf = pos.as_itrf();
 
-    // Earth angular velocity (rad/s)
-    const OMEGA: f64 = 7.292_115e-5;
+        // Earth angular velocity (rad/s)
+        const OMEGA: f64 = 7.292_115e-5;
 
-    // Velocity in ITRF: v = omega cross r = [-omega*y, omega*x, 0]
-    let v_itrf = [-OMEGA * itrf[1], OMEGA * itrf[0], 0.0];
+        // Velocity in ITRF: v = omega cross r = [-omega*y, omega*x, 0]
+        let v_itrf = [-OMEGA * itrf[1], OMEGA * itrf[0], 0.0];
 
-    // Rotate to J2000 using ERA (simplified — ignores precession/nutation)
-    let ut1 = if epoch.refer() == EpochRef::UT1 {
-        epoch.clone()
-    } else {
-        epoch.convert_to(EpochRef::UT1, frame)?
-    };
-    let (ut_a, ut_b) = ut1.value().as_jd_pair();
-    let era = sofars::erst::era00(ut_a, ut_b);
+        // Rotate to J2000 using ERA (simplified — ignores precession/nutation)
+        let ut1 = if epoch.refer() == EpochRef::UT1 {
+            epoch.clone()
+        } else {
+            epoch.convert_to(EpochRef::UT1, frame)?
+        };
+        let (ut_a, ut_b) = ut1.value().as_jd_pair();
+        let era = sofars::erst::era00(ut_a, ut_b);
 
-    // Rotate velocity from ITRF to J2000 by -ERA around z
-    let mut r = [[0.0; 3]; 3];
-    sofars::vm::ir(&mut r);
-    sofars::vm::rz(-era, &mut r);
-    let mut v_j2000 = [0.0; 3];
-    sofars::vm::rxp(&r, &v_itrf, &mut v_j2000);
+        // Rotate velocity from ITRF to J2000 by -ERA around z
+        let mut r = [[0.0; 3]; 3];
+        sofars::vm::ir(&mut r);
+        sofars::vm::rz(-era, &mut r);
+        let mut v_j2000 = [0.0; 3];
+        sofars::vm::rxp(&r, &v_itrf, &mut v_j2000);
 
-    Ok(v_j2000)
+        Ok(v_j2000)
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -632,6 +655,19 @@ mod tests {
         let frame = MeasFrame::new().with_direction(dir);
         let result = f.convert_to(FrequencyRef::LSRK, &frame);
         assert!(matches!(result, Err(MeasureError::MissingFrameData { .. })));
+    }
+
+    #[test]
+    fn line_name_hi_resolves_from_runtime_catalog() {
+        let f = MFrequency::from_line_name("HI").unwrap();
+        assert_eq!(f.refer(), FrequencyRef::REST);
+        assert!((f.hz() - 1.420_405_752e9).abs() < 5.0e3);
+    }
+
+    #[test]
+    fn line_name_unknown_is_rejected() {
+        let error = MFrequency::from_line_name("NOT_A_REAL_LINE").unwrap_err();
+        assert!(matches!(error, MeasureError::UnknownLineName { .. }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This wave closes the related measures work tracked across the source/line catalog, TaQL parity, direction-divergence, and performance issues.

- add CASA-table-backed source and spectral-line catalog loaders and wire named source/line resolution through `casa-types`
- extend TaQL `meas.*` parity coverage to MEASINFO-backed epoch and direction columns via casacore `register_meas()`
- document and regression-test the remaining APP-family casacore vs SOFA divergence, including the bounded IAU1976/1980 and IAU2000A residuals
- cache reusable frame-derived state on `MeasFrame` and enforce `<= 2x` release perf guards on the historical slow routes

## Notes

- the IAU2000A APP-family mismatch is treated as a bounded, regression-tested divergence for now
- casacore PR #1464 is referenced as upstream context only, not as independent confirmation
- current Rust TaQL still consumes explicit raw values plus refs, while casacore TaQL can consume `MEASINFO` columns directly; the new parity tests document that semantic gap explicitly

## Testing

- `cargo fmt --all`
- `cargo test -p casa-types`
- `cargo test -p casa-test-support --test taql_meas_column_interop -- --nocapture`
- `cargo test -p casa-test-support --test measures_interop accepted_direction_divergence_routes_are_bounded -- --nocapture`
- `cargo test -p casa-test-support --test measures_perf_vs_cpp --release -- --nocapture`
- `cargo test -p casa-test-support --test taql_meas_interop named_source_catalog_direction_matches_cpp -- --nocapture`
- `cargo test -p casa-test-support --test measures_interop rc_catalog_line_hi_matches_cpp -- --nocapture`
- `cargo clippy -p casa-types -p casa-test-support --all-targets -- -D warnings`

Full workspace tests, slow tests, and coverage were not run in this wave.