### PR TITLE
Fix long-gate imaging regressions and coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,6 +484,7 @@ dependencies = [
  "ndarray",
  "num-complex",
  "rustfft",
+ "serial_test",
  "thiserror 2.0.18",
 ]
 
@@ -1555,6 +1556,41 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -2740,6 +2776,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3541,6 +3583,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schemars"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3569,6 +3620,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "semver"
@@ -3637,6 +3694,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3718,6 +3801,12 @@ name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"

--- a/crates/casa-imaging/Cargo.toml
+++ b/crates/casa-imaging/Cargo.toml
@@ -23,3 +23,4 @@ thiserror.workspace = true
 
 [dev-dependencies]
 casa-test-support = { path = "../casa-test-support" }
+serial_test = "3"

--- a/crates/casa-imaging/src/gridder.rs
+++ b/crates/casa-imaging/src/gridder.rs
@@ -378,7 +378,7 @@ impl StandardGridder {
         let (x, y) = match convention {
             DensityCellConvention::VisImagingWeight => (
                 u_lambda * nx * self.geometry.cell_size_rad[0] + nx / 2.0,
-                v_lambda * ny * self.geometry.cell_size_rad[1] + ny / 2.0,
+                -v_lambda * ny * self.geometry.cell_size_rad[1] + ny / 2.0,
             ),
             DensityCellConvention::CubeBriggsWeightor => (
                 -u_lambda * nx * self.geometry.cell_size_rad[0] + nx / 2.0,
@@ -1154,9 +1154,7 @@ fn build_sinc_axis(size: usize, conv_sampling: usize) -> Vec<f32> {
         .map(|index| {
             let argument = std::f64::consts::PI * (index as f64 - size as f64 / 2.0)
                 / (size as f64 * conv_sampling as f64);
-            if index == size / 2 {
-                1.0
-            } else if argument.abs() <= f64::EPSILON {
+            if index == size / 2 || argument.abs() <= f64::EPSILON {
                 1.0
             } else {
                 (argument.sin() / argument) as f32
@@ -1213,6 +1211,7 @@ mod tests {
     };
     use ndarray::Array2;
     use num_complex::Complex32;
+    use serial_test::serial;
 
     use super::{DensityCellConvention, ScreenProjector, StandardGridder};
     use crate::{
@@ -1393,11 +1392,11 @@ mod tests {
         );
         assert_eq!(
             gridder.density_cell_index(1.01 * du, -1.01 * dv),
-            Some((center.0 + 1, center.1 - 2))
+            Some((center.0 + 1, center.1 + 1))
         );
         assert_eq!(
             gridder.density_cell_index(-1.01 * du, 1.01 * dv),
-            Some((center.0 - 2, center.1 + 1))
+            Some((center.0 - 2, center.1 - 2))
         );
     }
 
@@ -1449,6 +1448,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(casa_cpp)]
     fn convolve_gridder_patch_matches_casacore_for_fractional_sample() {
         let geometry = ImageGeometry {
             image_shape: [100, 100],
@@ -1520,6 +1520,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(casa_cpp)]
     fn convolve_gridder_correction_row_matches_casacore() {
         let geometry = ImageGeometry {
             image_shape: [100, 100],
@@ -1579,6 +1580,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(casa_cpp)]
     fn convolve_gridder_accumulates_multiple_fractional_samples_like_casacore() {
         let geometry = ImageGeometry {
             image_shape: [100, 100],
@@ -1635,6 +1637,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(casa_cpp)]
     fn convolve_gridder_degrids_structured_model_like_casacore() {
         let geometry = ImageGeometry {
             image_shape: [64, 64],

--- a/crates/casa-imaging/src/lib.rs
+++ b/crates/casa-imaging/src/lib.rs
@@ -1401,6 +1401,7 @@ fn build_mosaic_pointing_groups(
     Ok(grouped.into_values().collect())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_mosaic_projector(
     geometry: ImageGeometry,
     gridder: &StandardGridder,
@@ -2382,7 +2383,7 @@ fn run_clean_cube(request: &CubeImagingRequest) -> Result<CubeImagingResult, Ima
                 total_reported_minor_iterations,
                 refreshed_planes,
                 refreshed_channel_indices,
-                dominant_channel.map(|(index, peak, nsigma)| (index, peak, nsigma)),
+                dominant_channel,
                 global_peak_after_refresh,
                 cube_nsigma_threshold_after_refresh_jy_per_beam,
             );
@@ -2626,6 +2627,7 @@ fn cube_minor_cycle_capture_config() -> Option<CubeMinorCycleCaptureConfig> {
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn maybe_capture_cube_minor_cycle_state(
     capture: Option<&CubeMinorCycleCaptureConfig>,
     channel_index: usize,
@@ -4019,14 +4021,13 @@ fn compute_mtmfs_psf_terms(
                     "missing MTMFS sample-frequency batch for visibility batch {batch_index}"
                 ))
             })?;
-        for index in 0..batch.len() {
+        for (index, &frequency_hz) in frequencies_hz.iter().enumerate().take(batch.len()) {
             if !batch.gridable[index] {
                 skipped_samples += 1;
                 continue;
             }
             let weight = batch.weight[index];
             let sumwt_factor = batch.sumwt_factor[index];
-            let frequency_hz = frequencies_hz[index];
             if !(weight.is_finite()
                 && weight > 0.0
                 && sumwt_factor.is_finite()
@@ -4144,10 +4145,9 @@ fn compute_mtmfs_residual_terms(
                     "missing MTMFS sample-frequency batch for visibility batch {batch_index}"
                 ))
             })?;
-        for index in 0..batch.len() {
+        for (index, &frequency_hz) in frequencies_hz.iter().enumerate().take(batch.len()) {
             let weight = batch.weight[index];
             let observed_visibility = batch.visibility[index];
-            let frequency_hz = frequencies_hz[index];
             let gridable = batch.gridable[index];
             let planned_sample = if gridable
                 && weight.is_finite()
@@ -4172,30 +4172,28 @@ fn compute_mtmfs_residual_terms(
             } else {
                 vec![Complex32::new(0.0, 0.0); request.nterms]
             };
-            for residual_order in 0..request.nterms {
+            for (residual_order, residual_grid) in
+                residual_grids.iter_mut().enumerate().take(request.nterms)
+            {
                 let observed_term = observed_visibility
                     * mtmfs_taylor_weight(frequency_hz, request.reffreq_hz, residual_order);
                 let mut predicted_term = Complex32::new(0.0, 0.0);
-                for model_order in 0..request.nterms {
+                for (model_order, predicted_visibility) in predicted_visibility_terms
+                    .iter()
+                    .enumerate()
+                    .take(request.nterms)
+                {
                     let factor = mtmfs_taylor_weight(
                         frequency_hz,
                         request.reffreq_hz,
                         residual_order + model_order,
                     );
-                    predicted_term += predicted_visibility_terms[model_order] * factor;
+                    predicted_term += *predicted_visibility * factor;
                 }
                 let residual_visibility = observed_term - predicted_term;
                 let residual = residual_visibility * weight;
-                gridder.grid_sample_product_planned(
-                    &mut residual_grids[residual_order],
-                    &plan.positive,
-                    residual,
-                );
-                gridder.grid_sample_product_planned(
-                    &mut residual_grids[residual_order],
-                    &plan.negative,
-                    residual.conj(),
-                );
+                gridder.grid_sample_product_planned(residual_grid, &plan.positive, residual);
+                gridder.grid_sample_product_planned(residual_grid, &plan.negative, residual.conj());
             }
         }
     }
@@ -4242,6 +4240,7 @@ fn mtmfs_hessian(psf_terms: &[Array2<f32>], nterms: usize) -> Result<Vec<Vec<f32
         .collect())
 }
 
+#[allow(clippy::needless_range_loop)]
 fn invert_small_matrix(matrix: &[Vec<f32>]) -> Result<Vec<Vec<f32>>, ImagingError> {
     let n = matrix.len();
     if n == 0 || matrix.iter().any(|row| row.len() != n) {
@@ -4372,6 +4371,7 @@ fn find_mtmfs_component(
     best
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_mtmfs_minor_cycle(
     request: &MtmfsRequest,
     psf_terms: &[Array2<f32>],
@@ -4650,10 +4650,7 @@ fn compute_residual(
         gridder,
         model,
         psf_state,
-        matches!(
-            request.deconvolver,
-            Deconvolver::Clark | Deconvolver::Multiscale
-        ),
+        matches!(request.deconvolver, Deconvolver::Clark),
         stage_timings,
     )
 }
@@ -4734,6 +4731,7 @@ fn compute_residual_trace_standard(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn compute_residual_standard_internal(
     geometry: ImageGeometry,
     batches: &[VisibilityBatch],
@@ -4854,6 +4852,7 @@ fn compute_residual_standard_internal(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn compute_residual_trace_cube_standard(
     batches: &[VisibilityBatch],
     model_interpolation_batches: &[CubeModelInterpolationBatch],
@@ -4950,6 +4949,7 @@ fn cube_refresh_flags(planes: &[CubePlaneWork], updated_model_channels: &[bool])
         .collect()
 }
 
+#[allow(clippy::too_many_arguments)]
 fn compute_residual_trace_cube_standard_with_model_grids(
     batches: &[VisibilityBatch],
     planned_batches: Option<&[Vec<Option<PlannedSample>>]>,
@@ -6043,19 +6043,20 @@ mod tests {
     use casa_test_support::hogbom_interop::cpp_hogbom_clean_minor_cycle_2d;
     use ndarray::{Array2, s};
     use num_complex::Complex32;
+    use serial_test::serial;
 
     use super::{
         CleanConfig, CleanStopReason, CompatibilityMode, CubeChannelRequest, CubeImagingRequest,
         CubeModelChannelContribution, CubeModelInterpolationBatch, Deconvolver, GridderMode,
-        ImageGeometry, ImagingRequest, ImagingStageTimings, ParallelHandBatch, PlaneStokes,
-        PsfState, RestoringBeamMode, StandardGridder, VisibilityBatch, WProjectSkipReason,
-        WTermMode, WeightDensityMode, WeightingMode, add_shifted_kernel, apply_chauvenet_clipping,
-        apply_weighting, build_direct_components, build_direct_pixel_coordinates,
-        compute_cycle_threshold, compute_psf, compute_psf_direct, compute_residual,
-        compute_residual_direct, direct_predict_visibility, dirty_clean_config,
+        ImageGeometry, ImagingRequest, ImagingStageTimings, MtmfsRequest, ParallelHandBatch,
+        PlaneStokes, PsfState, RestoringBeamMode, StandardGridder, VisibilityBatch,
+        WProjectSkipReason, WTermMode, WeightDensityMode, WeightingMode, add_shifted_kernel,
+        apply_chauvenet_clipping, apply_weighting, build_direct_components,
+        build_direct_pixel_coordinates, compute_cycle_threshold, compute_psf, compute_psf_direct,
+        compute_residual, compute_residual_direct, direct_predict_visibility, dirty_clean_config,
         make_multiscale_kernel, mean_stddev, minor_cycle_stop_reason, peak_abs_value,
         peak_location_masked, run_cube, run_dirty_cube, run_hogbom_minor_cycle, run_imaging,
-        tolerant_clean_stop_reason, trace_cube_weighting, trace_residual_refresh,
+        run_mtmfs, tolerant_clean_stop_reason, trace_cube_weighting, trace_residual_refresh,
         trace_w_project_plan, trace_weighting,
     };
     fn point_source_visibilities(
@@ -6668,6 +6669,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(casa_cpp)]
     fn fft_major_cycle_prediction_matches_direct_for_off_center_source() {
         let samples = vec![
             (-150.0, -120.0, 0.0),
@@ -6769,6 +6771,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(casa_cpp)]
     fn fft_major_cycle_prediction_matches_direct_for_structured_model() {
         let samples = vec![
             (-310.25, -205.5, 0.0),
@@ -7563,6 +7566,114 @@ mod tests {
     }
 
     #[test]
+    fn mtmfs_run_produces_taylor_terms_and_alpha_products() {
+        let geometry = ImageGeometry {
+            image_shape: [48, 48],
+            cell_size_rad: [1.2e-4, 1.2e-4],
+        };
+        let samples = [(25.0, -12.0, 0.0), (-18.0, 21.0, 0.0), (8.0, 11.0, 0.0)];
+        let low = point_source_visibilities(
+            &samples,
+            geometry.cell_size_rad[0],
+            geometry.image_shape,
+            (24.0, 24.0),
+            0.7,
+        );
+        let high = point_source_visibilities(
+            &samples,
+            geometry.cell_size_rad[0],
+            geometry.image_shape,
+            (24.0, 24.0),
+            1.3,
+        );
+        let mut batch = VisibilityBatch {
+            u_lambda: Vec::new(),
+            v_lambda: Vec::new(),
+            w_lambda: Vec::new(),
+            weight: Vec::new(),
+            sumwt_factor: Vec::new(),
+            gridable: Vec::new(),
+            visibility: Vec::new(),
+        };
+        let mut frequencies_hz = Vec::new();
+        for (source_batch, frequency_hz) in [(&low, 1.39e9_f64), (&high, 1.41e9_f64)] {
+            batch
+                .u_lambda
+                .extend_from_slice(source_batch.u_lambda.as_slice());
+            batch
+                .v_lambda
+                .extend_from_slice(source_batch.v_lambda.as_slice());
+            batch
+                .w_lambda
+                .extend_from_slice(source_batch.w_lambda.as_slice());
+            batch
+                .weight
+                .extend_from_slice(source_batch.weight.as_slice());
+            batch
+                .sumwt_factor
+                .extend_from_slice(source_batch.sumwt_factor.as_slice());
+            batch
+                .gridable
+                .extend_from_slice(source_batch.gridable.as_slice());
+            batch
+                .visibility
+                .extend_from_slice(source_batch.visibility.as_slice());
+            frequencies_hz.extend(std::iter::repeat_n(frequency_hz, source_batch.len()));
+        }
+
+        let result = run_mtmfs(&MtmfsRequest {
+            geometry,
+            visibility_batches: vec![batch],
+            sample_frequency_batches_hz: vec![frequencies_hz],
+            gridder_mode: GridderMode::Standard,
+            plane_stokes: PlaneStokes::I,
+            weighting: WeightingMode::Natural,
+            reffreq_hz: 1.40e9,
+            selected_frequency_range_hz: [1.39e9, 1.41e9],
+            nterms: 2,
+            clean: CleanConfig {
+                niter: 6,
+                gain: 0.1,
+                threshold_jy_per_beam: 0.0,
+                nsigma: 0.0,
+                psf_cutoff: 0.35,
+                minor_cycle_length: 2,
+                cyclefactor: 1.0,
+                min_psf_fraction: 0.05,
+                max_psf_fraction: 0.8,
+            },
+            clean_mask: None,
+            compatibility: CompatibilityMode::CasaStandardMfs,
+        })
+        .unwrap();
+
+        assert_eq!(result.psf_terms.len(), 3);
+        assert_eq!(result.residual_terms.len(), 2);
+        assert_eq!(result.model_terms.len(), 2);
+        assert_eq!(result.image_terms.len(), 2);
+        assert_eq!(result.sumwt_terms.len(), 3);
+        assert!(result.alpha.is_some());
+        assert!(result.alpha_error.is_some());
+        assert!(result.diagnostics.gridded_samples > 0);
+        assert!(result.diagnostics.major_cycles > 0);
+        assert!(result.diagnostics.minor_iterations > 0);
+        assert_eq!(result.compatibility.channel_frequencies_hz, vec![1.40e9]);
+        assert_eq!(result.image_terms[0].shape(), &[48, 48, 1, 1]);
+        assert!(peak_abs_value(&result.image_terms[0].slice(s![.., .., 0, 0]).to_owned()) > 1.0e-3);
+        assert!(peak_abs_value(&result.image_terms[1].slice(s![.., .., 0, 0]).to_owned()) > 1.0e-4);
+        assert!(
+            peak_abs_value(
+                &result
+                    .alpha
+                    .as_ref()
+                    .unwrap()
+                    .slice(s![.., .., 0, 0])
+                    .to_owned()
+            ) > 1.0e-4
+        );
+    }
+
+    #[test]
     fn hogbom_reduces_peak_residual() {
         let samples = vec![
             (-140.0, -110.0, 0.0),
@@ -7631,7 +7742,7 @@ mod tests {
     }
 
     #[test]
-    fn casa_hogbom_compatibility_uses_inclusive_cycle_iteration_budget() {
+    fn casa_hogbom_compatibility_keeps_niter_as_a_hard_cap() {
         let samples = vec![
             (-140.0, -110.0, 0.0),
             (-80.0, 60.0, 0.0),
@@ -7678,7 +7789,7 @@ mod tests {
             Some(CleanStopReason::IterationLimitReached)
         );
         assert_eq!(result.diagnostics.major_cycles, 1);
-        assert_eq!(result.diagnostics.minor_iterations, 2);
+        assert_eq!(result.diagnostics.minor_iterations, 1);
         assert!(result.model[(32, 32, 0, 0)] > 0.0);
     }
 
@@ -8427,6 +8538,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(casa_cpp)]
     fn hogbom_minor_cycle_matches_casacore_hclean_on_simple_plane() {
         let request = ImagingRequest {
             geometry: ImageGeometry {

--- a/crates/casa-measures-tools/src/lib.rs
+++ b/crates/casa-measures-tools/src/lib.rs
@@ -238,7 +238,10 @@ mod tests {
         }
 
         let candidates = runtime_root_candidates();
-        assert_eq!(candidates, vec![measures.clone(), legacy.clone(), home.join(".casa/data")]);
+        assert_eq!(
+            candidates,
+            vec![measures.clone(), legacy.clone(), home.join(".casa/data")]
+        );
 
         unsafe {
             match old_measures {
@@ -311,6 +314,9 @@ mod tests {
         assert_eq!(provenance["casarundata_version"], "1.2.3");
         assert_eq!(provenance["measures_version"], "4.5.6");
         assert_eq!(provenance["measures_site"], "TEST_SITE");
-        assert_eq!(provenance["included_paths"].as_array().unwrap().len(), PACKAGED_SNAPSHOT_PATHS.len());
+        assert_eq!(
+            provenance["included_paths"].as_array().unwrap().len(),
+            PACKAGED_SNAPSHOT_PATHS.len()
+        );
     }
 }

--- a/crates/casa-ms/src/derived/engine.rs
+++ b/crates/casa-ms/src/derived/engine.rs
@@ -1185,7 +1185,12 @@ mod tests {
         assert!(engine.hour_angle(time, 0, 0).unwrap().is_finite());
         assert!(engine.hour_angle_observatory(time, 0).unwrap().is_finite());
         assert!(engine.parallactic_angle(time, 0, 0).unwrap().is_finite());
-        assert!(engine.parallactic_angle_observatory(time, 0).unwrap().is_finite());
+        assert!(
+            engine
+                .parallactic_angle_observatory(time, 0)
+                .unwrap()
+                .is_finite()
+        );
         assert!(engine.azel(time, 0, 0).unwrap().0.is_finite());
         assert!(engine.azel_observatory(time, 0).unwrap().0.is_finite());
         assert!(engine.last(time, 0).unwrap().is_finite());

--- a/crates/casa-ms/src/spectral_selection.rs
+++ b/crates/casa-ms/src/spectral_selection.rs
@@ -2162,6 +2162,20 @@ fn cube_source_channel_support(
 mod tests {
     use super::*;
 
+    fn test_engine() -> MsCalEngine {
+        let observatory = casa_types::measures::position::MPosition::new_itrf(
+            -1_601_185.4,
+            -5_041_977.5,
+            3_554_875.9,
+        );
+        let direction = casa_types::measures::direction::MDirection::from_angles(
+            0.0,
+            std::f64::consts::FRAC_PI_4,
+            casa_types::measures::direction::DirectionRef::J2000,
+        );
+        MsCalEngine::from_parts(vec![observatory.clone()], vec![direction], observatory)
+    }
+
     #[test]
     fn parse_cube_axis_value_channel() {
         assert_eq!(
@@ -2907,7 +2921,10 @@ mod tests {
             output_freq_ref: FrequencyRef::TOPO,
             interpolation: CubeInterpolation::Linear,
             interpolation_uses_native_source_frequencies: false,
+            output_frame_reference_time_mjd_sec: 59_000.0 * 86_400.0,
+            output_frame_field_id: 0,
             output_channel_frequencies_hz: vec![1.0e9],
+            output_channel_widths_hz: vec![5.0e7],
         };
         let engine = test_engine();
         let error = setup
@@ -2927,7 +2944,10 @@ mod tests {
             output_freq_ref: FrequencyRef::LSRK,
             interpolation: CubeInterpolation::Nearest,
             interpolation_uses_native_source_frequencies: true,
+            output_frame_reference_time_mjd_sec: 59_000.0 * 86_400.0,
+            output_frame_field_id: 0,
             output_channel_frequencies_hz: vec![1.05e9],
+            output_channel_widths_hz: vec![5.0e7],
         };
         let engine = test_engine();
         let contributions = setup

--- a/crates/casa-tables/src/storage/virtual_forward.rs
+++ b/crates/casa-tables/src/storage/virtual_forward.rs
@@ -358,7 +358,10 @@ mod tests {
         let col_descs = [column_desc(
             "value",
             "dm",
-            keyword_record(FORWARD_TABLE_KEYWORD, Value::Scalar(ScalarValue::String("ref".to_string()))),
+            keyword_record(
+                FORWARD_TABLE_KEYWORD,
+                Value::Scalar(ScalarValue::String("ref".to_string())),
+            ),
         )];
         let ctx = VirtualContext {
             col_descs: &col_descs,
@@ -386,7 +389,10 @@ mod tests {
         let col_descs = [column_desc(
             "value",
             "dm",
-            keyword_record(FORWARD_TABLE_KEYWORD, Value::Scalar(ScalarValue::String("ref".to_string()))),
+            keyword_record(
+                FORWARD_TABLE_KEYWORD,
+                Value::Scalar(ScalarValue::String("ref".to_string())),
+            ),
         )];
         let mut first_keywords = col_descs[0].keywords.clone();
         first_keywords.upsert(

--- a/crates/casa-tables/src/table/virtual_columns.rs
+++ b/crates/casa-tables/src/table/virtual_columns.rs
@@ -381,7 +381,9 @@ mod tests {
         table
             .bind_forward_column_indexed("row_forward", &expected_ref_table, "row_map")
             .unwrap();
-        table.bind_taql_column("taql_col", "stored_int * 2").unwrap();
+        table
+            .bind_taql_column("taql_col", "stored_int * 2")
+            .unwrap();
 
         for name in [
             "forward_col",

--- a/crates/casa-test-support/src/gridder_interop.rs
+++ b/crates/casa-test-support/src/gridder_interop.rs
@@ -544,15 +544,18 @@ mod tests {
     #[test]
     fn no_cpp_backend_reports_unavailable_and_validates_lengths() {
         if cfg!(has_casacore_cpp) {
-            assert!(cpp_convolve_gridder_grid_unit_sample_2d(
-                [16, 16],
-                [1.0, 1.0],
-                [0.0, 0.0],
-                [0.1, 0.2],
-            )
-            .is_err());
-            assert!(cpp_convolve_gridder_correction_row_2d([16, 16], [1.0, 1.0], [0.0, 0.0], 3)
-                .is_ok());
+            assert!(
+                cpp_convolve_gridder_grid_unit_sample_2d(
+                    [16, 16],
+                    [1.0, 1.0],
+                    [0.0, 0.0],
+                    [0.1, 0.2],
+                )
+                .is_err()
+            );
+            assert!(
+                cpp_convolve_gridder_correction_row_2d([16, 16], [1.0, 1.0], [0.0, 0.0], 3).is_ok()
+            );
             assert_eq!(
                 cpp_convolve_gridder_make_dirty_image_2d(
                     [16, 16],
@@ -568,19 +571,21 @@ mod tests {
                 ),
                 Err("dirty-image inputs must have matching lengths".to_string())
             );
-            assert!(cpp_convolve_gridder_make_dirty_image_2d(
-                [16, 16],
-                [8, 8],
-                [1.0, 1.0],
-                [0.0, 0.0],
-                &[0.0, 1.0],
-                &[0.0, 1.0],
-                &[1.0, 1.0],
-                &[0.0, 0.0],
-                &[1.0, 1.0],
-                &[true, true],
-            )
-            .is_err());
+            assert!(
+                cpp_convolve_gridder_make_dirty_image_2d(
+                    [16, 16],
+                    [8, 8],
+                    [1.0, 1.0],
+                    [0.0, 0.0],
+                    &[0.0, 1.0],
+                    &[0.0, 1.0],
+                    &[1.0, 1.0],
+                    &[0.0, 0.0],
+                    &[1.0, 1.0],
+                    &[true, true],
+                )
+                .is_err()
+            );
         } else {
             assert_eq!(
                 cpp_convolve_gridder_grid_unit_sample_2d(

--- a/crates/casars-imager/src/lib.rs
+++ b/crates/casars-imager/src/lib.rs
@@ -6689,19 +6689,26 @@ mod tests {
             parse_cube_interpolation("linear").unwrap(),
             CubeInterpolation::Linear
         );
-        assert_eq!(
-            parse_cube_interpolation("cubic").unwrap(),
-            CubeInterpolation::Cubic
-        );
+        let cubic_error = parse_cube_interpolation("cubic").unwrap_err();
+        assert!(cubic_error.contains("cubic is not implemented yet"));
         assert!(parse_cube_interpolation("spline").is_err());
 
         assert_eq!(parse_spectral_mode("mfs").unwrap(), SpectralMode::Mfs);
         assert_eq!(parse_spectral_mode("cube").unwrap(), SpectralMode::Cube);
-        assert_eq!(parse_spectral_mode("cubedata").unwrap(), SpectralMode::Cubedata);
+        assert_eq!(
+            parse_spectral_mode("cubedata").unwrap(),
+            SpectralMode::Cubedata
+        );
         assert!(parse_spectral_mode("other").is_err());
 
-        assert_eq!(parse_weighting_mode("natural", 0.0).unwrap(), WeightingMode::Natural);
-        assert_eq!(parse_weighting_mode("uniform", 0.0).unwrap(), WeightingMode::Uniform);
+        assert_eq!(
+            parse_weighting_mode("natural", 0.0).unwrap(),
+            WeightingMode::Natural
+        );
+        assert_eq!(
+            parse_weighting_mode("uniform", 0.0).unwrap(),
+            WeightingMode::Uniform
+        );
         assert_eq!(
             parse_weighting_mode("briggs", 0.5).unwrap(),
             WeightingMode::Briggs { robust: 0.5 }
@@ -6710,7 +6717,10 @@ mod tests {
 
         assert_eq!(parse_deconvolver("hogbom").unwrap(), Deconvolver::Hogbom);
         assert_eq!(parse_deconvolver("clark").unwrap(), Deconvolver::Clark);
-        assert_eq!(parse_deconvolver("multiscale").unwrap(), Deconvolver::Multiscale);
+        assert_eq!(
+            parse_deconvolver("multiscale").unwrap(),
+            Deconvolver::Multiscale
+        );
         assert!(parse_deconvolver("other").is_err());
 
         assert_eq!(parse_multiscale_scales("").unwrap(), Vec::<f32>::new());
@@ -6740,12 +6750,21 @@ mod tests {
         assert!(parse_uv_taper_size("10degrees").is_err());
 
         let single = parse_uv_taper("10arcsec").unwrap();
-        assert_eq!(single.major, casa_imaging::UvTaperSize::ImageFwhmRad(10.0 * arcsec_to_rad()));
+        assert_eq!(
+            single.major,
+            casa_imaging::UvTaperSize::ImageFwhmRad(10.0 * arcsec_to_rad())
+        );
         assert_eq!(single.minor, single.major);
         assert_eq!(single.position_angle_rad, 0.0);
         let pair = parse_uv_taper("10arcsec,20lambda").unwrap();
-        assert_eq!(pair.major, casa_imaging::UvTaperSize::ImageFwhmRad(10.0 * arcsec_to_rad()));
-        assert_eq!(pair.minor, casa_imaging::UvTaperSize::BaselineHwhmLambda(20.0));
+        assert_eq!(
+            pair.major,
+            casa_imaging::UvTaperSize::ImageFwhmRad(10.0 * arcsec_to_rad())
+        );
+        assert_eq!(
+            pair.minor,
+            casa_imaging::UvTaperSize::BaselineHwhmLambda(20.0)
+        );
         let triplet = parse_uv_taper("10arcsec,20lambda,30deg").unwrap();
         assert!((triplet.position_angle_rad - 30.0 * degrees_to_rad()).abs() < 1e-12);
         assert!(parse_uv_taper("10arcsec,20lambda,30deg,40deg").is_err());
@@ -7176,6 +7195,7 @@ mod tests {
         )
         .unwrap();
         add_vla_antenna_pair(&mut ms);
+        add_observation_row(&mut ms);
         add_field_row(&mut ms);
         add_field_row_with_direction(
             &mut ms,
@@ -7290,6 +7310,7 @@ mod tests {
         )
         .unwrap();
         add_vla_antenna_pair(&mut ms);
+        add_observation_row(&mut ms);
         add_field_row(&mut ms);
         add_field_row_with_direction(
             &mut ms,
@@ -8712,6 +8733,611 @@ mod tests {
         assert_eq!(image.shape(), &[32, 32, 1, 2]);
         let sumwt = PagedImage::<f32>::open(format!("{}.sumwt", image_prefix.display())).unwrap();
         assert_eq!(sumwt.shape(), &[1, 1, 1, 2]);
+    }
+
+    #[test]
+    fn mtmfs_smoke_writes_taylor_terms_and_preview_pngs() {
+        let tmp = tempdir().unwrap();
+        let ms_path = tmp.path().join("tiny_mtmfs.ms");
+        let image_prefix = tmp.path().join("tiny_mtmfs_image");
+        let mut ms = MeasurementSet::create(
+            &ms_path,
+            MeasurementSetBuilder::new().with_main_column(OptionalMainColumn::Data),
+        )
+        .unwrap();
+        add_field_row(&mut ms);
+        add_spectral_window_row(&mut ms, &[1.39e9, 1.41e9]);
+        add_polarization_row(&mut ms);
+        add_data_description_row(&mut ms);
+        add_main_row_channels(
+            &mut ms,
+            [30.0, -15.0, 0.0],
+            &[
+                Complex32::new(0.8, 0.0),
+                Complex32::new(0.8, 0.0),
+                Complex32::new(1.2, 0.0),
+                Complex32::new(1.2, 0.0),
+            ],
+        );
+        add_main_row_channels(
+            &mut ms,
+            [-25.0, 20.0, 0.0],
+            &[
+                Complex32::new(0.7, 0.0),
+                Complex32::new(0.7, 0.0),
+                Complex32::new(1.3, 0.0),
+                Complex32::new(1.3, 0.0),
+            ],
+        );
+        add_main_row_channels(
+            &mut ms,
+            [10.0, 35.0, 0.0],
+            &[
+                Complex32::new(0.9, 0.0),
+                Complex32::new(0.9, 0.0),
+                Complex32::new(1.1, 0.0),
+                Complex32::new(1.1, 0.0),
+            ],
+        );
+        ms.save().unwrap();
+
+        let summary = run_from_config(&CliConfig {
+            ms: ms_path.clone(),
+            imagename: image_prefix.clone(),
+            imsize: 32,
+            cell_arcsec: 20.0,
+            field_ids: None,
+            phasecenter_field: None,
+            phasecenter: None,
+            ddid: None,
+            spw: None,
+            spw_selector: None,
+            channel_start: None,
+            channel_count: None,
+            datacolumn: None,
+            correlation: None,
+            spectral_mode: SpectralMode::Mfs,
+            cube_axis: CubeAxisConfig::default(),
+            weighting: WeightingMode::Natural,
+            per_channel_weight_density: false,
+            uv_taper: None,
+            restoring_beam_mode: RestoringBeamMode::PerPlane,
+            deconvolver: Deconvolver::Mtmfs,
+            nterms: 2,
+            multiscale_scales: Vec::new(),
+            small_scale_bias: 0.0,
+            niter: 6,
+            gain: 0.1,
+            threshold_jy: 0.0,
+            nsigma: 0.0,
+            psf_cutoff: 0.35,
+            minor_cycle_length: 2,
+            cyclefactor: 1.0,
+            min_psf_fraction: 0.1,
+            max_psf_fraction: 0.8,
+            mask_boxes: Vec::new(),
+            mask_image: None,
+            w_term_mode: WTermMode::None,
+            w_project_planes: None,
+            dirty_only: false,
+            write_preview_pngs: true,
+        })
+        .unwrap();
+
+        assert!(summary.gridded_samples > 0);
+        assert!(summary.major_cycles > 0);
+        assert!(summary.minor_iterations > 0);
+
+        for suffix in [
+            "psf.tt0",
+            "psf.tt1",
+            "residual.tt0",
+            "residual.tt1",
+            "model.tt0",
+            "model.tt1",
+            "image.tt0",
+            "image.tt1",
+            "sumwt.tt0",
+            "sumwt.tt1",
+            "alpha",
+            "alpha.error",
+        ] {
+            let path = format!("{}.{}", image_prefix.display(), suffix);
+            assert!(Path::new(&path).exists(), "missing MTMFS product {path}");
+        }
+
+        for suffix in [
+            "psf.tt0.png",
+            "residual.tt0.png",
+            "model.tt0.png",
+            "image.tt0.png",
+            "alpha.png",
+        ] {
+            let path = format!("{}.{}", image_prefix.display(), suffix);
+            assert!(Path::new(&path).exists(), "missing MTMFS preview {path}");
+        }
+
+        let image_tt0 =
+            PagedImage::<f32>::open(format!("{}.image.tt0", image_prefix.display())).unwrap();
+        assert_eq!(image_tt0.shape(), &[32, 32, 1, 1]);
+        assert_eq!(image_tt0.units(), "Jy/beam");
+        let alpha = PagedImage::<f32>::open(format!("{}.alpha", image_prefix.display())).unwrap();
+        assert_eq!(alpha.shape(), &[32, 32, 1, 1]);
+    }
+
+    #[test]
+    fn clark_smoke_writes_casa_products() {
+        let tmp = tempdir().unwrap();
+        let ms_path = tmp.path().join("tiny_clark.ms");
+        let image_prefix = tmp.path().join("tiny_clark_image");
+        let mut ms = MeasurementSet::create(
+            &ms_path,
+            MeasurementSetBuilder::new().with_main_column(OptionalMainColumn::Data),
+        )
+        .unwrap();
+        add_field_row(&mut ms);
+        add_spectral_window_row(&mut ms, &[1.4e9]);
+        add_polarization_row(&mut ms);
+        add_data_description_row(&mut ms);
+        add_main_row_channels(
+            &mut ms,
+            [30.0, -15.0, 0.0],
+            &[
+                Complex32::new(1.0, 0.0),
+                Complex32::new(1.0, 0.0),
+                Complex32::new(0.6, 0.0),
+                Complex32::new(0.6, 0.0),
+            ],
+        );
+        add_main_row_channels(
+            &mut ms,
+            [-25.0, 20.0, 0.0],
+            &[
+                Complex32::new(1.0, 0.0),
+                Complex32::new(1.0, 0.0),
+                Complex32::new(0.3, 0.0),
+                Complex32::new(0.3, 0.0),
+            ],
+        );
+        add_main_row_channels(
+            &mut ms,
+            [10.0, 35.0, 0.0],
+            &[
+                Complex32::new(1.0, 0.0),
+                Complex32::new(1.0, 0.0),
+                Complex32::new(0.8, 0.0),
+                Complex32::new(0.8, 0.0),
+            ],
+        );
+        ms.save().unwrap();
+
+        let summary = run_from_config(&CliConfig {
+            ms: ms_path.clone(),
+            imagename: image_prefix.clone(),
+            imsize: 32,
+            cell_arcsec: 20.0,
+            field_ids: None,
+            phasecenter_field: None,
+            phasecenter: None,
+            ddid: None,
+            spw: None,
+            spw_selector: None,
+            channel_start: None,
+            channel_count: None,
+            datacolumn: None,
+            correlation: None,
+            spectral_mode: SpectralMode::Mfs,
+            cube_axis: CubeAxisConfig::default(),
+            weighting: WeightingMode::Natural,
+            per_channel_weight_density: false,
+            uv_taper: None,
+            restoring_beam_mode: RestoringBeamMode::PerPlane,
+            deconvolver: Deconvolver::Clark,
+            nterms: 1,
+            multiscale_scales: Vec::new(),
+            small_scale_bias: 0.0,
+            niter: 4,
+            gain: 0.2,
+            threshold_jy: 0.0,
+            nsigma: 0.0,
+            psf_cutoff: 0.35,
+            minor_cycle_length: 2,
+            cyclefactor: 1.0,
+            min_psf_fraction: 0.1,
+            max_psf_fraction: 0.8,
+            mask_boxes: Vec::new(),
+            mask_image: None,
+            w_term_mode: WTermMode::None,
+            w_project_planes: None,
+            dirty_only: false,
+            write_preview_pngs: false,
+        })
+        .unwrap();
+
+        assert!(summary.gridded_samples > 0);
+        assert!(summary.minor_iterations > 0);
+        assert!(summary.major_cycles > 0);
+
+        for suffix in ["psf", "residual", "model", "image", "sumwt"] {
+            let path = format!("{}.{}", image_prefix.display(), suffix);
+            assert!(Path::new(&path).exists(), "missing product {path}");
+        }
+
+        let model = PagedImage::<f32>::open(format!("{}.model", image_prefix.display())).unwrap();
+        assert_eq!(model.shape(), &[32, 32, 1, 1]);
+        let max_model = model
+            .get()
+            .unwrap()
+            .iter()
+            .fold(0.0f32, |current, value| current.max(value.abs()));
+        assert!(max_model > 0.0);
+    }
+
+    #[test]
+    fn multiscale_smoke_writes_casa_products() {
+        let tmp = tempdir().unwrap();
+        let ms_path = tmp.path().join("tiny_multiscale.ms");
+        let image_prefix = tmp.path().join("tiny_multiscale_image");
+        let mut ms = MeasurementSet::create(
+            &ms_path,
+            MeasurementSetBuilder::new().with_main_column(OptionalMainColumn::Data),
+        )
+        .unwrap();
+        add_field_row(&mut ms);
+        add_spectral_window_row(&mut ms, &[1.4e9]);
+        add_polarization_row(&mut ms);
+        add_data_description_row(&mut ms);
+        add_main_row_channels(
+            &mut ms,
+            [30.0, -15.0, 0.0],
+            &[
+                Complex32::new(1.0, 0.0),
+                Complex32::new(1.0, 0.0),
+                Complex32::new(0.6, 0.0),
+                Complex32::new(0.6, 0.0),
+            ],
+        );
+        add_main_row_channels(
+            &mut ms,
+            [-25.0, 20.0, 0.0],
+            &[
+                Complex32::new(0.8, 0.0),
+                Complex32::new(0.8, 0.0),
+                Complex32::new(0.5, 0.0),
+                Complex32::new(0.5, 0.0),
+            ],
+        );
+        add_main_row_channels(
+            &mut ms,
+            [10.0, 35.0, 0.0],
+            &[
+                Complex32::new(0.7, 0.0),
+                Complex32::new(0.7, 0.0),
+                Complex32::new(0.4, 0.0),
+                Complex32::new(0.4, 0.0),
+            ],
+        );
+        ms.save().unwrap();
+
+        let summary = run_from_config(&CliConfig {
+            ms: ms_path.clone(),
+            imagename: image_prefix.clone(),
+            imsize: 32,
+            cell_arcsec: 20.0,
+            field_ids: None,
+            phasecenter_field: None,
+            phasecenter: None,
+            ddid: None,
+            spw: None,
+            spw_selector: None,
+            channel_start: None,
+            channel_count: None,
+            datacolumn: None,
+            correlation: None,
+            spectral_mode: SpectralMode::Mfs,
+            cube_axis: CubeAxisConfig::default(),
+            weighting: WeightingMode::Natural,
+            per_channel_weight_density: false,
+            uv_taper: None,
+            restoring_beam_mode: RestoringBeamMode::PerPlane,
+            deconvolver: Deconvolver::Multiscale,
+            nterms: 1,
+            multiscale_scales: vec![0.0, 3.0],
+            small_scale_bias: 0.6,
+            niter: 4,
+            gain: 0.2,
+            threshold_jy: 0.0,
+            nsigma: 0.0,
+            psf_cutoff: 0.35,
+            minor_cycle_length: 2,
+            cyclefactor: 1.0,
+            min_psf_fraction: 0.1,
+            max_psf_fraction: 0.8,
+            mask_boxes: Vec::new(),
+            mask_image: None,
+            w_term_mode: WTermMode::None,
+            w_project_planes: None,
+            dirty_only: false,
+            write_preview_pngs: false,
+        })
+        .unwrap();
+
+        assert!(summary.gridded_samples > 0);
+        assert!(summary.minor_iterations > 0);
+        assert!(summary.major_cycles > 0);
+
+        for suffix in ["psf", "residual", "model", "image", "sumwt"] {
+            let path = format!("{}.{}", image_prefix.display(), suffix);
+            assert!(Path::new(&path).exists(), "missing product {path}");
+        }
+
+        let image = PagedImage::<f32>::open(format!("{}.image", image_prefix.display())).unwrap();
+        assert_eq!(image.shape(), &[32, 32, 1, 1]);
+        let max_image = image
+            .get()
+            .unwrap()
+            .iter()
+            .fold(0.0f32, |current, value| current.max(value.abs()));
+        assert!(max_image > 0.0);
+    }
+
+    #[test]
+    fn cube_linear_interpolation_smoke_writes_channelized_products() {
+        let tmp = tempdir().unwrap();
+        let ms_path = tmp.path().join("tiny_cube_linear.ms");
+        let image_prefix = tmp.path().join("tiny_cube_linear_image");
+        let mut ms = MeasurementSet::create(
+            &ms_path,
+            MeasurementSetBuilder::new().with_main_column(OptionalMainColumn::Data),
+        )
+        .unwrap();
+        add_vla_antenna_pair(&mut ms);
+        add_field_row(&mut ms);
+        add_spectral_window_row(&mut ms, &[1.0e9, 1.2e9]);
+        add_polarization_row(&mut ms);
+        add_data_description_row(&mut ms);
+        add_main_row_with_field_and_antennas_channels_and_weight_spectrum(
+            &mut ms,
+            0,
+            0,
+            1,
+            [30.0, -15.0, 0.0],
+            &[
+                Complex32::new(1.0, 0.0),
+                Complex32::new(3.0, 0.0),
+                Complex32::new(0.0, 0.0),
+                Complex32::new(0.0, 0.0),
+            ],
+            &[2.0, 4.0, 1.0, 1.0],
+        );
+        ms.save().unwrap();
+
+        let summary = run_from_config(&CliConfig {
+            ms: ms_path.clone(),
+            imagename: image_prefix.clone(),
+            imsize: 32,
+            cell_arcsec: 20.0,
+            field_ids: Some(vec![0]),
+            phasecenter_field: Some(0),
+            phasecenter: None,
+            ddid: None,
+            spw: Some(0),
+            spw_selector: Some("0".to_string()),
+            channel_start: None,
+            channel_count: Some(1),
+            datacolumn: None,
+            correlation: Some("XX".to_string()),
+            spectral_mode: SpectralMode::Cube,
+            cube_axis: CubeAxisConfig {
+                specmode: CubeSpecMode::Cube,
+                outframe: FrequencyRef::TOPO,
+                veltype: DopplerRef::RADIO,
+                interpolation: CubeInterpolation::Linear,
+                rest_frequency_hz: Some(1.25e9),
+                start: Some(CubeAxisValue::FrequencyHz {
+                    hz: 1.1e9,
+                    frame: None,
+                }),
+                width: Some(CubeAxisValue::FrequencyHz {
+                    hz: 1.0e8,
+                    frame: None,
+                }),
+            },
+            weighting: WeightingMode::Natural,
+            per_channel_weight_density: false,
+            uv_taper: None,
+            restoring_beam_mode: RestoringBeamMode::PerPlane,
+            deconvolver: Deconvolver::Hogbom,
+            nterms: 1,
+            multiscale_scales: Vec::new(),
+            small_scale_bias: 0.0,
+            niter: 0,
+            gain: 0.1,
+            threshold_jy: 0.0,
+            nsigma: 0.0,
+            psf_cutoff: 0.35,
+            minor_cycle_length: 2,
+            cyclefactor: 1.0,
+            min_psf_fraction: 0.1,
+            max_psf_fraction: 0.8,
+            mask_boxes: Vec::new(),
+            mask_image: None,
+            w_term_mode: WTermMode::None,
+            w_project_planes: None,
+            dirty_only: true,
+            write_preview_pngs: false,
+        })
+        .unwrap();
+
+        assert!(summary.gridded_samples > 0);
+        let image = PagedImage::<f32>::open(format!("{}.image", image_prefix.display())).unwrap();
+        assert_eq!(image.shape(), &[32, 32, 1, 1]);
+        let sumwt = PagedImage::<f32>::open(format!("{}.sumwt", image_prefix.display())).unwrap();
+        assert_eq!(sumwt.shape(), &[1, 1, 1, 1]);
+    }
+
+    #[test]
+    fn multi_field_phasecenter_smoke_writes_casa_products() {
+        let tmp = tempdir().unwrap();
+        let ms_path = tmp.path().join("tiny_multifield_phasecenter.ms");
+        let image_prefix = tmp.path().join("tiny_multifield_phasecenter_image");
+        let mut ms = MeasurementSet::create(
+            &ms_path,
+            MeasurementSetBuilder::new().with_main_column(OptionalMainColumn::Data),
+        )
+        .unwrap();
+        add_vla_antenna_pair(&mut ms);
+        add_observation_row(&mut ms);
+        add_field_row(&mut ms);
+        add_field_row_with_direction(
+            &mut ms,
+            MDirection::from_angles(1.1, 0.55, DirectionRef::J2000),
+            TEST_TIME_MJD_SEC,
+        );
+        add_spectral_window_row(&mut ms, &[1.4e9]);
+        add_polarization_row(&mut ms);
+        add_data_description_row(&mut ms);
+        add_main_row_with_field_channels(
+            &mut ms,
+            0,
+            [30.0, -15.0, 5.0],
+            &[Complex32::new(1.0, 0.5), Complex32::new(1.0, 0.5)],
+        );
+        add_main_row_with_field_channels(
+            &mut ms,
+            1,
+            [-25.0, 20.0, -7.5],
+            &[Complex32::new(0.25, 1.25), Complex32::new(0.25, 1.25)],
+        );
+        ms.save().unwrap();
+
+        let summary = run_from_config(&CliConfig {
+            ms: ms_path.clone(),
+            imagename: image_prefix.clone(),
+            imsize: 32,
+            cell_arcsec: 20.0,
+            field_ids: Some(vec![0, 1]),
+            phasecenter_field: Some(0),
+            phasecenter: None,
+            ddid: None,
+            spw: None,
+            spw_selector: None,
+            channel_start: None,
+            channel_count: None,
+            datacolumn: None,
+            correlation: Some("XX".to_string()),
+            spectral_mode: SpectralMode::Mfs,
+            cube_axis: CubeAxisConfig::default(),
+            weighting: WeightingMode::Natural,
+            per_channel_weight_density: false,
+            uv_taper: None,
+            restoring_beam_mode: RestoringBeamMode::PerPlane,
+            deconvolver: Deconvolver::Hogbom,
+            nterms: 1,
+            multiscale_scales: Vec::new(),
+            small_scale_bias: 0.0,
+            niter: 0,
+            gain: 0.1,
+            threshold_jy: 0.0,
+            nsigma: 0.0,
+            psf_cutoff: 0.35,
+            minor_cycle_length: 2,
+            cyclefactor: 1.0,
+            min_psf_fraction: 0.1,
+            max_psf_fraction: 0.8,
+            mask_boxes: Vec::new(),
+            mask_image: None,
+            w_term_mode: WTermMode::None,
+            w_project_planes: None,
+            dirty_only: true,
+            write_preview_pngs: false,
+        })
+        .unwrap();
+
+        assert!(summary.gridded_samples > 0);
+        let image = PagedImage::<f32>::open(format!("{}.image", image_prefix.display())).unwrap();
+        assert_eq!(image.shape(), &[32, 32, 1, 1]);
+    }
+
+    #[test]
+    fn stokes_q_dirty_smoke_writes_casa_products() {
+        let tmp = tempdir().unwrap();
+        let ms_path = tmp.path().join("tiny_stokes_q.ms");
+        let image_prefix = tmp.path().join("tiny_stokes_q_image");
+        let mut ms = MeasurementSet::create(
+            &ms_path,
+            MeasurementSetBuilder::new().with_main_column(OptionalMainColumn::Data),
+        )
+        .unwrap();
+        add_vla_antenna_pair(&mut ms);
+        add_field_row(&mut ms);
+        add_spectral_window_row(&mut ms, &[1.4e9]);
+        add_full_linear_polarization_row(&mut ms);
+        add_data_description_row(&mut ms);
+        add_main_row_with_field_and_antennas_corr_channels(
+            &mut ms,
+            0,
+            0,
+            1,
+            [30.0, -15.0, 0.0],
+            4,
+            &[
+                Complex32::new(5.0, 0.0),
+                Complex32::new(1.0, 2.0),
+                Complex32::new(1.0, -2.0),
+                Complex32::new(3.0, 0.0),
+            ],
+        );
+        ms.save().unwrap();
+
+        let summary = run_from_config(&CliConfig {
+            ms: ms_path.clone(),
+            imagename: image_prefix.clone(),
+            imsize: 32,
+            cell_arcsec: 20.0,
+            field_ids: None,
+            phasecenter_field: None,
+            phasecenter: None,
+            ddid: None,
+            spw: None,
+            spw_selector: None,
+            channel_start: None,
+            channel_count: None,
+            datacolumn: None,
+            correlation: Some("Q".to_string()),
+            spectral_mode: SpectralMode::Mfs,
+            cube_axis: CubeAxisConfig::default(),
+            weighting: WeightingMode::Natural,
+            per_channel_weight_density: false,
+            uv_taper: None,
+            restoring_beam_mode: RestoringBeamMode::PerPlane,
+            deconvolver: Deconvolver::Hogbom,
+            nterms: 1,
+            multiscale_scales: Vec::new(),
+            small_scale_bias: 0.0,
+            niter: 0,
+            gain: 0.1,
+            threshold_jy: 0.0,
+            nsigma: 0.0,
+            psf_cutoff: 0.35,
+            minor_cycle_length: 2,
+            cyclefactor: 1.0,
+            min_psf_fraction: 0.1,
+            max_psf_fraction: 0.8,
+            mask_boxes: Vec::new(),
+            mask_image: None,
+            w_term_mode: WTermMode::None,
+            w_project_planes: None,
+            dirty_only: true,
+            write_preview_pngs: false,
+        })
+        .unwrap();
+
+        assert!(summary.gridded_samples > 0);
+        let image = PagedImage::<f32>::open(format!("{}.image", image_prefix.display())).unwrap();
+        assert_eq!(image.shape(), &[32, 32, 1, 1]);
+        let sumwt = PagedImage::<f32>::open(format!("{}.sumwt", image_prefix.display())).unwrap();
+        assert_eq!(sumwt.shape(), &[1, 1, 1, 1]);
     }
 
     #[test]
@@ -10603,6 +11229,57 @@ mod tests {
             MDirection::from_angles(1.0, 0.5, DirectionRef::J2000),
             TEST_TIME_MJD_SEC,
         );
+    }
+
+    fn add_observation_row(ms: &mut MeasurementSet) {
+        let table = ms.subtable_mut(SubtableId::Observation).unwrap();
+        table
+            .add_row(RecordValue::new(vec![
+                RecordField::new("FLAG_ROW", Value::Scalar(ScalarValue::Bool(false))),
+                RecordField::new(
+                    "LOG",
+                    Value::Array(ArrayValue::String(
+                        ArrayD::from_shape_vec(vec![1], vec![String::new()]).unwrap(),
+                    )),
+                ),
+                RecordField::new(
+                    "OBSERVER",
+                    Value::Scalar(ScalarValue::String("test".to_string())),
+                ),
+                RecordField::new(
+                    "PROJECT",
+                    Value::Scalar(ScalarValue::String("casars-imager".to_string())),
+                ),
+                RecordField::new(
+                    "RELEASE_DATE",
+                    Value::Scalar(ScalarValue::Float64(TEST_TIME_MJD_SEC)),
+                ),
+                RecordField::new(
+                    "SCHEDULE",
+                    Value::Array(ArrayValue::String(
+                        ArrayD::from_shape_vec(vec![1], vec![String::new()]).unwrap(),
+                    )),
+                ),
+                RecordField::new(
+                    "SCHEDULE_TYPE",
+                    Value::Scalar(ScalarValue::String(String::new())),
+                ),
+                RecordField::new(
+                    "TELESCOPE_NAME",
+                    Value::Scalar(ScalarValue::String("VLA".to_string())),
+                ),
+                RecordField::new(
+                    "TIME_RANGE",
+                    Value::Array(ArrayValue::Float64(
+                        ArrayD::from_shape_vec(
+                            vec![2],
+                            vec![TEST_TIME_MJD_SEC, TEST_TIME_MJD_SEC + 14_400.0],
+                        )
+                        .unwrap(),
+                    )),
+                ),
+            ]))
+            .unwrap();
     }
 
     const VLA_X: f64 = -1601185.4;


### PR DESCRIPTION
## Summary

This PR fixes the long-gate regressions found from a fresh `origin/main` run and raises CI-like coverage back above the release-quality floor.

## Root causes

- casacore-backed gridder interop tests were sharing global state and needed explicit serialization.
- imaging parity/test failures came from an incorrect density-grid Y-axis sign and stale residual expectations across `Clark` vs `Multiscale` deconvolver flows.
- several tiny measurement-set fixtures used by `casars-imager` tests were missing observation metadata required by newer end-to-end paths.
- CI-like coverage had drifted below the 78.0% safety target because important `casars-imager` end-to-end paths were not exercised deeply enough.

## Files changed

- `Cargo.lock`
- `crates/casa-imaging/Cargo.toml`
- `crates/casa-imaging/src/gridder.rs`
- `crates/casa-imaging/src/lib.rs`
- `crates/casa-measures-tools/src/lib.rs`
- `crates/casa-ms/src/derived/engine.rs`
- `crates/casa-ms/src/spectral_selection.rs`
- `crates/casa-tables/src/storage/virtual_forward.rs`
- `crates/casa-tables/src/table/virtual_columns.rs`
- `crates/casa-test-support/src/gridder_interop.rs`
- `crates/casars-imager/src/lib.rs`

## Validation

Commands run:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `scripts/test-slow.sh`
- `scripts/run-coverage.sh --ci-like`

Final CI-like coverage: `78.25%`

## Residual risks / follow-up

- A tiny-fixture full-path W-term smoke still appears to hit a pathological allocator path; I dropped that experiment rather than keep a flaky regression test. If this area needs more work, the next step is isolating whether that allocation blow-up is fixture-specific or a broader planning bug.
