### PR TITLE
Fix long-gate coverage regressions

### DIFF
--- a/crates/casa-ms/src/msexplore.rs
+++ b/crates/casa-ms/src/msexplore.rs
@@ -7164,6 +7164,61 @@ impl ListObsPlotRenderStyle {
 mod tests {
     use super::*;
     use plotters::style::Color;
+    use tempfile::tempdir;
+
+    fn scatter_point_ref(row: usize) -> MsScatterPointRef {
+        MsScatterPointRef {
+            row,
+            corr: 0,
+            chan_start: 0,
+            chan_end: 1,
+        }
+    }
+
+    fn scatter_series(
+        label: &str,
+        color_group: &str,
+        y_axis: MsAxis,
+        points: &[(f64, f64)],
+        row_base: usize,
+    ) -> MsScatterSeries {
+        MsScatterSeries {
+            label: label.to_string(),
+            color_group: color_group.to_string(),
+            y_axis,
+            points: points.to_vec(),
+            provenance: (0..points.len())
+                .map(|offset| scatter_point_ref(row_base + offset))
+                .collect(),
+        }
+    }
+
+    fn scatter_plot_payload(
+        title: &str,
+        secondary_y_axis: Option<MsAxis>,
+        legend_position: MsLegendPosition,
+        series: Vec<MsScatterSeries>,
+    ) -> MsScatterPlotPayload {
+        MsScatterPlotPayload {
+            title: title.to_string(),
+            x_axis: MsAxis::Time,
+            y_axis: MsAxis::Amplitude,
+            secondary_y_axis,
+            x_label: "Time".to_string(),
+            y_label: "Amplitude".to_string(),
+            secondary_y_label: secondary_y_axis.map(|axis| axis.display_name().to_string()),
+            fixed_x_bounds: None,
+            fixed_y_bounds: None,
+            secondary_fixed_y_bounds: None,
+            showlegend: true,
+            legend_position,
+            showmajorgrid: true,
+            showminorgrid: true,
+            series,
+            header_lines: vec!["Synthetic header".to_string()],
+            summary: "Synthetic scatter payload".to_string(),
+        }
+    }
 
     #[test]
     fn preset_enum_surfaces_round_trip_and_cover_aliases() {
@@ -8129,5 +8184,282 @@ mod tests {
             "unexpectedly wide zero-span padding: {}",
             max - min
         );
+    }
+
+    #[test]
+    fn scatter_rendering_covers_dual_axis_and_grid_legend_paths() {
+        let dual_axis = scatter_plot_payload(
+            "Dual Axis Scatter",
+            Some(MsAxis::Phase),
+            MsLegendPosition::ExteriorRight,
+            vec![
+                scatter_series(
+                    "Amplitude A",
+                    "amp-a",
+                    MsAxis::Amplitude,
+                    &[(4_304_481_700.0, 1.0), (4_304_481_760.0, 2.5)],
+                    0,
+                ),
+                scatter_series(
+                    "Amplitude B",
+                    "amp-b",
+                    MsAxis::Amplitude,
+                    &[(4_304_481_700.0, 0.5), (4_304_481_760.0, 1.8)],
+                    10,
+                ),
+                scatter_series(
+                    "Phase",
+                    "phase",
+                    MsAxis::Phase,
+                    &[(4_304_481_700.0, -30.0), (4_304_481_760.0, 45.0)],
+                    20,
+                ),
+            ],
+        );
+        let image = render_scatter_image(&dual_axis, ListObsPlotTheme::light(), 960, 640)
+            .expect("render dual-axis scatter image");
+        assert_eq!(image.width(), 960);
+        assert_eq!(image.height(), 640);
+
+        let grid = MsScatterGridPayload {
+            title: "Grid Scatter".to_string(),
+            x_axis: MsAxis::Channel,
+            y_axis: MsAxis::Amplitude,
+            x_label: "Channel".to_string(),
+            y_label: "Amplitude".to_string(),
+            fixed_x_bounds: None,
+            fixed_y_bounds: None,
+            showlegend: true,
+            legend_position: MsLegendPosition::ExteriorBottom,
+            showmajorgrid: true,
+            showminorgrid: false,
+            iteraxis: MsIterationAxis::Field,
+            gridrows: 1,
+            gridcols: 2,
+            share_x_bounds: true,
+            share_y_bounds: true,
+            panels: vec![
+                MsScatterPanelPayload {
+                    key: "field=0".to_string(),
+                    label: "Field 0".to_string(),
+                    series: vec![
+                        scatter_series(
+                            "Field 0 RR",
+                            "rr",
+                            MsAxis::Amplitude,
+                            &[(0.0, 1.0), (1.0, 1.5), (2.0, 2.0)],
+                            30,
+                        ),
+                        scatter_series(
+                            "Field 0 LL",
+                            "ll",
+                            MsAxis::Amplitude,
+                            &[(0.0, 0.8), (1.0, 1.1), (2.0, 1.4)],
+                            40,
+                        ),
+                    ],
+                    summary: "Field 0".to_string(),
+                },
+                MsScatterPanelPayload {
+                    key: "field=1".to_string(),
+                    label: "Field 1".to_string(),
+                    series: vec![
+                        scatter_series(
+                            "Field 1 RR",
+                            "rr",
+                            MsAxis::Amplitude,
+                            &[(0.0, 2.5), (1.0, 2.0), (2.0, 1.7)],
+                            50,
+                        ),
+                        scatter_series(
+                            "Field 1 LL",
+                            "ll",
+                            MsAxis::Amplitude,
+                            &[(0.0, 2.2), (1.0, 1.8), (2.0, 1.3)],
+                            60,
+                        ),
+                    ],
+                    summary: "Field 1".to_string(),
+                },
+            ],
+            header_lines: vec!["Grid header".to_string()],
+            summary: "Grid summary".to_string(),
+        };
+        let image = render_scatter_grid_image(&grid, ListObsPlotTheme::dark(), 1280, 720)
+            .expect("render scatter grid image");
+        assert_eq!(image.width(), 1280);
+        assert_eq!(image.height(), 720);
+    }
+
+    #[test]
+    fn scatter_page_rendering_overplots_matching_cells_and_exports() {
+        let shared_series = vec![scatter_series(
+            "Amplitude",
+            "amp",
+            MsAxis::Amplitude,
+            &[(0.0, 1.0), (1.0, 1.5), (2.0, 1.75)],
+            70,
+        )];
+        let phase_series = vec![scatter_series(
+            "Phase",
+            "phase",
+            MsAxis::Phase,
+            &[(0.0, -15.0), (1.0, 5.0), (2.0, 30.0)],
+            80,
+        )];
+        let page = MsScatterPagePayload {
+            title: "Composite Page".to_string(),
+            exprange: MsPageExportRange::All,
+            gridrows: 1,
+            gridcols: 2,
+            header_lines: vec!["Composite header".to_string()],
+            items: vec![
+                MsScatterPageItemPayload {
+                    plotindex: 0,
+                    rowindex: 0,
+                    colindex: 0,
+                    plot: scatter_plot_payload(
+                        "Amplitude",
+                        None,
+                        MsLegendPosition::ExteriorTop,
+                        shared_series.clone(),
+                    ),
+                },
+                MsScatterPageItemPayload {
+                    plotindex: 1,
+                    rowindex: 0,
+                    colindex: 0,
+                    plot: scatter_plot_payload(
+                        "Phase",
+                        None,
+                        MsLegendPosition::ExteriorTop,
+                        phase_series.clone(),
+                    ),
+                },
+                MsScatterPageItemPayload {
+                    plotindex: 2,
+                    rowindex: 0,
+                    colindex: 1,
+                    plot: scatter_plot_payload(
+                        "Amplitude Detail",
+                        None,
+                        MsLegendPosition::UpperRight,
+                        vec![scatter_series(
+                            "Amplitude Detail",
+                            "detail",
+                            MsAxis::Amplitude,
+                            &[(0.0, 0.4), (1.0, 0.6), (2.0, 1.2)],
+                            90,
+                        )],
+                    ),
+                },
+            ],
+            summary: "Composite summary".to_string(),
+        };
+
+        let resolved = resolve_scatter_page_cells(&page).expect("resolve scatter page cells");
+        assert_eq!(resolved.len(), 2);
+        assert_eq!(resolved[0].title, "Amplitude, Phase");
+        assert_eq!(resolved[0].series.len(), 2);
+
+        let image = render_scatter_page_image(&page, ListObsPlotTheme::light(), 1440, 720)
+            .expect("render scatter page image");
+        assert_eq!(image.width(), 1440);
+        assert_eq!(image.height(), 720);
+
+        let output_dir = tempdir().expect("tempdir");
+        let txt_path = output_dir.path().join("page.txt");
+        let png_path = output_dir.path().join("page.png");
+        let pdf_path = output_dir.path().join("page.pdf");
+        let payload = MsPlotPayload::ScatterPage(page.clone());
+        export_msexplore_plot(
+            &payload,
+            ListObsPlotTheme::light(),
+            &txt_path,
+            MsExportFormat::Txt,
+            1440,
+            720,
+        )
+        .expect("export scatter manifest");
+        export_msexplore_plot(
+            &payload,
+            ListObsPlotTheme::light(),
+            &png_path,
+            MsExportFormat::Png,
+            1440,
+            720,
+        )
+        .expect("export scatter png");
+        export_msexplore_plot(
+            &payload,
+            ListObsPlotTheme::light(),
+            &pdf_path,
+            MsExportFormat::Pdf,
+            1440,
+            720,
+        )
+        .expect("export scatter pdf");
+
+        let manifest = std::fs::read_to_string(&txt_path).expect("read manifest");
+        assert!(manifest.contains("# msexplore-manifest-v1"));
+        assert!(manifest.contains("Composite Page"));
+        assert!(png_path.exists());
+        assert!(pdf_path.exists());
+        assert!(std::fs::metadata(&pdf_path).expect("pdf metadata").len() > 0);
+    }
+
+    #[test]
+    fn scatter_page_rejects_mismatched_overplot_axes() {
+        let page = MsScatterPagePayload {
+            title: "Bad Page".to_string(),
+            exprange: MsPageExportRange::Current,
+            gridrows: 1,
+            gridcols: 1,
+            header_lines: Vec::new(),
+            items: vec![
+                MsScatterPageItemPayload {
+                    plotindex: 0,
+                    rowindex: 0,
+                    colindex: 0,
+                    plot: scatter_plot_payload(
+                        "Amplitude",
+                        None,
+                        MsLegendPosition::ExteriorRight,
+                        vec![scatter_series(
+                            "Amplitude",
+                            "amp",
+                            MsAxis::Amplitude,
+                            &[(0.0, 1.0), (1.0, 1.5)],
+                            100,
+                        )],
+                    ),
+                },
+                MsScatterPageItemPayload {
+                    plotindex: 1,
+                    rowindex: 0,
+                    colindex: 0,
+                    plot: MsScatterPlotPayload {
+                        x_axis: MsAxis::Channel,
+                        x_label: "Channel".to_string(),
+                        ..scatter_plot_payload(
+                            "Weight",
+                            None,
+                            MsLegendPosition::ExteriorRight,
+                            vec![scatter_series(
+                                "Weight",
+                                "weight",
+                                MsAxis::Weight,
+                                &[(0.0, 2.0), (1.0, 3.0)],
+                                110,
+                            )],
+                        )
+                    },
+                },
+            ],
+            summary: "Bad summary".to_string(),
+        };
+
+        let error = resolve_scatter_page_cells(&page).expect_err("mismatched page should fail");
+        assert!(error.contains("mixes incompatible axes"));
     }
 }

--- a/crates/casars-imager/src/lib.rs
+++ b/crates/casars-imager/src/lib.rs
@@ -2318,8 +2318,11 @@ impl PointingDirectionResolver {
             };
         };
         let lower = entries.partition_point(|entry| entry.time_mjd_seconds < time_mjd_seconds);
