### PR TITLE
Add canonical provider contracts for UI interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,6 +435,7 @@ name = "casa-calibration"
 version = "0.14.0"
 dependencies = [
  "casa-ms",
+ "casa-provider-contracts",
  "casa-tables",
  "casa-test-support",
  "casa-types",
@@ -536,6 +537,7 @@ dependencies = [
 name = "casa-ms"
 version = "0.14.0"
 dependencies = [
+ "casa-provider-contracts",
  "casa-tables",
  "casa-test-support",
  "casa-types",
@@ -551,6 +553,15 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "casa-provider-contracts"
+version = "0.14.0"
+dependencies = [
+ "schemars",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -657,6 +668,7 @@ dependencies = [
 name = "casars-imagebrowser-protocol"
 version = "0.14.0"
 dependencies = [
+ "casa-provider-contracts",
  "schemars",
  "serde",
  "serde_json",
@@ -670,6 +682,7 @@ dependencies = [
  "casa-images",
  "casa-imaging",
  "casa-ms",
+ "casa-provider-contracts",
  "casa-tables",
  "casa-test-support",
  "casa-types",
@@ -691,17 +704,22 @@ version = "0.14.0"
 dependencies = [
  "casa-coordinates",
  "casa-images",
+ "casa-provider-contracts",
  "casa-tables",
  "casa-types",
  "ndarray",
  "numpy",
  "pyo3",
+ "schemars",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "casars-tablebrowser-protocol"
 version = "0.14.0"
 dependencies = [
+ "casa-provider-contracts",
  "schemars",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "crates/casa-provider-contracts",
     "crates/casars",
     "crates/casars-imager",
     "crates/casars-python",

--- a/crates/casa-calibration/Cargo.toml
+++ b/crates/casa-calibration/Cargo.toml
@@ -12,6 +12,7 @@ default = []
 slow-tests = []
 
 [dependencies]
+casa-provider-contracts = { path = "../casa-provider-contracts" }
 casa-ms = { path = "../casa-ms" }
 casa-tables = { path = "../casa-tables" }
 casa-types = { path = "../casa-types" }

--- a/crates/casa-calibration/src/task_contract.rs
+++ b/crates/casa-calibration/src/task_contract.rs
@@ -4,16 +4,23 @@
 use std::path::PathBuf;
 
 use casa_ms::{MsSelectionSpec, selection::MsSelection};
+use casa_provider_contracts::{
+    ProviderCliMachineActions, ProviderCliProjection, ProviderComponentSchemas,
+    ProviderProjectionMetadata, ProviderSurfaceKind, TaskOperationDescriptor, TaskSemanticContract,
+    derived_ui_schema_annotations, merged_components,
+};
 use schemars::{JsonSchema, schema::RootSchema, schema_for};
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 
 use crate::managed_output::CalibrationTaskResult;
 use crate::{
     ApplyCalibrationTableSpec, ApplyMode, ApplyPlanRequest, BandpassSolveCombine,
     BandpassSolveRequest, BandpassType, CalibrationStatsAxis, CalibrationStatsRequest,
     FluxScaleRequest, GainSolveCombine, GainSolveInterval, GainSolveMode, GainSolveRequest,
-    GainType, RefAntSelector, calibration_stats, execute_apply_from_path, fluxscale,
-    plan_apply_from_path, solve_bandpass_from_path, solve_gain_from_path, summarize_tables,
+    GainType, RefAntSelector, calibration_stats, command_schema, execute_apply_from_path,
+    fluxscale, plan_apply_from_path, solve_bandpass_from_path, solve_gain_from_path,
+    summarize_tables,
 };
 
 /// Stable protocol name advertised by `calibrate --protocol-info`.
@@ -28,6 +35,8 @@ pub struct CalibrationProtocolInfo {
     pub protocol_name: String,
     /// Monotonic protocol version for compatibility checks.
     pub protocol_version: u32,
+    /// Provider surface kind defined by the shared architecture contract.
+    pub surface_kind: ProviderSurfaceKind,
     /// Binary version implementing the protocol.
     pub binary_version: String,
 }
@@ -38,6 +47,7 @@ impl CalibrationProtocolInfo {
         Self {
             protocol_name: CALIBRATION_TASK_PROTOCOL_NAME.to_string(),
             protocol_version: CALIBRATION_TASK_PROTOCOL_VERSION,
+            surface_kind: ProviderSurfaceKind::Task,
             binary_version: env!("CARGO_PKG_VERSION").to_string(),
         }
     }
@@ -48,6 +58,14 @@ impl CalibrationProtocolInfo {
 pub struct CalibrationTaskSchemaBundle {
     /// Compatibility descriptor for the request/result schemas.
     pub protocol: CalibrationProtocolInfo,
+    /// Canonical semantic task contract.
+    pub semantic: TaskSemanticContract,
+    /// Shared component schemas reusable across projections.
+    pub components: ProviderComponentSchemas,
+    /// Presentation annotations carried with the canonical bundle.
+    pub annotations: JsonValue,
+    /// Derived projection metadata for UI and CLI consumers.
+    pub projections: ProviderProjectionMetadata,
     /// JSON schema for [`CalibrationTaskRequest`].
     pub request_schema: RootSchema,
     /// JSON schema for [`CalibrationTaskResult`].
@@ -57,12 +75,87 @@ pub struct CalibrationTaskSchemaBundle {
 impl CalibrationTaskSchemaBundle {
     /// Build the current request/result schema bundle.
     pub fn current() -> Self {
+        let request_schema = schema_for!(CalibrationTaskRequest);
+        let result_schema = schema_for!(CalibrationTaskResult);
+        let ui_schema = serde_json::to_value(command_schema("calibrate"))
+            .expect("serialize calibration ui schema projection");
         Self {
             protocol: CalibrationProtocolInfo::current(),
-            request_schema: schema_for!(CalibrationTaskRequest),
-            result_schema: schema_for!(CalibrationTaskResult),
+            semantic: TaskSemanticContract {
+                request_schema: request_schema.clone(),
+                result_schema: result_schema.clone(),
+                operations: calibration_task_operations(),
+            },
+            components: merged_components([&request_schema, &result_schema]),
+            annotations: derived_ui_schema_annotations(),
+            projections: ProviderProjectionMetadata {
+                cli: Some(ProviderCliProjection {
+                    machine_actions: ProviderCliMachineActions {
+                        ui_schema: Some("--ui-schema".to_string()),
+                        json_schema: Some("--json-schema".to_string()),
+                        protocol_info: Some("--protocol-info".to_string()),
+                        json_run: Some("--json-run <SOURCE>".to_string()),
+                        session: None,
+                    },
+                }),
+                ui_schema: Some(ui_schema),
+                python: None,
+            },
+            request_schema,
+            result_schema,
         }
     }
+
+    /// Return the launcher/TUI compatibility view projected from the bundle.
+    pub fn ui_schema_projection(&self) -> Result<casa_ms::ui_schema::UiCommandSchema, String> {
+        let value = self
+            .projections
+            .ui_schema
+            .clone()
+            .ok_or_else(|| "missing ui_schema projection".to_string())?;
+        serde_json::from_value(value)
+            .map_err(|error| format!("parse calibration ui schema: {error}"))
+    }
+}
+
+fn calibration_task_operations() -> Vec<TaskOperationDescriptor> {
+    vec![
+        TaskOperationDescriptor {
+            name: "summary".to_string(),
+            request_kind: "summary".to_string(),
+            result_kind: Some("summary".to_string()),
+        },
+        TaskOperationDescriptor {
+            name: "stats".to_string(),
+            request_kind: "stats".to_string(),
+            result_kind: Some("stats".to_string()),
+        },
+        TaskOperationDescriptor {
+            name: "plan_apply".to_string(),
+            request_kind: "plan_apply".to_string(),
+            result_kind: Some("plan_apply".to_string()),
+        },
+        TaskOperationDescriptor {
+            name: "execute_apply".to_string(),
+            request_kind: "execute_apply".to_string(),
+            result_kind: Some("apply".to_string()),
+        },
+        TaskOperationDescriptor {
+            name: "solve_gain".to_string(),
+            request_kind: "solve_gain".to_string(),
+            result_kind: Some("solve_gain".to_string()),
+        },
+        TaskOperationDescriptor {
+            name: "solve_bandpass".to_string(),
+            request_kind: "solve_bandpass".to_string(),
+            result_kind: Some("solve_bandpass".to_string()),
+        },
+        TaskOperationDescriptor {
+            name: "flux_scale".to_string(),
+            request_kind: "flux_scale".to_string(),
+            result_kind: Some("flux_scale".to_string()),
+        },
+    ]
 }
 
 /// Request for summarizing one or more calibration tables.
@@ -404,6 +497,8 @@ fn parse_time_range(value: &str) -> Result<(f64, f64), String> {
 mod tests {
     use std::path::PathBuf;
 
+    use casa_provider_contracts::ProviderSurfaceKind;
+
     use super::{
         CALIBRATION_TASK_PROTOCOL_NAME, CALIBRATION_TASK_PROTOCOL_VERSION, CalibrationProtocolInfo,
         CalibrationTaskRequest, CalibrationTaskResult, CalibrationTaskSchemaBundle,
@@ -462,6 +557,7 @@ mod tests {
         let info = CalibrationProtocolInfo::current();
         assert_eq!(info.protocol_name, CALIBRATION_TASK_PROTOCOL_NAME);
         assert_eq!(info.protocol_version, CALIBRATION_TASK_PROTOCOL_VERSION);
+        assert_eq!(info.surface_kind, ProviderSurfaceKind::Task);
         assert_eq!(info.binary_version, env!("CARGO_PKG_VERSION"));
     }
 
@@ -496,6 +592,17 @@ mod tests {
             bundle.protocol.protocol_version,
             CALIBRATION_TASK_PROTOCOL_VERSION
         );
+        assert_eq!(bundle.protocol.surface_kind, ProviderSurfaceKind::Task);
+        assert_eq!(bundle.semantic.operations.len(), 7);
+        assert!(
+            bundle
+                .semantic
+                .operations
+                .iter()
+                .any(|operation| operation.request_kind == "flux_scale")
+        );
+        assert!(bundle.components.contains_key("SummaryTaskRequest"));
+        assert!(bundle.projections.ui_schema.is_some());
         assert!(
             bundle
                 .request_schema
@@ -526,5 +633,7 @@ mod tests {
                 .definitions
                 .contains_key("CalibrationTableSummary")
         );
+        let ui_schema = bundle.ui_schema_projection().expect("ui schema projection");
+        assert_eq!(ui_schema.command_id, "calibrate");
     }
 }

--- a/crates/casa-images/src/bin/imexplore.rs
+++ b/crates/casa-images/src/bin/imexplore.rs
@@ -8,8 +8,8 @@ use std::process;
 
 use casa_images::{ImageBrowserSession, imexplore_ui_schema_json};
 use casars_imagebrowser_protocol::{
-    ImageBrowserCommand, ImageBrowserRequestEnvelope, ImageBrowserResponseEnvelope,
-    ImageBrowserViewport, PROTOCOL_VERSION,
+    ImageBrowserCommand, ImageBrowserProtocolInfo, ImageBrowserRequestEnvelope,
+    ImageBrowserResponseEnvelope, ImageBrowserViewport, PROTOCOL_VERSION, schema_bundle_json,
 };
 
 fn main() {
@@ -24,6 +24,22 @@ fn main() {
 
 fn run() -> Result<(), String> {
     let mut args = env::args().skip(1).peekable();
+    if args.peek().is_some_and(|arg| arg == "--json-schema") {
+        print!(
+            "{}",
+            schema_bundle_json(ui_schema_value()?)
+                .map_err(|error| format!("serialize imexplore schema bundle: {error}"))?
+        );
+        return Ok(());
+    }
+    if args.peek().is_some_and(|arg| arg == "--protocol-info") {
+        print!(
+            "{}",
+            serde_json::to_string_pretty(&ImageBrowserProtocolInfo::current())
+                .map_err(|error| format!("serialize imexplore protocol info: {error}"))?
+        );
+        return Ok(());
+    }
     if args.peek().is_some_and(|arg| arg == "--ui-schema") {
         print!("{}", imexplore_ui_schema_json("imexplore")?);
         return Ok(());
@@ -45,10 +61,15 @@ fn parse_path(args: impl IntoIterator<Item = String>) -> Result<PathBuf, String>
     let args = args.into_iter().collect::<Vec<_>>();
     if args.len() != 1 {
         return Err(
-            "usage: imexplore <image-path> | imexplore --session | imexplore --ui-schema".into(),
+            "usage: imexplore <image-path> | imexplore --session | imexplore --json-schema | imexplore --protocol-info | imexplore --ui-schema".into(),
         );
     }
     Ok(PathBuf::from(&args[0]))
+}
+
+fn ui_schema_value() -> Result<serde_json::Value, String> {
+    serde_json::from_str(&imexplore_ui_schema_json("imexplore")?)
+        .map_err(|error| format!("parse imexplore ui schema: {error}"))
 }
 
 fn run_snapshot(path: &PathBuf) -> Result<(), String> {

--- a/crates/casa-ms/Cargo.toml
+++ b/crates/casa-ms/Cargo.toml
@@ -12,6 +12,7 @@ default = []
 slow-tests = []
 
 [dependencies]
+casa-provider-contracts = { path = "../casa-provider-contracts" }
 casa-tables = { path = "../casa-tables" }
 casa-types = { path = "../casa-types" }
 image = { version = "0.25", default-features = false, features = ["png"] }

--- a/crates/casa-ms/src/lib.rs
+++ b/crates/casa-ms/src/lib.rs
@@ -74,6 +74,12 @@ pub use listobs::{
 };
 pub(crate) use listobs::{ListObsOptions, ListObsSummary, ListObsUvCoverage};
 pub use ms::MeasurementSet;
+pub use msexplore::task_contract::{
+    MSEXPLORE_TASK_PROTOCOL_NAME, MSEXPLORE_TASK_PROTOCOL_VERSION, MsExploreFlagEditRequest,
+    MsExplorePlotArtifact, MsExplorePlotExportRequest, MsExploreProtocolInfo,
+    MsExploreRunTaskRequest, MsExploreRunTaskResult, MsExploreTaskRequest, MsExploreTaskResult,
+    MsExploreTaskSchemaBundle,
+};
 pub use msexplore::{
     DEFAULT_MAX_PLOT_POINTS, MsAverageSpec, MsAxis, MsColorAxis, MsDataColumn, MsExploreSpec,
     MsExportFormat, MsFlagAction, MsFlagEditPreview, MsFlagEditSpec, MsFlagRegion, MsFlagRowEdit,

--- a/crates/casa-ms/src/listobs.rs
+++ b/crates/casa-ms/src/listobs.rs
@@ -29,6 +29,7 @@ use casa_types::measures::frequency::FrequencyRef;
 use casa_types::measures::position::MPosition;
 use casa_types::quanta::{MvAngle, MvTime};
 use ndarray::IxDyn;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::columns::uvw_column::UvwColumn;
@@ -42,7 +43,7 @@ const LISTOBS_UV_SCHEMA_VERSION: u32 = 1;
 const SPEED_OF_LIGHT_M_S: f64 = 299_792_458.0;
 
 /// Output formats supported by the `listobs` renderers and CLI.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub enum ListObsOutputFormat {
     /// CASA-like human-readable text.
     Text,
@@ -55,7 +56,7 @@ pub enum ListObsOutputFormat {
 /// This keeps the application layer thin: callers construct options once and
 /// then reuse the same summary builder and renderers regardless of whether the
 /// entrypoint is a standalone executable or a future Python binding.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct ListObsOptions {
     /// Render the verbose CASA-style text layout.
     pub verbose: bool,
@@ -171,7 +172,7 @@ impl ListObsOptions {
 /// `schema_version` is included so JSON consumers can pin their deserializers
 /// to a known shape as this summary grows. New optional fields may be added in
 /// future schema versions without changing the default text output.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct ListObsSummary {
     /// Version of the JSON schema emitted by [`render_json_pretty`](Self::render_json_pretty).
     pub schema_version: u32,
@@ -202,7 +203,7 @@ pub struct ListObsSummary {
 /// The payload is intentionally one-sided: it carries the observed baseline
 /// samples only. Consumers can mirror `(-u, -v)` at render time when they want
 /// the usual interferometric coverage display.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct ListObsUvCoverage {
     /// Version of the JSON schema emitted by [`render_json_pretty`](Self::render_json_pretty).
     pub schema_version: u32,
@@ -223,7 +224,7 @@ pub struct ListObsUvCoverage {
 }
 
 /// One baseline/field/SPW UV track.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct ListObsUvTrack {
     /// Baseline antenna 1 id.
     pub antenna1: i32,
@@ -240,7 +241,7 @@ pub struct ListObsUvTrack {
 }
 
 /// One UVW sample converted to wavelengths.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct ListObsUvPoint {
     /// MAIN-table row index.
     pub row: usize,
@@ -255,7 +256,7 @@ pub struct ListObsUvPoint {
 }
 
 /// General metadata about the summarized MeasurementSet.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct MeasurementSetInfo {
     /// Filesystem path of the MeasurementSet root, if the MS is disk-backed.
     pub path: Option<String>,
@@ -290,7 +291,7 @@ pub struct MeasurementSetInfo {
 }
 
 /// Summary of one OBSERVATION subtable row.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct ObservationSummary {
     /// Row index in the OBSERVATION subtable.
     pub observation_id: usize,
@@ -309,7 +310,7 @@ pub struct ObservationSummary {
 }
 
 /// Summary of one MAIN-table scan group.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct ScanSummary {
     /// OBSERVATION_ID for the grouped rows.
     pub observation_id: i32,
@@ -348,7 +349,7 @@ pub struct ScanSummary {
 }
 
 /// Summary of one FIELD subtable row.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct FieldSummary {
     /// Row index in the FIELD subtable.
     pub field_id: usize,
@@ -371,7 +372,7 @@ pub struct FieldSummary {
 }
 
 /// Summary of one POLARIZATION subtable row.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct PolarizationSummary {
     /// Row index in the POLARIZATION subtable.
     pub polarization_id: usize,
@@ -382,7 +383,7 @@ pub struct PolarizationSummary {
 }
 
 /// Summary of one DATA_DESCRIPTION subtable row.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct DataDescriptionSummary {
     /// Row index in the DATA_DESCRIPTION subtable.
     pub data_description_id: usize,
@@ -395,7 +396,7 @@ pub struct DataDescriptionSummary {
 }
 
 /// Summary of one SPECTRAL_WINDOW subtable row.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct SpectralWindowSummary {
     /// Row index in the SPECTRAL_WINDOW subtable.
     pub spectral_window_id: usize,
@@ -428,7 +429,7 @@ pub struct SpectralWindowSummary {
 }
 
 /// Summary of one SOURCE subtable row.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct SourceSummary {
     /// SOURCE_ID column value.
     pub source_id: i32,
@@ -453,7 +454,7 @@ pub struct SourceSummary {
 }
 
 /// Summary of one ANTENNA subtable row.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct AntennaSummary {
     /// Row index in the ANTENNA subtable.
     pub antenna_id: usize,

--- a/crates/casa-ms/src/msexplore.rs
+++ b/crates/casa-ms/src/msexplore.rs
@@ -25,6 +25,7 @@
 //! waves can extend the implementation without redesigning the interface.
 
 pub mod cli;
+pub mod task_contract;
 
 use std::fmt;
 use std::io::Cursor;
@@ -102,7 +103,7 @@ struct ScatterPanelRenderContext<'a> {
 }
 
 /// Stable preset identifiers for common MeasurementSet plots.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum MsPlotPreset {
     /// UV coverage from grouped UVW samples.
@@ -326,7 +327,7 @@ impl fmt::Display for MsPlotPreset {
 }
 
 /// Supported plot axes for MeasurementSet data.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum MsAxis {
     /// Visibility amplitude.
@@ -562,7 +563,7 @@ impl fmt::Display for MsAxis {
 }
 
 /// Visibility data column or derived column expression.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum MsDataColumn {
     /// MAIN.DATA.
@@ -637,7 +638,7 @@ impl fmt::Display for MsDataColumn {
 }
 
 /// Metadata axis used to group colors or series.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum MsColorAxis {
     /// Disable metadata grouping.
@@ -688,7 +689,7 @@ impl fmt::Display for MsColorAxis {
 }
 
 /// Plot export format for `msexplore`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum MsExportFormat {
     /// Raster PNG export.
@@ -796,7 +797,7 @@ impl MsSelectionSpec {
 }
 
 /// Averaging controls modeled after CASA `plotms`.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Default)]
 pub struct MsAverageSpec {
     /// Channel bin size used for channel/frequency plots.
     pub avgchannel: Option<usize>,
@@ -817,7 +818,7 @@ pub struct MsAverageSpec {
 }
 
 /// Transform controls modeled after CASA `plotms`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct MsTransformSpec {
     /// Enable transform controls.
     pub transform: bool,
@@ -856,7 +857,7 @@ impl Default for MsTransformSpec {
 }
 
 /// Page-layout controls for one plot page.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct MsLayoutSpec {
     /// Number of grid rows.
     pub gridrows: usize,
@@ -883,7 +884,7 @@ impl Default for MsLayoutSpec {
 }
 
 /// Page export range behavior for multi-plot page composition.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum MsPageExportRange {
     /// Resolve bounds independently for each occupied page cell.
@@ -910,7 +911,7 @@ impl fmt::Display for MsPageExportRange {
 }
 
 /// Legend placement options accepted by `msexplore`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
 pub enum MsLegendPosition {
     /// Place the legend inside the plot at upper right.
     #[default]
@@ -969,7 +970,7 @@ impl fmt::Display for MsLegendPosition {
 }
 
 /// Page header items accepted by `msexplore`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub enum MsPageHeaderItem {
     /// MeasurementSet filename.
     #[serde(rename = "filename")]
@@ -1024,7 +1025,7 @@ impl fmt::Display for MsPageHeaderItem {
 }
 
 /// Supported iteration axes for multi-panel plot pages.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum MsIterationAxis {
     /// Iterate one panel per FIELD row.
@@ -1092,7 +1093,7 @@ impl fmt::Display for MsIterationAxis {
 }
 
 /// Iteration controls for multi-plot pages.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
 pub struct MsIterationSpec {
     /// Iteration axis identifier.
     pub iteraxis: Option<MsIterationAxis>,
@@ -1107,7 +1108,7 @@ pub struct MsIterationSpec {
 }
 
 /// Presentation controls for a single plot.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct MsPlotStyleSpec {
     /// Optional plot title override.
     pub title: Option<String>,
@@ -1140,7 +1141,7 @@ impl Default for MsPlotStyleSpec {
 }
 
 /// One staged flag-edit request.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct MsFlagEditSpec {
     /// Whether the region should be flagged or unflagged.
     pub action: MsFlagAction,
@@ -1167,7 +1168,7 @@ struct FlagEditPreviewContext<'a> {
 }
 
 /// Inclusive rectangular region used for staged flag editing.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct MsFlagRegion {
     /// Inclusive minimum X value.
     pub x_min: f64,
@@ -1180,7 +1181,7 @@ pub struct MsFlagRegion {
 }
 
 /// Supported flag-edit actions.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum MsFlagAction {
     /// Mark matching samples as flagged.
@@ -1190,7 +1191,7 @@ pub enum MsFlagAction {
 }
 
 /// One plotted visibility sample selected by a staged flag edit.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct MsFlagSampleEdit {
     /// MAIN row index.
     pub row: usize,
@@ -1205,7 +1206,7 @@ pub struct MsFlagSampleEdit {
 }
 
 /// One MAIN-row FLAG_ROW transition produced by a staged edit.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct MsFlagRowEdit {
     /// MAIN row index.
     pub row: usize,
@@ -1218,7 +1219,7 @@ pub struct MsFlagRowEdit {
 }
 
 /// Preview of a staged `msexplore` flag edit before optional writeback.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct MsFlagEditPreview {
     /// Plot title associated with the staged edit.
     pub plot_title: String,
@@ -1253,7 +1254,7 @@ pub struct MsFlagEditPreview {
 }
 
 /// One plot request on a page.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct MsPlotSpec {
     /// Optional stable preset identifier.
     pub preset: Option<MsPlotPreset>,
@@ -1874,7 +1875,7 @@ impl MsPlotSpec {
 }
 
 /// Top-level `msexplore` request.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct MsExploreSpec {
     /// MeasurementSet root directory.
     pub ms_path: PathBuf,

--- a/crates/casa-ms/src/msexplore/cli.rs
+++ b/crates/casa-ms/src/msexplore/cli.rs
@@ -7,6 +7,9 @@ use std::path::PathBuf;
 
 use serde::Deserialize;
 
+use super::task_contract::{
+    MsExploreProtocolInfo, MsExploreTaskRequest, MsExploreTaskSchemaBundle,
+};
 use super::{
     DEFAULT_MAX_PLOT_POINTS, MsAxis, MsColorAxis, MsDataColumn, MsExploreSpec, MsExportFormat,
     MsFlagAction, MsFlagEditSpec, MsFlagRegion, MsIterationAxis, MsLegendPosition,
@@ -31,6 +34,9 @@ const SUMMARY: &str = "explore and export common MeasurementSet plotms-style plo
 enum CliAction {
     Help,
     UiSchema,
+    JsonSchema,
+    ProtocolInfo,
+    JsonRun(String),
     Run(Box<CliOptions>),
 }
 
@@ -174,7 +180,7 @@ pub fn run_env(program_name: &str) -> i32 {
     let schema = command_schema(program_name);
     match parse_args(std::env::args_os().skip(1)) {
         Ok(CliAction::Help) => {
-            print!("{}", schema.render_help());
+            print!("{}", render_help(&schema));
             0
         }
         Ok(CliAction::UiSchema) => match schema.render_json_pretty() {
@@ -187,6 +193,37 @@ pub fn run_env(program_name: &str) -> i32 {
                 1
             }
         },
+        Ok(CliAction::JsonSchema) => {
+            match serde_json::to_string_pretty(&MsExploreTaskSchemaBundle::current()) {
+                Ok(json) => {
+                    print!("{json}");
+                    0
+                }
+                Err(error) => {
+                    eprintln!("Error: failed to serialize --json-schema output: {error}");
+                    1
+                }
+            }
+        }
+        Ok(CliAction::ProtocolInfo) => {
+            match serde_json::to_string_pretty(&MsExploreProtocolInfo::current()) {
+                Ok(json) => {
+                    print!("{json}");
+                    0
+                }
+                Err(error) => {
+                    eprintln!("Error: failed to serialize --protocol-info output: {error}");
+                    1
+                }
+            }
+        }
+        Ok(CliAction::JsonRun(source)) => match run_json_request(&source) {
+            Ok(()) => 0,
+            Err(error) => {
+                eprintln!("Error: {error}");
+                1
+            }
+        },
         Ok(CliAction::Run(options)) => match run(*options) {
             Ok(()) => 0,
             Err(error) => {
@@ -196,7 +233,7 @@ pub fn run_env(program_name: &str) -> i32 {
         },
         Err(error) => {
             eprintln!("Error: {error}\n");
-            eprintln!("{}", schema.render_help());
+            eprintln!("{}", render_help(&schema));
             1
         }
     }
@@ -212,7 +249,10 @@ pub fn build_explore_spec_from_args(
     match parse_args(args)? {
         CliAction::Run(options) => build_explore_spec(&options),
         CliAction::Help => Err("help actions do not produce an msexplore spec".to_string()),
-        CliAction::UiSchema => {
+        CliAction::UiSchema
+        | CliAction::JsonSchema
+        | CliAction::ProtocolInfo
+        | CliAction::JsonRun(_) => {
             Err("ui-schema actions do not produce an msexplore spec".to_string())
         }
     }
@@ -1277,6 +1317,15 @@ fn run(options: CliOptions) -> Result<(), String> {
     Ok(())
 }
 
+fn run_json_request(source: &str) -> Result<(), String> {
+    let request = MsExploreTaskRequest::read_from_source(source)?;
+    let result = request.execute()?;
+    let rendered = serde_json::to_string_pretty(&result)
+        .map_err(|error| format!("failed to serialize msexplore task result: {error}"))?;
+    println!("{rendered}");
+    Ok(())
+}
+
 fn build_explore_spec(options: &CliOptions) -> Result<MsExploreSpec, String> {
     if let Some(page_spec_path) = &options.page_spec {
         let page_spec = load_page_spec_file(page_spec_path)?;
@@ -1589,6 +1638,19 @@ fn merge_header_items(target: &mut Vec<MsPageHeaderItem>, extra: Vec<MsPageHeade
 
 fn parse_args(args: impl IntoIterator<Item = OsString>) -> Result<CliAction, String> {
     let args = args.into_iter().collect::<Vec<_>>();
+    if args.iter().any(|arg| arg == "--json-schema") {
+        return Ok(CliAction::JsonSchema);
+    }
+    if args.iter().any(|arg| arg == "--protocol-info") {
+        return Ok(CliAction::ProtocolInfo);
+    }
+    if let Some(index) = args.iter().position(|arg| arg == "--json-run") {
+        let source = args
+            .get(index + 1)
+            .and_then(|value| value.to_str())
+            .ok_or_else(|| "missing value for --json-run".to_string())?;
+        return Ok(CliAction::JsonRun(source.to_string()));
+    }
     if args.iter().any(|arg| arg == "--ui-schema") {
         return Ok(CliAction::UiSchema);
     }
@@ -2052,6 +2114,13 @@ fn parse_args(args: impl IntoIterator<Item = OsString>) -> Result<CliAction, Str
         plot_width: plot_width.max(1),
         plot_height: plot_height.max(1),
     })))
+}
+
+fn render_help(schema: &UiCommandSchema) -> String {
+    format!(
+        "{}\n\nMachine-readable:\n  --ui-schema              Emit the launcher/TUI schema\n  --json-schema            Emit the canonical msexplore task JSON schema\n  --protocol-info          Emit the msexplore task protocol descriptor\n  --json-run <SOURCE>      Execute one JSON MsExploreTaskRequest from SOURCE or - for stdin\n",
+        schema.render_help()
+    )
 }
 
 fn write_output(path: Option<&std::path::Path>, overwrite: bool, text: &str) -> Result<(), String> {

--- a/crates/casa-ms/src/msexplore/task_contract.rs
+++ b/crates/casa-ms/src/msexplore/task_contract.rs
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//! Canonical `msexplore` task request/result contracts shared by CLI and UIs.
+
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use casa_provider_contracts::{
+    ProviderCliMachineActions, ProviderCliProjection, ProviderComponentSchemas,
+    ProviderProjectionMetadata, ProviderSurfaceKind, TaskOperationDescriptor, TaskSemanticContract,
+    derived_ui_schema_annotations, merged_components,
+};
+use schemars::{JsonSchema, schema::RootSchema, schema_for};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+use super::cli::command_schema;
+use super::{
+    MsExploreSpec, MsExportFormat, MsFlagEditPreview, MsFlagEditSpec, build_msexplore_payload,
+    export_msexplore_plot, preview_msexplore_flag_edit_for_request,
+};
+use crate::{MeasurementSet, MeasurementSetSummary};
+
+/// Stable protocol name advertised by `msexplore --protocol-info`.
+pub const MSEXPLORE_TASK_PROTOCOL_NAME: &str = "casa_msexplore_task";
+/// Stable protocol version advertised by `msexplore --protocol-info`.
+pub const MSEXPLORE_TASK_PROTOCOL_VERSION: u32 = 1;
+
+/// Version/compatibility information for the JSON task protocol.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct MsExploreProtocolInfo {
+    /// Stable protocol identifier.
+    pub protocol_name: String,
+    /// Monotonic protocol version for compatibility checks.
+    pub protocol_version: u32,
+    /// Provider surface kind defined by the shared architecture contract.
+    pub surface_kind: ProviderSurfaceKind,
+    /// Binary version implementing the protocol.
+    pub binary_version: String,
+}
+
+impl MsExploreProtocolInfo {
+    /// Build the current `msexplore` protocol descriptor.
+    pub fn current() -> Self {
+        Self {
+            protocol_name: MSEXPLORE_TASK_PROTOCOL_NAME.to_string(),
+            protocol_version: MSEXPLORE_TASK_PROTOCOL_VERSION,
+            surface_kind: ProviderSurfaceKind::Task,
+            binary_version: env!("CARGO_PKG_VERSION").to_string(),
+        }
+    }
+}
+
+/// Optional staged flag edit performed as part of one `msexplore` task request.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct MsExploreFlagEditRequest {
+    /// Staged flag edit specification.
+    pub edit: MsFlagEditSpec,
+    /// Apply the edit to disk instead of only previewing it.
+    #[serde(default)]
+    pub apply: bool,
+    /// Optional preview-output path written as JSON.
+    pub output_path: Option<PathBuf>,
+}
+
+/// Optional plot export performed as part of one `msexplore` task request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct MsExplorePlotExportRequest {
+    /// Destination path for the exported plot.
+    pub output_path: PathBuf,
+    /// Export format.
+    pub format: MsExportFormat,
+    /// Raster width in pixels.
+    pub width: u32,
+    /// Raster height in pixels.
+    pub height: u32,
+}
+
+/// One end-to-end `msexplore` task request.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct MsExploreRunTaskRequest {
+    /// Canonical `msexplore` plot/summary request.
+    pub spec: MsExploreSpec,
+    /// Optional summary-output path written in the requested summary format.
+    pub summary_output_path: Option<PathBuf>,
+    /// Permit replacement of existing output artifacts.
+    #[serde(default)]
+    pub overwrite_outputs: bool,
+    /// Optional staged flag edit request.
+    pub flag_edit: Option<MsExploreFlagEditRequest>,
+    /// Optional plot export request.
+    pub plot_export: Option<MsExplorePlotExportRequest>,
+}
+
+impl MsExploreRunTaskRequest {
+    /// Execute the request and return structured output metadata.
+    pub fn execute(&self) -> Result<MsExploreRunTaskResult, String> {
+        let mut ms = MeasurementSet::open(&self.spec.ms_path).map_err(|error| {
+            if self.spec.ms_path.is_dir() {
+                format!(
+                    "msexplore currently supports MeasurementSets only; failed to open {} as an MS: {error}",
+                    self.spec.ms_path.display()
+                )
+            } else {
+                format!(
+                    "open MeasurementSet {}: {error}",
+                    self.spec.ms_path.display()
+                )
+            }
+        })?;
+
+        let summary = MeasurementSetSummary::from_ms_with_options(
+            &ms,
+            &self.spec.selection.to_summary_options(),
+        )
+        .map_err(|error| error.to_string())?;
+        if let Some(path) = self.summary_output_path.as_deref() {
+            let rendered = summary
+                .render(self.spec.summary_format)
+                .map_err(|error| error.to_string())?;
+            write_output(path, self.overwrite_outputs, &rendered)?;
+        }
+
+        let flag_edit_preview = if let Some(flag_edit) = &self.flag_edit {
+            let preview = if flag_edit.apply {
+                let preview = crate::apply_msexplore_flag_edit_for_request(
+                    &mut ms,
+                    &self.spec,
+                    &flag_edit.edit,
+                )?;
+                ms.save().map_err(|error| error.to_string())?;
+                preview
+            } else {
+                preview_msexplore_flag_edit_for_request(&ms, &self.spec, &flag_edit.edit)?
+            };
+            if let Some(path) = flag_edit.output_path.as_deref() {
+                let json = serde_json::to_string_pretty(&preview)
+                    .map_err(|error| format!("serialize flag preview: {error}"))?;
+                write_output(path, self.overwrite_outputs, &json)?;
+            }
+            Some(preview)
+        } else {
+            None
+        };
+
+        let plot_export = if let Some(plot_export) = &self.plot_export {
+            let payload = build_msexplore_payload(&ms, &self.spec)?;
+            export_msexplore_plot(
+                &payload,
+                crate::MeasurementSetPlotTheme::light(),
+                &plot_export.output_path,
+                plot_export.format,
+                plot_export.width,
+                plot_export.height,
+            )?;
+            Some(MsExplorePlotArtifact {
+                output_path: plot_export.output_path.clone(),
+                format: plot_export.format,
+                width: plot_export.width,
+                height: plot_export.height,
+            })
+        } else {
+            None
+        };
+
+        Ok(MsExploreRunTaskResult {
+            summary,
+            summary_output_path: self.summary_output_path.clone(),
+            flag_edit_preview,
+            flag_edit_output_path: self
+                .flag_edit
+                .as_ref()
+                .and_then(|flag_edit| flag_edit.output_path.clone()),
+            plot_export,
+        })
+    }
+}
+
+/// Metadata for one plot artifact written by `msexplore`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct MsExplorePlotArtifact {
+    /// Destination path for the exported plot.
+    pub output_path: PathBuf,
+    /// Export format.
+    pub format: MsExportFormat,
+    /// Raster width in pixels.
+    pub width: u32,
+    /// Raster height in pixels.
+    pub height: u32,
+}
+
+/// Structured result for one `msexplore` task execution.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct MsExploreRunTaskResult {
+    /// Structured MeasurementSet summary.
+    pub summary: MeasurementSetSummary,
+    /// Summary artifact path when one was written.
+    pub summary_output_path: Option<PathBuf>,
+    /// Structured staged-flag preview when requested.
+    pub flag_edit_preview: Option<MsFlagEditPreview>,
+    /// Flag-preview artifact path when one was written.
+    pub flag_edit_output_path: Option<PathBuf>,
+    /// Plot artifact metadata when a plot was exported.
+    pub plot_export: Option<MsExplorePlotArtifact>,
+}
+
+/// Canonical `msexplore` task request envelope.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", content = "request", rename_all = "snake_case")]
+pub enum MsExploreTaskRequest {
+    /// Execute one `msexplore` request.
+    Run(MsExploreRunTaskRequest),
+}
+
+impl MsExploreTaskRequest {
+    /// Execute the request and return the canonical task result envelope.
+    pub fn execute(&self) -> Result<MsExploreTaskResult, String> {
+        match self {
+            Self::Run(request) => Ok(MsExploreTaskResult::Run(request.execute()?)),
+        }
+    }
+
+    /// Read one task request from a file path or `-` for stdin.
+    pub fn read_from_source(source: &str) -> Result<Self, String> {
+        let payload = if source == "-" {
+            let mut payload = String::new();
+            std::io::stdin()
+                .read_to_string(&mut payload)
+                .map_err(|error| format!("failed to read JSON request from stdin: {error}"))?;
+            payload
+        } else {
+            fs::read_to_string(source).map_err(|error| {
+                format!(
+                    "failed to read JSON request from {}: {error}",
+                    Path::new(source).display()
+                )
+            })?
+        };
+        serde_json::from_str(&payload)
+            .map_err(|error| format!("failed to parse msexplore task request: {error}"))
+    }
+}
+
+/// Canonical `msexplore` task result envelope.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", content = "result", rename_all = "snake_case")]
+pub enum MsExploreTaskResult {
+    /// Completed end-to-end `msexplore` run.
+    Run(MsExploreRunTaskResult),
+}
+
+/// JSON-schema bundle for the public `msexplore` task protocol.
+#[derive(Debug, Clone, Serialize)]
+pub struct MsExploreTaskSchemaBundle {
+    /// Compatibility descriptor for the request/result schemas.
+    pub protocol: MsExploreProtocolInfo,
+    /// Canonical semantic task contract.
+    pub semantic: TaskSemanticContract,
+    /// Shared component schemas reusable across projections.
+    pub components: ProviderComponentSchemas,
+    /// Presentation annotations carried with the canonical bundle.
+    pub annotations: JsonValue,
+    /// Derived projection metadata for UI and CLI consumers.
+    pub projections: ProviderProjectionMetadata,
+    /// JSON schema for [`MsExploreTaskRequest`].
+    pub request_schema: RootSchema,
+    /// JSON schema for [`MsExploreTaskResult`].
+    pub result_schema: RootSchema,
+}
+
+impl MsExploreTaskSchemaBundle {
+    /// Build the current request/result schema bundle.
+    pub fn current() -> Self {
+        let request_schema = schema_for!(MsExploreTaskRequest);
+        let result_schema = schema_for!(MsExploreTaskResult);
+        let ui_schema = serde_json::to_value(command_schema("msexplore"))
+            .expect("serialize msexplore ui schema projection");
+        Self {
+            protocol: MsExploreProtocolInfo::current(),
+            semantic: TaskSemanticContract {
+                request_schema: request_schema.clone(),
+                result_schema: result_schema.clone(),
+                operations: vec![TaskOperationDescriptor {
+                    name: "run".to_string(),
+                    request_kind: "run".to_string(),
+                    result_kind: Some("run".to_string()),
+                }],
+            },
+            components: merged_components([&request_schema, &result_schema]),
+            annotations: derived_ui_schema_annotations(),
+            projections: ProviderProjectionMetadata {
+                cli: Some(ProviderCliProjection {
+                    machine_actions: ProviderCliMachineActions {
+                        ui_schema: Some("--ui-schema".to_string()),
+                        json_schema: Some("--json-schema".to_string()),
+                        protocol_info: Some("--protocol-info".to_string()),
+                        json_run: Some("--json-run <SOURCE>".to_string()),
+                        session: None,
+                    },
+                }),
+                ui_schema: Some(ui_schema),
+                python: None,
+            },
+            request_schema,
+            result_schema,
+        }
+    }
+
+    /// Return the launcher/TUI compatibility view projected from the bundle.
+    pub fn ui_schema_projection(&self) -> Result<crate::ui_schema::UiCommandSchema, String> {
+        let value = self
+            .projections
+            .ui_schema
+            .clone()
+            .ok_or_else(|| "missing ui_schema projection".to_string())?;
+        serde_json::from_value(value).map_err(|error| format!("parse msexplore ui schema: {error}"))
+    }
+}
+
+fn write_output(path: &Path, overwrite: bool, text: &str) -> Result<(), String> {
+    if path.exists() && !overwrite {
+        return Err(format!(
+            "refusing to overwrite existing output {}; pass overwrite_outputs=true to replace it",
+            path.display()
+        ));
+    }
+    fs::write(path, text).map_err(|error| format!("write output {}: {error}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use casa_provider_contracts::ProviderSurfaceKind;
+
+    use super::{
+        MSEXPLORE_TASK_PROTOCOL_NAME, MSEXPLORE_TASK_PROTOCOL_VERSION, MsExploreProtocolInfo,
+        MsExploreTaskSchemaBundle,
+    };
+
+    #[test]
+    fn schema_bundle_uses_current_protocol_and_projection() {
+        let bundle = MsExploreTaskSchemaBundle::current();
+        assert_eq!(bundle.protocol.protocol_name, MSEXPLORE_TASK_PROTOCOL_NAME);
+        assert_eq!(
+            bundle.protocol.protocol_version,
+            MSEXPLORE_TASK_PROTOCOL_VERSION
+        );
+        assert_eq!(bundle.protocol.surface_kind, ProviderSurfaceKind::Task);
+        assert_eq!(bundle.semantic.operations.len(), 1);
+        assert_eq!(bundle.semantic.operations[0].request_kind, "run");
+        assert!(bundle.components.contains_key("MsExploreRunTaskRequest"));
+        let ui_schema = bundle.ui_schema_projection().expect("ui schema projection");
+        assert_eq!(ui_schema.command_id, "msexplore");
+    }
+
+    #[test]
+    fn protocol_info_matches_public_constants() {
+        let info = MsExploreProtocolInfo::current();
+        assert_eq!(info.protocol_name, MSEXPLORE_TASK_PROTOCOL_NAME);
+        assert_eq!(info.protocol_version, MSEXPLORE_TASK_PROTOCOL_VERSION);
+        assert_eq!(info.surface_kind, ProviderSurfaceKind::Task);
+    }
+}

--- a/crates/casa-ms/tests/msexplore_cli.rs
+++ b/crates/casa-ms/tests/msexplore_cli.rs
@@ -12,7 +12,7 @@ use casa_ms::msexplore::cli::command_schema;
 use casa_ms::msexplore::cli::{UiArgumentParser, UiValueKind};
 use casa_ms::subtables::SubTable;
 use casa_ms::{
-    DEFAULT_MAX_PLOT_POINTS, MeasurementSet, MeasurementSetPlotTheme,
+    DEFAULT_MAX_PLOT_POINTS, MSEXPLORE_TASK_PROTOCOL_NAME, MeasurementSet, MeasurementSetPlotTheme,
     MeasurementSetSummaryOutputFormat, MsAxis, MsColorAxis, MsDataColumn, MsExploreSpec,
     MsFlagAction, MsFlagEditSpec, MsFlagRegion, MsIterationAxis, MsLayoutSpec, MsLegendPosition,
     MsPageExportRange, MsPageHeaderItem, MsPlotPayload, MsPlotPreset, MsPlotSpec, MsSelectionSpec,
@@ -82,6 +82,9 @@ fn msexplore_help_mentions_plot_controls() {
     assert!(stdout.contains("--msselect <EXPR>"));
     assert!(stdout.contains("--page-spec <PATH>"));
     assert!(stdout.contains("--ui-schema"));
+    assert!(stdout.contains("--json-schema"));
+    assert!(stdout.contains("--protocol-info"));
+    assert!(stdout.contains("--json-run <SOURCE>"));
 }
 
 #[test]
@@ -93,7 +96,43 @@ fn msexplore_ui_schema_round_trips_help() {
     assert!(help.status.success());
 
     let help_text = String::from_utf8(help.stdout).expect("utf8 help stdout");
-    assert_eq!(command_schema("msexplore").render_help(), help_text);
+    assert!(help_text.contains(&command_schema("msexplore").render_help()));
+}
+
+#[test]
+fn msexplore_json_schema_emits_canonical_task_bundle() {
+    let output = Command::new(env!("CARGO_BIN_EXE_msexplore"))
+        .arg("--json-schema")
+        .output()
+        .expect("run msexplore --json-schema");
+    assert!(output.status.success());
+
+    let schema = serde_json::from_slice::<serde_json::Value>(&output.stdout).expect("parse schema");
+    assert_eq!(
+        schema["protocol"]["protocol_name"],
+        MSEXPLORE_TASK_PROTOCOL_NAME
+    );
+    assert_eq!(schema["protocol"]["protocol_version"], 1);
+    assert_eq!(schema["protocol"]["surface_kind"], "task");
+    assert_eq!(schema["semantic"]["operations"][0]["request_kind"], "run");
+    assert_eq!(
+        schema["projections"]["ui_schema"]["command_id"],
+        "msexplore"
+    );
+}
+
+#[test]
+fn msexplore_protocol_info_reports_task_surface() {
+    let output = Command::new(env!("CARGO_BIN_EXE_msexplore"))
+        .arg("--protocol-info")
+        .output()
+        .expect("run msexplore --protocol-info");
+    assert!(output.status.success());
+
+    let info = serde_json::from_slice::<serde_json::Value>(&output.stdout).expect("parse info");
+    assert_eq!(info["protocol_name"], MSEXPLORE_TASK_PROTOCOL_NAME);
+    assert_eq!(info["protocol_version"], 1);
+    assert_eq!(info["surface_kind"], "task");
 }
 
 #[test]

--- a/crates/casa-provider-contracts/Cargo.toml
+++ b/crates/casa-provider-contracts/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "casars-tablebrowser-protocol"
+name = "casa-provider-contracts"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
-description = "Wire protocol for the casacore table browser session"
+description = "Canonical provider contract bundle types shared across casa-rs surfaces"
 repository.workspace = true
 publish = false
 
@@ -12,7 +12,6 @@ publish = false
 workspace = true
 
 [dependencies]
-casa-provider-contracts = { path = "../casa-provider-contracts" }
 schemars = { version = "0.8", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/casa-provider-contracts/src/lib.rs
+++ b/crates/casa-provider-contracts/src/lib.rs
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//! Shared canonical provider-contract bundle types.
+//!
+//! These structs intentionally stay small and transport-oriented so task and
+//! session providers can expose one machine-readable schema bundle while
+//! retaining compatibility projections such as the legacy `--ui-schema` view.
+
+use std::collections::BTreeMap;
+
+use schemars::JsonSchema;
+use schemars::schema::{RootSchema, Schema};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value as JsonValue, json};
+
+/// Stable provider surface kind advertised in canonical schema bundles.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderSurfaceKind {
+    /// One-shot request/result operation.
+    Task,
+    /// Stateful command/response protocol.
+    Session,
+    /// Handle-oriented object API.
+    Object,
+}
+
+/// Merged reusable component schemas extracted from one or more root schemas.
+pub type ProviderComponentSchemas = BTreeMap<String, Schema>;
+
+/// CLI machine-action projections derived from the canonical contract.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProviderCliMachineActions {
+    /// Legacy compatibility view used by the current launcher/TUI integration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ui_schema: Option<String>,
+    /// Canonical schema bundle action.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub json_schema: Option<String>,
+    /// Protocol descriptor action.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub protocol_info: Option<String>,
+    /// One-shot task execution action.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub json_run: Option<String>,
+    /// Stateful session action.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session: Option<String>,
+}
+
+/// CLI projection metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProviderCliProjection {
+    /// Known machine-facing flags derived from the canonical contract.
+    pub machine_actions: ProviderCliMachineActions,
+}
+
+/// Projection metadata for derived consumer views.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ProviderProjectionMetadata {
+    /// CLI projection metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cli: Option<ProviderCliProjection>,
+    /// Legacy `--ui-schema` compatibility view when the surface still exposes it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ui_schema: Option<JsonValue>,
+    /// Python binding projection metadata for direct in-process object surfaces.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub python: Option<JsonValue>,
+}
+
+/// One task operation exposed by a task-surface request/result bundle.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TaskOperationDescriptor {
+    /// Stable operation identifier used on the wire.
+    pub name: String,
+    /// Tagged request discriminator for the operation.
+    pub request_kind: String,
+    /// Tagged result discriminator when the result envelope is variant-based.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_kind: Option<String>,
+}
+
+/// Semantic task contract exposed by the canonical bundle.
+#[derive(Debug, Clone, Serialize)]
+pub struct TaskSemanticContract {
+    /// Canonical tagged request envelope schema.
+    pub request_schema: RootSchema,
+    /// Canonical tagged result envelope schema.
+    pub result_schema: RootSchema,
+    /// Stable task operations carried by the envelope schemas.
+    pub operations: Vec<TaskOperationDescriptor>,
+}
+
+/// Semantic session contract exposed by the canonical bundle.
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionSemanticContract {
+    /// Session transport identifier.
+    pub transport: String,
+    /// Canonical tagged request envelope schema.
+    pub request_schema: RootSchema,
+    /// Canonical tagged response envelope schema.
+    pub response_schema: RootSchema,
+}
+
+/// One constructor exposed by an object surface.
+#[derive(Debug, Clone, Serialize)]
+pub struct ObjectConstructorDescriptor {
+    /// Stable constructor identifier.
+    pub name: String,
+    /// Canonical constructor parameter schema.
+    pub parameters_schema: RootSchema,
+}
+
+/// One property exposed by an object surface.
+#[derive(Debug, Clone, Serialize)]
+pub struct ObjectPropertyDescriptor {
+    /// Stable property identifier.
+    pub name: String,
+    /// Canonical property value schema.
+    pub value_schema: RootSchema,
+    /// Whether the property can be read.
+    pub readable: bool,
+    /// Whether the property can be written directly.
+    pub writable: bool,
+}
+
+/// One method exposed by an object surface.
+#[derive(Debug, Clone, Serialize)]
+pub struct ObjectMethodDescriptor {
+    /// Stable method identifier.
+    pub name: String,
+    /// Canonical method parameter schema.
+    pub parameters_schema: RootSchema,
+    /// Canonical method result schema when the method returns a value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_schema: Option<RootSchema>,
+    /// Whether the method mutates persistent state.
+    pub mutating: bool,
+}
+
+/// One object type carried by an object-surface schema bundle.
+#[derive(Debug, Clone, Serialize)]
+pub struct ObjectTypeContract {
+    /// Stable object type name.
+    pub name: String,
+    /// Constructors exposed by the object.
+    pub constructors: Vec<ObjectConstructorDescriptor>,
+    /// Properties exposed by the object.
+    pub properties: Vec<ObjectPropertyDescriptor>,
+    /// Methods exposed by the object.
+    pub methods: Vec<ObjectMethodDescriptor>,
+    /// Explicit lifecycle operations when the surface exposes them.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub lifecycle_operations: Vec<String>,
+}
+
+/// Semantic object contract exposed by the canonical bundle.
+#[derive(Debug, Clone, Serialize)]
+pub struct ObjectSemanticContract {
+    /// Object types exposed by the bundle.
+    pub objects: Vec<ObjectTypeContract>,
+}
+
+/// Merge reusable component definitions from one or more root schemas.
+pub fn merged_components<'a>(
+    schemas: impl IntoIterator<Item = &'a RootSchema>,
+) -> ProviderComponentSchemas {
+    let mut merged = ProviderComponentSchemas::new();
+    for root in schemas {
+        for (name, schema) in &root.definitions {
+            merged.insert(name.clone(), schema.clone());
+        }
+    }
+    merged
+}
+
+/// Annotations noting that the legacy UI schema is a derived compatibility view.
+pub fn derived_ui_schema_annotations() -> JsonValue {
+    json!({
+        "ui_schema": {
+            "status": "derived_compatibility_view"
+        }
+    })
+}

--- a/crates/casa-tables/src/bin/tablebrowser.rs
+++ b/crates/casa-tables/src/bin/tablebrowser.rs
@@ -8,7 +8,8 @@ use std::process;
 
 use casa_tables::{TableBrowser, TableBrowserView};
 use casars_tablebrowser_protocol::{
-    BrowserCommand, BrowserRequestEnvelope, BrowserViewport, PROTOCOL_VERSION,
+    BrowserCommand, BrowserProtocolInfo, BrowserRequestEnvelope, BrowserViewport, PROTOCOL_VERSION,
+    schema_bundle_json,
 };
 use serde_json::json;
 
@@ -72,6 +73,22 @@ fn main() {
 
 fn run() -> Result<(), String> {
     let mut args = env::args().skip(1).peekable();
+    if args.peek().is_some_and(|arg| arg == "--json-schema") {
+        print!(
+            "{}",
+            schema_bundle_json(ui_schema_value())
+                .map_err(|error| format!("serialize tablebrowser schema bundle: {error}"))?
+        );
+        return Ok(());
+    }
+    if args.peek().is_some_and(|arg| arg == "--protocol-info") {
+        print!(
+            "{}",
+            serde_json::to_string_pretty(&BrowserProtocolInfo::current())
+                .map_err(|error| format!("serialize tablebrowser protocol info: {error}"))?
+        );
+        return Ok(());
+    }
     if args.peek().is_some_and(|arg| arg == "--ui-schema") {
         print!("{}", ui_schema_json()?);
         return Ok(());
@@ -443,7 +460,12 @@ fn run_session() -> Result<(), String> {
 }
 
 fn ui_schema_json() -> Result<String, String> {
-    let schema = json!({
+    serde_json::to_string_pretty(&ui_schema_value())
+        .map_err(|error| format!("serialize ui schema: {error}"))
+}
+
+fn ui_schema_value() -> serde_json::Value {
+    json!({
         "schema_version": 1,
         "command_id": "tablebrowser",
         "invocation_name": "tablebrowser",
@@ -487,8 +509,7 @@ fn ui_schema_json() -> Result<String, String> {
             }
         ],
         "managed_output": null
-    });
-    serde_json::to_string_pretty(&schema).map_err(|error| format!("serialize ui schema: {error}"))
+    })
 }
 
 fn print_section(title: &str, lines: &[String]) {
@@ -510,6 +531,8 @@ tablebrowser - inspect arbitrary casacore tables
 Usage:
   tablebrowser [OPTIONS] <table-path>
   tablebrowser --session
+  tablebrowser --json-schema
+  tablebrowser --protocol-info
   tablebrowser --ui-schema
 
 Options:
@@ -519,6 +542,8 @@ Options:
   --open-linked N     follow discovered linked-table index N before rendering
   --inspect TARGET    cell:<row>:<column> | keyword:<path> | column-keyword:<column>:<path>
   --session           run the long-lived JSON Lines browser session on stdio
+  --json-schema       print the canonical session schema bundle
+  --protocol-info     print the tablebrowser session protocol descriptor
   --ui-schema         print the launcher schema consumed by casars
   -h, --help          show this help
 

--- a/crates/casa-tables/tests/tablebrowser_cli.rs
+++ b/crates/casa-tables/tests/tablebrowser_cli.rs
@@ -30,6 +30,42 @@ fn ui_schema_matches_launcher_contract() {
 }
 
 #[test]
+fn json_schema_emits_canonical_session_bundle() {
+    let output = Command::new(tablebrowser_bin())
+        .arg("--json-schema")
+        .output()
+        .expect("run tablebrowser --json-schema");
+    assert!(output.status.success());
+
+    let schema = serde_json::from_slice::<serde_json::Value>(&output.stdout).expect("parse schema");
+    assert_eq!(
+        schema["protocol"]["protocol_name"],
+        "casa_tablebrowser_session"
+    );
+    assert_eq!(schema["protocol"]["protocol_version"], 1);
+    assert_eq!(schema["protocol"]["surface_kind"], "session");
+    assert_eq!(schema["semantic"]["transport"], "jsonl_stdio");
+    assert_eq!(
+        schema["projections"]["ui_schema"]["command_id"],
+        "tablebrowser"
+    );
+}
+
+#[test]
+fn protocol_info_reports_session_surface() {
+    let output = Command::new(tablebrowser_bin())
+        .arg("--protocol-info")
+        .output()
+        .expect("run tablebrowser --protocol-info");
+    assert!(output.status.success());
+
+    let info = serde_json::from_slice::<serde_json::Value>(&output.stdout).expect("parse info");
+    assert_eq!(info["protocol_name"], "casa_tablebrowser_session");
+    assert_eq!(info["protocol_version"], 1);
+    assert_eq!(info["surface_kind"], "session");
+}
+
+#[test]
 fn session_returns_structured_errors_for_invalid_requests() {
     let mut child = Command::new(tablebrowser_bin())
         .arg("--session")

--- a/crates/casars-imagebrowser-protocol/Cargo.toml
+++ b/crates/casars-imagebrowser-protocol/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 workspace = true
 
 [dependencies]
+casa-provider-contracts = { path = "../casa-provider-contracts" }
 schemars = { version = "0.8", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/casars-imagebrowser-protocol/src/lib.rs
+++ b/crates/casars-imagebrowser-protocol/src/lib.rs
@@ -1,11 +1,105 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 //! Wire protocol for the `imagebrowser` subprocess session.
 
+use casa_provider_contracts::{
+    ProviderCliMachineActions, ProviderCliProjection, ProviderComponentSchemas,
+    ProviderProjectionMetadata, ProviderSurfaceKind, SessionSemanticContract,
+    derived_ui_schema_annotations, merged_components,
+};
 use schemars::{JsonSchema, schema_for};
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+/// Stable protocol name advertised by `imexplore --protocol-info`.
+pub const IMAGEBROWSER_SESSION_PROTOCOL_NAME: &str = "casa_imagebrowser_session";
 
 /// Current JSON protocol version.
 pub const PROTOCOL_VERSION: u32 = 1;
+
+/// Version/compatibility information for the imagebrowser session protocol.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ImageBrowserProtocolInfo {
+    /// Stable protocol identifier.
+    pub protocol_name: String,
+    /// Monotonic protocol version for compatibility checks.
+    pub protocol_version: u32,
+    /// Provider surface kind defined by the shared architecture contract.
+    pub surface_kind: ProviderSurfaceKind,
+    /// Binary version implementing the protocol.
+    pub binary_version: String,
+}
+
+impl ImageBrowserProtocolInfo {
+    /// Build the current imagebrowser session protocol descriptor.
+    pub fn current() -> Self {
+        Self {
+            protocol_name: IMAGEBROWSER_SESSION_PROTOCOL_NAME.to_string(),
+            protocol_version: PROTOCOL_VERSION,
+            surface_kind: ProviderSurfaceKind::Session,
+            binary_version: env!("CARGO_PKG_VERSION").to_string(),
+        }
+    }
+}
+
+/// Canonical JSON-schema bundle for the public imagebrowser session protocol.
+#[derive(Debug, Clone, Serialize)]
+pub struct ImageBrowserSessionSchemaBundle {
+    /// Compatibility descriptor for the session protocol.
+    pub protocol: ImageBrowserProtocolInfo,
+    /// Canonical semantic session contract.
+    pub semantic: SessionSemanticContract,
+    /// Shared component schemas reusable across projections.
+    pub components: ProviderComponentSchemas,
+    /// Presentation annotations carried with the canonical bundle.
+    pub annotations: JsonValue,
+    /// Derived projection metadata for UI and CLI consumers.
+    pub projections: ProviderProjectionMetadata,
+    /// JSON schema for [`ImageBrowserRequestEnvelope`].
+    pub request_schema: schemars::schema::RootSchema,
+    /// JSON schema for [`ImageBrowserResponseEnvelope`].
+    pub response_schema: schemars::schema::RootSchema,
+}
+
+impl ImageBrowserSessionSchemaBundle {
+    /// Build the current imagebrowser schema bundle.
+    pub fn current(ui_schema: JsonValue) -> Self {
+        let request_schema = schema_for!(ImageBrowserRequestEnvelope);
+        let response_schema = schema_for!(ImageBrowserResponseEnvelope);
+        Self {
+            protocol: ImageBrowserProtocolInfo::current(),
+            semantic: SessionSemanticContract {
+                transport: "jsonl_stdio".to_string(),
+                request_schema: request_schema.clone(),
+                response_schema: response_schema.clone(),
+            },
+            components: merged_components([&request_schema, &response_schema]),
+            annotations: derived_ui_schema_annotations(),
+            projections: ProviderProjectionMetadata {
+                cli: Some(ProviderCliProjection {
+                    machine_actions: ProviderCliMachineActions {
+                        ui_schema: Some("--ui-schema".to_string()),
+                        json_schema: Some("--json-schema".to_string()),
+                        protocol_info: Some("--protocol-info".to_string()),
+                        json_run: None,
+                        session: Some("--session".to_string()),
+                    },
+                }),
+                ui_schema: Some(ui_schema),
+                python: None,
+            },
+            request_schema,
+            response_schema,
+        }
+    }
+
+    /// Return the launcher/TUI compatibility view projected from the bundle.
+    pub fn ui_schema_projection(&self) -> Result<JsonValue, String> {
+        self.projections
+            .ui_schema
+            .clone()
+            .ok_or_else(|| "missing ui_schema projection".to_string())
+    }
+}
 
 /// Render viewport requested by the consumer.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -512,6 +606,11 @@ pub fn response_schema_json() -> Result<String, serde_json::Error> {
     serde_json::to_string_pretty(&schema_for!(ImageBrowserResponseEnvelope))
 }
 
+/// Returns the canonical schema bundle for the public imagebrowser session protocol.
+pub fn schema_bundle_json(ui_schema: JsonValue) -> Result<String, serde_json::Error> {
+    serde_json::to_string_pretty(&ImageBrowserSessionSchemaBundle::current(ui_schema))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -681,5 +780,22 @@ mod tests {
                 .unwrap()
                 .contains("ImageBrowserResponseEnvelope")
         );
+    }
+
+    #[test]
+    fn schema_bundle_uses_current_protocol_and_transport() {
+        let bundle = ImageBrowserSessionSchemaBundle::current(serde_json::json!({
+            "schema_version": 1,
+            "command_id": "imexplore",
+        }));
+        assert_eq!(
+            bundle.protocol.protocol_name,
+            IMAGEBROWSER_SESSION_PROTOCOL_NAME
+        );
+        assert_eq!(bundle.protocol.protocol_version, PROTOCOL_VERSION);
+        assert_eq!(bundle.protocol.surface_kind, ProviderSurfaceKind::Session);
+        assert_eq!(bundle.semantic.transport, "jsonl_stdio");
+        assert!(bundle.components.contains_key("ImageBrowserCommand"));
+        assert!(bundle.components.contains_key("ImageBrowserResponse"));
     }
 }

--- a/crates/casars-imager/Cargo.toml
+++ b/crates/casars-imager/Cargo.toml
@@ -16,6 +16,7 @@ slow-tests = []
 workspace = true
 
 [dependencies]
+casa-provider-contracts = { path = "../casa-provider-contracts" }
 casa-coordinates = { path = "../casa-coordinates" }
 casa-images = { path = "../casa-images" }
 casa-imaging = { path = "../casa-imaging" }

--- a/crates/casars-imager/src/task_contract.rs
+++ b/crates/casars-imager/src/task_contract.rs
@@ -13,13 +13,20 @@ use casa_ms::{
     CubeAxisConfig, CubeAxisValue, CubeInterpolation,
     parse_rest_frequency_hz as parse_ms_rest_frequency_hz,
 };
+use casa_provider_contracts::{
+    ProviderCliMachineActions, ProviderCliProjection, ProviderComponentSchemas,
+    ProviderProjectionMetadata, ProviderSurfaceKind, TaskOperationDescriptor, TaskSemanticContract,
+    derived_ui_schema_annotations, merged_components,
+};
 use casa_types::measures::doppler::DopplerRef;
 use casa_types::measures::frequency::FrequencyRef;
 use schemars::{JsonSchema, schema::RootSchema, schema_for};
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 
 use crate::{
-    ChannelRunSummary, CliConfig, FrontendStageTimings, RunSummary, SpectralMode, run_from_config,
+    ChannelRunSummary, CliConfig, FrontendStageTimings, RunSummary, SpectralMode, command_schema,
+    run_from_config,
 };
 
 /// Stable protocol name advertised by `casars-imager --protocol-info`.
@@ -34,6 +41,8 @@ pub struct ImagerProtocolInfo {
     pub protocol_name: String,
     /// Monotonic protocol version for compatibility checks.
     pub protocol_version: u32,
+    /// Provider surface kind defined by the shared architecture contract.
+    pub surface_kind: ProviderSurfaceKind,
     /// Binary version implementing the protocol.
     pub binary_version: String,
 }
@@ -44,6 +53,7 @@ impl ImagerProtocolInfo {
         Self {
             protocol_name: IMAGER_TASK_PROTOCOL_NAME.to_string(),
             protocol_version: IMAGER_TASK_PROTOCOL_VERSION,
+            surface_kind: ProviderSurfaceKind::Task,
             binary_version: env!("CARGO_PKG_VERSION").to_string(),
         }
     }
@@ -54,6 +64,14 @@ impl ImagerProtocolInfo {
 pub struct ImagerTaskSchemaBundle {
     /// Compatibility descriptor for the request/result schemas.
     pub protocol: ImagerProtocolInfo,
+    /// Canonical semantic task contract.
+    pub semantic: TaskSemanticContract,
+    /// Shared component schemas reusable across projections.
+    pub components: ProviderComponentSchemas,
+    /// Presentation annotations carried with the canonical bundle.
+    pub annotations: JsonValue,
+    /// Derived projection metadata for UI and CLI consumers.
+    pub projections: ProviderProjectionMetadata,
     /// JSON schema for [`ImagerTaskRequest`].
     pub request_schema: RootSchema,
     /// JSON schema for [`ImagerTaskResult`].
@@ -63,11 +81,49 @@ pub struct ImagerTaskSchemaBundle {
 impl ImagerTaskSchemaBundle {
     /// Build the current request/result schema bundle.
     pub fn current() -> Self {
+        let request_schema = schema_for!(ImagerTaskRequest);
+        let result_schema = schema_for!(ImagerTaskResult);
+        let ui_schema = serde_json::to_value(command_schema("casars-imager"))
+            .expect("serialize imager ui schema projection");
         Self {
             protocol: ImagerProtocolInfo::current(),
-            request_schema: schema_for!(ImagerTaskRequest),
-            result_schema: schema_for!(ImagerTaskResult),
+            semantic: TaskSemanticContract {
+                request_schema: request_schema.clone(),
+                result_schema: result_schema.clone(),
+                operations: vec![TaskOperationDescriptor {
+                    name: "run".to_string(),
+                    request_kind: "run".to_string(),
+                    result_kind: Some("run".to_string()),
+                }],
+            },
+            components: merged_components([&request_schema, &result_schema]),
+            annotations: derived_ui_schema_annotations(),
+            projections: ProviderProjectionMetadata {
+                cli: Some(ProviderCliProjection {
+                    machine_actions: ProviderCliMachineActions {
+                        ui_schema: Some("--ui-schema".to_string()),
+                        json_schema: Some("--json-schema".to_string()),
+                        protocol_info: Some("--protocol-info".to_string()),
+                        json_run: Some("--json-run <SOURCE>".to_string()),
+                        session: None,
+                    },
+                }),
+                ui_schema: Some(ui_schema),
+                python: None,
+            },
+            request_schema,
+            result_schema,
         }
+    }
+
+    /// Return the launcher/TUI compatibility view projected from the bundle.
+    pub fn ui_schema_projection(&self) -> Result<casa_ms::ui_schema::UiCommandSchema, String> {
+        let value = self
+            .projections
+            .ui_schema
+            .clone()
+            .ok_or_else(|| "missing ui_schema projection".to_string())?;
+        serde_json::from_value(value).map_err(|error| format!("parse imager ui schema: {error}"))
     }
 }
 
@@ -1208,6 +1264,7 @@ mod tests {
     use std::path::PathBuf;
 
     use casa_imaging::{Deconvolver, RestoringBeamMode, WTermMode, WeightingMode};
+    use casa_provider_contracts::ProviderSurfaceKind;
 
     use super::{
         IMAGER_TASK_PROTOCOL_NAME, IMAGER_TASK_PROTOCOL_VERSION, ImagerRunTaskRequest,
@@ -1223,10 +1280,17 @@ mod tests {
             bundle.protocol.protocol_version,
             IMAGER_TASK_PROTOCOL_VERSION
         );
+        assert_eq!(bundle.protocol.surface_kind, ProviderSurfaceKind::Task);
+        assert_eq!(bundle.semantic.operations.len(), 1);
+        assert_eq!(bundle.semantic.operations[0].request_kind, "run");
+        assert!(bundle.components.contains_key("ImagerRunTaskRequest"));
+        assert!(bundle.projections.ui_schema.is_some());
         let request_schema = serde_json::to_value(&bundle.request_schema).unwrap();
         let result_schema = serde_json::to_value(&bundle.result_schema).unwrap();
         assert!(request_schema.to_string().contains("ImagerTaskRequest"));
         assert!(result_schema.to_string().contains("ImagerTaskResult"));
+        let ui_schema = bundle.ui_schema_projection().expect("ui schema projection");
+        assert_eq!(ui_schema.command_id, "imager");
     }
 
     #[test]

--- a/crates/casars-python/Cargo.toml
+++ b/crates/casars-python/Cargo.toml
@@ -15,11 +15,15 @@ crate-type = ["cdylib"]
 [dependencies]
 casa-coordinates = { path = "../casa-coordinates" }
 casa-images = { path = "../casa-images" }
+casa-provider-contracts = { path = "../casa-provider-contracts" }
 casa-tables = { path = "../casa-tables" }
 casa-types = { path = "../casa-types" }
 ndarray.workspace = true
 numpy = "0.28"
 pyo3 = { version = "0.28", features = ["extension-module"] }
+schemars = "0.8"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [lints]
 workspace = true

--- a/crates/casars-python/python/casars/_task_runtime.py
+++ b/crates/casars-python/python/casars/_task_runtime.py
@@ -40,6 +40,7 @@ class ProtocolInfo:
     protocol_name: str
     protocol_version: int
     binary_version: str
+    surface_kind: str | None = None
 
 
 def configure_calibrate_binary(binary: StrPath | None) -> None:
@@ -199,6 +200,7 @@ def _validated_protocol_info(binary: str) -> ProtocolInfo:
         protocol_name=str(payload["protocol_name"]),
         protocol_version=int(payload["protocol_version"]),
         binary_version=str(payload["binary_version"]),
+        surface_kind=str(payload["surface_kind"]) if "surface_kind" in payload else None,
     )
     if info.protocol_name != CALIBRATION_PROTOCOL_NAME:
         raise CalibrationProtocolMismatchError(

--- a/crates/casars-python/python/casars/data.py
+++ b/crates/casars-python/python/casars/data.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from functools import lru_cache
+import json
 from os import PathLike
 from typing import Any, TypeAlias
 
@@ -14,6 +17,38 @@ from . import _core
 StrPath: TypeAlias = str | PathLike[str]
 ArrayLike: TypeAlias = npt.NDArray[Any]
 RecordLike: TypeAlias = dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ProtocolInfo:
+    """Compatibility descriptor for the canonical `casars.data` object surface."""
+
+    protocol_name: str
+    protocol_version: int
+    surface_kind: str
+    binding_version: str
+
+
+@lru_cache(maxsize=1)
+def protocol_info() -> ProtocolInfo:
+    """Return the canonical object-surface protocol descriptor emitted by Rust."""
+
+    payload = json.loads(_core.data_protocol_info_json())
+    return ProtocolInfo(
+        protocol_name=str(payload["protocol_name"]),
+        protocol_version=int(payload["protocol_version"]),
+        surface_kind=str(payload["surface_kind"]),
+        binding_version=str(payload["binding_version"]),
+    )
+
+
+@lru_cache(maxsize=1)
+def schema_bundle() -> dict[str, Any]:
+    """Return the canonical object-surface schema bundle emitted by Rust."""
+
+    payload = json.loads(_core.data_schema_bundle_json())
+    assert isinstance(payload, dict)
+    return payload
 
 
 class Image:
@@ -197,4 +232,13 @@ class Table:
         self._inner.set_column_keywords(column, dict(keywords))
 
 
-__all__ = ["ArrayLike", "Image", "RecordLike", "StrPath", "Table"]
+__all__ = [
+    "ArrayLike",
+    "Image",
+    "ProtocolInfo",
+    "RecordLike",
+    "StrPath",
+    "Table",
+    "protocol_info",
+    "schema_bundle",
+]

--- a/crates/casars-python/python/casars/tasks/calibrate.py
+++ b/crates/casars-python/python/casars/tasks/calibrate.py
@@ -298,7 +298,7 @@ def fluxscale(
     """Run the first-wave ``fluxscale`` stage."""
 
     return invoke_calibration_task(
-        kind="fluxscale",
+        kind="flux_scale",
         request={
             "input_table": os.fspath(input_table),
             "output_table": os.fspath(output_table),

--- a/crates/casars-python/python/tests/test_calibrate.py
+++ b/crates/casars-python/python/tests/test_calibrate.py
@@ -148,6 +148,7 @@ def _write_stub_binary(
             print(json.dumps({{
                 "protocol_name": "casa_calibration_task",
                 "protocol_version": {protocol_version},
+                "surface_kind": "task",
                 "binary_version": {version!r},
             }}))
             raise SystemExit(0)
@@ -167,6 +168,7 @@ def _write_stub_binary(
             print(json.dumps({{"request_schema": {{"definitions": {{}}}}, "result_schema": {{}}, "protocol": {{
                 "protocol_name": "casa_calibration_task",
                 "protocol_version": {protocol_version},
+                "surface_kind": "task",
                 "binary_version": {version!r},
             }}}}))
             raise SystemExit(0)

--- a/crates/casars-python/python/tests/test_data.py
+++ b/crates/casars-python/python/tests/test_data.py
@@ -1,11 +1,58 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 import subprocess
 
 import numpy as np
 
-from casars.data import Image, Table
+from casars.data import Image, Table, protocol_info, schema_bundle
+
+
+def test_data_schema_bundle_reports_object_surface() -> None:
+    info = protocol_info()
+    assert info.protocol_name == "casars_data_objects"
+    assert info.protocol_version == 1
+    assert info.surface_kind == "object"
+
+    bundle = schema_bundle()
+    assert bundle["protocol"]["protocol_name"] == "casars_data_objects"
+    assert bundle["protocol"]["protocol_version"] == 1
+    assert bundle["protocol"]["surface_kind"] == "object"
+    assert bundle["projections"]["python"]["module"] == "casars.data"
+    assert "LogicalInputValue" in bundle["components"]
+    assert "LogicalOutputValue" in bundle["components"]
+    assert "LogicalComplex128" in bundle["components"]
+
+    objects = {entry["name"]: entry for entry in bundle["semantic"]["objects"]}
+    assert set(objects) == {"Image", "Table"}
+    assert {prop["name"] for prop in objects["Image"]["properties"]} == {
+        "shape",
+        "pixel_type",
+        "units",
+        "image_info",
+        "misc_info",
+        "mask_names",
+        "default_mask_name",
+    }
+    assert {method["name"] for method in objects["Image"]["methods"]} == {
+        "get_slice",
+        "put_slice",
+        "get_plane",
+        "get_mask_slice",
+    }
+    assert {method["name"] for method in objects["Table"]["methods"]} == {
+        "column_keywords",
+        "get_cell",
+        "set_cell",
+        "get_column",
+        "put_column",
+        "set_column_keywords",
+    }
+
+    image_methods = {entry["name"]: entry for entry in objects["Image"]["methods"]}
+    mask_result = image_methods["get_mask_slice"]["result_schema"]
+    assert "null" in json.dumps(mask_result)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]

--- a/crates/casars-python/src/lib.rs
+++ b/crates/casars-python/src/lib.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+mod object_contract;
+
 use std::collections::BTreeSet;
 use std::path::PathBuf;
 
@@ -17,6 +19,8 @@ use pyo3::types::{
     PyAny, PyAnyMethods, PyBool, PyComplex, PyDict, PyDictMethods, PyIterator, PyList,
     PyListMethods, PySequence, PyString,
 };
+
+use crate::object_contract::{DataObjectProtocolInfo, DataObjectSchemaBundle};
 
 #[pyclass(name = "Image", module = "casars._core", unsendable)]
 struct PyImage {
@@ -895,9 +899,24 @@ where
     Ok(array.into_pyarray(py).into_any().unbind())
 }
 
+#[pyfunction]
+fn data_protocol_info_json() -> PyResult<String> {
+    serde_json::to_string_pretty(&DataObjectProtocolInfo::current())
+        .map_err(|error| PyRuntimeError::new_err(format!("serialize data protocol info: {error}")))
+}
+
+#[pyfunction]
+fn data_schema_bundle_json() -> PyResult<String> {
+    DataObjectSchemaBundle::current()
+        .to_json_string()
+        .map_err(|error| PyRuntimeError::new_err(format!("serialize data schema bundle: {error}")))
+}
+
 #[pymodule]
 fn _core(_py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<PyImage>()?;
     module.add_class::<PyTable>()?;
+    module.add_function(wrap_pyfunction!(data_protocol_info_json, module)?)?;
+    module.add_function(wrap_pyfunction!(data_schema_bundle_json, module)?)?;
     Ok(())
 }

--- a/crates/casars-python/src/object_contract.rs
+++ b/crates/casars-python/src/object_contract.rs
@@ -1,0 +1,608 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//! Canonical object-surface schema bundle for `casars.data`.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use casa_provider_contracts::{
+    ObjectConstructorDescriptor, ObjectMethodDescriptor, ObjectPropertyDescriptor,
+    ObjectSemanticContract, ObjectTypeContract, ProviderComponentSchemas,
+    ProviderProjectionMetadata, ProviderSurfaceKind, merged_components,
+};
+use schemars::{JsonSchema, schema_for};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value as JsonValue, json};
+
+/// Stable protocol name advertised by the `casars.data` object bundle.
+pub const DATA_OBJECT_PROTOCOL_NAME: &str = "casars_data_objects";
+/// Stable protocol version advertised by the `casars.data` object bundle.
+pub const DATA_OBJECT_PROTOCOL_VERSION: u32 = 1;
+
+/// Version/compatibility information for the object-surface schema bundle.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct DataObjectProtocolInfo {
+    /// Stable protocol identifier.
+    pub protocol_name: String,
+    /// Monotonic protocol version for compatibility checks.
+    pub protocol_version: u32,
+    /// Provider surface kind defined by the shared architecture contract.
+    pub surface_kind: ProviderSurfaceKind,
+    /// Python binding version implementing the contract.
+    pub binding_version: String,
+}
+
+impl DataObjectProtocolInfo {
+    /// Build the current `casars.data` protocol descriptor.
+    pub fn current() -> Self {
+        Self {
+            protocol_name: DATA_OBJECT_PROTOCOL_NAME.to_string(),
+            protocol_version: DATA_OBJECT_PROTOCOL_VERSION,
+            surface_kind: ProviderSurfaceKind::Object,
+            binding_version: env!("CARGO_PKG_VERSION").to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum ImagePixelTypeDescriptor {
+    Float32,
+    Float64,
+    Complex64,
+    Complex128,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+struct LogicalComplex64 {
+    /// Real component.
+    real: f32,
+    /// Imaginary component.
+    imag: f32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+struct LogicalComplex128 {
+    /// Real component.
+    real: f64,
+    /// Imaginary component.
+    imag: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
+enum LogicalInputScalarValue {
+    /// Python/Rust bool.
+    Bool(bool),
+    /// Python int mapped to CASA Int64.
+    Int64(i64),
+    /// Python float mapped to CASA Double.
+    Float64(f64),
+    /// Python complex mapped to CASA DComplex.
+    Complex128(LogicalComplex128),
+    /// Python str mapped to CASA String.
+    String(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
+enum LogicalOutputScalarValue {
+    /// CASA Bool.
+    Bool(bool),
+    /// CASA uChar.
+    UInt8(u8),
+    /// CASA uShort.
+    UInt16(u16),
+    /// CASA uInt.
+    UInt32(u32),
+    /// CASA Short.
+    Int16(i16),
+    /// CASA Int.
+    Int32(i32),
+    /// CASA Int64.
+    Int64(i64),
+    /// CASA Float.
+    Float32(f32),
+    /// CASA Double.
+    Float64(f64),
+    /// CASA Complex.
+    Complex64(LogicalComplex64),
+    /// CASA DComplex.
+    Complex128(LogicalComplex128),
+    /// CASA String.
+    String(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+struct OpenObjectRequest {
+    /// Existing persistent image/table path.
+    path: PathBuf,
+    /// Whether the opened object permits writes.
+    #[serde(default)]
+    writable: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+struct ArrayRegionRequest {
+    /// Inclusive starting coordinate in CASA/Rust axis order.
+    start: Vec<usize>,
+    /// Requested region shape in CASA/Rust axis order.
+    shape: Vec<usize>,
+    /// Optional positive per-axis stride.
+    stride: Option<Vec<usize>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+struct ImagePlaneRequest {
+    /// Axis orthogonal to the returned plane.
+    axis: usize,
+    /// Plane index along `axis`.
+    index: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+struct LogicalNdArray {
+    /// Logical dtype name such as `float32`, `complex128`, or `bool`.
+    dtype: String,
+    /// Shape in CASA/Rust axis order.
+    shape: Vec<usize>,
+    /// Semantic axis-order label carried across projections.
+    axis_order: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
+enum LogicalInputValue {
+    /// Scalar CASA/Python value.
+    Scalar(LogicalInputScalarValue),
+    /// N-dimensional typed array.
+    NdArray(LogicalNdArray),
+    /// Nested record value.
+    Record(BTreeMap<String, LogicalInputValue>),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
+enum LogicalOutputValue {
+    /// Missing value represented as Python `None`.
+    Null,
+    /// Scalar CASA/Python value.
+    Scalar(LogicalOutputScalarValue),
+    /// N-dimensional typed array.
+    NdArray(LogicalNdArray),
+    /// Nested record value.
+    Record(BTreeMap<String, LogicalOutputValue>),
+    /// Table-reference path returned as a Python string.
+    TableRef(PathBuf),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
+enum LogicalColumnInputValue {
+    /// Dense column payload that projects to a NumPy array.
+    NdArray(LogicalNdArray),
+    /// Row-wise payload list for strings, records, or variable-shape arrays.
+    ValueList(Vec<LogicalInputValue>),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
+enum LogicalColumnOutputValue {
+    /// Dense column payload that projects to a NumPy array.
+    NdArray(LogicalNdArray),
+    /// Row-wise payload list for strings, records, missing values, or variable-shape arrays.
+    ValueList(Vec<LogicalOutputValue>),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+struct ImagePutSliceRequest {
+    /// Logical array payload written into the image.
+    data: LogicalNdArray,
+    /// Inclusive starting coordinate in CASA/Rust axis order.
+    start: Vec<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+struct TableColumnKeywordsRequest {
+    /// Target column name.
+    column: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+struct TableCellRequest {
+    /// Target row index.
+    row: usize,
+    /// Target column name.
+    column: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+struct TableSetCellRequest {
+    /// Target row index.
+    row: usize,
+    /// Target column name.
+    column: String,
+    /// Replacement value encoded with the logical CASA/Python input value model.
+    value: LogicalInputValue,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+struct TableColumnRequest {
+    /// Target column name.
+    column: String,
+    /// Starting row index.
+    #[serde(default)]
+    start: usize,
+    /// Number of rows to read; `null` means to the end.
+    count: Option<usize>,
+    /// Positive row stride.
+    #[serde(default = "one")]
+    step: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+struct TablePutColumnRequest {
+    /// Target column name.
+    column: String,
+    /// Replacement values encoded with the logical CASA/Python input value model.
+    values: LogicalColumnInputValue,
+    /// Starting row index.
+    #[serde(default)]
+    start: usize,
+    /// Positive row stride.
+    #[serde(default = "one")]
+    step: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+struct TableSetColumnKeywordsRequest {
+    /// Target column name.
+    column: String,
+    /// Replacement keyword record.
+    keywords: BTreeMap<String, LogicalInputValue>,
+}
+
+/// Canonical schema bundle for the `casars.data` object surface.
+#[derive(Debug, Clone, Serialize)]
+pub struct DataObjectSchemaBundle {
+    /// Compatibility descriptor for the object-surface bundle.
+    pub protocol: DataObjectProtocolInfo,
+    /// Canonical object semantic contract.
+    pub semantic: ObjectSemanticContract,
+    /// Shared component schemas reusable across objects.
+    pub components: ProviderComponentSchemas,
+    /// Presentation annotations carried with the canonical bundle.
+    pub annotations: JsonValue,
+    /// Projection metadata for direct Python consumers.
+    pub projections: ProviderProjectionMetadata,
+}
+
+impl DataObjectSchemaBundle {
+    /// Build the current object-surface schema bundle.
+    pub fn current() -> Self {
+        let open_schema = schema_for!(OpenObjectRequest);
+        let array_region_schema = schema_for!(ArrayRegionRequest);
+        let plane_request_schema = schema_for!(ImagePlaneRequest);
+        let logical_array_schema = schema_for!(LogicalNdArray);
+        let optional_logical_array_schema = schema_for!(Option<LogicalNdArray>);
+        let image_put_slice_schema = schema_for!(ImagePutSliceRequest);
+        let pixel_type_schema = schema_for!(ImagePixelTypeDescriptor);
+        let input_scalar_schema = schema_for!(LogicalInputScalarValue);
+        let output_scalar_schema = schema_for!(LogicalOutputScalarValue);
+        let input_value_schema = schema_for!(LogicalInputValue);
+        let output_value_schema = schema_for!(LogicalOutputValue);
+        let input_record_schema = schema_for!(BTreeMap<String, LogicalInputValue>);
+        let output_record_schema = schema_for!(BTreeMap<String, LogicalOutputValue>);
+        let optional_output_record_schema =
+            schema_for!(Option<BTreeMap<String, LogicalOutputValue>>);
+        let string_list_schema = schema_for!(Vec<String>);
+        let optional_string_schema = schema_for!(Option<String>);
+        let shape_schema = schema_for!(Vec<usize>);
+        let units_schema = schema_for!(String);
+        let row_count_schema = schema_for!(usize);
+        let table_cell_request_schema = schema_for!(TableCellRequest);
+        let table_set_cell_schema = schema_for!(TableSetCellRequest);
+        let table_column_request_schema = schema_for!(TableColumnRequest);
+        let table_put_column_schema = schema_for!(TablePutColumnRequest);
+        let table_column_keywords_request_schema = schema_for!(TableColumnKeywordsRequest);
+        let table_set_column_keywords_schema = schema_for!(TableSetColumnKeywordsRequest);
+        let column_input_schema = schema_for!(LogicalColumnInputValue);
+        let column_output_schema = schema_for!(LogicalColumnOutputValue);
+        let written_count_schema = schema_for!(usize);
+
+        let components = merged_components([
+            &open_schema,
+            &array_region_schema,
+            &plane_request_schema,
+            &logical_array_schema,
+            &optional_logical_array_schema,
+            &image_put_slice_schema,
+            &pixel_type_schema,
+            &input_scalar_schema,
+            &output_scalar_schema,
+            &input_value_schema,
+            &output_value_schema,
+            &input_record_schema,
+            &output_record_schema,
+            &optional_output_record_schema,
+            &string_list_schema,
+            &optional_string_schema,
+            &shape_schema,
+            &units_schema,
+            &row_count_schema,
+            &table_cell_request_schema,
+            &table_set_cell_schema,
+            &table_column_request_schema,
+            &table_put_column_schema,
+            &table_column_keywords_request_schema,
+            &table_set_column_keywords_schema,
+            &column_input_schema,
+            &column_output_schema,
+            &written_count_schema,
+        ]);
+
+        Self {
+            protocol: DataObjectProtocolInfo::current(),
+            semantic: ObjectSemanticContract {
+                objects: vec![
+                    ObjectTypeContract {
+                        name: "Image".to_string(),
+                        constructors: vec![ObjectConstructorDescriptor {
+                            name: "open".to_string(),
+                            parameters_schema: open_schema.clone(),
+                        }],
+                        properties: vec![
+                            ObjectPropertyDescriptor {
+                                name: "shape".to_string(),
+                                value_schema: shape_schema.clone(),
+                                readable: true,
+                                writable: false,
+                            },
+                            ObjectPropertyDescriptor {
+                                name: "pixel_type".to_string(),
+                                value_schema: pixel_type_schema.clone(),
+                                readable: true,
+                                writable: false,
+                            },
+                            ObjectPropertyDescriptor {
+                                name: "units".to_string(),
+                                value_schema: units_schema.clone(),
+                                readable: true,
+                                writable: false,
+                            },
+                            ObjectPropertyDescriptor {
+                                name: "image_info".to_string(),
+                                value_schema: output_record_schema.clone(),
+                                readable: true,
+                                writable: false,
+                            },
+                            ObjectPropertyDescriptor {
+                                name: "misc_info".to_string(),
+                                value_schema: output_record_schema.clone(),
+                                readable: true,
+                                writable: false,
+                            },
+                            ObjectPropertyDescriptor {
+                                name: "mask_names".to_string(),
+                                value_schema: string_list_schema.clone(),
+                                readable: true,
+                                writable: false,
+                            },
+                            ObjectPropertyDescriptor {
+                                name: "default_mask_name".to_string(),
+                                value_schema: optional_string_schema.clone(),
+                                readable: true,
+                                writable: false,
+                            },
+                        ],
+                        methods: vec![
+                            ObjectMethodDescriptor {
+                                name: "get_slice".to_string(),
+                                parameters_schema: array_region_schema.clone(),
+                                result_schema: Some(logical_array_schema.clone()),
+                                mutating: false,
+                            },
+                            ObjectMethodDescriptor {
+                                name: "put_slice".to_string(),
+                                parameters_schema: image_put_slice_schema.clone(),
+                                result_schema: None,
+                                mutating: true,
+                            },
+                            ObjectMethodDescriptor {
+                                name: "get_plane".to_string(),
+                                parameters_schema: plane_request_schema.clone(),
+                                result_schema: Some(logical_array_schema.clone()),
+                                mutating: false,
+                            },
+                            ObjectMethodDescriptor {
+                                name: "get_mask_slice".to_string(),
+                                parameters_schema: array_region_schema.clone(),
+                                result_schema: Some(optional_logical_array_schema),
+                                mutating: false,
+                            },
+                        ],
+                        lifecycle_operations: Vec::new(),
+                    },
+                    ObjectTypeContract {
+                        name: "Table".to_string(),
+                        constructors: vec![ObjectConstructorDescriptor {
+                            name: "open".to_string(),
+                            parameters_schema: open_schema,
+                        }],
+                        properties: vec![
+                            ObjectPropertyDescriptor {
+                                name: "row_count".to_string(),
+                                value_schema: row_count_schema,
+                                readable: true,
+                                writable: false,
+                            },
+                            ObjectPropertyDescriptor {
+                                name: "column_names".to_string(),
+                                value_schema: string_list_schema,
+                                readable: true,
+                                writable: false,
+                            },
+                            ObjectPropertyDescriptor {
+                                name: "keywords".to_string(),
+                                value_schema: output_record_schema.clone(),
+                                readable: true,
+                                writable: false,
+                            },
+                        ],
+                        methods: vec![
+                            ObjectMethodDescriptor {
+                                name: "column_keywords".to_string(),
+                                parameters_schema: table_column_keywords_request_schema,
+                                result_schema: Some(optional_output_record_schema),
+                                mutating: false,
+                            },
+                            ObjectMethodDescriptor {
+                                name: "get_cell".to_string(),
+                                parameters_schema: table_cell_request_schema,
+                                result_schema: Some(output_value_schema),
+                                mutating: false,
+                            },
+                            ObjectMethodDescriptor {
+                                name: "set_cell".to_string(),
+                                parameters_schema: table_set_cell_schema,
+                                result_schema: None,
+                                mutating: true,
+                            },
+                            ObjectMethodDescriptor {
+                                name: "get_column".to_string(),
+                                parameters_schema: table_column_request_schema,
+                                result_schema: Some(column_output_schema),
+                                mutating: false,
+                            },
+                            ObjectMethodDescriptor {
+                                name: "put_column".to_string(),
+                                parameters_schema: table_put_column_schema,
+                                result_schema: Some(written_count_schema),
+                                mutating: true,
+                            },
+                            ObjectMethodDescriptor {
+                                name: "set_column_keywords".to_string(),
+                                parameters_schema: table_set_column_keywords_schema,
+                                result_schema: None,
+                                mutating: true,
+                            },
+                        ],
+                        lifecycle_operations: Vec::new(),
+                    },
+                ],
+            },
+            components,
+            annotations: json!({
+                "python": {
+                    "module": "casars.data",
+                    "notes": {
+                        "logical_arrays": "LogicalNdArray values project to numpy.ndarray instances in the direct Python binding; the schema captures dtype, shape, and CASA/Rust axis-order semantics rather than a transport encoding.",
+                        "records": "Record and keyword schemas map to nested dict[str, Any] values in Python.",
+                        "logical_values": "LogicalInputValue and LogicalOutputValue capture the recursive CASA scalar/array/record value model used by the Python binding, including complex numbers and non-JSON array payloads."
+                    },
+                    "objects": {
+                        "Image": {
+                            "python_class": "casars.data.Image",
+                            "return_types": {
+                                "get_slice": "numpy.ndarray",
+                                "get_plane": "numpy.ndarray",
+                                "get_mask_slice": "numpy.ndarray | None"
+                            }
+                        },
+                        "Table": {
+                            "python_class": "casars.data.Table",
+                            "return_types": {
+                                "get_cell": "Any",
+                                "get_column": "numpy.ndarray | list[numpy.ndarray] | list[Any]",
+                                "column_keywords": "dict[str, Any] | None"
+                            }
+                        }
+                    }
+                }
+            }),
+            projections: ProviderProjectionMetadata {
+                cli: None,
+                ui_schema: None,
+                python: Some(json!({
+                    "module": "casars.data",
+                    "objects": [
+                        { "name": "Image", "class_name": "Image" },
+                        { "name": "Table", "class_name": "Table" }
+                    ]
+                })),
+            },
+        }
+    }
+
+    /// Serialize the current bundle as pretty-printed JSON.
+    pub fn to_json_string(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(self)
+    }
+}
+
+const fn one() -> usize {
+    1
+}
+
+#[cfg(test)]
+mod tests {
+    use casa_provider_contracts::ProviderSurfaceKind;
+
+    use super::{
+        DATA_OBJECT_PROTOCOL_NAME, DATA_OBJECT_PROTOCOL_VERSION, DataObjectProtocolInfo,
+        DataObjectSchemaBundle,
+    };
+
+    #[test]
+    fn bundle_uses_current_protocol_and_objects() {
+        let bundle = DataObjectSchemaBundle::current();
+        assert_eq!(bundle.protocol.protocol_name, DATA_OBJECT_PROTOCOL_NAME);
+        assert_eq!(
+            bundle.protocol.protocol_version,
+            DATA_OBJECT_PROTOCOL_VERSION
+        );
+        assert_eq!(bundle.protocol.surface_kind, ProviderSurfaceKind::Object);
+        assert_eq!(bundle.semantic.objects.len(), 2);
+        assert_eq!(bundle.semantic.objects[0].name, "Image");
+        assert_eq!(bundle.semantic.objects[1].name, "Table");
+        assert_eq!(
+            bundle
+                .projections
+                .python
+                .as_ref()
+                .and_then(|value| value["module"].as_str()),
+            Some("casars.data")
+        );
+        assert!(bundle.components.contains_key("LogicalNdArray"));
+        assert!(bundle.components.contains_key("LogicalInputValue"));
+        assert!(bundle.components.contains_key("LogicalOutputValue"));
+        assert!(bundle.components.contains_key("LogicalComplex128"));
+
+        let image = bundle
+            .semantic
+            .objects
+            .iter()
+            .find(|object| object.name == "Image")
+            .expect("image object");
+        let get_mask_slice = image
+            .methods
+            .iter()
+            .find(|method| method.name == "get_mask_slice")
+            .expect("get_mask_slice method");
+        let result_schema = serde_json::to_value(
+            get_mask_slice
+                .result_schema
+                .as_ref()
+                .expect("result schema"),
+        )
+        .expect("serialize get_mask_slice schema");
+        assert!(result_schema.to_string().contains("\"null\""));
+    }
+
+    #[test]
+    fn protocol_info_matches_public_constants() {
+        let info = DataObjectProtocolInfo::current();
+        assert_eq!(info.protocol_name, DATA_OBJECT_PROTOCOL_NAME);
+        assert_eq!(info.protocol_version, DATA_OBJECT_PROTOCOL_VERSION);
+        assert_eq!(info.surface_kind, ProviderSurfaceKind::Object);
+    }
+}

--- a/crates/casars-tablebrowser-protocol/src/lib.rs
+++ b/crates/casars-tablebrowser-protocol/src/lib.rs
@@ -8,11 +8,105 @@
 //! addresses, typed inspector payloads, and capability flags so later edit-mode
 //! extensions can target the same contract without a wire redesign.
 
+use casa_provider_contracts::{
+    ProviderCliMachineActions, ProviderCliProjection, ProviderComponentSchemas,
+    ProviderProjectionMetadata, ProviderSurfaceKind, SessionSemanticContract,
+    derived_ui_schema_annotations, merged_components,
+};
 use schemars::{JsonSchema, schema_for};
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+/// Stable protocol name advertised by `tablebrowser --protocol-info`.
+pub const TABLEBROWSER_SESSION_PROTOCOL_NAME: &str = "casa_tablebrowser_session";
 
 /// Current JSON protocol version.
 pub const PROTOCOL_VERSION: u32 = 1;
+
+/// Version/compatibility information for the tablebrowser session protocol.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct BrowserProtocolInfo {
+    /// Stable protocol identifier.
+    pub protocol_name: String,
+    /// Monotonic protocol version for compatibility checks.
+    pub protocol_version: u32,
+    /// Provider surface kind defined by the shared architecture contract.
+    pub surface_kind: ProviderSurfaceKind,
+    /// Binary version implementing the protocol.
+    pub binary_version: String,
+}
+
+impl BrowserProtocolInfo {
+    /// Build the current tablebrowser session protocol descriptor.
+    pub fn current() -> Self {
+        Self {
+            protocol_name: TABLEBROWSER_SESSION_PROTOCOL_NAME.to_string(),
+            protocol_version: PROTOCOL_VERSION,
+            surface_kind: ProviderSurfaceKind::Session,
+            binary_version: env!("CARGO_PKG_VERSION").to_string(),
+        }
+    }
+}
+
+/// Canonical JSON-schema bundle for the public tablebrowser session protocol.
+#[derive(Debug, Clone, Serialize)]
+pub struct BrowserSessionSchemaBundle {
+    /// Compatibility descriptor for the session protocol.
+    pub protocol: BrowserProtocolInfo,
+    /// Canonical semantic session contract.
+    pub semantic: SessionSemanticContract,
+    /// Shared component schemas reusable across projections.
+    pub components: ProviderComponentSchemas,
+    /// Presentation annotations carried with the canonical bundle.
+    pub annotations: JsonValue,
+    /// Derived projection metadata for UI and CLI consumers.
+    pub projections: ProviderProjectionMetadata,
+    /// JSON schema for [`BrowserRequestEnvelope`].
+    pub request_schema: schemars::schema::RootSchema,
+    /// JSON schema for [`BrowserResponseEnvelope`].
+    pub response_schema: schemars::schema::RootSchema,
+}
+
+impl BrowserSessionSchemaBundle {
+    /// Build the current tablebrowser schema bundle.
+    pub fn current(ui_schema: JsonValue) -> Self {
+        let request_schema = schema_for!(BrowserRequestEnvelope);
+        let response_schema = schema_for!(BrowserResponseEnvelope);
+        Self {
+            protocol: BrowserProtocolInfo::current(),
+            semantic: SessionSemanticContract {
+                transport: "jsonl_stdio".to_string(),
+                request_schema: request_schema.clone(),
+                response_schema: response_schema.clone(),
+            },
+            components: merged_components([&request_schema, &response_schema]),
+            annotations: derived_ui_schema_annotations(),
+            projections: ProviderProjectionMetadata {
+                cli: Some(ProviderCliProjection {
+                    machine_actions: ProviderCliMachineActions {
+                        ui_schema: Some("--ui-schema".to_string()),
+                        json_schema: Some("--json-schema".to_string()),
+                        protocol_info: Some("--protocol-info".to_string()),
+                        json_run: None,
+                        session: Some("--session".to_string()),
+                    },
+                }),
+                ui_schema: Some(ui_schema),
+                python: None,
+            },
+            request_schema,
+            response_schema,
+        }
+    }
+
+    /// Return the launcher/TUI compatibility view projected from the bundle.
+    pub fn ui_schema_projection(&self) -> Result<JsonValue, String> {
+        self.projections
+            .ui_schema
+            .clone()
+            .ok_or_else(|| "missing ui_schema projection".to_string())
+    }
+}
 
 /// Render viewport requested by the consumer.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -589,6 +683,11 @@ pub fn response_schema_json() -> Result<String, serde_json::Error> {
     serde_json::to_string_pretty(&schema_for!(BrowserResponseEnvelope))
 }
 
+/// Render the canonical schema bundle as pretty JSON.
+pub fn schema_bundle_json(ui_schema: JsonValue) -> Result<String, serde_json::Error> {
+    serde_json::to_string_pretty(&BrowserSessionSchemaBundle::current(ui_schema))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -608,6 +707,23 @@ mod tests {
             response_schema_json().expect("response schema"),
             include_str!("../schemas/response.schema.json"),
         );
+    }
+
+    #[test]
+    fn schema_bundle_uses_current_protocol_and_transport() {
+        let bundle = BrowserSessionSchemaBundle::current(serde_json::json!({
+            "schema_version": 1,
+            "command_id": "tablebrowser",
+        }));
+        assert_eq!(
+            bundle.protocol.protocol_name,
+            TABLEBROWSER_SESSION_PROTOCOL_NAME
+        );
+        assert_eq!(bundle.protocol.protocol_version, PROTOCOL_VERSION);
+        assert_eq!(bundle.protocol.surface_kind, ProviderSurfaceKind::Session);
+        assert_eq!(bundle.semantic.transport, "jsonl_stdio");
+        assert!(bundle.components.contains_key("BrowserCommand"));
+        assert!(bundle.components.contains_key("BrowserResponse"));
     }
 
     #[test]

--- a/crates/casars/src/registry.rs
+++ b/crates/casars/src/registry.rs
@@ -6,11 +6,12 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::time::SystemTime;
 
-use casa_calibration::command_schema as calibrate_command_schema;
+use casa_calibration::CalibrationTaskSchemaBundle;
 use casa_images::imexplore_ui_schema_json;
-use casa_ms::msexplore::cli::command_schema as msexplore_command_schema;
+use casa_ms::MsExploreTaskSchemaBundle;
 use casa_ms::ui_schema::UiCommandSchema;
-use casars_imager::command_schema as imager_command_schema;
+use casars_imagebrowser_protocol::ImageBrowserSessionSchemaBundle;
+use casars_imager::ImagerTaskSchemaBundle;
 
 #[derive(Debug, Clone)]
 pub(crate) struct RegistryApp {
@@ -75,22 +76,28 @@ impl ResolvedCommand {
 impl RegistryApp {
     pub(crate) fn load_schema(&self) -> Result<UiCommandSchema, String> {
         if !self.has_explicit_binary_override() && self.id == "msexplore" {
-            return Ok(msexplore_command_schema("msexplore"));
+            return MsExploreTaskSchemaBundle::current().ui_schema_projection();
         }
         if !self.has_explicit_binary_override() && self.id == "calibrate" {
-            return Ok(calibrate_command_schema("calibrate"));
+            return CalibrationTaskSchemaBundle::current().ui_schema_projection();
         }
         if !self.has_explicit_binary_override() && self.id == "imager" {
-            return Ok(imager_command_schema("casars-imager"));
+            return ImagerTaskSchemaBundle::current().ui_schema_projection();
         }
         if !self.has_explicit_binary_override() && self.id == "imexplore" {
-            let json = imexplore_ui_schema_json("imexplore")?;
-            return serde_json::from_str(&json)
-                .map_err(|error| format!("parse embedded imexplore schema: {error}"));
+            let ui_schema = serde_json::from_str(&imexplore_ui_schema_json("imexplore")?)
+                .map_err(|error| format!("parse embedded imexplore schema: {error}"))?;
+            let projected =
+                ImageBrowserSessionSchemaBundle::current(ui_schema).ui_schema_projection()?;
+            return serde_json::from_value(projected)
+                .map_err(|error| format!("parse embedded imexplore schema projection: {error}"));
         }
         match &self.kind {
             RegistryAppKind::Subprocess { binary_name, .. } => {
                 let resolved = self.resolve_command()?;
+                if let Some(schema) = load_canonical_ui_schema(&resolved, binary_name)? {
+                    return Ok(schema);
+                }
                 let output = resolved
                     .command()
                     .arg("--ui-schema")
@@ -225,6 +232,28 @@ impl RegistryApp {
             (_, _) => "Ready. Press r to run the selected command.",
         }
     }
+}
+
+fn load_canonical_ui_schema(
+    resolved: &ResolvedCommand,
+    binary_name: &str,
+) -> Result<Option<UiCommandSchema>, String> {
+    let output = resolved
+        .command()
+        .arg("--json-schema")
+        .output()
+        .map_err(|error| format!("spawn {binary_name} --json-schema: {error}"))?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    let bundle = serde_json::from_slice::<serde_json::Value>(&output.stdout)
+        .map_err(|error| format!("parse {binary_name} --json-schema output: {error}"))?;
+    let Some(ui_schema) = bundle.pointer("/projections/ui_schema").cloned() else {
+        return Ok(None);
+    };
+    serde_json::from_value(ui_schema)
+        .map(Some)
+        .map_err(|error| format!("parse {binary_name} projected ui schema: {error}"))
 }
 
 pub(crate) fn resolve_app(id: Option<&str>) -> Result<RegistryApp, String> {
@@ -627,7 +656,7 @@ mod tests {
         let error = imexplore_app()
             .load_schema()
             .expect_err("missing override binary should fail");
-        assert!(error.contains("spawn imexplore --ui-schema"));
+        assert!(error.contains("spawn imexplore --json-schema"));
 
         unsafe {
             env::remove_var("CASARS_IMEXPLORE_BIN");
@@ -653,7 +682,7 @@ mod tests {
         let error = imexplore_app()
             .load_schema()
             .expect_err("echo output should not parse as JSON");
-        assert!(error.contains("parse imexplore --ui-schema output"));
+        assert!(error.contains("parse imexplore --json-schema output"));
 
         unsafe {
             env::remove_var("CASARS_IMEXPLORE_BIN");

--- a/crates/casars/src/tests.rs
+++ b/crates/casars/src/tests.rs
@@ -9831,9 +9831,10 @@ fn write_fake_msexplore_script(root: &Path, body: &str) -> PathBuf {
     let schema_json = msexplore_command_schema("msexplore")
         .render_json_pretty()
         .expect("serialize schema");
+    let bundle_json = fake_canonical_bundle_json(&schema_json, "casa_msexplore_task", "task");
     let path = root.join("fake-msexplore.sh");
     let script = format!(
-        "#!/bin/sh\nif [ \"$1\" = \"--ui-schema\" ]; then\ncat <<'EOF'\n{schema_json}\nEOF\nexit 0\nfi\n{body}"
+        "#!/bin/sh\nif [ \"$1\" = \"--json-schema\" ]; then\ncat <<'EOF'\n{bundle_json}\nEOF\nexit 0\nfi\nif [ \"$1\" = \"--ui-schema\" ]; then\ncat <<'EOF'\n{schema_json}\nEOF\nexit 0\nfi\n{body}"
     );
     fs::write(&path, script).expect("write fake script");
     let mut permissions = fs::metadata(&path).expect("metadata").permissions();
@@ -9852,6 +9853,8 @@ fn write_fake_tablebrowser_script(
     use std::os::unix::fs::PermissionsExt;
 
     let schema_json = fake_tablebrowser_schema_json();
+    let bundle_json =
+        fake_canonical_bundle_json(&schema_json, "casa_tablebrowser_session", "session");
     let mut session_body = String::new();
     if let Some(raw_response) = raw_response {
         session_body.push_str("IFS= read -r line || exit 0\n");
@@ -9878,7 +9881,7 @@ fn write_fake_tablebrowser_script(
 
     let path = root.join("fake-tablebrowser.sh");
     let script = format!(
-        "#!/bin/sh\nif [ \"$1\" = \"--ui-schema\" ]; then\ncat <<'EOF'\n{schema_json}\nEOF\nexit 0\nfi\nif [ \"$1\" = \"--session\" ]; then\n{session_body}exit 0\nfi\necho \"unexpected args: $@\" >&2\nexit 1\n"
+        "#!/bin/sh\nif [ \"$1\" = \"--json-schema\" ]; then\ncat <<'EOF'\n{bundle_json}\nEOF\nexit 0\nfi\nif [ \"$1\" = \"--ui-schema\" ]; then\ncat <<'EOF'\n{schema_json}\nEOF\nexit 0\nfi\nif [ \"$1\" = \"--session\" ]; then\n{session_body}exit 0\nfi\necho \"unexpected args: $@\" >&2\nexit 1\n"
     );
     fs::write(&path, script).expect("write fake tablebrowser script");
     let mut permissions = fs::metadata(&path).expect("metadata").permissions();
@@ -9929,6 +9932,8 @@ fn write_fake_imexplore_script(
     use std::os::unix::fs::PermissionsExt;
 
     let schema_json = fake_imexplore_schema_json();
+    let bundle_json =
+        fake_canonical_bundle_json(&schema_json, "casa_imagebrowser_session", "session");
     let mut session_body = String::new();
     if let Some(raw_response) = raw_response {
         session_body.push_str("IFS= read -r line || exit 0\n");
@@ -9955,13 +9960,41 @@ fn write_fake_imexplore_script(
 
     let path = root.join("fake-imexplore.sh");
     let script = format!(
-        "#!/bin/sh\nif [ \"$1\" = \"--ui-schema\" ]; then\ncat <<'EOF'\n{schema_json}\nEOF\nexit 0\nfi\nif [ \"$1\" = \"--session\" ]; then\n{session_body}exit 0\nfi\necho \"unexpected args: $@\" >&2\nexit 1\n"
+        "#!/bin/sh\nif [ \"$1\" = \"--json-schema\" ]; then\ncat <<'EOF'\n{bundle_json}\nEOF\nexit 0\nfi\nif [ \"$1\" = \"--ui-schema\" ]; then\ncat <<'EOF'\n{schema_json}\nEOF\nexit 0\nfi\nif [ \"$1\" = \"--session\" ]; then\n{session_body}exit 0\nfi\necho \"unexpected args: $@\" >&2\nexit 1\n"
     );
     fs::write(&path, script).expect("write fake imexplore script");
     let mut permissions = fs::metadata(&path).expect("metadata").permissions();
     permissions.set_mode(0o755);
     fs::set_permissions(&path, permissions).expect("chmod script");
     path
+}
+
+fn fake_canonical_bundle_json(
+    schema_json: &str,
+    protocol_name: &str,
+    surface_kind: &str,
+) -> String {
+    let ui_schema =
+        serde_json::from_str::<serde_json::Value>(schema_json).expect("parse fake ui schema");
+    serde_json::to_string_pretty(&serde_json::json!({
+        "protocol": {
+            "protocol_name": protocol_name,
+            "protocol_version": 1,
+            "surface_kind": surface_kind,
+            "binary_version": "test"
+        },
+        "semantic": {},
+        "components": {},
+        "annotations": {
+            "ui_schema": {
+                "status": "derived_compatibility_view"
+            }
+        },
+        "projections": {
+            "ui_schema": ui_schema
+        }
+    }))
+    .expect("serialize fake canonical bundle")
 }
 
 fn fake_imexplore_schema_json() -> String {

--- a/docs/provider-contracts.md
+++ b/docs/provider-contracts.md
@@ -250,18 +250,11 @@ This is the intended classification for current and near-term surfaces.
 
 - `calibrate`: task surface
 - `casars-imager`: task surface
+- `msexplore`: task surface
 - `tablebrowser`: session surface
 - `imexplore`: session surface
 - `casars.data.Image`: object surface
 - `casars.data.Table`: object surface
-
-`msexplore` needs an explicit decision. It should be treated as either:
-
-- a task surface with one-shot plot/export operations, or
-- a session surface if the backend owns durable interactive exploration state
-
-It should not remain indefinitely as only a launcher-oriented `--ui-schema`
-producer without a clearly identified canonical provider contract.
 
 ## Implementation Guidance
 

--- a/docs/python/data.md
+++ b/docs/python/data.md
@@ -2,6 +2,12 @@
 
 `casars.data` exposes persistent file-backed objects only.
 
+The module also publishes its canonical object-surface contract directly from
+Rust:
+
+- `protocol_info()` returns the stable object protocol descriptor
+- `schema_bundle()` returns the canonical schema bundle for `Image` and `Table`
+
 ## Images
 
 Use `Image.open(path, writable=False)` to open an existing CASA-compatible image. The v1 surface is intentionally narrow:

--- a/docs/python/versioning.md
+++ b/docs/python/versioning.md
@@ -17,6 +17,7 @@ The current protocol contract is:
 
 - protocol name: `casa_calibration_task`
 - protocol version: `1`
+- surface kind: `task`
 
 If the binary reports a different protocol name or version, the Python wrapper raises immediately instead of attempting a best-effort invocation. This is the guard against version skew between the Python package and the task binary.
 
@@ -37,6 +38,13 @@ The `casars.data` surface has its own narrower stability boundary in v1:
 - stable in v1: reading existing persistent images and tables
 - stable in v1: writing pixel slices into existing persistent images with `Image.put_slice`
 - deferred from v1: image creation, coordinate-system authoring, and broader image metadata editing
+
+The direct object-surface contract published by `casars.data.protocol_info()`
+and `casars.data.schema_bundle()` is currently:
+
+- protocol name: `casars_data_objects`
+- protocol version: `1`
+- surface kind: `object`
 
 That boundary is intentional. The v1 compatibility promise covers file-backed data access and pixel updates, not the full CASA image-authoring surface.
 

--- a/docs/tablebrowser-protocol.md
+++ b/docs/tablebrowser-protocol.md
@@ -15,11 +15,19 @@ without redesigning the wire format.
 - Encoding: UTF-8 JSON
 - Framing: one object per line
 - Versioning: top-level `version` field in both directions
+- Protocol descriptor: `tablebrowser --protocol-info`
+- Canonical schema bundle: `tablebrowser --json-schema`
 
 The committed JSON Schemas live in:
 
 - `crates/casars-tablebrowser-protocol/schemas/request.schema.json`
 - `crates/casars-tablebrowser-protocol/schemas/response.schema.json`
+
+The canonical schema bundle now wraps those envelope schemas with:
+
+- protocol metadata including `surface_kind: "session"`
+- a `semantic.transport` value of `jsonl_stdio`
+- derived projection metadata for the legacy `--ui-schema` launcher view
 
 ## Request Envelope
 


### PR DESCRIPTION
## Summary
- add shared canonical provider-contract bundle types for task, session, and object surfaces
- migrate `msexplore`, `tablebrowser`, `imexplore`, `calibrate`, `imager`, and `casars.data` to canonical JSON schema bundles with compatibility projections
- update `casars` launcher loading, Python data/task wrappers, docs, and contract-focused tests to consume the canonical interfaces

## Testing
- cargo fmt --all
- cargo test -q -p casa-provider-contracts -p casars-imagebrowser-protocol -p casars-tablebrowser-protocol -p casars-python --lib
- cargo test -q -p casa-ms --test msexplore_cli
- cargo test -q -p casars registry
- ./.venv/bin/python -m pip install -e crates/casars-python
- ./.venv/bin/python -m pytest crates/casars-python/python/tests/test_data.py -q

## Notes
- Full workspace gates (`clippy --workspace --all-targets -D warnings`, `cargo test --workspace`, slow tests, coverage) were not run locally.
