### PR TITLE
Fix CASA parity cell interpolation

### DIFF
--- a/crates/casars-imager/tests/imager_casa_parity.rs
+++ b/crates/casars-imager/tests/imager_casa_parity.rs
@@ -5556,7 +5556,7 @@ tclean(
     deconvolver=os.environ["CASA_DECONVOLVER"],
     scales=[] if os.environ["CASA_SCALES"] == "" else [int(float(v)) for v in os.environ["CASA_SCALES"].split(",")],
     imsize=int(os.environ["CASA_IMSIZE"]),
-    cell=f'{{os.environ["CASA_CELL_ARCSEC"]}}arcsec',
+    cell=f'{os.environ["CASA_CELL_ARCSEC"]}arcsec',
     niter=int(os.environ["CASA_NITER"]),
     robust=float(os.environ["CASA_ROBUST"]),
     gain=0.1,


### PR DESCRIPTION
## Summary
Partial fix for the long-gates run. This change repairs the CASA parity test harness so CASA `tclean` receives the actual `CASA_CELL_ARCSEC` value instead of the literal placeholder string.

## Root Cause
- `crates/casars-imager/tests/imager_casa_parity.rs` used `cell=f'{{os.environ["CASA_CELL_ARCSEC"]}}arcsec'` inside a raw Python script string.
- Because that helper is not wrapped in Rust `format!`, the doubled braces were passed through literally, so CASA saw `{os.environ["CASA_CELL_ARCSEC"]}arcsec` and rejected the image parameters with `cellsize must be nonzero`.

## Files Changed
- `crates/casars-imager/tests/imager_casa_parity.rs`

## Validation
Commands run during this automation:
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `scripts/test-slow.sh`
- `cargo test -p casars-imager --features slow-tests --test imager_casa_parity briggs_dirty_products_track_casa_headers_and_pixels -- --exact`
- `cargo test -p casars-imager --features slow-tests --test imager_casa_parity uniform_dirty_products_track_casa_headers_and_pixels -- --exact`
- `cargo test -p casars-imager --features slow-tests --test imager_casa_parity clark_products_track_casa_on_ngc5921 -- --exact`

Results:
- `cargo fmt --all -- --check`: passed
- `cargo clippy --workspace --all-targets -- -D warnings`: passed
- `cargo test --workspace`: initially failed due `No space left on device`; passed after `cargo clean` reclaimed ~28.9 GiB
- `scripts/test-slow.sh`: still failing after this harness fix

## Remaining Blockers
The repo is still not green on `origin/main` after this fix. Current failing slow tests are:
- `briggs_dirty_products_track_casa_headers_and_pixels`: `sumwt` mismatch (`left=32451.377`, `right=2049164.6`)
- `uniform_dirty_products_track_casa_headers_and_pixels`: `sumwt` mismatch (`left=965.512`, `right=1023.3183`)
- `clark_products_track_casa_on_ngc5921`: Clark model sum mismatch (`left=0.0041529615`, `right=0.13854139`)
- `clean_products_reopen_in_casa_and_rust`: CASA fails to open the Rust-written image with `CoordinateSystem.cc : 2762 Failed AlwaysAssert coords[nc-1] != 0`

## Coverage
- CI-like coverage percentage: not run in this branch because the slow-gate suite is still red before `scripts/run-coverage.sh --ci-like`

## Residual Risks / Follow-up
- The remaining failures point at real imaging implementation issues, not the test harness.
- The weighting parity drift likely lives in MFS uniform/Briggs weighting or `sumwt` accounting.
- The clean-image reopen failure likely lives in the CASA-compatible image coordinate metadata write path.