-        for candidate_index in [lower.checked_sub(1), Some(lower)].into_iter().flatten() {
-            let entry = entries[candidate_index];
+        for entry in [lower.checked_sub(1), Some(lower)]
+            .into_iter()
+            .flatten()
+            .filter_map(|candidate_index| entries.get(candidate_index).copied())
+        {
             if time_mjd_seconds >= entry.time_mjd_seconds - entry.interval_seconds
                 && time_mjd_seconds <= entry.time_mjd_seconds + entry.interval_seconds
             {
@@ -7852,6 +7855,136 @@ mod tests {
     }
 
     #[test]
+    fn prepare_geometry_trace_uses_pointing_rows_when_time_window_matches() {
+        let tmp = tempdir().unwrap();
+        let ms_path = tmp.path().join("geometry_pointing.ms");
+        let mut ms = MeasurementSet::create(
+            &ms_path,
+            MeasurementSetBuilder::new().with_main_column(OptionalMainColumn::Data),
+        )
+        .unwrap();
+        add_vla_antenna_pair(&mut ms);
+        add_field_row(&mut ms);
+        add_spectral_window_row(&mut ms, &[1.4e9]);
+        add_polarization_row(&mut ms);
+        add_data_description_row(&mut ms);
+        add_main_row_with_field_and_antennas_channels(
+            &mut ms,
+            0,
+            0,
+            1,
+            [30.0, -15.0, 5.0],
+            &[Complex32::new(1.0, 0.5), Complex32::new(0.0, 0.0)],
+        );
+        add_pointing_row(&mut ms, 0, [1.2, 0.4], TEST_TIME_MJD_SEC, 5.0);
+        add_pointing_row(&mut ms, 1, [1.3, 0.45], TEST_TIME_MJD_SEC, 5.0);
+        ms.save().unwrap();
+
+        let config = CliConfig {
+            ms: ms_path,
+            imagename: PathBuf::from("unused"),
+            imsize: 32,
+            cell_arcsec: 20.0,
+            field_ids: Some(vec![0]),
+            phasecenter_field: Some(0),
+            phasecenter: None,
+            ddid: None,
+            spw: None,
+            spw_selector: None,
+            channel_start: None,
+            channel_count: None,
+            datacolumn: None,
+            correlation: Some("XX".to_string()),
+            spectral_mode: SpectralMode::Mfs,
+            cube_axis: CubeAxisConfig::default(),
+            weighting: WeightingMode::Natural,
+            per_channel_weight_density: false,
+            uv_taper: None,
+            restoring_beam_mode: RestoringBeamMode::PerPlane,
+            deconvolver: Deconvolver::Hogbom,
+            nterms: 1,
+            multiscale_scales: Vec::new(),
+            small_scale_bias: 0.0,
+            niter: 0,
+            gain: 0.1,
+            threshold_jy: 0.0,
+            nsigma: 0.0,
+            psf_cutoff: 0.35,
+            minor_cycle_length: 2,
+            cyclefactor: 1.0,
+            min_psf_fraction: 0.1,
+            max_psf_fraction: 0.8,
+            mask_boxes: Vec::new(),
+            mask_image: None,
+            w_term_mode: WTermMode::None,
+            w_project_planes: None,
+            dirty_only: true,
+            write_preview_pngs: false,
+        };
+
+        let trace = build_prepare_geometry_trace_from_config(&config).unwrap();
+
+        assert_eq!(trace.rows.len(), 1);
+        assert_eq!(trace.rows[0].antenna1_pointing_row, Some(0));
+        assert_eq!(trace.rows[0].antenna2_pointing_row, Some(1));
+        assert!(!trace.rows[0].antenna1_pointing_used_fallback);
+        assert!(!trace.rows[0].antenna2_pointing_used_fallback);
+        assert_eq!(trace.rows[0].antenna1_pointing_direction_rad, [1.2, 0.4]);
+        assert_eq!(trace.rows[0].antenna2_pointing_direction_rad, [1.3, 0.45]);
+    }
+
+    #[test]
+    fn pointing_direction_resolver_prefers_row_ids_and_falls_back_when_needed() {
+        let first = PointingDirectionRow {
+            row_index: 0,
+            antenna_id: 0,
+            time_mjd_seconds: TEST_TIME_MJD_SEC,
+            interval_seconds: 5.0,
+            angles_rad: [1.2, 0.4],
+        };
+        let second = PointingDirectionRow {
+            row_index: 1,
+            antenna_id: 0,
+            time_mjd_seconds: TEST_TIME_MJD_SEC + 30.0,
+            interval_seconds: 5.0,
+            angles_rad: [1.25, 0.45],
+        };
+        let other_antenna = PointingDirectionRow {
+            row_index: 2,
+            antenna_id: 1,
+            time_mjd_seconds: TEST_TIME_MJD_SEC,
+            interval_seconds: 5.0,
+            angles_rad: [1.3, 0.5],
+        };
+        let resolver = PointingDirectionResolver {
+            by_antenna: BTreeMap::from([(0, vec![first, second]), (1, vec![other_antenna])]),
+            by_row_index: HashMap::from([(0, first), (1, second), (2, other_antenna)]),
+        };
+
+        let fallback_angles = [0.9, 0.1];
+        let explicit = resolver.resolve(Some(0), 0, TEST_TIME_MJD_SEC + 100.0, fallback_angles);
+        assert_eq!(explicit.source_row_index, Some(0));
+        assert!(!explicit.used_fallback);
+        assert_eq!(explicit.angles_rad, [1.2, 0.4]);
+
+        let nearest = resolver.resolve(None, 0, TEST_TIME_MJD_SEC + 31.0, fallback_angles);
+        assert_eq!(nearest.source_row_index, Some(1));
+        assert!(!nearest.used_fallback);
+        assert_eq!(nearest.angles_rad, [1.25, 0.45]);
+
+        let no_matching_window =
+            resolver.resolve(Some(2), 0, TEST_TIME_MJD_SEC + 500.0, fallback_angles);
+        assert_eq!(no_matching_window.source_row_index, None);
+        assert!(no_matching_window.used_fallback);
+        assert_eq!(no_matching_window.angles_rad, fallback_angles);
+
+        let missing_antenna = resolver.resolve(None, 9, TEST_TIME_MJD_SEC, fallback_angles);
+        assert_eq!(missing_antenna.source_row_index, None);
+        assert!(missing_antenna.used_fallback);
+        assert_eq!(missing_antenna.angles_rad, fallback_angles);
+    }
+
+    #[test]
     fn prepare_plane_trace_records_weight_spectrum_for_stokes_i_collapse() {
         let tmp = tempdir().unwrap();
         let ms_path = tmp.path().join("trace_weight_spectrum.ms");
@@ -8399,6 +8532,209 @@ mod tests {
             2
         );
         assert!((trace.samples[1].source_contributions[0].factor - 1.0).abs() < 1.0e-6);
+    }
+
+    fn synthetic_cube_trace_config(ms_path: PathBuf) -> CliConfig {
+        CliConfig {
+            ms: ms_path,
+            imagename: PathBuf::from("unused"),
+            imsize: 32,
+            cell_arcsec: 20.0,
+            field_ids: Some(vec![0]),
+            phasecenter_field: Some(0),
+            phasecenter: None,
+            ddid: None,
+            spw: Some(0),
+            spw_selector: Some("0".to_string()),
+            channel_start: None,
+            channel_count: Some(1),
+            datacolumn: None,
+            correlation: Some("XX".to_string()),
+            spectral_mode: SpectralMode::Cube,
+            cube_axis: CubeAxisConfig {
+                specmode: CubeSpecMode::Cube,
+                outframe: FrequencyRef::TOPO,
+                veltype: DopplerRef::RADIO,
+                interpolation: CubeInterpolation::Linear,
+                rest_frequency_hz: Some(1.25e9),
+                start: Some(CubeAxisValue::FrequencyHz {
+                    hz: 1.1e9,
+                    frame: None,
+                }),
+                width: Some(CubeAxisValue::FrequencyHz {
+                    hz: 1.0e8,
+                    frame: None,
+                }),
+            },
+            weighting: WeightingMode::Natural,
+            per_channel_weight_density: false,
+            uv_taper: None,
+            restoring_beam_mode: RestoringBeamMode::PerPlane,
+            deconvolver: Deconvolver::Hogbom,
+            nterms: 1,
+            multiscale_scales: Vec::new(),
+            small_scale_bias: 0.0,
+            niter: 0,
+            gain: 0.1,
+            threshold_jy: 0.0,
+            nsigma: 0.0,
+            psf_cutoff: 0.35,
+            minor_cycle_length: 2,
+            cyclefactor: 1.0,
+            min_psf_fraction: 0.1,
+            max_psf_fraction: 0.8,
+            mask_boxes: Vec::new(),
+            mask_image: None,
+            w_term_mode: WTermMode::None,
+            w_project_planes: None,
+            dirty_only: true,
+            write_preview_pngs: false,
+        }
+    }
+
+    fn write_synthetic_cube_trace_ms(ms_path: &Path) {
+        let mut ms = MeasurementSet::create(
+            ms_path,
+            MeasurementSetBuilder::new()
+                .with_main_column(OptionalMainColumn::Data)
+                .with_main_column(OptionalMainColumn::WeightSpectrum),
+        )
+        .unwrap();
+        add_vla_antenna_pair(&mut ms);
+        add_field_row(&mut ms);
+        add_spectral_window_row(&mut ms, &[1.0e9, 1.2e9]);
+        add_polarization_row(&mut ms);
+        add_data_description_row(&mut ms);
+        add_main_row_with_field_and_antennas_channels_and_weight_spectrum(
+            &mut ms,
+            0,
+            0,
+            1,
+            [30.0, -15.0, 0.0],
+            &[
+                Complex32::new(1.0, 0.0),
+                Complex32::new(3.0, 0.0),
+                Complex32::new(0.0, 0.0),
+                Complex32::new(0.0, 0.0),
+            ],
+            &[2.0, 4.0, 1.0, 1.0],
+        );
+        ms.save().unwrap();
+    }
+
+    #[test]
+    fn cube_channel_w_project_trace_wrapper_emits_cube_channel_metadata() {
+        let tmp = tempdir().unwrap();
+        let ms_path = tmp.path().join("trace_cube_wproject.ms");
+        write_synthetic_cube_trace_ms(&ms_path);
+
+        let mut config = synthetic_cube_trace_config(ms_path);
+        config.w_term_mode = WTermMode::WProject;
+        config.w_project_planes = Some(4);
+
+        let trace = build_cube_channel_w_project_trace_from_config(&config, 0).unwrap();
+
+        assert_eq!(trace.schema_version, ORACLE_SCHEMA_VERSION);
+        assert_eq!(trace.spectral_mode, "cube");
+        assert_eq!(trace.channel_index, Some(0));
+        assert_eq!(trace.requested_plane_count, Some(4));
+        assert!(trace.channel_frequency_hz.is_some());
+        assert!(trace.plane_count >= 1);
+        assert_eq!(trace.gridded_samples, 1);
+        assert_eq!(trace.samples.len(), 1);
+        assert!(trace.skipped_samples.is_empty());
+    }
+
+    #[test]
+    fn cube_residual_refresh_wrappers_trace_single_plane_models() {
+        let tmp = tempdir().unwrap();
+        let ms_path = tmp.path().join("trace_cube_residual.ms");
+        write_synthetic_cube_trace_ms(&ms_path);
+
+        let config = synthetic_cube_trace_config(ms_path);
+        let mut model = Array2::<f32>::zeros((config.imsize, config.imsize));
+        model[(config.imsize / 2, config.imsize / 2)] = 2.0;
+
+        let single_plane =
+            trace_cube_channel_residual_refresh_from_config(&config, 0, &model).unwrap();
+        let model_cube = vec![model.clone()];
+        let explicit_cube = trace_cube_channel_residual_refresh_from_config_with_model_cube(
+            &config,
+            0,
+            &model_cube,
+        )
+        .unwrap();
+        let model_lambda =
+            trace_cube_channel_residual_refresh_from_config_with_model_cube_model_channel_lambda(
+                &config,
+                0,
+                &model_cube,
+            )
+            .unwrap();
+
+        for trace in [&single_plane, &explicit_cube, &model_lambda] {
+            assert_eq!(trace.samples.len(), 1);
+            assert_eq!(trace.gridded_samples, 1);
+            assert_eq!(trace.skipped_samples, 0);
+            assert_eq!(trace.residual_image.dim(), (config.imsize, config.imsize));
+            assert!(trace.psf_peak.is_finite());
+            assert!(trace.normalization_sumwt.is_finite());
+            assert!(trace.reported_sumwt.is_finite());
+            assert!(trace.samples[0].gridable);
+        }
+
+        assert_eq!(single_plane.samples, explicit_cube.samples);
+        assert_eq!(single_plane.residual_image, explicit_cube.residual_image);
+        assert_eq!(single_plane.samples, model_lambda.samples);
+        assert_eq!(single_plane.residual_image, model_lambda.residual_image);
+    }
+
+    #[test]
+    fn cube_trace_wrappers_reject_non_cube_requests_and_invalid_models() {
+        let tmp = tempdir().unwrap();
+        let ms_path = tmp.path().join("trace_cube_wrapper_errors.ms");
+        write_synthetic_cube_trace_ms(&ms_path);
+
+        let cube_config = synthetic_cube_trace_config(ms_path.clone());
+        let invalid_shape = Array2::<f32>::zeros((8, 8));
+        assert!(
+            trace_cube_channel_residual_refresh_from_config(&cube_config, 0, &invalid_shape)
+                .unwrap_err()
+                .contains("model shape")
+        );
+        assert!(build_cube_channel_w_project_trace_from_config(&cube_config, 99).is_err());
+        assert!(
+            trace_cube_channel_residual_refresh_from_config_with_model_cube(&cube_config, 0, &[],)
+                .unwrap_err()
+                .contains("model plane count 0")
+        );
+
+        let mut mfs_config = synthetic_cube_trace_config(ms_path);
+        mfs_config.spectral_mode = SpectralMode::Mfs;
+        mfs_config.channel_count = None;
+        mfs_config.channel_start = None;
+        mfs_config.w_term_mode = WTermMode::None;
+        mfs_config.w_project_planes = None;
+        let model = Array2::<f32>::zeros((mfs_config.imsize, mfs_config.imsize));
+        assert!(
+            build_cube_channel_w_project_trace_from_config(&mfs_config, 0)
+                .unwrap_err()
+                .contains("requires cube input")
+        );
+        assert!(
+            trace_cube_channel_residual_refresh_from_config(&mfs_config, 0, &model)
+                .unwrap_err()
+                .contains("requires cube input")
+        );
+        assert!(
+            trace_cube_channel_residual_refresh_from_config_with_model_cube(
+                &mfs_config,
+                0,
+                &[model],
+            )
+            .unwrap_err()
+            .contains("requires cube input")
+        );
     }
 
     #[test]
@@ -11444,6 +11780,41 @@ mod tests {
                         .unwrap(),
                     )),
                 ),
+            ]))
+            .unwrap();
+    }
+
+    fn add_pointing_row(
+        ms: &mut MeasurementSet,
+        antenna_id: i32,
+        direction_rad: [f64; 2],
+        time_mjd_sec: f64,
+        interval_seconds: f64,
+    ) {
+        let table = ms.subtable_mut(SubtableId::Pointing).unwrap();
+        let direction = ArrayValue::Float64(
+            ArrayD::from_shape_vec(vec![2, 1], direction_rad.to_vec()).unwrap(),
+        );
+        table
+            .add_row(RecordValue::new(vec![
+                RecordField::new("ANTENNA_ID", Value::Scalar(ScalarValue::Int32(antenna_id))),
+                RecordField::new("DIRECTION", Value::Array(direction.clone())),
+                RecordField::new(
+                    "INTERVAL",
+                    Value::Scalar(ScalarValue::Float64(interval_seconds)),
+                ),
+                RecordField::new(
+                    "NAME",
+                    Value::Scalar(ScalarValue::String(format!("pointing-{antenna_id}"))),
+                ),
+                RecordField::new("NUM_POLY", Value::Scalar(ScalarValue::Int32(0))),
+                RecordField::new("TARGET", Value::Array(direction)),
+                RecordField::new("TIME", Value::Scalar(ScalarValue::Float64(time_mjd_sec))),
+                RecordField::new(
+                    "TIME_ORIGIN",
+                    Value::Scalar(ScalarValue::Float64(time_mjd_sec)),
+                ),
+                RecordField::new("TRACKING", Value::Scalar(ScalarValue::Bool(true))),
             ]))
             .unwrap();
     }

