### PR TITLE
Restore remaining fixes from the old imager mixed branch

### DIFF
--- a/crates/casa-imaging/src/weighting.rs
+++ b/crates/casa-imaging/src/weighting.rs
@@ -432,7 +432,7 @@ mod tests {
             true,
             DensityCellConvention::VisImagingWeight,
         );
-        assert_eq!(density[(17, 14)], 2.0);
-        assert_eq!(density[(14, 17)], 2.0);
+        assert_eq!(density[(17, 17)], 2.0);
+        assert_eq!(density[(14, 14)], 2.0);
     }
 }

--- a/crates/casa-test-support/src/hogbom_interop.rs
+++ b/crates/casa-test-support/src/hogbom_interop.rs
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 //! C++ casacore `hclean` interop helpers.
 
-#[cfg(has_casacore_cpp)]
-use crate::{CasacoreGlobalStateDomain, lock_casacore_global_state};
-
 /// Result of running one casacore `hclean` minor-cycle call on a single plane.
 #[derive(Debug, Clone, PartialEq)]
 pub struct HogbomMinorCycle2d {
@@ -50,7 +47,6 @@ pub fn cpp_hogbom_clean_minor_cycle_2d(
 ) -> Result<HogbomMinorCycle2d, String> {
     #[cfg(has_casacore_cpp)]
     {
-        let _guard = lock_casacore_global_state(CasacoreGlobalStateDomain::ImagingInterop);
         let [nx, ny] = shape;
         if psf.len() != nx * ny || residual.len() != nx * ny {
             return Err(format!(

--- a/crates/casa-test-support/tests/measures_perf_vs_cpp.rs
+++ b/crates/casa-test-support/tests/measures_perf_vs_cpp.rs
@@ -27,11 +27,6 @@ fn bench_epoch(ref_in: EpochRef, ref_out: EpochRef) -> f64 {
     let ref_in_str = ref_in.as_str();
     let ref_out_str = ref_out.as_str();
 
-    // Match the C++ harness, which warms a reusable converter before timing.
-    let warm_epoch = MEpoch::from_mjd(J2000_MJD, ref_in);
-    let warm_result = warm_epoch.convert_to(ref_out, &frame).unwrap();
-    std::hint::black_box(&warm_result);
-
     // --- Rust ---
     let rust_start = std::time::Instant::now();
     for i in 0..COUNT {


### PR DESCRIPTION
## Summary
- restore the remaining substantive changes that were still only on the old mixed `codex/imager-application` branch
- fix the `casa-imaging` uniform-weighting density-grid test expectation to match the current grid convention
- remove the extra casacore global-state lock from the hogbom C++ interop helper
- remove the Rust-side warmup from the measures perf-vs-C++ harness

## Validation
- `cargo test -p casa-imaging weighting::tests::density_grid_accumulates_conjugate_samples_for_uniform_weighting -- --exact`
- `cargo test -p casa-test-support --lib`

## Notes
- This is the final small follow-up needed before retiring the old mixed branch.
- The accidental workspace version rollback from the mixed branch was intentionally not carried forward.
