### PR TITLE
Default importvla output path when vis is unset

### DIFF
--- a/crates/casa-vla/src/cli.rs
+++ b/crates/casa-vla/src/cli.rs
@@ -469,7 +469,25 @@ fn read_json_source(source: &str) -> Result<String, String> {
 }
 
 fn run(options: ImportVlaOptions, json_output: bool) -> Result<(), VlaError> {
-    let report = import_archive_files_to_measurement_set_from_options(&options)?;
+    let cleanup_vis = if options.vis.is_none() {
+        Some(options.effective_vis_for_import()?)
+    } else {
+        None
+    };
+    let report = match import_archive_files_to_measurement_set_from_options(&options) {
+        Ok(report) => report,
+        Err(error) => {
+            if let Some(path) = cleanup_vis.as_deref().filter(|path| path.exists()) {
+                cleanup_failed_import_output(path).map_err(|cleanup_error| {
+                    VlaError::import(format!(
+                        "{error}; cleanup failed for {}: {cleanup_error}",
+                        path.display()
+                    ))
+                })?;
+            }
+            return Err(error);
+        }
+    };
     if json_output {
         let payload = json!({
             "mode": "disk-import",
@@ -487,6 +505,14 @@ fn run(options: ImportVlaOptions, json_output: bool) -> Result<(), VlaError> {
         render_import_text(&report);
     }
     Ok(())
+}
+
+fn cleanup_failed_import_output(path: &std::path::Path) -> Result<(), std::io::Error> {
+    if path.is_dir() {
+        fs::remove_dir_all(path)
+    } else {
+        fs::remove_file(path)
+    }
 }
 
 fn render_options_json(options: &ImportVlaOptions) -> serde_json::Value {
@@ -1010,7 +1036,7 @@ mod tests {
     }
 
     #[test]
-    fn run_without_vis_uses_import_path_with_default_output_name() {
+    fn run_without_vis_cleans_up_failed_default_output_path() {
         let path = synthetic_archive_file().path().to_path_buf();
         let result = with_temp_cwd(|temp| {
             let expected_vis = temp.join(
@@ -1028,8 +1054,8 @@ mod tests {
                 true,
             );
             assert!(
-                expected_vis.exists(),
-                "default import path should be created in temp cwd"
+                !expected_vis.exists(),
+                "failed implicit imports should clean up the derived temp cwd output"
             );
             result
         });

--- a/crates/casa-vla/src/cli.rs
+++ b/crates/casa-vla/src/cli.rs
@@ -12,7 +12,7 @@ use crate::task_contract::{
 };
 use crate::{
     AntennaNameScheme, BandName, ImportVlaOptions, VlaError,
-    import_archive_files_to_measurement_set_from_options, scan_disk_archive_files_from_options,
+    import_archive_files_to_measurement_set_from_options,
 };
 pub use casa_ms::ui_schema::{
     UiActionKind, UiArgumentParser, UiArgumentSchema, UiCommandSchema, UiValueKind,
@@ -136,7 +136,7 @@ pub fn command_schema(program_name: &str) -> UiCommandSchema {
                 value_kind: UiValueKind::Path,
                 default: None,
                 choices: &[],
-                help: "Output MeasurementSet path; leave blank to run a scan only",
+                help: "Output MeasurementSet path; defaults to ./<first-archive-stem>.ms for imports",
                 group: "Output",
                 required: false,
                 advanced: false,
@@ -469,46 +469,22 @@ fn read_json_source(source: &str) -> Result<String, String> {
 }
 
 fn run(options: ImportVlaOptions, json_output: bool) -> Result<(), VlaError> {
-    if options.vis.is_some() {
-        let report = import_archive_files_to_measurement_set_from_options(&options)?;
-        if json_output {
-            let payload = json!({
-                "mode": "disk-import",
-                "options": render_options_json(&options),
-                "report": report,
-            });
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&payload).map_err(|error| {
-                    VlaError::InvalidArgument {
-                        argument: "json",
-                        message: error.to_string(),
-                    }
-                })?
-            );
-        } else {
-            render_import_text(&options, &report);
-        }
+    let report = import_archive_files_to_measurement_set_from_options(&options)?;
+    if json_output {
+        let payload = json!({
+            "mode": "disk-import",
+            "options": render_options_json(&options),
+            "report": report,
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&payload).map_err(|error| VlaError::InvalidArgument {
+                argument: "json",
+                message: error.to_string(),
+            })?
+        );
     } else {
-        let summary = scan_disk_archive_files_from_options(&options)?;
-        if json_output {
-            let payload = json!({
-                "mode": "disk-scan",
-                "options": render_options_json(&options),
-                "summary": summary,
-            });
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&payload).map_err(|error| {
-                    VlaError::InvalidArgument {
-                        argument: "json",
-                        message: error.to_string(),
-                    }
-                })?
-            );
-        } else {
-            render_text(&options, &summary);
-        }
+        render_import_text(&report);
     }
     Ok(())
 }
@@ -533,6 +509,7 @@ fn render_options_json(options: &ImportVlaOptions) -> serde_json::Value {
     })
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 fn render_text(options: &ImportVlaOptions, summary: &crate::ArchiveSummary) {
     println!("importvla disk scan");
     if let Some(vis) = &options.vis {
@@ -565,12 +542,9 @@ fn render_text(options: &ImportVlaOptions, summary: &crate::ArchiveSummary) {
     println!("note: this first wave scans disk archive files and reassembles logical records.");
 }
 
-fn render_import_text(options: &ImportVlaOptions, report: &crate::ImportReport) {
+fn render_import_text(report: &crate::ImportReport) {
     println!("importvla disk import");
-    if let Some(vis) = &options.vis {
-        println!("vis: {}", vis.display());
-    }
-    println!("archive files: {}", options.archivefiles.len());
+    println!("vis: {}", report.vis.display());
     println!("logical records seen: {}", report.logical_records_seen);
     println!(
         "logical records imported: {}",
@@ -691,6 +665,8 @@ mod tests {
     use crate::task_contract::ImportVlaScanTaskRequest;
     use crate::{ArchiveFileSummary, ArchiveSummary, ImportReport};
     use std::collections::BTreeMap;
+    use std::path::Path;
+    use std::sync::{Mutex, OnceLock};
     use tempfile::{NamedTempFile, tempdir};
 
     fn sample_options() -> ImportVlaOptions {
@@ -769,6 +745,29 @@ mod tests {
         file
     }
 
+    struct CurrentDirGuard(PathBuf);
+
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.0);
+        }
+    }
+
+    fn cwd_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn with_temp_cwd<T>(f: impl FnOnce(&Path) -> T) -> T {
+        let _lock = cwd_lock().lock().expect("cwd lock");
+        let restore = CurrentDirGuard(std::env::current_dir().expect("original cwd"));
+        let temp = tempdir().expect("temp cwd");
+        std::env::set_current_dir(temp.path()).expect("set temp cwd");
+        let result = f(temp.path());
+        drop(restore);
+        result
+    }
+
     #[test]
     fn command_schema_describes_public_importvla_surface() {
         let schema = command_schema("importvla");
@@ -806,7 +805,7 @@ mod tests {
             OsString::from("--archivefiles"),
             OsString::from("a.exp,b.xp1"),
         ])
-        .expect("scan args")
+        .expect("implicit vis args")
         {
             CliAction::Run { options, json } => {
                 assert_eq!(options.archivefiles.len(), 2);
@@ -971,7 +970,7 @@ mod tests {
         let report = sample_report();
 
         render_text(&options, &summary);
-        render_import_text(&options, &report);
+        render_import_text(&report);
 
         let help = render_help(&command_schema("importvla-test"));
         assert!(help.contains("Machine-readable:"));
@@ -979,16 +978,9 @@ mod tests {
     }
 
     #[test]
-    fn run_scan_and_json_request_cover_real_archive_paths_when_available() {
+    fn run_json_request_covers_explicit_scan_operation_when_archive_is_available() {
         let archive = synthetic_archive_file();
         let path = archive.path().to_path_buf();
-        let options = ImportVlaOptions {
-            archivefiles: vec![path.clone()],
-            ..ImportVlaOptions::default()
-        };
-        run(options.clone(), false).expect("run text scan");
-        run(options, true).expect("run json scan");
-
         let request_file = NamedTempFile::new().expect("request file");
         let request = ImportVlaTaskRequest::Scan(ImportVlaScanTaskRequest {
             options: ImportVlaOptions {
@@ -1015,6 +1007,36 @@ mod tests {
             ..ImportVlaOptions::default()
         };
         assert!(run(options, true).is_err());
+    }
+
+    #[test]
+    fn run_without_vis_uses_import_path_with_default_output_name() {
+        let path = synthetic_archive_file().path().to_path_buf();
+        let result = with_temp_cwd(|temp| {
+            let expected_vis = temp.join(
+                path.file_stem()
+                    .expect("archive stem")
+                    .to_string_lossy()
+                    .to_string()
+                    + ".ms",
+            );
+            let result = run(
+                ImportVlaOptions {
+                    archivefiles: vec![path.clone()],
+                    ..ImportVlaOptions::default()
+                },
+                true,
+            );
+            assert!(
+                expected_vis.exists(),
+                "default import path should be created in temp cwd"
+            );
+            result
+        });
+
+        let error = result.expect_err("synthetic archive import should fail later in import");
+        assert!(!error.to_string().contains("scan"));
+        assert!(!error.to_string().contains("required for import"));
     }
 
     #[test]

--- a/crates/casa-vla/src/importer.rs
+++ b/crates/casa-vla/src/importer.rs
@@ -142,19 +142,13 @@ struct SpectralWindowEntry {
 ///
 /// The current implementation accepts the task-style `importvla` option shape,
 /// but this wave only supports disk-file input plus the subset of selectors
-/// needed by the native writer: `archivefiles`, `vis`, `project`,
+/// needed by the native writer: `archivefiles`, optional `vis`, `project`,
 /// `antnamescheme`, `autocorr`, `applytsys`, and `keepblanks`.
 pub fn import_archive_files_to_measurement_set_from_options(
     options: &ImportVlaOptions,
 ) -> Result<ImportReport, VlaError> {
     validate_import_options(options)?;
-    let vis = options
-        .vis
-        .clone()
-        .ok_or_else(|| VlaError::InvalidArgument {
-            argument: "vis",
-            message: "a MeasurementSet output path is required for import".to_string(),
-        })?;
+    let vis = options.effective_vis_for_import()?;
     if vis.exists() {
         return Err(VlaError::InvalidArgument {
             argument: "vis",

--- a/crates/casa-vla/src/options.rs
+++ b/crates/casa-vla/src/options.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 //! Task-style options for CASA `importvla` compatibility.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use casa_types::quanta::Quantity;
@@ -180,13 +180,48 @@ impl ImportVlaOptions {
         }
         Ok(&self.archivefiles)
     }
+
+    /// Return the configured MeasurementSet path, deriving a default when unset.
+    pub fn effective_vis_for_import(&self) -> Result<PathBuf, VlaError> {
+        match &self.vis {
+            Some(path) => Ok(path.clone()),
+            None => {
+                let cwd = std::env::current_dir().map_err(|error| VlaError::InvalidArgument {
+                    argument: "vis",
+                    message: format!("resolve current working directory for default vis: {error}"),
+                })?;
+                self.default_vis_path_in(&cwd)
+            }
+        }
+    }
+
+    pub(crate) fn default_vis_path_in(&self, cwd: &Path) -> Result<PathBuf, VlaError> {
+        let first_archive = self
+            .require_archivefiles()?
+            .first()
+            .ok_or(VlaError::NoArchiveFiles)?;
+        let stem = first_archive
+            .file_stem()
+            .filter(|value| !value.is_empty())
+            .or_else(|| first_archive.file_name())
+            .ok_or_else(|| VlaError::InvalidArgument {
+                argument: "vis",
+                message: format!(
+                    "could not derive a default MeasurementSet name from {}",
+                    first_archive.display()
+                ),
+            })?;
+        let mut file_name = stem.to_os_string();
+        file_name.push(".ms");
+        Ok(cwd.join(file_name))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{AntennaNameScheme, BandName, ImportVlaOptions};
     use crate::VlaError;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::str::FromStr;
 
     #[test]
@@ -299,6 +334,36 @@ mod tests {
         assert_eq!(
             populated.require_archivefiles().unwrap(),
             &[PathBuf::from("one.xp1"), PathBuf::from("two.xp5")]
+        );
+    }
+
+    #[test]
+    fn effective_vis_for_import_uses_explicit_path_when_present() {
+        let options = ImportVlaOptions {
+            archivefiles: vec![PathBuf::from("one.xp1")],
+            vis: Some(PathBuf::from("/tmp/explicit.ms")),
+            ..ImportVlaOptions::default()
+        };
+
+        assert_eq!(
+            options.effective_vis_for_import().unwrap(),
+            PathBuf::from("/tmp/explicit.ms")
+        );
+    }
+
+    #[test]
+    fn default_vis_path_in_uses_first_archive_stem_in_cwd() {
+        let options = ImportVlaOptions {
+            archivefiles: vec![
+                PathBuf::from("/data/AG189_1_46182.76468_46183.09488.exp"),
+                PathBuf::from("/data/other.xp1"),
+            ],
+            ..ImportVlaOptions::default()
+        };
+
+        assert_eq!(
+            options.default_vis_path_in(Path::new("/work")).unwrap(),
+            PathBuf::from("/work/AG189_1_46182.76468_46183.09488.ms")
         );
     }
 }

--- a/crates/casars/src/tests.rs
+++ b/crates/casars/src/tests.rs
@@ -8749,6 +8749,8 @@ fn importvla_workflow_runs_against_real_archive_and_renders_stdout() {
     let config = ConfigStore::load_for_tests(temp.path().join("casars.toml"));
     let mut app = AppState::from_schema_with_config(importvla_app(), schema, config);
     app.set_text_value("archivefiles", archive_path.to_string_lossy().as_ref());
+    let vis_path = temp.path().join("workflow-import.ms");
+    app.set_text_value("vis", vis_path.to_string_lossy().as_ref());
 
     start_run_with_default_importvla_launcher(&mut app);
     assert!(app.wait_for_idle_for_test(Duration::from_secs(60)));
@@ -8763,8 +8765,9 @@ fn importvla_workflow_runs_against_real_archive_and_renders_stdout() {
         matches!(
             app.active_result_content(),
             crate::app::ResultContent::Lines(lines)
-                if lines.iter().any(|line| line.contains("importvla disk scan"))
-                    && lines.iter().any(|line| line.contains("logical records"))
+                if lines.iter().any(|line| line.contains("importvla disk import"))
+                    && lines.iter().any(|line| line.contains("logical records imported"))
+                    && lines.iter().any(|line| line.contains(vis_path.to_string_lossy().as_ref()))
         ),
         "content={:?}",
         app.active_result_content()


### PR DESCRIPTION
Wave issue: #85
Closes #84

## Summary
- derive a default `./<first-archive-stem>.ms` output path when `importvla` is run without `vis`
- make the text CLI import path default to import mode instead of implicit scan-only behavior when `--archivefiles` is present
- update CLI and workflow regression coverage so the new behavior is tested without leaving repo-local MS artifacts behind

## Verification
- `cargo test -p casa-vla --lib`
- `just quick`
- `just verify`

## Notes
- remaining import performance work stays open in `#83` and wave `#86`
- explicit JSON scan entrypoints remain available for scan-only behavior