--- a/crates/casars/src/tests.rs
+++ b/crates/casars/src/tests.rs
@@ -44,7 +44,8 @@ use ratatui::Terminal;
 use ratatui::backend::{CrosstermBackend, TestBackend};
 use ratatui::layout::Rect;
 use ratatui_graphics::{
-    KittyAnimationControl, KittyAnimationGap, ProtocolType, TerminalCapabilities,
+    KittyAnimationControl, KittyAnimationGap, KittyStoredImageStore, ProtocolType,
+    TerminalCapabilities,
 };
 use tar::Archive;
 use tempfile::tempdir;
@@ -67,7 +68,8 @@ use crate::registry::{
 use crate::theme::theme;
 use crate::ui;
 use crate::{
-    KittyMovieOverlay, KittyMovieOverlayMode, first_movie_frame, kitty_movie_overlay_mode,
+    KITTY_MOVIE_OVERLAY_ID_BASE, KITTY_MOVIE_OVERLAY_IMAGE_ID_BASE, KittyMovieOverlay,
+    KittyMovieOverlayMode, SoftwareMovieSlots, first_movie_frame, kitty_movie_overlay_mode,
     loop_forever, movie_debug_log, movie_frame_number, movie_gap, run_with_app, run_with_cli_args,
     terminal_picker, test_env_lock,
 };
@@ -1890,6 +1892,131 @@ fn disabled_overlay_runtime_helpers_are_safe_noops() {
     overlay
         .control_animation_with(&mut backend, KittyAnimationControl::default())
         .expect("noop animation control");
+}
+
+#[cfg(unix)]
+#[test]
+fn software_direct_overlay_refresh_uploads_reuses_and_clears_movie_frames() {
+    let _guard = launcher_env_lock();
+    let temp = tempdir().expect("tempdir");
+    let script = write_fake_imexplore_script(
+        temp.path(),
+        &[fake_imexplore_snapshot_json_with_profile(
+            ProtocolImageView::Plane,
+            ProtocolImageFocus::Content,
+            "Image ready",
+            vec!["raster".to_string()],
+            vec![
+                "View: Plane".to_string(),
+                "Hidden axis Frequency (2): 0/2".to_string(),
+                "Value: 1".to_string(),
+            ],
+            Some(ImageBrowserProbe {
+                pixel_indices: vec![0, 0, 0],
+                pixel_axes: vec![],
+                value: 1.0,
+                masked: false,
+                finite: true,
+                world_axes: vec![],
+            }),
+            Some(fake_image_profile_payload()),
+            Some(ImageNonDisplayAxisState {
+                axis: 2,
+                label: "Frequency".to_string(),
+                index: 0,
+                length: 3,
+                pixel: 0,
+            }),
+            image_parameters("0,0,0", "3,3,2", "1,1,1"),
+        )],
+        None,
+    );
+    set_imexplore_launcher_bin(&script);
+
+    let schema = imexplore_app()
+        .load_schema()
+        .expect("load fake imexplore schema");
+    let config = ConfigStore::load_for_tests(temp.path().join("casars.toml"));
+    let mut app = AppState::from_schema_with_config(imexplore_app(), schema, config);
+    app.set_text_value("image_path", "/tmp/fake.image");
+    app.start_run_for_test();
+    app.prepare_graphics_for_test(140, 32);
+    app.on_tick();
+    app.note_image_plane_presented();
+    app.seed_image_spectrum_content_for_test((320, 120));
+    app.set_text_value_and_apply("fps", "10");
+    app.handle_key_event(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE));
+
+    let layout = ui::compute_layout(Rect::new(0, 0, 140, 32), &app);
+    let bundle = app
+        .current_direct_image_movie_bundle_info(&layout)
+        .expect("direct movie bundle info");
+
+    let mut store = KittyStoredImageStore::with_starting_ids(
+        KITTY_MOVIE_OVERLAY_IMAGE_ID_BASE,
+        KITTY_MOVIE_OVERLAY_ID_BASE,
+    )
+    .expect("kitty stored image store");
+    let slots = SoftwareMovieSlots {
+        plane: store.allocate_slot().expect("plane slot"),
+        spectrum: store.allocate_slot().expect("spectrum slot"),
+    };
+    let mut overlay = KittyMovieOverlay {
+        mode: KittyMovieOverlayMode::SoftwareDirect,
+        manager: None,
+        software_store: Some(store),
+        software_slots: Some(slots),
+        handle: None,
+        software_images: Vec::new(),
+        active_movie_key: None,
+        active_axis: None,
+        active_axis_index: None,
+        active_canvas: None,
+        uploaded_axis_indices: Vec::new(),
+        seen_axis_indices: Vec::new(),
+        active_fps: 0.0,
+        seeding_started_at: None,
+        looping_started_at: None,
+        looping: false,
+    };
+    let mut backend = CrosstermBackend::new(io::stdout());
+
+    overlay
+        .refresh_software_frame(&mut backend, &mut app, &layout, Some(bundle.clone()))
+        .expect("refresh software direct overlay");
+    assert!(app.image_movie_direct_overlay_active());
+    assert_eq!(overlay.active_movie_key, Some(bundle.movie_key));
+    assert_eq!(overlay.software_images.len(), bundle.axis_length);
+    let first_plane = overlay.software_images[bundle.axis_index]
+        .plane
+        .expect("plane image id");
+    let first_spectrum = overlay.software_images[bundle.axis_index]
+        .spectrum
+        .expect("spectrum image id");
+
+    let repeated_bundle = app
+        .current_direct_image_movie_bundle_info(&layout)
+        .expect("repeat direct movie bundle info");
+    overlay
+        .refresh_software_frame(&mut backend, &mut app, &layout, Some(repeated_bundle))
+        .expect("refresh software direct overlay from cache");
+    assert_eq!(
+        overlay.software_images[bundle.axis_index].plane,
+        Some(first_plane)
+    );
+    assert_eq!(
+        overlay.software_images[bundle.axis_index].spectrum,
+        Some(first_spectrum)
+    );
+
+    app.handle_key_event(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE));
+    assert!(!app.image_movie_playing_for_test());
+    overlay
+        .refresh_software_frame(&mut backend, &mut app, &layout, None)
+        .expect("clear software direct overlay");
+    assert!(!app.image_movie_direct_overlay_active());
+    assert_eq!(overlay.active_movie_key, None);
+    assert!(overlay.software_images.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
This PR fixes the long-gate failures uncovered by the release-quality automation run and restores the branch to a fully green state.

## Root Causes
- `PointingDirectionResolver::resolve` in `casars-imager` assumed the partition-point upper candidate was always in-bounds. When the requested time was later than the last POINTING row, it could index past the end of the antenna row slice and panic.
- CI-like coverage on fresh `origin/main` was below the automation threshold (`77.17%` initially, below the required `78.0%`). The missing coverage was concentrated in higher-risk plotting/export paths, direct-overlay lifecycle logic, and cube/POINTING trace wrappers.

## Files Changed
- `crates/casars-imager/src/lib.rs`
- `crates/casa-ms/src/msexplore.rs`
- `crates/casars/src/tests.rs`

## Validation Commands Run
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `scripts/test-slow.sh`
- `scripts/run-coverage.sh --ci-like`

## Final CI-like Coverage
- `78.00% coverage, 67703/86802 lines covered`

## Residual Risks / Follow-up Items
- Coverage is exactly at the current floor, so future unrelated edits in low-covered modules can drop the CI-like gate back under `78.0%`.
- The new tests strengthen risky execution paths, but a substantial share of remaining uncovered code is still in large TUI and table-storage surfaces.
