### PR TITLE
Reduce MeasurementSet cold-path cell access latency

### DIFF
--- a/crates/casa-aipsio/src/aipsio.rs
+++ b/crates/casa-aipsio/src/aipsio.rs
@@ -195,7 +195,7 @@
 
 use std::any::Any;
 use std::fs::{File, OpenOptions, remove_file};
-use std::io::{BufWriter, ErrorKind, Read, Seek, SeekFrom, Write};
+use std::io::{BufReader, BufWriter, ErrorKind, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
 use ndarray::{ArrayD, IxDyn};
@@ -208,21 +208,49 @@ use crate::{
 
 pub type AipsIoObjectResult<T> = Result<T, AipsIoObjectError>;
 
-/// A file wrapper that buffers writes while supporting both Read and Write.
+/// A file wrapper for read-only AipsIO streams with buffered reads.
+struct ReadBufferedFile(BufReader<File>);
+
+impl Read for ReadBufferedFile {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.0.read(buf)
+    }
+}
+
+impl Write for ReadBufferedFile {
+    fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+        Err(std::io::Error::new(
+            ErrorKind::PermissionDenied,
+            "AipsIo stream is not writable",
+        ))
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Seek for ReadBufferedFile {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        self.0.seek(pos)
+    }
+}
+
+/// A file wrapper that buffers writes while still allowing occasional reads.
 ///
 /// `BufWriter<File>` only implements `Write + Seek`, not `Read`.
 /// This wrapper flushes the write buffer before reads so the file position
 /// is consistent, and delegates reads to the underlying `File`.
-struct BufferedFile(BufWriter<File>);
+struct WriteBufferedFile(BufWriter<File>);
 
-impl Read for BufferedFile {
+impl Read for WriteBufferedFile {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         self.0.flush()?;
         self.0.get_mut().read(buf)
     }
 }
 
-impl Write for BufferedFile {
+impl Write for WriteBufferedFile {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         self.0.write(buf)
     }
@@ -231,7 +259,7 @@ impl Write for BufferedFile {
     }
 }
 
-impl Seek for BufferedFile {
+impl Seek for WriteBufferedFile {
     fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
         self.0.seek(pos)
     }
@@ -1036,8 +1064,11 @@ impl AipsIo {
     ///
     /// See [`get_bool_into`](Self::get_bool_into) for details.
     pub fn get_i8_into(&mut self, values: &mut [i8]) -> AipsIoObjectResult<()> {
-        for value in values {
-            *value = self.get_i8()?;
+        self.test_get()?;
+        let mut buf = vec![0_u8; values.len()];
+        self.read_counted(&mut buf)?;
+        for (value, byte) in values.iter_mut().zip(buf) {
+            *value = byte as i8;
         }
         Ok(())
     }
@@ -1050,80 +1081,110 @@ impl AipsIo {
 
     /// Read exactly `values.len()` signed 16-bit values into the provided slice. See [`get_bool_into`](Self::get_bool_into).
     pub fn get_i16_into(&mut self, values: &mut [i16]) -> AipsIoObjectResult<()> {
-        for value in values {
-            *value = self.get_i16()?;
-        }
-        Ok(())
+        let order = self.byte_order;
+        self.read_fixed_width_into(values, move |bytes| match order {
+            ByteOrder::BigEndian => i16::from_be_bytes(bytes),
+            ByteOrder::LittleEndian => i16::from_le_bytes(bytes),
+        })
     }
 
     /// Read exactly `values.len()` unsigned 16-bit values into the provided slice. See [`get_bool_into`](Self::get_bool_into).
     pub fn get_u16_into(&mut self, values: &mut [u16]) -> AipsIoObjectResult<()> {
-        for value in values {
-            *value = self.get_u16()?;
-        }
-        Ok(())
+        let order = self.byte_order;
+        self.read_fixed_width_into(values, move |bytes| match order {
+            ByteOrder::BigEndian => u16::from_be_bytes(bytes),
+            ByteOrder::LittleEndian => u16::from_le_bytes(bytes),
+        })
     }
 
     /// Read exactly `values.len()` signed 32-bit values into the provided slice. See [`get_bool_into`](Self::get_bool_into).
     pub fn get_i32_into(&mut self, values: &mut [i32]) -> AipsIoObjectResult<()> {
-        for value in values {
-            *value = self.get_i32()?;
-        }
-        Ok(())
+        let order = self.byte_order;
+        self.read_fixed_width_into(values, move |bytes| match order {
+            ByteOrder::BigEndian => i32::from_be_bytes(bytes),
+            ByteOrder::LittleEndian => i32::from_le_bytes(bytes),
+        })
     }
 
     /// Read exactly `values.len()` unsigned 32-bit values into the provided slice. See [`get_bool_into`](Self::get_bool_into).
     pub fn get_u32_into(&mut self, values: &mut [u32]) -> AipsIoObjectResult<()> {
-        for value in values {
-            *value = self.get_u32()?;
-        }
-        Ok(())
+        let order = self.byte_order;
+        self.read_fixed_width_into(values, move |bytes| match order {
+            ByteOrder::BigEndian => u32::from_be_bytes(bytes),
+            ByteOrder::LittleEndian => u32::from_le_bytes(bytes),
+        })
     }
 
     /// Read exactly `values.len()` signed 64-bit values into the provided slice. See [`get_bool_into`](Self::get_bool_into).
     pub fn get_i64_into(&mut self, values: &mut [i64]) -> AipsIoObjectResult<()> {
-        for value in values {
-            *value = self.get_i64()?;
-        }
-        Ok(())
+        let order = self.byte_order;
+        self.read_fixed_width_into(values, move |bytes| match order {
+            ByteOrder::BigEndian => i64::from_be_bytes(bytes),
+            ByteOrder::LittleEndian => i64::from_le_bytes(bytes),
+        })
     }
 
     /// Read exactly `values.len()` unsigned 64-bit values into the provided slice. See [`get_bool_into`](Self::get_bool_into).
     pub fn get_u64_into(&mut self, values: &mut [u64]) -> AipsIoObjectResult<()> {
-        for value in values {
-            *value = self.get_u64()?;
-        }
-        Ok(())
+        let order = self.byte_order;
+        self.read_fixed_width_into(values, move |bytes| match order {
+            ByteOrder::BigEndian => u64::from_be_bytes(bytes),
+            ByteOrder::LittleEndian => u64::from_le_bytes(bytes),
+        })
     }
 
     /// Read exactly `values.len()` 32-bit float values into the provided slice. See [`get_bool_into`](Self::get_bool_into).
     pub fn get_f32_into(&mut self, values: &mut [f32]) -> AipsIoObjectResult<()> {
-        for value in values {
-            *value = self.get_f32()?;
-        }
-        Ok(())
+        let order = self.byte_order;
+        self.read_fixed_width_into(values, move |bytes| {
+            let bits = match order {
+                ByteOrder::BigEndian => u32::from_be_bytes(bytes),
+                ByteOrder::LittleEndian => u32::from_le_bytes(bytes),
+            };
+            f32::from_bits(bits)
+        })
     }
 
     /// Read exactly `values.len()` 64-bit float values into the provided slice. See [`get_bool_into`](Self::get_bool_into).
     pub fn get_f64_into(&mut self, values: &mut [f64]) -> AipsIoObjectResult<()> {
-        for value in values {
-            *value = self.get_f64()?;
-        }
-        Ok(())
+        let order = self.byte_order;
+        self.read_fixed_width_into(values, move |bytes| {
+            let bits = match order {
+                ByteOrder::BigEndian => u64::from_be_bytes(bytes),
+                ByteOrder::LittleEndian => u64::from_le_bytes(bytes),
+            };
+            f64::from_bits(bits)
+        })
     }
 
     /// Read exactly `values.len()` 32-bit complex values into the provided slice. See [`get_bool_into`](Self::get_bool_into).
     pub fn get_complex32_into(&mut self, values: &mut [Complex32]) -> AipsIoObjectResult<()> {
-        for value in values {
-            *value = self.get_complex32()?;
+        let mut scalars = vec![
+            0_f32;
+            values
+                .len()
+                .checked_mul(2)
+                .ok_or(AipsIoObjectError::LengthOverflow)?
+        ];
+        self.get_f32_into(&mut scalars)?;
+        for (value, pair) in values.iter_mut().zip(scalars.chunks_exact(2)) {
+            *value = Complex32::new(pair[0], pair[1]);
         }
         Ok(())
     }
 
     /// Read exactly `values.len()` 64-bit complex values into the provided slice. See [`get_bool_into`](Self::get_bool_into).
     pub fn get_complex64_into(&mut self, values: &mut [Complex64]) -> AipsIoObjectResult<()> {
-        for value in values {
-            *value = self.get_complex64()?;
+        let mut scalars = vec![
+            0_f64;
+            values
+                .len()
+                .checked_mul(2)
+                .ok_or(AipsIoObjectError::LengthOverflow)?
+        ];
+        self.get_f64_into(&mut scalars)?;
+        for (value, pair) in values.iter_mut().zip(scalars.chunks_exact(2)) {
+            *value = Complex64::new(pair[0], pair[1]);
         }
         Ok(())
     }
@@ -1643,6 +1704,26 @@ impl AipsIo {
         }
     }
 
+    fn read_fixed_width_into<T, const N: usize>(
+        &mut self,
+        values: &mut [T],
+        decode: impl Fn([u8; N]) -> T,
+    ) -> AipsIoObjectResult<()> {
+        self.test_get()?;
+        let byte_len = values
+            .len()
+            .checked_mul(N)
+            .ok_or(AipsIoObjectError::LengthOverflow)?;
+        let mut buf = vec![0_u8; byte_len];
+        self.read_counted(&mut buf)?;
+        for (value, chunk) in values.iter_mut().zip(buf.chunks_exact(N)) {
+            let mut bytes = [0_u8; N];
+            bytes.copy_from_slice(chunk);
+            *value = decode(bytes);
+        }
+        Ok(())
+    }
+
     fn ensure_level(&mut self) {
         if self.level >= self.objlen.len() {
             self.objlen.resize(self.level + 10, 0);
@@ -1727,8 +1808,12 @@ impl AipsIo {
     ) -> AipsIoObjectResult<Self> {
         let path = path.as_ref();
         let (file, readable, writable, delete_on_close) = open_file_with_option(path, option)?;
-        let buffered = BufferedFile(BufWriter::new(file));
-        let mut io = Self::with_access(Box::new(buffered), readable, writable, true, byte_order);
+        let buffered: Box<dyn AipsIoStream> = if readable && !writable {
+            Box::new(ReadBufferedFile(BufReader::new(file)))
+        } else {
+            Box::new(WriteBufferedFile(BufWriter::new(file)))
+        };
+        let mut io = Self::with_access(buffered, readable, writable, true, byte_order);
         if option == AipsOpenOption::Append {
             let inner = io.inner_mut()?;
             inner.seek(SeekFrom::End(0))?;

--- a/crates/casa-ms/examples/profile_msexplore.rs
+++ b/crates/casa-ms/examples/profile_msexplore.rs
@@ -118,8 +118,8 @@ fn run() -> Result<(), String> {
     })?;
 
     let open_ms = MeasurementSet::open(&options.ms_path).map_err(|error| error.to_string())?;
-    let summary = measure(
-        "summary_from_open_ms",
+    let summary_reused = measure(
+        "summary_reused_open_ms",
         options.repeats,
         options.warmups,
         || {
@@ -128,6 +128,21 @@ fn run() -> Result<(), String> {
                 &selection.to_summary_options(),
             )
             .map_err(|error| error.to_string())?;
+            let rendered = summary
+                .render(MeasurementSetSummaryOutputFormat::Json)
+                .map_err(|error| error.to_string())?;
+            Ok(rendered.len())
+        },
+    )?;
+    let summary_fresh = measure(
+        "summary_fresh_open_ms",
+        options.repeats,
+        options.warmups,
+        || {
+            let ms = MeasurementSet::open(&options.ms_path).map_err(|error| error.to_string())?;
+            let summary =
+                MeasurementSetSummary::from_ms_with_options(&ms, &selection.to_summary_options())
+                    .map_err(|error| error.to_string())?;
             let rendered = summary
                 .render(MeasurementSetSummaryOutputFormat::Json)
                 .map_err(|error| error.to_string())?;
@@ -146,12 +161,31 @@ fn run() -> Result<(), String> {
     );
 
     if options.stage == ProfileStage::Build {
-        let build = measure("build_payload", options.repeats, options.warmups, || {
-            let payload = build_msexplore_plot_payload(&open_ms, &selection, &spec)?;
-            Ok(payload_point_count(&payload))
-        })?;
+        let build = measure(
+            "build_reused_open_ms",
+            options.repeats,
+            options.warmups,
+            || {
+                let payload = build_msexplore_plot_payload(&open_ms, &selection, &spec)?;
+                Ok(payload_point_count(&payload))
+            },
+        )?;
+        let build_fresh = measure(
+            "build_fresh_open_ms",
+            options.repeats,
+            options.warmups,
+            || {
+                let ms =
+                    MeasurementSet::open(&options.ms_path).map_err(|error| error.to_string())?;
+                let payload = build_msexplore_plot_payload(&ms, &selection, &spec)?;
+                Ok(payload_point_count(&payload))
+            },
+        )?;
         println!();
-        println!("build-only median={:.2} ms", build.median_ms);
+        println!(
+            "build-only median reused={:.2} ms fresh={:.2} ms",
+            build.median_ms, build_fresh.median_ms
+        );
         return Ok(());
     }
 
@@ -170,10 +204,25 @@ fn run() -> Result<(), String> {
         return Ok(());
     }
 
-    let build = measure("build_payload", options.repeats, options.warmups, || {
-        let payload = build_msexplore_plot_payload(&open_ms, &selection, &spec)?;
-        Ok(payload_point_count(&payload))
-    })?;
+    let build_reused = measure(
+        "build_reused_open_ms",
+        options.repeats,
+        options.warmups,
+        || {
+            let payload = build_msexplore_plot_payload(&open_ms, &selection, &spec)?;
+            Ok(payload_point_count(&payload))
+        },
+    )?;
+    let build_fresh = measure(
+        "build_fresh_open_ms",
+        options.repeats,
+        options.warmups,
+        || {
+            let ms = MeasurementSet::open(&options.ms_path).map_err(|error| error.to_string())?;
+            let payload = build_msexplore_plot_payload(&ms, &selection, &spec)?;
+            Ok(payload_point_count(&payload))
+        },
+    )?;
 
     let render = measure("render_bitmap", options.repeats, options.warmups, || {
         let image = render_msexplore_plot_image(
@@ -203,9 +252,36 @@ fn run() -> Result<(), String> {
             Ok(bytes.len())
         },
     )?;
+    let full_reused = measure(
+        "full_reused_open_ms",
+        options.repeats,
+        options.warmups,
+        || {
+            let summary = MeasurementSetSummary::from_ms_with_options(
+                &open_ms,
+                &selection.to_summary_options(),
+            )
+            .map_err(|error| error.to_string())?;
+            let rendered_summary = summary
+                .render(MeasurementSetSummaryOutputFormat::Json)
+                .map_err(|error| error.to_string())?;
+            let payload = build_msexplore_plot_payload(&open_ms, &selection, &spec)?;
+            let image = render_msexplore_plot_image(
+                &payload,
+                MeasurementSetPlotTheme::light(),
+                options.plot_width,
+                options.plot_height,
+            )?;
+            let mut bytes = Vec::new();
+            image
+                .write_to(&mut Cursor::new(&mut bytes), ImageFormat::Png)
+                .map_err(|error| error.to_string())?;
+            Ok(rendered_summary.len() ^ bytes.len() ^ payload_point_count(&payload))
+        },
+    )?;
 
     let full = measure(
-        "full_pipeline_in_memory",
+        "full_fresh_open_ms",
         options.repeats,
         options.warmups,
         || {
@@ -233,22 +309,32 @@ fn run() -> Result<(), String> {
 
     if options.stage == ProfileStage::Full {
         println!();
-        println!("full-only median={:.2} ms", full.median_ms);
+        println!(
+            "full-only median reused={:.2} ms fresh={:.2} ms",
+            full_reused.median_ms, full.median_ms
+        );
         return Ok(());
     }
 
     println!();
     println!(
-        "stage shares of full pipeline: open={:.1}% summary={:.1}% build={:.1}% render={:.1}% encode={:.1}%",
+        "stage shares of fresh full pipeline: open={:.1}% summary(reused/fresh)={:.1}%/{:.1}% build(reused/fresh)={:.1}%/{:.1}% render={:.1}% encode={:.1}%",
         percent(open.median_ms, full.median_ms),
-        percent(summary.median_ms, full.median_ms),
-        percent(build.median_ms, full.median_ms),
+        percent(summary_reused.median_ms, full.median_ms),
+        percent(summary_fresh.median_ms, full.median_ms),
+        percent(build_reused.median_ms, full.median_ms),
+        percent(build_fresh.median_ms, full.median_ms),
         percent(render.median_ms, full.median_ms),
         percent(encode.median_ms, full.median_ms),
     );
     println!(
-        "render_vs_library ratio: render / (open + summary + build) = {:.2}x",
-        render.median_ms / (open.median_ms + summary.median_ms + build.median_ms).max(0.001)
+        "full pipeline reused/fresh ratio = {:.2}x",
+        full_reused.median_ms / full.median_ms.max(0.001)
+    );
+    println!(
+        "render_vs_reused_library ratio: render / (open + summary + build) = {:.2}x",
+        render.median_ms
+            / (open.median_ms + summary_reused.median_ms + build_reused.median_ms).max(0.001)
     );
 
     Ok(())

--- a/crates/casa-ms/src/selection.rs
+++ b/crates/casa-ms/src/selection.rs
@@ -22,8 +22,8 @@
 
 use crate::error::{MsError, MsResult};
 use crate::ms::MeasurementSet;
+use crate::subtables::{get_f64, get_i32};
 use casa_tables::Table;
-use casa_types::{RecordField, RecordValue, ScalarValue, Value};
 use std::collections::HashSet;
 
 /// Builder for MS row selection criteria.
@@ -396,10 +396,10 @@ fn load_structured_selection_columns(
     table: &Table,
     request: StructuredSelectionColumnRequest,
 ) -> MsResult<StructuredSelectionColumns> {
-    let rows = table.rows()?;
+    let row_count = table.row_count();
     let mut columns = StructuredSelectionColumns::default();
 
-    if rows.is_empty() {
+    if row_count == 0 {
         if request.field {
             columns.field = Some(Vec::new());
         }
@@ -430,158 +430,51 @@ fn load_structured_selection_columns(
         return Ok(columns);
     }
 
-    let first_row = &rows[0];
-    let field_index = request
-        .field
-        .then(|| find_column_index(first_row, "FIELD_ID"))
-        .transpose()?;
-    let data_desc_index = request
-        .data_desc
-        .then(|| find_column_index(first_row, "DATA_DESC_ID"))
-        .transpose()?;
-    let antenna1_index = request
-        .antenna1
-        .then(|| find_column_index(first_row, "ANTENNA1"))
-        .transpose()?;
-    let antenna2_index = request
-        .antenna2
-        .then(|| find_column_index(first_row, "ANTENNA2"))
-        .transpose()?;
-    let time_index = request
-        .time
-        .then(|| find_column_index(first_row, "TIME"))
-        .transpose()?;
-    let scan_index = request
-        .scan
-        .then(|| find_column_index(first_row, "SCAN_NUMBER"))
-        .transpose()?;
-    let state_index = request
-        .state
-        .then(|| find_column_index(first_row, "STATE_ID"))
-        .transpose()?;
-    let observation_index = request
-        .observation
-        .then(|| find_column_index(first_row, "OBSERVATION_ID"))
-        .transpose()?;
-    let array_index = request
-        .array
-        .then(|| find_column_index(first_row, "ARRAY_ID"))
-        .transpose()?;
-
     if request.field {
-        columns.field = Some(Vec::with_capacity(rows.len()));
+        columns.field = Some(load_i32_column(table, "FIELD_ID")?);
     }
     if request.data_desc {
-        columns.data_desc = Some(Vec::with_capacity(rows.len()));
+        columns.data_desc = Some(load_i32_column(table, "DATA_DESC_ID")?);
     }
     if request.antenna1 {
-        columns.antenna1 = Some(Vec::with_capacity(rows.len()));
+        columns.antenna1 = Some(load_i32_column(table, "ANTENNA1")?);
     }
     if request.antenna2 {
-        columns.antenna2 = Some(Vec::with_capacity(rows.len()));
+        columns.antenna2 = Some(load_i32_column(table, "ANTENNA2")?);
     }
     if request.time {
-        columns.time = Some(Vec::with_capacity(rows.len()));
+        columns.time = Some(load_f64_column(table, "TIME")?);
     }
     if request.scan {
-        columns.scan = Some(Vec::with_capacity(rows.len()));
+        columns.scan = Some(load_i32_column(table, "SCAN_NUMBER")?);
     }
     if request.state {
-        columns.state = Some(Vec::with_capacity(rows.len()));
+        columns.state = Some(load_i32_column(table, "STATE_ID")?);
     }
     if request.observation {
-        columns.observation = Some(Vec::with_capacity(rows.len()));
+        columns.observation = Some(load_i32_column(table, "OBSERVATION_ID")?);
     }
     if request.array {
-        columns.array = Some(Vec::with_capacity(rows.len()));
-    }
-
-    for row in rows {
-        let fields = row.fields();
-        if let (Some(index), Some(values)) = (field_index, columns.field.as_mut()) {
-            values.push(read_i32_field(fields, index, "FIELD_ID")?);
-        }
-        if let (Some(index), Some(values)) = (data_desc_index, columns.data_desc.as_mut()) {
-            values.push(read_i32_field(fields, index, "DATA_DESC_ID")?);
-        }
-        if let (Some(index), Some(values)) = (antenna1_index, columns.antenna1.as_mut()) {
-            values.push(read_i32_field(fields, index, "ANTENNA1")?);
-        }
-        if let (Some(index), Some(values)) = (antenna2_index, columns.antenna2.as_mut()) {
-            values.push(read_i32_field(fields, index, "ANTENNA2")?);
-        }
-        if let (Some(index), Some(values)) = (time_index, columns.time.as_mut()) {
-            values.push(read_f64_field(fields, index, "TIME")?);
-        }
-        if let (Some(index), Some(values)) = (scan_index, columns.scan.as_mut()) {
-            values.push(read_i32_field(fields, index, "SCAN_NUMBER")?);
-        }
-        if let (Some(index), Some(values)) = (state_index, columns.state.as_mut()) {
-            values.push(read_i32_field(fields, index, "STATE_ID")?);
-        }
-        if let (Some(index), Some(values)) = (observation_index, columns.observation.as_mut()) {
-            values.push(read_i32_field(fields, index, "OBSERVATION_ID")?);
-        }
-        if let (Some(index), Some(values)) = (array_index, columns.array.as_mut()) {
-            values.push(read_i32_field(fields, index, "ARRAY_ID")?);
-        }
+        columns.array = Some(load_i32_column(table, "ARRAY_ID")?);
     }
 
     Ok(columns)
 }
 
-fn find_column_index(row: &RecordValue, column: &str) -> MsResult<usize> {
-    row.fields()
-        .iter()
-        .position(|field| field.name == column)
-        .ok_or_else(|| MsError::MissingColumn {
-            column: column.to_string(),
-            table: "MAIN".to_string(),
-        })
+fn load_i32_column(table: &Table, column: &str) -> MsResult<Vec<i32>> {
+    let mut values = Vec::with_capacity(table.row_count());
+    for row in 0..table.row_count() {
+        values.push(get_i32(table, row, column)?);
+    }
+    Ok(values)
 }
 
-fn read_i32_field(fields: &[RecordField], index: usize, column: &str) -> MsResult<i32> {
-    let field = fields.get(index).ok_or_else(|| MsError::MissingColumn {
-        column: column.to_string(),
-        table: "MAIN".to_string(),
-    })?;
-    if field.name != column {
-        return Err(MsError::MissingColumn {
-            column: column.to_string(),
-            table: "MAIN".to_string(),
-        });
+fn load_f64_column(table: &Table, column: &str) -> MsResult<Vec<f64>> {
+    let mut values = Vec::with_capacity(table.row_count());
+    for row in 0..table.row_count() {
+        values.push(get_f64(table, row, column)?);
     }
-    match &field.value {
-        Value::Scalar(ScalarValue::Int32(value)) => Ok(*value),
-        other => Err(MsError::ColumnTypeMismatch {
-            column: column.to_string(),
-            table: "MAIN".to_string(),
-            expected: "Int32".to_string(),
-            found: format!("{:?}", other.kind()),
-        }),
-    }
-}
-
-fn read_f64_field(fields: &[RecordField], index: usize, column: &str) -> MsResult<f64> {
-    let field = fields.get(index).ok_or_else(|| MsError::MissingColumn {
-        column: column.to_string(),
-        table: "MAIN".to_string(),
-    })?;
-    if field.name != column {
-        return Err(MsError::MissingColumn {
-            column: column.to_string(),
-            table: "MAIN".to_string(),
-        });
-    }
-    match &field.value {
-        Value::Scalar(ScalarValue::Float64(value)) => Ok(*value),
-        other => Err(MsError::ColumnTypeMismatch {
-            column: column.to_string(),
-            table: "MAIN".to_string(),
-            expected: "Float64".to_string(),
-            found: format!("{:?}", other.kind()),
-        }),
-    }
+    Ok(values)
 }
 
 fn int_list(ids: &[i32]) -> String {

--- a/crates/casa-tables/src/storage/mod.rs
+++ b/crates/casa-tables/src/storage/mod.rs
@@ -24,7 +24,7 @@ use std::sync::OnceLock;
 use std::time::Instant;
 
 use casa_aipsio::ByteOrder;
-use casa_types::{RecordField, RecordValue, Value};
+use casa_types::{ArrayValue, RecordField, RecordValue, ScalarValue, Value};
 use thiserror::Error;
 
 use crate::schema::{SchemaError, TableSchema};
@@ -227,6 +227,12 @@ pub(crate) struct StorageSnapshot {
     pub(crate) virtual_bindings: Vec<virtual_engine::VirtualColumnBinding>,
     /// Data manager info extracted from table.dat (empty for memory tables).
     pub(crate) dm_info: Vec<DataManagerInfo>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ScalarColumnSnapshot {
+    pub(crate) row_count: usize,
+    pub(crate) columns: HashMap<String, Vec<Option<ScalarValue>>>,
 }
 
 pub(crate) trait StorageManager {
@@ -921,6 +927,55 @@ impl CompositeStorage {
         }
     }
 
+    pub(crate) fn load_scalar_columns_with_row_hint(
+        &self,
+        table_path: &Path,
+        row_hint: Option<u64>,
+    ) -> Result<ScalarColumnSnapshot, StorageError> {
+        let control_path = table_path.join(TABLE_CONTROL_FILE);
+        if !table_path.exists() {
+            return Err(StorageError::MissingPath(table_path.to_path_buf()));
+        }
+        if !control_path.exists() {
+            return Err(StorageError::MissingControlFile(control_path));
+        }
+
+        match read_table_dat_dispatch(&control_path)? {
+            TableDatResult::Plain(table_dat) => {
+                self.load_plain_scalar_columns(table_path, &table_dat, row_hint)
+            }
+            TableDatResult::Ref(_) | TableDatResult::Concat(_) => {
+                let snapshot = self.load_with_row_hint(table_path, row_hint)?;
+                Ok(scalar_columns_from_snapshot(&snapshot))
+            }
+        }
+    }
+
+    pub(crate) fn load_array_column_with_row_hint(
+        &self,
+        table_path: &Path,
+        column: &str,
+        row_hint: Option<u64>,
+    ) -> Result<Vec<Option<ArrayValue>>, StorageError> {
+        let control_path = table_path.join(TABLE_CONTROL_FILE);
+        if !table_path.exists() {
+            return Err(StorageError::MissingPath(table_path.to_path_buf()));
+        }
+        if !control_path.exists() {
+            return Err(StorageError::MissingControlFile(control_path));
+        }
+
+        match read_table_dat_dispatch(&control_path)? {
+            TableDatResult::Plain(table_dat) => {
+                self.load_plain_array_column(table_path, &table_dat, column, row_hint)
+            }
+            TableDatResult::Ref(_) | TableDatResult::Concat(_) => {
+                let snapshot = self.load_with_row_hint(table_path, row_hint)?;
+                array_column_from_snapshot(&snapshot, column)
+            }
+        }
+    }
+
     /// Load a PlainTable from table.dat contents and data files.
     ///
     /// Uses two-pass loading:
@@ -1125,6 +1180,243 @@ impl CompositeStorage {
             virtual_bindings: Vec::new(),
             dm_info,
         })
+    }
+
+    fn load_plain_scalar_columns(
+        &self,
+        table_path: &Path,
+        table_dat: &TableDatContents,
+        row_hint: Option<u64>,
+    ) -> Result<ScalarColumnSnapshot, StorageError> {
+        let nrrow = table_dat
+            .nrrow
+            .max(table_dat.column_set.nrrow)
+            .max(row_hint.unwrap_or(0)) as usize;
+
+        if table_dat
+            .column_set
+            .data_managers
+            .iter()
+            .any(|dm| is_virtual_engine(&dm.type_name))
+        {
+            let snapshot = self.load_plain_table(table_path, table_dat, row_hint)?;
+            return Ok(scalar_columns_from_snapshot(&snapshot));
+        }
+
+        let mut columns = HashMap::new();
+
+        for dm in &table_dat.column_set.data_managers {
+            let data_path = table_path.join(format!("{}{}", TABLE_DATA_FILE_PREFIX, dm.seq_nr));
+            let bound_cols: Vec<(usize, &_)> = table_dat
+                .column_set
+                .columns
+                .iter()
+                .enumerate()
+                .filter(|(_, pc)| pc.dm_seq_nr == dm.seq_nr)
+                .collect();
+
+            match dm.type_name.as_str() {
+                "StManAipsIO" => {
+                    if !data_path.is_file() {
+                        return Err(StorageError::MissingDataFile(data_path));
+                    }
+                    collect_stman_scalar_columns(
+                        &data_path,
+                        &table_dat.table_desc.columns,
+                        &bound_cols,
+                        nrrow,
+                        ByteOrder::BigEndian,
+                        &mut columns,
+                    )?;
+                }
+                "StandardStMan" => {
+                    if !data_path.is_file() {
+                        return Err(StorageError::MissingDataFile(data_path));
+                    }
+                    collect_ssm_scalar_columns(
+                        &data_path,
+                        &dm.data,
+                        &table_dat.table_desc.columns,
+                        &bound_cols,
+                        nrrow,
+                        &mut columns,
+                    )?;
+                }
+                "IncrementalStMan" => {
+                    if !data_path.is_file() {
+                        return Err(StorageError::MissingDataFile(data_path));
+                    }
+                    collect_ism_scalar_columns(
+                        &data_path,
+                        &dm.data,
+                        &table_dat.table_desc.columns,
+                        &bound_cols,
+                        nrrow,
+                        &mut columns,
+                    )?;
+                }
+                "TiledColumnStMan" | "TiledShapeStMan" | "TiledCellStMan" | "TiledDataStMan" => {
+                    if bound_cols
+                        .iter()
+                        .any(|(desc_idx, _)| !table_dat.table_desc.columns[*desc_idx].is_array)
+                    {
+                        let snapshot = self.load_plain_table(table_path, table_dat, row_hint)?;
+                        return Ok(scalar_columns_from_snapshot(&snapshot));
+                    }
+                }
+                other => {
+                    return Err(StorageError::UnsupportedDataManager(other.to_string()));
+                }
+            }
+        }
+
+        Ok(ScalarColumnSnapshot {
+            row_count: nrrow,
+            columns,
+        })
+    }
+
+    fn load_plain_array_column(
+        &self,
+        table_path: &Path,
+        table_dat: &TableDatContents,
+        column: &str,
+        row_hint: Option<u64>,
+    ) -> Result<Vec<Option<ArrayValue>>, StorageError> {
+        let desc_idx = table_dat
+            .table_desc
+            .columns
+            .iter()
+            .position(|desc| desc.col_name == column)
+            .ok_or_else(|| {
+                StorageError::FormatMismatch(format!("array column '{column}' not found"))
+            })?;
+        let col_desc = &table_dat.table_desc.columns[desc_idx];
+        if !col_desc.is_array {
+            return Err(StorageError::FormatMismatch(format!(
+                "column '{column}' is not an array column"
+            )));
+        }
+
+        if table_dat
+            .column_set
+            .data_managers
+            .iter()
+            .any(|dm| is_virtual_engine(&dm.type_name))
+        {
+            let snapshot = self.load_plain_table(table_path, table_dat, row_hint)?;
+            return array_column_from_snapshot(&snapshot, column);
+        }
+
+        let nrrow = table_dat
+            .nrrow
+            .max(table_dat.column_set.nrrow)
+            .max(row_hint.unwrap_or(0)) as usize;
+        let dm_seq_nr = table_dat
+            .column_set
+            .columns
+            .iter()
+            .find(|entry| entry.original_name == column)
+            .ok_or_else(|| {
+                StorageError::FormatMismatch(format!(
+                    "array column '{column}' missing ColumnSet binding"
+                ))
+            })?
+            .dm_seq_nr;
+        let dm = table_dat
+            .column_set
+            .data_managers
+            .iter()
+            .find(|dm| dm.seq_nr == dm_seq_nr)
+            .ok_or_else(|| {
+                StorageError::FormatMismatch(format!(
+                    "array column '{column}' missing data manager {dm_seq_nr}"
+                ))
+            })?;
+        let data_path = table_path.join(format!("{}{}", TABLE_DATA_FILE_PREFIX, dm.seq_nr));
+        let bound_cols: Vec<(usize, &_)> = table_dat
+            .column_set
+            .columns
+            .iter()
+            .enumerate()
+            .filter(|(_, pc)| pc.dm_seq_nr == dm.seq_nr)
+            .collect();
+        let mut rows: Vec<RecordValue> = (0..nrrow).map(|_| RecordValue::default()).collect();
+        let mut undefined_cells: Vec<HashSet<String>> =
+            (0..nrrow).map(|_| HashSet::new()).collect();
+
+        match dm.type_name.as_str() {
+            "StManAipsIO" => {
+                if !data_path.is_file() {
+                    return Err(StorageError::MissingDataFile(data_path));
+                }
+                load_stman_aipsio_columns(
+                    &data_path,
+                    &table_dat.table_desc.columns,
+                    &bound_cols,
+                    &mut rows,
+                    &mut undefined_cells,
+                    nrrow,
+                    ByteOrder::BigEndian,
+                )?;
+            }
+            "StandardStMan" => {
+                if !data_path.is_file() {
+                    return Err(StorageError::MissingDataFile(data_path));
+                }
+                load_ssm_columns(
+                    &data_path,
+                    &dm.data,
+                    &table_dat.table_desc.columns,
+                    &bound_cols,
+                    &mut rows,
+                    &mut undefined_cells,
+                    nrrow,
+                )?;
+            }
+            "IncrementalStMan" => {
+                if !data_path.is_file() {
+                    return Err(StorageError::MissingDataFile(data_path));
+                }
+                load_ism_columns(
+                    &data_path,
+                    &dm.data,
+                    &table_dat.table_desc.columns,
+                    &bound_cols,
+                    &mut rows,
+                    &mut undefined_cells,
+                    nrrow,
+                )?;
+            }
+            "TiledColumnStMan" | "TiledShapeStMan" | "TiledCellStMan" | "TiledDataStMan" => {
+                tiled_stman::load_tiled_columns(
+                    table_path,
+                    dm,
+                    &table_dat.table_desc.columns,
+                    &bound_cols,
+                    &mut rows,
+                    &mut undefined_cells,
+                    nrrow,
+                )?;
+            }
+            other => {
+                return Err(StorageError::UnsupportedDataManager(other.to_string()));
+            }
+        }
+
+        let snapshot = StorageSnapshot {
+            row_count: nrrow,
+            rows,
+            undefined_cells,
+            keywords: RecordValue::default(),
+            column_keywords: HashMap::new(),
+            schema: None,
+            table_info: TableInfo::default(),
+            virtual_columns: HashSet::new(),
+            virtual_bindings: Vec::new(),
+            dm_info: Vec::new(),
+        };
+        array_column_from_snapshot(&snapshot, column)
     }
 
     fn load_plain_table_metadata(
@@ -1832,6 +2124,249 @@ impl CompositeStorage {
             default_tile_shape,
             bindings,
         )
+    }
+}
+
+fn scalar_columns_from_snapshot(snapshot: &StorageSnapshot) -> ScalarColumnSnapshot {
+    let mut columns: HashMap<String, Vec<Option<ScalarValue>>> = HashMap::new();
+    for (row_index, row) in snapshot.rows.iter().enumerate() {
+        for (name, values) in &mut columns {
+            values.push(match row.get(name) {
+                Some(Value::Scalar(value)) => Some(value.clone()),
+                _ => None,
+            });
+        }
+        for field in row.fields() {
+            if let Value::Scalar(value) = &field.value {
+                let entry = columns
+                    .entry(field.name.clone())
+                    .or_insert_with(|| vec![None; row_index]);
+                entry.push(Some(value.clone()));
+            }
+        }
+    }
+    for values in columns.values_mut() {
+        if values.len() < snapshot.row_count {
+            values.resize(snapshot.row_count, None);
+        }
+    }
+    ScalarColumnSnapshot {
+        row_count: snapshot.row_count,
+        columns,
+    }
+}
+
+fn array_column_from_snapshot(
+    snapshot: &StorageSnapshot,
+    column: &str,
+) -> Result<Vec<Option<ArrayValue>>, StorageError> {
+    snapshot
+        .rows
+        .iter()
+        .map(|row| match row.get(column) {
+            Some(Value::Array(value)) => Ok(Some(value.clone())),
+            Some(other) => Err(StorageError::FormatMismatch(format!(
+                "column '{column}' expected array value, found {:?}",
+                other.kind()
+            ))),
+            None => Ok(None),
+        })
+        .collect()
+}
+
+fn collect_stman_scalar_columns(
+    data_path: &Path,
+    all_col_descs: &[table_control::ColumnDescContents],
+    bound_cols: &[(usize, &table_control::PlainColumnEntry)],
+    nrrow: usize,
+    byte_order: ByteOrder,
+    columns: &mut HashMap<String, Vec<Option<ScalarValue>>>,
+) -> Result<(), StorageError> {
+    let col_info: Vec<StManColumnInfo> = bound_cols
+        .iter()
+        .map(|(desc_idx, _)| {
+            let c = &all_col_descs[*desc_idx];
+            let nrelem = if c.is_array && !c.shape.is_empty() {
+                c.shape.iter().map(|&s| s as usize).product()
+            } else {
+                0
+            };
+            StManColumnInfo {
+                is_array: c.is_array,
+                nrelem,
+            }
+        })
+        .collect();
+    let stman_data = read_stman_file(data_path, &col_info, byte_order)?;
+    for (stman_col_idx, (desc_idx, _)) in bound_cols.iter().enumerate() {
+        if stman_col_idx >= stman_data.columns.len() {
+            break;
+        }
+        let col_desc = &all_col_descs[*desc_idx];
+        if col_desc.is_array || col_desc.is_record() {
+            continue;
+        }
+        let values =
+            scalar_values_from_stman_data(&stman_data.columns[stman_col_idx], col_desc, nrrow)?;
+        columns.insert(col_desc.col_name.clone(), values);
+    }
+    Ok(())
+}
+
+fn collect_ssm_scalar_columns(
+    data_path: &Path,
+    dm_blob: &[u8],
+    all_col_descs: &[table_control::ColumnDescContents],
+    bound_cols: &[(usize, &table_control::PlainColumnEntry)],
+    nrrow: usize,
+    columns: &mut HashMap<String, Vec<Option<ScalarValue>>>,
+) -> Result<(), StorageError> {
+    let col_descs: Vec<&table_control::ColumnDescContents> = bound_cols
+        .iter()
+        .map(|(desc_idx, _)| &all_col_descs[*desc_idx])
+        .collect();
+    let ssm_columns = read_ssm_file(data_path, dm_blob, &col_descs, nrrow)?;
+    for (col_name, col_result) in &ssm_columns {
+        let col_desc = col_descs
+            .iter()
+            .find(|c| c.col_name == *col_name)
+            .ok_or_else(|| {
+                StorageError::FormatMismatch(format!(
+                    "SSM returned column '{col_name}' not in descriptor"
+                ))
+            })?;
+        if col_desc.is_array || col_desc.is_record() {
+            continue;
+        }
+        let values = scalar_values_from_ssm_data(col_result, col_desc, nrrow)?;
+        columns.insert(col_name.clone(), values);
+    }
+    Ok(())
+}
+
+fn collect_ism_scalar_columns(
+    data_path: &Path,
+    dm_blob: &[u8],
+    all_col_descs: &[table_control::ColumnDescContents],
+    bound_cols: &[(usize, &table_control::PlainColumnEntry)],
+    nrrow: usize,
+    columns: &mut HashMap<String, Vec<Option<ScalarValue>>>,
+) -> Result<(), StorageError> {
+    let col_descs: Vec<&table_control::ColumnDescContents> = bound_cols
+        .iter()
+        .map(|(desc_idx, _)| &all_col_descs[*desc_idx])
+        .collect();
+    let ism_columns = read_ism_file(data_path, dm_blob, &col_descs, nrrow)?;
+    for (col_name, col_result) in &ism_columns {
+        let col_desc = col_descs
+            .iter()
+            .find(|c| c.col_name == *col_name)
+            .ok_or_else(|| {
+                StorageError::FormatMismatch(format!(
+                    "ISM returned column '{col_name}' not in descriptor"
+                ))
+            })?;
+        if col_desc.is_array || col_desc.is_record() {
+            continue;
+        }
+        let values = scalar_values_from_ism_data(col_result, col_desc, nrrow)?;
+        columns.insert(col_name.clone(), values);
+    }
+    Ok(())
+}
+
+fn scalar_values_from_stman_data(
+    data: &StManColumnData,
+    col_desc: &table_control::ColumnDescContents,
+    nrrow: usize,
+) -> Result<Vec<Option<ScalarValue>>, StorageError> {
+    match data {
+        StManColumnData::Flat(raw) => {
+            let mut values = Vec::with_capacity(nrrow);
+            for row_idx in 0..nrrow {
+                let value = extract_row_value(raw, col_desc, row_idx, nrrow)?;
+                let scalar = scalar_value_from_value(value, &col_desc.col_name)?;
+                if (col_desc.option & 2) != 0
+                    && scalar_value_is_default(
+                        &Value::Scalar(scalar.clone()),
+                        col_desc.require_primitive_type()?,
+                    )
+                {
+                    values.push(None);
+                } else {
+                    values.push(Some(scalar));
+                }
+            }
+            Ok(values)
+        }
+        StManColumnData::Indirect(per_row) => {
+            scalar_values_from_indirect(per_row, &col_desc.col_name)
+        }
+    }
+}
+
+fn scalar_values_from_ssm_data(
+    data: &standard_stman::SsmColumnResult,
+    col_desc: &table_control::ColumnDescContents,
+    nrrow: usize,
+) -> Result<Vec<Option<ScalarValue>>, StorageError> {
+    match data {
+        standard_stman::SsmColumnResult::Flat(raw) => {
+            let mut values = Vec::with_capacity(nrrow);
+            for row_idx in 0..nrrow {
+                let value = extract_row_value(raw, col_desc, row_idx, nrrow)?;
+                values.push(Some(scalar_value_from_value(value, &col_desc.col_name)?));
+            }
+            Ok(values)
+        }
+        standard_stman::SsmColumnResult::Indirect(per_row) => {
+            scalar_values_from_indirect(per_row, &col_desc.col_name)
+        }
+    }
+}
+
+fn scalar_values_from_ism_data(
+    data: &IsmColumnResult,
+    col_desc: &table_control::ColumnDescContents,
+    nrrow: usize,
+) -> Result<Vec<Option<ScalarValue>>, StorageError> {
+    match data {
+        IsmColumnResult::Flat(raw) => {
+            let mut values = Vec::with_capacity(nrrow);
+            for row_idx in 0..nrrow {
+                let value = extract_row_value(raw, col_desc, row_idx, nrrow)?;
+                values.push(Some(scalar_value_from_value(value, &col_desc.col_name)?));
+            }
+            Ok(values)
+        }
+        IsmColumnResult::Indirect(per_row) => {
+            scalar_values_from_indirect(per_row, &col_desc.col_name)
+        }
+    }
+}
+
+fn scalar_values_from_indirect(
+    per_row: &[Option<Value>],
+    column: &str,
+) -> Result<Vec<Option<ScalarValue>>, StorageError> {
+    per_row
+        .iter()
+        .map(|value| {
+            value
+                .clone()
+                .map(|value| scalar_value_from_value(value, column))
+                .transpose()
+        })
+        .collect()
+}
+
+fn scalar_value_from_value(value: Value, column: &str) -> Result<ScalarValue, StorageError> {
+    match value {
+        Value::Scalar(scalar) => Ok(scalar),
+        other => Err(StorageError::FormatMismatch(format!(
+            "column '{column}' expected scalar value, found {:?}",
+            other.kind()
+        ))),
     }
 }
 

--- a/crates/casa-tables/src/table/columns.rs
+++ b/crates/casa-tables/src/table/columns.rs
@@ -532,6 +532,23 @@ impl Table {
         row_index: usize,
         column: &str,
     ) -> Result<&ArrayValue, TableError> {
+        self.require_column(column)?;
+        if row_index >= self.row_count() {
+            return Err(TableError::RowOutOfBounds {
+                row_index,
+                row_count: self.row_count(),
+            });
+        }
+        match self.inner.array_cell(row_index, column)? {
+            crate::table_impl::LazyArrayLookup::Hit(array) => return Ok(array),
+            crate::table_impl::LazyArrayLookup::Missing => {
+                return Err(TableError::ColumnNotFound {
+                    row_index,
+                    column: column.to_string(),
+                });
+            }
+            crate::table_impl::LazyArrayLookup::Unknown => {}
+        }
         match self.cell(row_index, column)? {
             Some(Value::Array(array)) => Ok(array),
             Some(value) => Err(TableError::ColumnTypeMismatch {
@@ -553,6 +570,23 @@ impl Table {
         row_index: usize,
         column: &str,
     ) -> Result<&ScalarValue, TableError> {
+        self.require_column(column)?;
+        if row_index >= self.row_count() {
+            return Err(TableError::RowOutOfBounds {
+                row_index,
+                row_count: self.row_count(),
+            });
+        }
+        match self.inner.scalar_cell(row_index, column)? {
+            crate::table_impl::LazyScalarLookup::Hit(scalar) => return Ok(scalar),
+            crate::table_impl::LazyScalarLookup::Missing => {
+                return Err(TableError::ColumnNotFound {
+                    row_index,
+                    column: column.to_string(),
+                });
+            }
+            crate::table_impl::LazyScalarLookup::Unknown => {}
+        }
         match self.cell(row_index, column)? {
             Some(Value::Scalar(scalar)) => Ok(scalar),
             Some(value) => Err(TableError::ColumnTypeMismatch {

--- a/crates/casa-tables/src/table/tests.rs
+++ b/crates/casa-tables/src/table/tests.rs
@@ -1096,6 +1096,55 @@ fn get_scalar_cell_returns_borrow() {
 }
 
 #[test]
+fn lazy_disk_open_reads_cells_without_materializing_rows() {
+    let schema = TableSchema::new(vec![
+        ColumnSchema::scalar("id", PrimitiveType::Int32),
+        ColumnSchema::array_fixed("data", PrimitiveType::Int32, vec![2]),
+    ])
+    .expect("schema");
+
+    for dm in [
+        DataManagerKind::StManAipsIO,
+        DataManagerKind::StandardStMan,
+        DataManagerKind::IncrementalStMan,
+    ] {
+        let mut table = Table::with_schema(schema.clone());
+        table
+            .add_row(RecordValue::new(vec![
+                RecordField::new("id", Value::Scalar(ScalarValue::Int32(42))),
+                RecordField::new("data", Value::Array(ArrayValue::from_i32_vec(vec![7, 9]))),
+            ]))
+            .expect("push row");
+
+        let root = unique_test_dir(&format!("lazy_scalar_open_{dm:?}"));
+        std::fs::create_dir_all(&root).expect("create test dir");
+        table
+            .save(TableOptions::new(&root).with_data_manager(dm))
+            .expect("save disk-backed table");
+
+        let reopened = Table::open(TableOptions::new(&root)).expect("open lazy table");
+        assert!(!reopened.inner.has_loaded_rows());
+        assert_eq!(
+            reopened.get_scalar_cell(0, "id").expect("scalar access"),
+            &ScalarValue::Int32(42)
+        );
+        assert!(
+            !reopened.inner.has_loaded_rows(),
+            "scalar access should not force row materialization for {dm:?}"
+        );
+
+        let array = reopened.get_array_cell(0, "data").expect("array access");
+        assert_eq!(array, &ArrayValue::from_i32_vec(vec![7, 9]));
+        assert!(
+            !reopened.inner.has_loaded_rows(),
+            "array access should not force row materialization for {dm:?}"
+        );
+
+        std::fs::remove_dir_all(&root).expect("cleanup test dir");
+    }
+}
+
+#[test]
 fn get_scalar_cell_rejects_non_scalar() {
     let table = Table::from_rows(vec![RecordValue::new(vec![RecordField::new(
         "data",

--- a/crates/casa-tables/src/table_impl.rs
+++ b/crates/casa-tables/src/table_impl.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::PathBuf;
 
-use casa_types::RecordValue;
+use casa_types::{ArrayValue, RecordValue, ScalarValue, Value};
 
-use crate::schema::TableSchema;
+use crate::schema::{ColumnType, TableSchema};
 use crate::storage::CompositeStorage;
 use crate::table::TableError;
 
@@ -20,6 +20,34 @@ struct LazyRowsSource {
 struct LoadedRows {
     rows: Vec<RecordValue>,
     undefined_cells: Vec<HashSet<String>>,
+}
+
+#[derive(Debug)]
+struct LoadedScalarColumns {
+    columns: HashMap<String, Vec<Option<ScalarValue>>>,
+}
+
+pub(crate) enum LazyScalarLookup<'a> {
+    Hit(&'a ScalarValue),
+    Missing,
+    Unknown,
+}
+
+pub(crate) enum LazyArrayLookup<'a> {
+    Hit(&'a ArrayValue),
+    Missing,
+    Unknown,
+}
+
+fn lazy_array_column_store(
+    schema: Option<&TableSchema>,
+) -> HashMap<String, OnceCell<Vec<Option<ArrayValue>>>> {
+    schema
+        .into_iter()
+        .flat_map(|schema| schema.columns())
+        .filter(|column| matches!(column.column_type(), ColumnType::Array(_)))
+        .map(|column| (column.name().to_string(), OnceCell::new()))
+        .collect()
 }
 
 fn eager_loaded_rows(
@@ -38,6 +66,8 @@ fn eager_loaded_rows(
 #[derive(Debug, Default)]
 pub(crate) struct TableImpl {
     loaded_rows: OnceCell<LoadedRows>,
+    loaded_scalar_columns: OnceCell<LoadedScalarColumns>,
+    loaded_array_columns: HashMap<String, OnceCell<Vec<Option<ArrayValue>>>>,
     lazy_rows: Option<LazyRowsSource>,
     persisted_row_count: usize,
     keywords: RecordValue,
@@ -56,6 +86,8 @@ impl TableImpl {
             .expect("initialize empty row store");
         Self {
             loaded_rows,
+            loaded_scalar_columns: OnceCell::new(),
+            loaded_array_columns: HashMap::new(),
             lazy_rows: None,
             persisted_row_count: 0,
             keywords: RecordValue::default(),
@@ -72,6 +104,8 @@ impl TableImpl {
             .expect("initialize eager row store");
         Self {
             loaded_rows,
+            loaded_scalar_columns: OnceCell::new(),
+            loaded_array_columns: HashMap::new(),
             lazy_rows: None,
             persisted_row_count,
             keywords: RecordValue::default(),
@@ -94,6 +128,8 @@ impl TableImpl {
             .expect("initialize eager row store");
         Self {
             loaded_rows,
+            loaded_scalar_columns: OnceCell::new(),
+            loaded_array_columns: lazy_array_column_store(schema.as_ref()),
             lazy_rows: None,
             persisted_row_count,
             keywords,
@@ -111,6 +147,8 @@ impl TableImpl {
     ) -> Self {
         Self {
             loaded_rows: OnceCell::new(),
+            loaded_scalar_columns: OnceCell::new(),
+            loaded_array_columns: lazy_array_column_store(schema.as_ref()),
             lazy_rows: Some(LazyRowsSource {
                 path,
                 row_count_hint: row_count,
@@ -133,6 +171,40 @@ impl TableImpl {
                 ))
             })?;
         Ok(eager_loaded_rows(snapshot.rows, snapshot.undefined_cells))
+    }
+
+    fn load_scalar_columns_now(source: &LazyRowsSource) -> Result<LoadedScalarColumns, TableError> {
+        let storage = CompositeStorage;
+        let snapshot = storage
+            .load_scalar_columns_with_row_hint(&source.path, Some(source.row_count_hint as u64))
+            .map_err(|err| {
+                TableError::Storage(format!(
+                    "failed to load scalar columns for table {}: {err}",
+                    source.path.display()
+                ))
+            })?;
+        Ok(LoadedScalarColumns {
+            columns: snapshot.columns,
+        })
+    }
+
+    fn load_array_column_now(
+        source: &LazyRowsSource,
+        column: &str,
+    ) -> Result<Vec<Option<ArrayValue>>, TableError> {
+        let storage = CompositeStorage;
+        storage
+            .load_array_column_with_row_hint(
+                &source.path,
+                column,
+                Some(source.row_count_hint as u64),
+            )
+            .map_err(|err| {
+                TableError::Storage(format!(
+                    "failed to load array column '{column}' for table {}: {err}",
+                    source.path.display()
+                ))
+            })
     }
 
     fn ensure_loaded(&self) -> Result<&LoadedRows, TableError> {
@@ -203,6 +275,78 @@ impl TableImpl {
 
     pub(crate) fn row(&self, row_index: usize) -> Result<Option<&RecordValue>, TableError> {
         Ok(self.ensure_loaded()?.rows.get(row_index))
+    }
+
+    pub(crate) fn scalar_cell(
+        &self,
+        row_index: usize,
+        column: &str,
+    ) -> Result<LazyScalarLookup<'_>, TableError> {
+        if let Some(loaded) = self.loaded_rows.get() {
+            let Some(row) = loaded.rows.get(row_index) else {
+                return Ok(LazyScalarLookup::Missing);
+            };
+            return Ok(match row.get(column) {
+                Some(Value::Scalar(scalar)) => LazyScalarLookup::Hit(scalar),
+                Some(_) => LazyScalarLookup::Unknown,
+                None => LazyScalarLookup::Missing,
+            });
+        }
+
+        let Some(source) = &self.lazy_rows else {
+            return Ok(LazyScalarLookup::Unknown);
+        };
+
+        if self.loaded_scalar_columns.get().is_none() {
+            let loaded = Self::load_scalar_columns_now(source)?;
+            let _ = self.loaded_scalar_columns.set(loaded);
+        }
+        let columns = self
+            .loaded_scalar_columns
+            .get()
+            .expect("scalar columns initialized before access");
+        let Some(values) = columns.columns.get(column) else {
+            return Ok(LazyScalarLookup::Unknown);
+        };
+        match values.get(row_index) {
+            Some(Some(value)) => Ok(LazyScalarLookup::Hit(value)),
+            Some(None) | None => Ok(LazyScalarLookup::Missing),
+        }
+    }
+
+    pub(crate) fn array_cell(
+        &self,
+        row_index: usize,
+        column: &str,
+    ) -> Result<LazyArrayLookup<'_>, TableError> {
+        if let Some(loaded) = self.loaded_rows.get() {
+            let Some(row) = loaded.rows.get(row_index) else {
+                return Ok(LazyArrayLookup::Missing);
+            };
+            return Ok(match row.get(column) {
+                Some(Value::Array(array)) => LazyArrayLookup::Hit(array),
+                Some(_) => LazyArrayLookup::Unknown,
+                None => LazyArrayLookup::Missing,
+            });
+        }
+
+        let Some(source) = &self.lazy_rows else {
+            return Ok(LazyArrayLookup::Unknown);
+        };
+        let Some(cached_column) = self.loaded_array_columns.get(column) else {
+            return Ok(LazyArrayLookup::Unknown);
+        };
+        if cached_column.get().is_none() {
+            let loaded = Self::load_array_column_now(source, column)?;
+            let _ = cached_column.set(loaded);
+        }
+        let values = cached_column
+            .get()
+            .expect("array column initialized before access");
+        match values.get(row_index) {
+            Some(Some(value)) => Ok(LazyArrayLookup::Hit(value)),
+            Some(None) | None => Ok(LazyArrayLookup::Missing),
+        }
     }
 
     pub(crate) fn row_mut(
@@ -298,10 +442,17 @@ impl TableImpl {
                 .expect("replace eager row store");
             loaded_rows
         };
+        self.loaded_scalar_columns = OnceCell::new();
+        self.loaded_array_columns = lazy_array_column_store(schema.as_ref());
         self.persisted_row_count = self.loaded_rows.get().map_or(0, |loaded| loaded.rows.len());
         self.lazy_rows = None;
         self.keywords = keywords;
         self.column_keywords = column_keywords;
         self.schema = schema;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn has_loaded_rows(&self) -> bool {
+        self.loaded_rows.get().is_some()
     }
 }

--- a/crates/casars/src/tests.rs
+++ b/crates/casars/src/tests.rs
@@ -321,7 +321,7 @@ fn calibrate_guided_flow_runs_inspect_and_solve_gain_on_ngc5921() {
         .expect("solve-gain output table");
 
     start_run_with_default_calibrate_launcher(&mut app);
-    assert!(app.wait_for_idle_for_test(Duration::from_secs(120)));
+    assert!(app.wait_for_idle_for_test(Duration::from_secs(60)));
     assert!(
         Path::new(&gain_table).exists(),
         "expected {gain_table} to exist"
@@ -8753,7 +8753,7 @@ fn importvla_workflow_runs_against_real_archive_and_renders_stdout() {
     app.set_text_value("vis", vis_path.to_string_lossy().as_ref());
 
     start_run_with_default_importvla_launcher(&mut app);
-    assert!(app.wait_for_idle_for_test(Duration::from_secs(60)));
+    assert!(app.wait_for_idle_for_test(Duration::from_secs(120)));
     assert!(
         app.stderr_for_test().trim().is_empty(),
         "status={} stderr={}",


### PR DESCRIPTION
Wave issue: #88

## Summary
- improve `casa-aipsio` cold-read behavior with buffered read-only opens and bulk typed slice decoding
- add lazy disk-backed scalar and per-column array caches behind `casa-tables` `TableImpl`
- route `casa-ms` structured selection through table/column access instead of forcing full row materialization
- add regression coverage for lazy disk-backed cell access and adjust the real-archive `casars` importvla workflow timeout to match current branch reality

## Verification
- `cargo test -p casa-tables lazy_disk_open_reads_cells_without_materializing_rows -- --nocapture`
- `cargo test -p casa-ms apply_spw_selection_without_matching_ddid_returns_no_rows -- --nocapture`
- `cargo test -p casars importvla_workflow_runs_against_real_archive_and_renders_stdout -- --nocapture`
- `python3 scripts/smoke-casars-apps.py --app msexplore`
- `just quick`
- `just verify`

## Measured outcome
- fresh current importvla MS full pipeline: about `3.56 s`
- fresh summary: about `0.89 s`
- fresh build: about `3.05 s`
- reused-open full pipeline: about `1.33 s`
- Rust CLI export: about `4.79 s`
- warm CASA `plotms`: about `1.93 s`

## Follow-up
- broader storage-manager boundary audit and enforcement: #91
