### PR TITLE
Fix CASA parity harness setup regressions

### DIFF
--- a/crates/casa-coordinates/src/direction.rs
+++ b/crates/casa-coordinates/src/direction.rs
@@ -562,14 +562,12 @@ impl Coordinate for DirectionCoordinate {
             "projection",
             Value::Scalar(ScalarValue::String(self.projection.name().into())),
         );
-        if !self.projection.parameters().is_empty() {
-            rec.upsert(
-                "projection_parameters",
-                Value::Array(casa_types::ArrayValue::from_f64_vec(
-                    self.projection.parameters().to_vec(),
-                )),
-            );
-        }
+        rec.upsert(
+            "projection_parameters",
+            Value::Array(casa_types::ArrayValue::from_f64_vec(
+                serialized_projection_parameters(&self.projection),
+            )),
+        );
         rec.upsert(
             "crval",
             Value::Array(casa_types::ArrayValue::from_f64_vec(self.crval.to_vec())),
@@ -606,14 +604,12 @@ impl Coordinate for DirectionCoordinate {
             "projection",
             Value::Scalar(ScalarValue::String(self.projection.name().into())),
         );
-        if !self.projection.parameters().is_empty() {
-            rec.upsert(
-                "projection_parameters",
-                Value::Array(ArrayValue::from_f64_vec(
-                    self.projection.parameters().to_vec(),
-                )),
-            );
-        }
+        rec.upsert(
+            "projection_parameters",
+            Value::Array(ArrayValue::from_f64_vec(serialized_projection_parameters(
+                &self.projection,
+            ))),
+        );
         rec.upsert(
             "crval",
             Value::Array(ArrayValue::from_f64_vec(self.crval.to_vec())),
@@ -658,6 +654,14 @@ impl Coordinate for DirectionCoordinate {
 
     fn clone_box(&self) -> Box<dyn Coordinate> {
         Box::new(self.clone())
+    }
+}
+
+fn serialized_projection_parameters(projection: &Projection) -> Vec<f64> {
+    if projection.parameters().is_empty() {
+        vec![0.0, 0.0]
+    } else {
+        projection.parameters().to_vec()
     }
 }
 
@@ -903,6 +907,10 @@ mod tests {
                 "rad".into(),
                 "rad".into()
             ])))
+        );
+        assert_eq!(
+            rec.get("projection_parameters"),
+            Some(&Value::Array(ArrayValue::from_f64_vec(vec![0.0, 0.0])))
         );
         assert_eq!(
             rec.get("longpole"),

--- a/crates/casars-imager/tests/imager_casa_parity.rs
+++ b/crates/casars-imager/tests/imager_casa_parity.rs
@@ -5556,7 +5556,7 @@ tclean(
     deconvolver=os.environ["CASA_DECONVOLVER"],
     scales=[] if os.environ["CASA_SCALES"] == "" else [int(float(v)) for v in os.environ["CASA_SCALES"].split(",")],
     imsize=int(os.environ["CASA_IMSIZE"]),
-    cell=f'{{os.environ["CASA_CELL_ARCSEC"]}}arcsec',
+    cell=f'{os.environ["CASA_CELL_ARCSEC"]}arcsec',
     niter=int(os.environ["CASA_NITER"]),
     robust=float(os.environ["CASA_ROBUST"]),
     gain=0.1,


### PR DESCRIPTION
## Summary
This is a blocked partial fix from the long-gates automation.

The branch fixes two concrete CASA parity setup/serialization issues:
- the slow `casars-imager` CASA parity helpers now interpolate `CASA_CELL_ARCSEC` correctly instead of passing the literal Python string `{os.environ["CASA_CELL_ARCSEC"]}arcsec`
- direction-coordinate serialization now always writes `projection_parameters`, matching casacore `DirectionCoordinate::save()` expectations and adding a regression assertion for the legacy CASA record form

## Root Causes
- Three slow parity tests were failing for a harness reason: the CASA `tclean()` Python snippets in [`crates/casars-imager/tests/imager_casa_parity.rs`] were building an invalid `cell=` quantity string.
- CASA/casacore expects serialized direction coordinates to define `projection_parameters`, but the Rust serializer omitted that field for default projections.
- After fixing those setup issues, the remaining slow failures are real product mismatches in `casars-imager`, not harness breakage.

## Files Changed
- `crates/casars-imager/tests/imager_casa_parity.rs`
- `crates/casa-coordinates/src/direction.rs`

## Validation Run
Commands run on this branch:
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `scripts/test-slow.sh`
- `cargo test -p casa-coordinates direction::tests::casa_record_serialization_uses_legacy_fields -- --exact`
- `cargo test -p casars-imager --features slow-tests --test imager_casa_parity briggs_dirty_products_track_casa_headers_and_pixels`
- `cargo test -p casars-imager --features slow-tests --test imager_casa_parity uniform_dirty_products_track_casa_headers_and_pixels`
- `cargo test -p casars-imager --features slow-tests --test imager_casa_parity clark_products_track_casa_on_ngc5921`
- `cargo test -p casars-imager --features slow-tests --test imager_casa_parity clean_products_reopen_in_casa_and_rust`

Results:
- `cargo fmt --all -- --check`: passed
- `cargo clippy --workspace --all-targets -- -D warnings`: passed
- `cargo test --workspace`: passed during this run
- `scripts/test-slow.sh`: still fails in the slow `casars-imager` parity suite after the harness fix

## Remaining Blockers / Residual Risks
The branch does **not** make the repo green yet. Remaining slow failures are:
- `briggs_dirty_products_track_casa_headers_and_pixels`
  - current mismatch: `sumwt` (`left=32451.377`, `right=2049164.6`)
- `uniform_dirty_products_track_casa_headers_and_pixels`
  - current mismatch: `sumwt` (`left=965.512`, `right=1023.3183`)
- `clark_products_track_casa_on_ngc5921`
  - current mismatch: model sum (`left=0.0041529615`, `right=0.13854139`)
- `clean_products_reopen_in_casa_and_rust`
  - CASA still cannot reopen the Rust-written image; current failure is a casacore `CoordinateSystem::restore` assertion

These remaining failures suggest at least two follow-up tracks:
- reconcile CASA-style `.sumwt` semantics for reweighted `uniform`/`briggs` imaging
- finish CASA-compatible image coordinate serialization for the clean-image reopen path

## CI-like Coverage
- Final CI-like coverage percentage: not reached in this run
- `scripts/run-coverage.sh --ci-like` was not run because the required long-gate sequence stopped at `scripts/test-slow.sh` with real failing parity tests
