### PR TITLE
Close remaining MeasurementSet performance gaps

### DIFF
--- a/crates/casa-calibration/src/cli.rs
+++ b/crates/casa-calibration/src/cli.rs
@@ -3746,6 +3746,7 @@ mod tests {
                 planning_measurement_set_spectral_windows_ns: 750_000,
                 planning_calibration_table_plans_ns: 900_000,
                 open_measurement_set_ns: 2_000_000,
+                row_field_index_lookup_ns: 2_500,
                 ensure_corrected_data_ns: 3_000,
                 correlation_lookup_ns: 4_000,
                 calibration_load_ns: 5_000,

--- a/crates/casa-calibration/src/execute.rs
+++ b/crates/casa-calibration/src/execute.rs
@@ -21,7 +21,10 @@
 //! - solver output beyond the existing planner surface
 
 use std::collections::{BTreeSet, HashMap};
+use std::fs::{File, OpenOptions, create_dir_all};
+use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use std::time::Instant;
 
 use casa_ms::column_def::build_table_schema;
@@ -46,6 +49,271 @@ use crate::plan::{
     ApplyCalibrationTablePlan, ApplyInterpolationMode, ApplyMode, ApplyPlan, ApplyPlanError,
     ApplyPlanRequest, ApplyRowPlan, plan_apply_with_timings,
 };
+
+const PERF_ENV: &str = "CASA_RS_CALIBRATION_PERF";
+const PERF_DIR_ENV: &str = "CASA_RS_CALIBRATION_PERF_DIR";
+
+fn calibration_profile_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| match std::env::var("CASA_RS_CALIBRATION_PROFILE") {
+        Ok(value) => {
+            let trimmed = value.trim();
+            !trimmed.is_empty()
+                && trimmed != "0"
+                && !trimmed.eq_ignore_ascii_case("false")
+                && !trimmed.eq_ignore_ascii_case("off")
+        }
+        Err(_) => false,
+    })
+}
+
+fn log_calibration_profile(phase: &str, seconds: f64, detail: impl Into<Option<String>>) {
+    let mut line = format!("[casa-calibration profile] phase={phase} dt={seconds:.3}s");
+    if let Some(detail) = detail.into() {
+        if !detail.is_empty() {
+            line.push(' ');
+            line.push_str(&detail);
+        }
+    }
+    eprintln!("{line}");
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum CalibrationPerfEventKind {
+    ApplyPlanSummary,
+    ApplyCompleted,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct CalibrationPerfEvent {
+    kind: CalibrationPerfEventKind,
+    monotonic_ns: u64,
+    ms_path: String,
+    apply_mode: String,
+    selected_row_count: usize,
+    calibration_table_count: usize,
+    parang: bool,
+    created_corrected_data_column: bool,
+    updated_row_count: usize,
+    flagged_row_count: usize,
+    flagged_sample_count: usize,
+    planning_ns: u64,
+    planning_selection_ns: u64,
+    planning_selected_rows_ns: u64,
+    planning_measurement_set_spectral_windows_ns: u64,
+    planning_calibration_table_plans_ns: u64,
+    open_measurement_set_ns: u64,
+    row_field_index_lookup_ns: u64,
+    ensure_corrected_data_ns: u64,
+    correlation_lookup_ns: u64,
+    calibration_load_ns: u64,
+    row_loop_ns: u64,
+    row_read_total_ns: u64,
+    row_fetch_ns: u64,
+    row_compute_ns: u64,
+    row_read_overhead_ns: u64,
+    row_writeback_ns: u64,
+    save_ns: u64,
+    execute_apply_plan_ns: u64,
+    execute_apply_plan_unattributed_ns: u64,
+    drop_ns: u64,
+    total_ns: u64,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct ExecuteApplyPlanTraceSummary {
+    selected_row_count: usize,
+    calibration_table_count: usize,
+    parang: bool,
+    created_corrected_data_column: bool,
+    updated_row_count: usize,
+    flagged_row_count: usize,
+    flagged_sample_count: usize,
+    row_field_index_lookup_ns: u64,
+    ensure_corrected_data_ns: u64,
+    correlation_lookup_ns: u64,
+    calibration_load_ns: u64,
+    row_loop_ns: u64,
+    row_read_total_ns: u64,
+    row_fetch_ns: u64,
+    row_compute_ns: u64,
+    row_read_overhead_ns: u64,
+    row_writeback_ns: u64,
+    save_ns: u64,
+    execute_apply_plan_ns: u64,
+    execute_apply_plan_unattributed_ns: u64,
+}
+
+struct CalibrationPerfTracer {
+    started_at: Option<Instant>,
+    json_file: Option<File>,
+    log_file: Option<File>,
+}
+
+impl CalibrationPerfTracer {
+    fn from_env() -> Self {
+        if std::env::var_os(PERF_ENV).is_none() {
+            return Self::disabled();
+        }
+        let output_dir = std::env::var_os(PERF_DIR_ENV)
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("/tmp"));
+        if create_dir_all(&output_dir).is_err() {
+            return Self::disabled();
+        }
+        let pid = std::process::id();
+        let json_path = output_dir.join(format!("casa-calibration-perf-{pid}.jsonl"));
+        let log_path = output_dir.join(format!("casa-calibration-perf-{pid}.log"));
+        let json_file = open_append_file(&json_path);
+        let log_file = open_append_file(&log_path);
+        if json_file.is_none() && log_file.is_none() {
+            return Self::disabled();
+        }
+        Self {
+            started_at: Some(Instant::now()),
+            json_file,
+            log_file,
+        }
+    }
+
+    const fn disabled() -> Self {
+        Self {
+            started_at: None,
+            json_file: None,
+            log_file: None,
+        }
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.started_at.is_some()
+    }
+
+    fn monotonic_ns(&self) -> u64 {
+        self.started_at
+            .map(|started| started.elapsed().as_nanos() as u64)
+            .unwrap_or_default()
+    }
+
+    fn write_event(&mut self, event: &CalibrationPerfEvent) {
+        if let Some(file) = self.json_file.as_mut() {
+            let _ = serde_json::to_writer(&mut *file, event);
+            let _ = writeln!(file);
+            let _ = file.flush();
+        }
+        if let Some(file) = self.log_file.as_mut() {
+            let _ = writeln!(
+                file,
+                "[+{:>7} ms] kind={:?} rows={} total_ms={:.2} planning_ms={:.2} row_field_index_ms={:.2} row_read_ms={:.2} row_read_overhead_ms={:.2} row_write_ms={:.2} save_ms={:.2} unattributed_ms={:.2}",
+                event.monotonic_ns / 1_000_000,
+                event.kind,
+                event.selected_row_count,
+                event.total_ns as f64 / 1_000_000.0,
+                event.planning_ns as f64 / 1_000_000.0,
+                event.row_field_index_lookup_ns as f64 / 1_000_000.0,
+                event.row_read_total_ns as f64 / 1_000_000.0,
+                event.row_read_overhead_ns as f64 / 1_000_000.0,
+                event.row_writeback_ns as f64 / 1_000_000.0,
+                event.save_ns as f64 / 1_000_000.0,
+                event.execute_apply_plan_unattributed_ns as f64 / 1_000_000.0
+            );
+            let _ = file.flush();
+        }
+    }
+
+    fn emit_apply_plan_summary(
+        &mut self,
+        ms_path: &str,
+        plan: &ApplyPlan,
+        summary: ExecuteApplyPlanTraceSummary,
+    ) {
+        if !self.is_enabled() {
+            return;
+        }
+        self.write_event(&CalibrationPerfEvent {
+            kind: CalibrationPerfEventKind::ApplyPlanSummary,
+            monotonic_ns: self.monotonic_ns(),
+            ms_path: ms_path.to_string(),
+            apply_mode: format!("{:?}", plan.apply_mode),
+            selected_row_count: summary.selected_row_count,
+            calibration_table_count: summary.calibration_table_count,
+            parang: summary.parang,
+            created_corrected_data_column: summary.created_corrected_data_column,
+            updated_row_count: summary.updated_row_count,
+            flagged_row_count: summary.flagged_row_count,
+            flagged_sample_count: summary.flagged_sample_count,
+            planning_ns: 0,
+            planning_selection_ns: 0,
+            planning_selected_rows_ns: 0,
+            planning_measurement_set_spectral_windows_ns: 0,
+            planning_calibration_table_plans_ns: 0,
+            open_measurement_set_ns: 0,
+            row_field_index_lookup_ns: summary.row_field_index_lookup_ns,
+            ensure_corrected_data_ns: summary.ensure_corrected_data_ns,
+            correlation_lookup_ns: summary.correlation_lookup_ns,
+            calibration_load_ns: summary.calibration_load_ns,
+            row_loop_ns: summary.row_loop_ns,
+            row_read_total_ns: summary.row_read_total_ns,
+            row_fetch_ns: summary.row_fetch_ns,
+            row_compute_ns: summary.row_compute_ns,
+            row_read_overhead_ns: summary.row_read_overhead_ns,
+            row_writeback_ns: summary.row_writeback_ns,
+            save_ns: summary.save_ns,
+            execute_apply_plan_ns: summary.execute_apply_plan_ns,
+            execute_apply_plan_unattributed_ns: summary.execute_apply_plan_unattributed_ns,
+            drop_ns: 0,
+            total_ns: summary.execute_apply_plan_ns,
+        });
+    }
+
+    fn emit_apply_completed(
+        &mut self,
+        ms_path: &str,
+        report: &ApplyExecutionReport,
+        drop_ns: u64,
+        summary: ExecuteApplyPlanTraceSummary,
+    ) {
+        if !self.is_enabled() {
+            return;
+        }
+        self.write_event(&CalibrationPerfEvent {
+            kind: CalibrationPerfEventKind::ApplyCompleted,
+            monotonic_ns: self.monotonic_ns(),
+            ms_path: ms_path.to_string(),
+            apply_mode: format!("{:?}", report.plan.apply_mode),
+            selected_row_count: summary.selected_row_count,
+            calibration_table_count: summary.calibration_table_count,
+            parang: summary.parang,
+            created_corrected_data_column: report.created_corrected_data_column,
+            updated_row_count: report.updated_row_count,
+            flagged_row_count: report.flagged_row_count,
+            flagged_sample_count: report.flagged_sample_count,
+            planning_ns: report.timings.planning_ns,
+            planning_selection_ns: report.timings.planning_selection_ns,
+            planning_selected_rows_ns: report.timings.planning_selected_rows_ns,
+            planning_measurement_set_spectral_windows_ns: report
+                .timings
+                .planning_measurement_set_spectral_windows_ns,
+            planning_calibration_table_plans_ns: report.timings.planning_calibration_table_plans_ns,
+            open_measurement_set_ns: report.timings.open_measurement_set_ns,
+            row_field_index_lookup_ns: summary.row_field_index_lookup_ns,
+            ensure_corrected_data_ns: summary.ensure_corrected_data_ns,
+            correlation_lookup_ns: summary.correlation_lookup_ns,
+            calibration_load_ns: summary.calibration_load_ns,
+            row_loop_ns: summary.row_loop_ns,
+            row_read_total_ns: summary.row_read_total_ns,
+            row_fetch_ns: summary.row_fetch_ns,
+            row_compute_ns: summary.row_compute_ns,
+            row_read_overhead_ns: summary.row_read_overhead_ns,
+            row_writeback_ns: summary.row_writeback_ns,
+            save_ns: summary.save_ns,
+            execute_apply_plan_ns: summary.execute_apply_plan_ns,
+            execute_apply_plan_unattributed_ns: summary.execute_apply_plan_unattributed_ns,
+            drop_ns,
+            total_ns: report.timings.total_ns,
+        });
+    }
+}
 
 /// Outcome summary for one executor run.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -81,6 +349,8 @@ pub struct ApplyExecutionTimings {
     pub planning_calibration_table_plans_ns: u64,
     /// Time spent opening the MeasurementSet from disk.
     pub open_measurement_set_ns: u64,
+    /// Time spent resolving cached field indices for the MS main-table row record.
+    pub row_field_index_lookup_ns: u64,
     /// Time spent creating or seeding `CORRECTED_DATA` when needed.
     pub ensure_corrected_data_ns: u64,
     /// Time spent loading per-DDID correlation metadata.
@@ -247,30 +517,36 @@ pub(crate) fn evaluate_apply_rows(
                 data_desc_id: row.data_desc_id,
                 correlation_types: Vec::new(),
             })?;
-
-        let data = ms
-            .main_table()
-            .get_array_cell(row.row_index, VisibilityDataColumn::Data.name())
-            .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+        let main_row = ms.main_table().row(row.row_index).map_err(|source| {
+            ApplyExecutionError::MutateMeasurementSet {
                 path: ms_path.clone(),
                 source: MsError::from(source),
-            })?
-            .clone();
-        let original_flags = ms
-            .main_table()
-            .get_array_cell(row.row_index, "FLAG")
-            .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
-                path: ms_path.clone(),
-                source: MsError::from(source),
-            })?
-            .clone();
+            }
+        })?;
+        let data = array_row_value(
+            main_row,
+            row.row_index,
+            VisibilityDataColumn::Data.name(),
+            None,
+        )
+        .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+            path: ms_path.clone(),
+            source: MsError::from(source),
+        })?;
+        let original_flags =
+            array_row_value(main_row, row.row_index, "FLAG", None).map_err(|source| {
+                ApplyExecutionError::MutateMeasurementSet {
+                    path: ms_path.clone(),
+                    source: MsError::from(source),
+                }
+            })?;
 
         let result = apply_row(
             row,
             ExecutionRowInputs {
                 correlation_types,
-                data: &data,
-                original_flags: &original_flags,
+                data,
+                original_flags,
                 original_weight: None,
                 has_weight_spectrum: false,
             },
@@ -282,7 +558,9 @@ pub(crate) fn evaluate_apply_rows(
             row.row_index,
             EvaluatedApplyRow {
                 corrected_data: result.corrected_data,
-                flags: result.updated_flags.unwrap_or(original_flags),
+                flags: result
+                    .updated_flags
+                    .unwrap_or_else(|| original_flags.clone()),
             },
         );
     }
@@ -297,47 +575,84 @@ pub fn execute_apply_from_path(
 ) -> Result<ApplyExecutionReport, ApplyExecutionError> {
     let path = path.as_ref().to_path_buf();
     let total_started_at = Instant::now();
-    let open_started_at = Instant::now();
-    let mut ms =
-        MeasurementSet::open(&path).map_err(|source| ApplyExecutionError::OpenMeasurementSet {
-            path: path.display().to_string(),
-            source,
+    let mut perf_tracer = CalibrationPerfTracer::from_env();
+    let (mut report, plan_trace_summary, pre_drop_total_ns) = {
+        let open_started_at = Instant::now();
+        let mut ms = MeasurementSet::open(&path).map_err(|source| {
+            ApplyExecutionError::OpenMeasurementSet {
+                path: path.display().to_string(),
+                source,
+            }
         })?;
-    let open_measurement_set_ns = open_started_at.elapsed().as_nanos() as u64;
-    let planning_started_at = Instant::now();
-    let (plan, plan_timings) = plan_apply_with_timings(&ms, request)?;
-    let planning_ns = planning_started_at.elapsed().as_nanos() as u64;
-    if plan.apply_mode == ApplyMode::Trial {
-        return Ok(ApplyExecutionReport {
-            plan,
-            created_corrected_data_column: false,
-            wrote_measurement_set: false,
-            updated_row_count: 0,
-            flagged_row_count: 0,
-            flagged_sample_count: 0,
-            timings: ApplyExecutionTimings {
-                planning_ns,
-                planning_selection_ns: plan_timings.selection_ns,
-                planning_selected_rows_ns: plan_timings.selected_rows_ns,
-                planning_measurement_set_spectral_windows_ns: plan_timings
-                    .measurement_set_spectral_windows_ns,
-                planning_calibration_table_plans_ns: plan_timings.calibration_table_plans_ns,
-                open_measurement_set_ns,
-                total_ns: total_started_at.elapsed().as_nanos() as u64,
-                ..ApplyExecutionTimings::default()
-            },
-        });
-    }
+        let open_measurement_set_ns = open_started_at.elapsed().as_nanos() as u64;
+        let planning_started_at = Instant::now();
+        let (plan, plan_timings) = plan_apply_with_timings(&ms, request)?;
+        let planning_ns = planning_started_at.elapsed().as_nanos() as u64;
+        if plan.apply_mode == ApplyMode::Trial {
+            return Ok(ApplyExecutionReport {
+                plan,
+                created_corrected_data_column: false,
+                wrote_measurement_set: false,
+                updated_row_count: 0,
+                flagged_row_count: 0,
+                flagged_sample_count: 0,
+                timings: ApplyExecutionTimings {
+                    planning_ns,
+                    planning_selection_ns: plan_timings.selection_ns,
+                    planning_selected_rows_ns: plan_timings.selected_rows_ns,
+                    planning_measurement_set_spectral_windows_ns: plan_timings
+                        .measurement_set_spectral_windows_ns,
+                    planning_calibration_table_plans_ns: plan_timings.calibration_table_plans_ns,
+                    open_measurement_set_ns,
+                    total_ns: total_started_at.elapsed().as_nanos() as u64,
+                    ..ApplyExecutionTimings::default()
+                },
+            });
+        }
 
-    let mut report = execute_apply_plan(&mut ms, plan)?;
-    report.timings.planning_ns = planning_ns;
-    report.timings.planning_selection_ns = plan_timings.selection_ns;
-    report.timings.planning_selected_rows_ns = plan_timings.selected_rows_ns;
-    report.timings.planning_measurement_set_spectral_windows_ns =
-        plan_timings.measurement_set_spectral_windows_ns;
-    report.timings.planning_calibration_table_plans_ns = plan_timings.calibration_table_plans_ns;
-    report.timings.open_measurement_set_ns = open_measurement_set_ns;
-    report.timings.total_ns = total_started_at.elapsed().as_nanos() as u64;
+        let (mut report, trace_summary) =
+            execute_apply_plan(&mut ms, plan, Some(&mut perf_tracer))?;
+        report.timings.planning_ns = planning_ns;
+        report.timings.planning_selection_ns = plan_timings.selection_ns;
+        report.timings.planning_selected_rows_ns = plan_timings.selected_rows_ns;
+        report.timings.planning_measurement_set_spectral_windows_ns =
+            plan_timings.measurement_set_spectral_windows_ns;
+        report.timings.planning_calibration_table_plans_ns =
+            plan_timings.calibration_table_plans_ns;
+        report.timings.open_measurement_set_ns = open_measurement_set_ns;
+        let pre_drop_total_ns = total_started_at.elapsed().as_nanos() as u64;
+        if calibration_profile_enabled() {
+            log_calibration_profile(
+                "execute_apply_from_path.pre_drop",
+                pre_drop_total_ns as f64 / 1_000_000_000.0,
+                Some(format!(
+                    "rows={} report_total_so_far={:.3}s",
+                    report.updated_row_count,
+                    pre_drop_total_ns as f64 / 1_000_000_000.0
+                )),
+            );
+        }
+        (report, trace_summary, pre_drop_total_ns)
+    };
+    let after_drop_ns = total_started_at.elapsed().as_nanos() as u64;
+    let drop_ns = after_drop_ns.saturating_sub(pre_drop_total_ns);
+    if calibration_profile_enabled() {
+        log_calibration_profile(
+            "execute_apply_from_path.drop",
+            drop_ns as f64 / 1_000_000_000.0,
+            Some(format!(
+                "total_after_drop={:.3}s",
+                after_drop_ns as f64 / 1_000_000_000.0
+            )),
+        );
+    }
+    report.timings.total_ns = after_drop_ns;
+    perf_tracer.emit_apply_completed(
+        &path.display().to_string(),
+        &report,
+        drop_ns,
+        plan_trace_summary,
+    );
     Ok(report)
 }
 
@@ -347,6 +662,7 @@ pub fn execute_apply(
     request: &ApplyPlanRequest,
 ) -> Result<ApplyExecutionReport, ApplyExecutionError> {
     let total_started_at = Instant::now();
+    let mut perf_tracer = CalibrationPerfTracer::from_env();
     let planning_started_at = Instant::now();
     let (plan, plan_timings) = plan_apply_with_timings(ms, request)?;
     let planning_ns = planning_started_at.elapsed().as_nanos() as u64;
@@ -370,7 +686,8 @@ pub fn execute_apply(
             },
         });
     }
-    let mut report = execute_apply_plan(ms, plan)?;
+    let ms_path = display_ms_path(ms);
+    let (mut report, trace_summary) = execute_apply_plan(ms, plan, Some(&mut perf_tracer))?;
     report.timings.planning_ns = planning_ns;
     report.timings.planning_selection_ns = plan_timings.selection_ns;
     report.timings.planning_selected_rows_ns = plan_timings.selected_rows_ns;
@@ -378,14 +695,17 @@ pub fn execute_apply(
         plan_timings.measurement_set_spectral_windows_ns;
     report.timings.planning_calibration_table_plans_ns = plan_timings.calibration_table_plans_ns;
     report.timings.total_ns = total_started_at.elapsed().as_nanos() as u64;
+    perf_tracer.emit_apply_completed(&ms_path, &report, 0, trace_summary);
     Ok(report)
 }
 
 fn execute_apply_plan(
     ms: &mut MeasurementSet,
     plan: ApplyPlan,
-) -> Result<ApplyExecutionReport, ApplyExecutionError> {
+    perf_tracer: Option<&mut CalibrationPerfTracer>,
+) -> Result<(ApplyExecutionReport, ExecuteApplyPlanTraceSummary), ApplyExecutionError> {
     let ms_path = display_ms_path(ms);
+    let execute_apply_plan_started_at = Instant::now();
     let ensure_corrected_data_started_at = Instant::now();
     let created_corrected_data_column = ensure_corrected_data_column(ms).map_err(|source| {
         ApplyExecutionError::CreateCorrectedData {
@@ -424,6 +744,8 @@ fn execute_apply_plan(
     let mut updated_row_count = 0;
     let mut flagged_row_count = 0;
     let mut flagged_sample_count = 0;
+    let mut row_read_total_ns = 0_u64;
+    let mut row_fetch_ns = 0_u64;
     let mut row_compute_ns = 0_u64;
     let mut row_writeback_ns = 0_u64;
     let any_calwt = plan
@@ -435,44 +757,120 @@ fn execute_apply_plan(
         .main_table()
         .schema()
         .is_some_and(|schema| schema.contains_column("WEIGHT_SPECTRUM"));
+    let use_partial_main_save = !created_corrected_data_column;
+    let mut changed_columns: Vec<&'static str> = vec![VisibilityDataColumn::CorrectedData.name()];
+    let row_field_index_lookup_started_at = Instant::now();
+    let row_field_indices = plan
+        .selected_rows
+        .first()
+        .map(|row| cached_apply_row_field_indices(ms.main_table(), row.row_index))
+        .transpose()
+        .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+            path: ms_path.clone(),
+            source: MsError::from(source),
+        })?
+        .unwrap_or_default();
+    let row_field_index_lookup_ns = row_field_index_lookup_started_at.elapsed().as_nanos() as u64;
+    let row_loop_started_at = Instant::now();
+    if use_partial_main_save {
+        let anticipated_updates = plan.selected_rows.len();
+        ms.main_table_mut().reserve_array_cell_updates(
+            VisibilityDataColumn::CorrectedData.name(),
+            anticipated_updates,
+        );
+        ms.main_table_mut()
+            .reserve_array_cell_updates("FLAG", anticipated_updates);
+        ms.main_table_mut()
+            .reserve_array_cell_updates("WEIGHT", anticipated_updates);
+        ms.main_table_mut()
+            .reserve_array_cell_updates("WEIGHT_SPECTRUM", anticipated_updates);
+    }
 
-    for row in &plan.selected_rows {
+    let prefetched_inputs = {
+        let selected_row_indices: Vec<usize> =
+            plan.selected_rows.iter().map(|row| row.row_index).collect();
+        let row_read_started_at = Instant::now();
+        let row_fetch_started_at = Instant::now();
+        let data_values = ms
+            .main_table()
+            .get_array_cells_owned(VisibilityDataColumn::Data.name(), &selected_row_indices)
+            .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                path: ms_path.clone(),
+                source: MsError::from(source),
+            })?;
+        let flag_values = ms
+            .main_table()
+            .get_array_cells_owned("FLAG", &selected_row_indices)
+            .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                path: ms_path.clone(),
+                source: MsError::from(source),
+            })?;
+        let weight_values = if any_calwt {
+            Some(
+                ms.main_table()
+                    .get_array_cells_owned("WEIGHT", &selected_row_indices)
+                    .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                        path: ms_path.clone(),
+                        source: MsError::from(source),
+                    })?,
+            )
+        } else {
+            None
+        };
+        row_fetch_ns += row_fetch_started_at.elapsed().as_nanos() as u64;
+        row_read_total_ns += row_read_started_at.elapsed().as_nanos() as u64;
+        let mut prefetched_inputs = Vec::with_capacity(plan.selected_rows.len());
+
+        for (prefetch_idx, row) in plan.selected_rows.iter().enumerate() {
+            let data = data_values[prefetch_idx].clone().ok_or_else(|| {
+                ApplyExecutionError::MutateMeasurementSet {
+                    path: ms_path.clone(),
+                    source: MsError::from(TableError::ColumnNotFound {
+                        row_index: row.row_index,
+                        column: VisibilityDataColumn::Data.name().to_string(),
+                    }),
+                }
+            })?;
+            let original_flags = flag_values[prefetch_idx].clone().ok_or_else(|| {
+                ApplyExecutionError::MutateMeasurementSet {
+                    path: ms_path.clone(),
+                    source: MsError::from(TableError::ColumnNotFound {
+                        row_index: row.row_index,
+                        column: "FLAG".to_string(),
+                    }),
+                }
+            })?;
+            let original_weight = weight_values
+                .as_ref()
+                .map(|weights| {
+                    weights[prefetch_idx].clone().ok_or_else(|| {
+                        ApplyExecutionError::MutateMeasurementSet {
+                            path: ms_path.clone(),
+                            source: MsError::from(TableError::ColumnNotFound {
+                                row_index: row.row_index,
+                                column: "WEIGHT".to_string(),
+                            }),
+                        }
+                    })
+                })
+                .transpose()?;
+            prefetched_inputs.push(PrefetchedExecutionRowInputs {
+                data,
+                original_flags,
+                original_weight,
+            });
+        }
+
+        prefetched_inputs
+    };
+
+    for (row, prefetched_inputs) in plan.selected_rows.iter().zip(&prefetched_inputs) {
         let correlation_types = correlation_types_by_ddid
             .get(&row.data_desc_id)
             .ok_or_else(|| ApplyExecutionError::UnsupportedCorrelationLayout {
                 data_desc_id: row.data_desc_id,
                 correlation_types: Vec::new(),
             })?;
-
-        let data = ms
-            .main_table()
-            .get_array_cell(row.row_index, VisibilityDataColumn::Data.name())
-            .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
-                path: ms_path.clone(),
-                source: MsError::from(source),
-            })?
-            .clone();
-        let original_flags = ms
-            .main_table()
-            .get_array_cell(row.row_index, "FLAG")
-            .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
-                path: ms_path.clone(),
-                source: MsError::from(source),
-            })?
-            .clone();
-        let original_weight = any_calwt.then(|| {
-            ms.main_table()
-                .get_array_cell(row.row_index, "WEIGHT")
-                .cloned()
-                .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
-                    path: ms_path.clone(),
-                    source: MsError::from(source),
-                })
-        });
-        let original_weight = match original_weight {
-            Some(result) => Some(result?),
-            None => None,
-        };
         let row_compute_started_at = Instant::now();
         let ExecutionRowResult {
             corrected_data,
@@ -481,15 +879,11 @@ fn execute_apply_plan(
             updated_weight_spectrum,
             newly_flagged_samples,
             row_became_fully_flagged,
-        } = apply_row(
+        } = apply_row_prefetched(
             row,
-            ExecutionRowInputs {
-                correlation_types,
-                data: &data,
-                original_flags: &original_flags,
-                original_weight: original_weight.as_ref(),
-                has_weight_spectrum: any_calwt && has_weight_spectrum,
-            },
+            correlation_types,
+            prefetched_inputs,
+            any_calwt && has_weight_spectrum,
             &plan,
             &loaded_tables,
             parang_state.as_ref(),
@@ -497,93 +891,230 @@ fn execute_apply_plan(
         row_compute_ns += row_compute_started_at.elapsed().as_nanos() as u64;
 
         let row_writeback_started_at = Instant::now();
-        ms.main_table_mut()
-            .set_cell(
-                row.row_index,
-                VisibilityDataColumn::CorrectedData.name(),
-                Value::Array(corrected_data),
-            )
-            .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
-                path: ms_path.clone(),
-                source: MsError::from(source),
-            })?;
-
-        if let Some(updated_flags) = updated_flags {
+        if use_partial_main_save {
             ms.main_table_mut()
-                .set_cell(row.row_index, "FLAG", Value::Array(updated_flags))
-                .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
-                    path: ms_path.clone(),
-                    source: MsError::from(source),
-                })?;
-            if row_became_fully_flagged {
-                ms.main_table_mut()
-                    .set_cell(
-                        row.row_index,
-                        "FLAG_ROW",
-                        Value::Scalar(ScalarValue::Bool(true)),
-                    )
-                    .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
-                        path: ms_path.clone(),
-                        source: MsError::from(source),
-                    })?;
-                flagged_row_count += 1;
-            }
-            flagged_sample_count += newly_flagged_samples;
-        }
-        if let Some(updated_weight) = updated_weight {
-            ms.main_table_mut()
-                .set_cell(row.row_index, "WEIGHT", Value::Array(updated_weight))
-                .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
-                    path: ms_path.clone(),
-                    source: MsError::from(source),
-                })?;
-        }
-        if let Some(updated_weight_spectrum) = updated_weight_spectrum {
-            ms.main_table_mut()
-                .set_cell(
+                .set_array_cell_assuming_valid(
                     row.row_index,
-                    "WEIGHT_SPECTRUM",
-                    Value::Array(updated_weight_spectrum),
+                    VisibilityDataColumn::CorrectedData.name(),
+                    corrected_data,
                 )
                 .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
                     path: ms_path.clone(),
                     source: MsError::from(source),
                 })?;
-        }
 
+            if let Some(updated_flags) = updated_flags {
+                if !changed_columns.contains(&"FLAG") {
+                    changed_columns.push("FLAG");
+                }
+                ms.main_table_mut()
+                    .set_array_cell_assuming_valid(row.row_index, "FLAG", updated_flags)
+                    .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                        path: ms_path.clone(),
+                        source: MsError::from(source),
+                    })?;
+                if row_became_fully_flagged {
+                    if !changed_columns.contains(&"FLAG_ROW") {
+                        changed_columns.push("FLAG_ROW");
+                    }
+                    ms.main_table_mut()
+                        .set_scalar_cell_assuming_valid(
+                            row.row_index,
+                            "FLAG_ROW",
+                            ScalarValue::Bool(true),
+                        )
+                        .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                            path: ms_path.clone(),
+                            source: MsError::from(source),
+                        })?;
+                    flagged_row_count += 1;
+                }
+                flagged_sample_count += newly_flagged_samples;
+            }
+            if let Some(updated_weight) = updated_weight {
+                if !changed_columns.contains(&"WEIGHT") {
+                    changed_columns.push("WEIGHT");
+                }
+                ms.main_table_mut()
+                    .set_array_cell_assuming_valid(row.row_index, "WEIGHT", updated_weight)
+                    .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                        path: ms_path.clone(),
+                        source: MsError::from(source),
+                    })?;
+            }
+            if let Some(updated_weight_spectrum) = updated_weight_spectrum {
+                if !changed_columns.contains(&"WEIGHT_SPECTRUM") {
+                    changed_columns.push("WEIGHT_SPECTRUM");
+                }
+                ms.main_table_mut()
+                    .set_array_cell_assuming_valid(
+                        row.row_index,
+                        "WEIGHT_SPECTRUM",
+                        updated_weight_spectrum,
+                    )
+                    .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                        path: ms_path.clone(),
+                        source: MsError::from(source),
+                    })?;
+            }
+        } else {
+            let row_record = ms
+                .main_table_mut()
+                .row_mut(row.row_index)
+                .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                    path: ms_path.clone(),
+                    source: MsError::from(source),
+                })?;
+            write_row_value(
+                row_record,
+                VisibilityDataColumn::CorrectedData.name(),
+                row_field_indices.corrected_data,
+                Value::Array(corrected_data),
+            );
+
+            if let Some(updated_flags) = updated_flags {
+                write_row_value(
+                    row_record,
+                    "FLAG",
+                    row_field_indices.flag,
+                    Value::Array(updated_flags),
+                );
+                if row_became_fully_flagged {
+                    write_row_value(
+                        row_record,
+                        "FLAG_ROW",
+                        row_field_indices.flag_row,
+                        Value::Scalar(ScalarValue::Bool(true)),
+                    );
+                    flagged_row_count += 1;
+                }
+                flagged_sample_count += newly_flagged_samples;
+            }
+            if let Some(updated_weight) = updated_weight {
+                write_row_value(
+                    row_record,
+                    "WEIGHT",
+                    row_field_indices.weight,
+                    Value::Array(updated_weight),
+                );
+            }
+            if let Some(updated_weight_spectrum) = updated_weight_spectrum {
+                write_row_value(
+                    row_record,
+                    "WEIGHT_SPECTRUM",
+                    row_field_indices.weight_spectrum,
+                    Value::Array(updated_weight_spectrum),
+                );
+            }
+        }
         updated_row_count += 1;
         row_writeback_ns += row_writeback_started_at.elapsed().as_nanos() as u64;
     }
+    let row_loop_ns = row_loop_started_at.elapsed().as_nanos() as u64;
 
     let save_started_at = Instant::now();
-    ms.save_main_table_only_assuming_valid().map_err(|source| {
-        ApplyExecutionError::MutateMeasurementSet {
-            path: ms_path,
-            source,
-        }
-    })?;
+    if use_partial_main_save {
+        let changed_row_indices: Vec<usize> =
+            plan.selected_rows.iter().map(|row| row.row_index).collect();
+        ms.main_table()
+            .save_selected_rows_in_place_assuming_valid(&changed_columns, &changed_row_indices)
+            .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                path: ms_path.clone(),
+                source: MsError::from(source),
+            })?;
+    } else {
+        ms.save_main_table_only_assuming_valid().map_err(|source| {
+            ApplyExecutionError::MutateMeasurementSet {
+                path: ms_path.clone(),
+                source,
+            }
+        })?;
+    }
     let save_ns = save_started_at.elapsed().as_nanos() as u64;
-
-    Ok(ApplyExecutionReport {
-        plan,
+    let row_read_overhead_ns = row_read_total_ns.saturating_sub(row_fetch_ns);
+    let execute_apply_plan_ns = execute_apply_plan_started_at.elapsed().as_nanos() as u64;
+    let bucketed_ns = ensure_corrected_data_ns
+        + correlation_lookup_ns
+        + calibration_load_ns
+        + row_field_index_lookup_ns
+        + row_read_total_ns
+        + row_compute_ns
+        + row_writeback_ns
+        + save_ns;
+    let execute_apply_plan_unattributed_ns = execute_apply_plan_ns.saturating_sub(bucketed_ns);
+    let trace_summary = ExecuteApplyPlanTraceSummary {
+        selected_row_count: plan.selected_rows.len(),
+        calibration_table_count: plan.calibration_tables.len(),
+        parang: plan.parang,
         created_corrected_data_column,
-        wrote_measurement_set: true,
         updated_row_count,
         flagged_row_count,
         flagged_sample_count,
-        timings: ApplyExecutionTimings {
-            planning_ns: 0,
-            open_measurement_set_ns: 0,
-            ensure_corrected_data_ns,
-            correlation_lookup_ns,
-            calibration_load_ns,
-            row_compute_ns,
-            row_writeback_ns,
-            save_ns,
-            total_ns: 0,
-            ..ApplyExecutionTimings::default()
+        row_field_index_lookup_ns,
+        ensure_corrected_data_ns,
+        correlation_lookup_ns,
+        calibration_load_ns,
+        row_loop_ns,
+        row_read_total_ns,
+        row_fetch_ns,
+        row_compute_ns,
+        row_read_overhead_ns,
+        row_writeback_ns,
+        save_ns,
+        execute_apply_plan_ns,
+        execute_apply_plan_unattributed_ns,
+    };
+    if let Some(perf_tracer) = perf_tracer {
+        perf_tracer.emit_apply_plan_summary(&ms_path, &plan, trace_summary);
+    }
+    if calibration_profile_enabled() {
+        log_calibration_profile(
+            "execute_apply_plan",
+            execute_apply_plan_ns as f64 / 1_000_000_000.0,
+            Some(format!(
+                "rows={} row_loop={:.3}s bucketed={:.3}s unattributed={:.3}s ensure_corrected_data={:.3}s correlation_lookup={:.3}s calibration_load={:.3}s row_field_index_lookup={:.3}s row_read_total={:.3}s row_fetch={:.3}s row_compute={:.3}s row_read_overhead={:.3}s row_writeback={:.3}s save={:.3}s",
+                plan.selected_rows.len(),
+                row_loop_ns as f64 / 1_000_000_000.0,
+                bucketed_ns as f64 / 1_000_000_000.0,
+                execute_apply_plan_unattributed_ns as f64 / 1_000_000_000.0,
+                ensure_corrected_data_ns as f64 / 1_000_000_000.0,
+                correlation_lookup_ns as f64 / 1_000_000_000.0,
+                calibration_load_ns as f64 / 1_000_000_000.0,
+                row_field_index_lookup_ns as f64 / 1_000_000_000.0,
+                row_read_total_ns as f64 / 1_000_000_000.0,
+                row_fetch_ns as f64 / 1_000_000_000.0,
+                row_compute_ns as f64 / 1_000_000_000.0,
+                row_read_overhead_ns as f64 / 1_000_000_000.0,
+                row_writeback_ns as f64 / 1_000_000_000.0,
+                save_ns as f64 / 1_000_000_000.0
+            )),
+        );
+    }
+
+    Ok((
+        ApplyExecutionReport {
+            plan,
+            created_corrected_data_column,
+            wrote_measurement_set: true,
+            updated_row_count,
+            flagged_row_count,
+            flagged_sample_count,
+            timings: ApplyExecutionTimings {
+                planning_ns: 0,
+                open_measurement_set_ns: 0,
+                row_field_index_lookup_ns,
+                ensure_corrected_data_ns,
+                correlation_lookup_ns,
+                calibration_load_ns,
+                row_compute_ns,
+                row_writeback_ns,
+                save_ns,
+                total_ns: 0,
+                ..ApplyExecutionTimings::default()
+            },
         },
-    })
+        trace_summary,
+    ))
 }
 
 struct ExecutionRowResult {
@@ -601,6 +1132,12 @@ struct ExecutionRowInputs<'a> {
     original_flags: &'a ArrayValue,
     original_weight: Option<&'a ArrayValue>,
     has_weight_spectrum: bool,
+}
+
+struct PrefetchedExecutionRowInputs {
+    data: ArrayValue,
+    original_flags: ArrayValue,
+    original_weight: Option<ArrayValue>,
 }
 
 struct ParallacticAngleState {
@@ -868,6 +1405,30 @@ fn apply_row(
         newly_flagged_samples,
         row_became_fully_flagged,
     })
+}
+
+fn apply_row_prefetched(
+    row: &ApplyRowPlan,
+    correlation_types: &[i32],
+    inputs: &PrefetchedExecutionRowInputs,
+    has_weight_spectrum: bool,
+    plan: &ApplyPlan,
+    loaded_tables: &[LoadedCalibrationTable],
+    parang_state: Option<&ParallacticAngleState>,
+) -> Result<ExecutionRowResult, ApplyExecutionError> {
+    apply_row(
+        row,
+        ExecutionRowInputs {
+            correlation_types,
+            data: &inputs.data,
+            original_flags: &inputs.original_flags,
+            original_weight: inputs.original_weight.as_ref(),
+            has_weight_spectrum,
+        },
+        plan,
+        loaded_tables,
+        parang_state,
+    )
 }
 
 impl ParallacticAngleState {
@@ -1953,10 +2514,125 @@ fn ensure_corrected_data_column(ms: &mut MeasurementSet) -> Result<bool, TableEr
     Ok(true)
 }
 
+#[derive(Clone, Copy, Default)]
+struct ApplyRowFieldIndices {
+    data: Option<usize>,
+    corrected_data: Option<usize>,
+    flag: Option<usize>,
+    flag_row: Option<usize>,
+    weight: Option<usize>,
+    weight_spectrum: Option<usize>,
+}
+
+fn cached_apply_row_field_indices(
+    table: &Table,
+    row_index: usize,
+) -> Result<ApplyRowFieldIndices, TableError> {
+    if let Some(schema) = table.schema() {
+        let mut indices = ApplyRowFieldIndices::default();
+        for (field_index, column) in schema.columns().iter().enumerate() {
+            match column.name() {
+                name if name == VisibilityDataColumn::Data.name() => {
+                    indices.data = Some(field_index);
+                }
+                name if name == VisibilityDataColumn::CorrectedData.name() => {
+                    indices.corrected_data = Some(field_index);
+                }
+                "FLAG" => indices.flag = Some(field_index),
+                "FLAG_ROW" => indices.flag_row = Some(field_index),
+                "WEIGHT" => indices.weight = Some(field_index),
+                "WEIGHT_SPECTRUM" => indices.weight_spectrum = Some(field_index),
+                _ => {}
+            }
+        }
+        return Ok(indices);
+    }
+
+    let row = table.row(row_index)?;
+    let mut indices = ApplyRowFieldIndices::default();
+    for (field_index, field) in row.fields().iter().enumerate() {
+        match field.name.as_str() {
+            name if name == VisibilityDataColumn::Data.name() => {
+                indices.data = Some(field_index);
+            }
+            name if name == VisibilityDataColumn::CorrectedData.name() => {
+                indices.corrected_data = Some(field_index);
+            }
+            "FLAG" => indices.flag = Some(field_index),
+            "FLAG_ROW" => indices.flag_row = Some(field_index),
+            "WEIGHT" => indices.weight = Some(field_index),
+            "WEIGHT_SPECTRUM" => indices.weight_spectrum = Some(field_index),
+            _ => {}
+        }
+    }
+    Ok(indices)
+}
+
+fn cached_row_value<'a>(
+    row: &'a casa_types::RecordValue,
+    column: &str,
+    field_index: Option<usize>,
+) -> Option<&'a Value> {
+    if let Some(field_index) = field_index {
+        if let Some(field) = row.fields().get(field_index) {
+            if field.name == column {
+                return Some(&field.value);
+            }
+        }
+    }
+    row.get(column)
+}
+
+fn array_row_value<'a>(
+    row: &'a casa_types::RecordValue,
+    row_index: usize,
+    column: &str,
+    field_index: Option<usize>,
+) -> Result<&'a ArrayValue, TableError> {
+    match cached_row_value(row, column, field_index) {
+        Some(Value::Array(array)) => Ok(array),
+        Some(value) => Err(TableError::ColumnTypeMismatch {
+            row_index,
+            column: column.to_string(),
+            expected: "array",
+            found: value.kind(),
+        }),
+        None => Err(TableError::ColumnNotFound {
+            row_index,
+            column: column.to_string(),
+        }),
+    }
+}
+
+fn write_row_value(
+    row: &mut casa_types::RecordValue,
+    column: &str,
+    field_index: Option<usize>,
+    value: Value,
+) {
+    if let Some(field_index) = field_index {
+        if let Some(field) = row.fields_mut().get_mut(field_index) {
+            if field.name == column {
+                field.value = value;
+                return;
+            }
+        }
+    }
+    if let Some(existing) = row.get_mut(column) {
+        *existing = value;
+    } else {
+        row.upsert(column, value);
+    }
+}
+
 fn display_ms_path(ms: &MeasurementSet) -> String {
     ms.path()
         .map(|path| path.display().to_string())
         .unwrap_or_else(|| "<in-memory>".to_string())
+}
+
+fn open_append_file(path: &Path) -> Option<File> {
+    OpenOptions::new().create(true).append(true).open(path).ok()
 }
 
 fn median_f32(values: &[f32]) -> f32 {
@@ -2128,6 +2804,9 @@ fn get_f64_array(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::sync::{Mutex, OnceLock};
+
     use casa_ms::{MeasurementSet, MeasurementSetBuilder, OptionalMainColumn};
     use casa_tables::{ArrayShapeContract, ColumnSchema, ColumnType, Table};
     use casa_types::measures::direction::{DirectionRef, MDirection};
@@ -2136,6 +2815,12 @@ mod tests {
         ArrayValue, Complex64, PrimitiveType, RecordField, RecordValue, ScalarValue, Value,
     };
     use ndarray::{ArrayD, IxDyn, ShapeBuilder};
+    use tempfile::TempDir;
+
+    fn perf_env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     fn row(fields: Vec<RecordField>) -> RecordValue {
         RecordValue::new(fields)
@@ -2143,6 +2828,106 @@ mod tests {
 
     fn scalar_table(fields: Vec<RecordField>) -> Table {
         Table::from_rows_memory(vec![row(fields)])
+    }
+
+    #[test]
+    fn calibration_perf_tracer_from_env_writes_jsonl_and_summary_log() {
+        let _guard = perf_env_lock().lock().expect("perf env lock");
+        let tempdir = TempDir::new().expect("tempdir");
+        unsafe {
+            std::env::set_var(PERF_ENV, "1");
+            std::env::set_var(PERF_DIR_ENV, tempdir.path());
+        }
+
+        let mut tracer = CalibrationPerfTracer::from_env();
+        assert!(tracer.is_enabled());
+        tracer.write_event(&CalibrationPerfEvent {
+            kind: CalibrationPerfEventKind::ApplyCompleted,
+            monotonic_ns: 42,
+            ms_path: "/tmp/test.ms".to_string(),
+            apply_mode: "CalFlag".to_string(),
+            selected_row_count: 8,
+            calibration_table_count: 1,
+            parang: false,
+            created_corrected_data_column: true,
+            updated_row_count: 8,
+            flagged_row_count: 2,
+            flagged_sample_count: 5,
+            planning_ns: 11,
+            planning_selection_ns: 12,
+            planning_selected_rows_ns: 13,
+            planning_measurement_set_spectral_windows_ns: 14,
+            planning_calibration_table_plans_ns: 15,
+            open_measurement_set_ns: 16,
+            row_field_index_lookup_ns: 17,
+            ensure_corrected_data_ns: 18,
+            correlation_lookup_ns: 19,
+            calibration_load_ns: 20,
+            row_loop_ns: 21,
+            row_read_total_ns: 22,
+            row_fetch_ns: 23,
+            row_compute_ns: 24,
+            row_read_overhead_ns: 25,
+            row_writeback_ns: 26,
+            save_ns: 27,
+            execute_apply_plan_ns: 28,
+            execute_apply_plan_unattributed_ns: 29,
+            drop_ns: 30,
+            total_ns: 31,
+        });
+        drop(tracer);
+
+        unsafe {
+            std::env::remove_var(PERF_ENV);
+            std::env::remove_var(PERF_DIR_ENV);
+        }
+
+        let mut json_paths = fs::read_dir(tempdir.path())
+            .expect("read perf dir")
+            .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+            .filter(|path| {
+                path.extension()
+                    .is_some_and(|extension| extension == "jsonl")
+            })
+            .collect::<Vec<_>>();
+        json_paths.sort();
+        let mut log_paths = fs::read_dir(tempdir.path())
+            .expect("read perf dir")
+            .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+            .filter(|path| path.extension().is_some_and(|extension| extension == "log"))
+            .collect::<Vec<_>>();
+        log_paths.sort();
+        assert_eq!(json_paths.len(), 1);
+        assert_eq!(log_paths.len(), 1);
+
+        let json = fs::read_to_string(json_paths[0].clone()).expect("json trace");
+        assert!(json.contains("\"kind\":\"apply_completed\""));
+        assert!(json.contains("\"row_read_overhead_ns\":25"));
+
+        let log = fs::read_to_string(log_paths[0].clone()).expect("summary log");
+        assert!(log.contains("kind=ApplyCompleted"));
+        assert!(log.contains("row_read_overhead_ms=0.00"));
+    }
+
+    #[test]
+    fn cached_apply_row_field_indices_uses_schema_without_rows() {
+        let main_schema = MeasurementSetBuilder::new()
+            .with_main_column(OptionalMainColumn::Data)
+            .with_main_column(OptionalMainColumn::CorrectedData)
+            .with_main_column(OptionalMainColumn::WeightSpectrum)
+            .build_schemas()
+            .expect("schemas")
+            .main;
+        let table = Table::with_schema(main_schema);
+
+        let indices = cached_apply_row_field_indices(&table, 0).expect("schema lookup");
+
+        assert!(indices.data.is_some());
+        assert!(indices.corrected_data.is_some());
+        assert!(indices.flag.is_some());
+        assert!(indices.flag_row.is_some());
+        assert!(indices.weight.is_some());
+        assert!(indices.weight_spectrum.is_some());
     }
 
     fn default_main_value(column: &ColumnSchema) -> Value {

--- a/crates/casa-calibration/src/plan.rs
+++ b/crates/casa-calibration/src/plan.rs
@@ -500,11 +500,20 @@ fn build_selected_rows(
         .data_description()
         .map_err(|source| ApplyPlanError::Selection { source })?;
     let table = ms.main_table();
+    let data_desc_ids = load_i32_column(table, "DATA_DESC_ID")?;
+    let field_ids = load_i32_column(table, "FIELD_ID")?;
+    let observation_ids = load_i32_column(table, "OBSERVATION_ID")?;
+    let antenna1s = load_i32_column(table, "ANTENNA1")?;
+    let antenna2s = load_i32_column(table, "ANTENNA2")?;
+    let feed1s = load_i32_column(table, "FEED1")?;
+    let feed2s = load_i32_column(table, "FEED2")?;
+    let times = load_f64_column(table, "TIME")?;
+    let intervals = load_f64_column(table, "INTERVAL")?;
 
     row_indices
         .iter()
         .map(|&row_index| {
-            let data_desc_id = get_i32(table, row_index, "DATA_DESC_ID")?;
+            let data_desc_id = value_at_i32(&data_desc_ids, row_index, "DATA_DESC_ID")?;
             let ddid_index = usize::try_from(data_desc_id).map_err(|_| {
                 ApplyPlanError::MissingDataDescription {
                     row_index,
@@ -520,8 +529,8 @@ fn build_selected_rows(
 
             Ok(ApplyRowPlan {
                 row_index,
-                field_id: get_i32(table, row_index, "FIELD_ID")?,
-                observation_id: get_i32(table, row_index, "OBSERVATION_ID")?,
+                field_id: value_at_i32(&field_ids, row_index, "FIELD_ID")?,
+                observation_id: value_at_i32(&observation_ids, row_index, "OBSERVATION_ID")?,
                 data_desc_id,
                 data_spw_id: dd
                     .spectral_window_id(ddid_index)
@@ -529,15 +538,87 @@ fn build_selected_rows(
                 polarization_id: dd
                     .polarization_id(ddid_index)
                     .map_err(|source| ApplyPlanError::Selection { source })?,
-                antenna1: get_i32(table, row_index, "ANTENNA1")?,
-                antenna2: get_i32(table, row_index, "ANTENNA2")?,
-                feed1: get_i32(table, row_index, "FEED1")?,
-                feed2: get_i32(table, row_index, "FEED2")?,
-                time_seconds: get_f64(table, row_index, "TIME")?,
-                interval_seconds: get_f64(table, row_index, "INTERVAL")?,
+                antenna1: value_at_i32(&antenna1s, row_index, "ANTENNA1")?,
+                antenna2: value_at_i32(&antenna2s, row_index, "ANTENNA2")?,
+                feed1: value_at_i32(&feed1s, row_index, "FEED1")?,
+                feed2: value_at_i32(&feed2s, row_index, "FEED2")?,
+                time_seconds: value_at_f64(&times, row_index, "TIME")?,
+                interval_seconds: value_at_f64(&intervals, row_index, "INTERVAL")?,
             })
         })
         .collect()
+}
+
+fn load_i32_column(table: &Table, column: &str) -> Result<Vec<Option<i32>>, ApplyPlanError> {
+    table
+        .get_scalar_cells_owned(column)
+        .map_err(|source| ApplyPlanError::Selection {
+            source: MsError::from(source),
+        })?
+        .into_iter()
+        .enumerate()
+        .map(|(row_index, value)| match value {
+            Some(casa_types::ScalarValue::Int32(v)) => Ok(Some(v)),
+            Some(other) => Err(ApplyPlanError::ScalarTypeMismatch {
+                context: format!("{column} row {row_index}"),
+                expected: "Int32",
+                found: scalar_kind(&other),
+            }),
+            None => Ok(None),
+        })
+        .collect()
+}
+
+fn load_f64_column(table: &Table, column: &str) -> Result<Vec<Option<f64>>, ApplyPlanError> {
+    table
+        .get_scalar_cells_owned(column)
+        .map_err(|source| ApplyPlanError::Selection {
+            source: MsError::from(source),
+        })?
+        .into_iter()
+        .enumerate()
+        .map(|(row_index, value)| match value {
+            Some(casa_types::ScalarValue::Float64(v)) => Ok(Some(v)),
+            Some(other) => Err(ApplyPlanError::ScalarTypeMismatch {
+                context: format!("{column} row {row_index}"),
+                expected: "Float64",
+                found: scalar_kind(&other),
+            }),
+            None => Ok(None),
+        })
+        .collect()
+}
+
+fn value_at_i32(
+    values: &[Option<i32>],
+    row_index: usize,
+    column: &str,
+) -> Result<i32, ApplyPlanError> {
+    values
+        .get(row_index)
+        .and_then(|value| *value)
+        .ok_or_else(|| ApplyPlanError::Selection {
+            source: MsError::MissingColumn {
+                column: column.to_string(),
+                table: format!("MAIN row {row_index}"),
+            },
+        })
+}
+
+fn value_at_f64(
+    values: &[Option<f64>],
+    row_index: usize,
+    column: &str,
+) -> Result<f64, ApplyPlanError> {
+    values
+        .get(row_index)
+        .and_then(|value| *value)
+        .ok_or_else(|| ApplyPlanError::Selection {
+            source: MsError::MissingColumn {
+                column: column.to_string(),
+                table: format!("MAIN row {row_index}"),
+            },
+        })
 }
 
 fn load_ms_spectral_windows(
@@ -1032,6 +1113,7 @@ fn get_string(table: &Table, row_index: usize, column: &str) -> Result<String, A
     }
 }
 
+#[cfg(test)]
 fn get_i32(table: &Table, row_index: usize, column: &str) -> Result<i32, ApplyPlanError> {
     match table
         .get_scalar_cell(row_index, column)
@@ -1047,6 +1129,7 @@ fn get_i32(table: &Table, row_index: usize, column: &str) -> Result<i32, ApplyPl
     }
 }
 
+#[cfg(test)]
 fn get_f64(table: &Table, row_index: usize, column: &str) -> Result<f64, ApplyPlanError> {
     match table
         .get_scalar_cell(row_index, column)

--- a/crates/casa-ms/src/msexplore.rs
+++ b/crates/casa-ms/src/msexplore.rs
@@ -2164,20 +2164,263 @@ impl PointBudget {
     }
 
     fn record_points(&mut self, additional_points: usize, context: &str) -> Result<(), String> {
-        let next_points = self
+        self.rendered_points = self
             .rendered_points
             .checked_add(additional_points)
             .ok_or_else(|| format!("{context} exceeded the supported plotted-point range"))?;
-        if let Some(max_plot_points) = self.max_plot_points
-            && next_points > max_plot_points
-        {
-            return Err(format!(
-                "{context} would render more than {max_plot_points} points; narrow the selection, add averaging, or raise --max-points"
-            ));
-        }
-        self.rendered_points = next_points;
         Ok(())
     }
+}
+
+fn allocate_series_point_quotas(lengths: &[usize], budget: usize) -> Vec<usize> {
+    let total_points = lengths.iter().sum::<usize>();
+    if total_points <= budget {
+        return lengths.to_vec();
+    }
+    if budget == 0 {
+        return vec![0; lengths.len()];
+    }
+
+    let mut quotas = vec![0usize; lengths.len()];
+    let mut remainders = Vec::new();
+    let mut assigned = 0usize;
+    for (index, &length) in lengths.iter().enumerate() {
+        if length == 0 {
+            continue;
+        }
+        let scaled = length.saturating_mul(budget);
+        let base = scaled / total_points;
+        let remainder = scaled % total_points;
+        quotas[index] = base;
+        assigned += base;
+        remainders.push((index, remainder, length));
+    }
+
+    remainders.sort_by(|left, right| right.1.cmp(&left.1).then_with(|| right.2.cmp(&left.2)));
+    let mut remaining = budget.saturating_sub(assigned);
+    for (index, _, _) in remainders {
+        if remaining == 0 {
+            break;
+        }
+        quotas[index] += 1;
+        remaining -= 1;
+    }
+
+    quotas
+}
+
+fn sampled_indices(length: usize, take: usize) -> Vec<usize> {
+    if take >= length {
+        return (0..length).collect();
+    }
+    if take == 0 {
+        return Vec::new();
+    }
+    if take == 1 {
+        return vec![length / 2];
+    }
+
+    (0..take)
+        .map(|slot| slot.saturating_mul(length.saturating_sub(1)) / (take - 1))
+        .collect()
+}
+
+fn compact_scatter_series(
+    series: Vec<MsScatterSeries>,
+    max_plot_points: usize,
+) -> (Vec<MsScatterSeries>, usize, usize) {
+    let lengths = series
+        .iter()
+        .map(|entry| entry.points.len())
+        .collect::<Vec<_>>();
+    let total_points = lengths.iter().sum::<usize>();
+    if total_points <= max_plot_points {
+        return (series, total_points, total_points);
+    }
+
+    let quotas = allocate_series_point_quotas(&lengths, max_plot_points);
+    let mut kept_points = 0usize;
+    let compacted = series
+        .into_iter()
+        .zip(quotas)
+        .filter_map(|(entry, quota)| {
+            if quota == 0 || entry.points.is_empty() {
+                return None;
+            }
+            let indices = sampled_indices(entry.points.len(), quota);
+            kept_points += indices.len();
+            let points = indices.iter().map(|&index| entry.points[index]).collect();
+            let provenance = indices
+                .iter()
+                .map(|&index| entry.provenance[index].clone())
+                .collect();
+            Some(MsScatterSeries {
+                label: entry.label,
+                color_group: entry.color_group,
+                y_axis: entry.y_axis,
+                points,
+                provenance,
+            })
+        })
+        .collect();
+
+    (compacted, total_points, kept_points)
+}
+
+fn compact_payload_to_budget(
+    payload: MsPlotPayload,
+    point_budget: &PointBudget,
+) -> Result<MsPlotPayload, String> {
+    let Some(max_plot_points) = point_budget.max_plot_points else {
+        return Ok(payload);
+    };
+    if point_budget.rendered_points <= max_plot_points {
+        return Ok(payload);
+    }
+
+    let warning = format!(
+        "Downsampled plot from {} to at most {} points using evenly spaced per-series decimation.",
+        point_budget.rendered_points, max_plot_points
+    );
+
+    let payload = match payload {
+        MsPlotPayload::ListObs(payload) => MsPlotPayload::ListObs(payload),
+        MsPlotPayload::Scatter(mut payload) => {
+            let (series, original_points, kept_points) =
+                compact_scatter_series(payload.series, max_plot_points);
+            if kept_points == 0 {
+                return Err(format!(
+                    "{} produced no drawable points after point-budget decimation",
+                    payload.title
+                ));
+            }
+            payload.series = series;
+            payload.header_lines.push(warning.clone());
+            payload.summary = format!(
+                "{} Decimated points from {} to {}.",
+                payload.summary, original_points, kept_points
+            );
+            MsPlotPayload::Scatter(payload)
+        }
+        MsPlotPayload::ScatterGrid(mut payload) => {
+            let total_points = payload
+                .panels
+                .iter()
+                .map(|panel| {
+                    panel
+                        .series
+                        .iter()
+                        .map(|series| series.points.len())
+                        .sum::<usize>()
+                })
+                .sum::<usize>();
+            let lengths = payload
+                .panels
+                .iter()
+                .flat_map(|panel| panel.series.iter().map(|series| series.points.len()))
+                .collect::<Vec<_>>();
+            let quotas = allocate_series_point_quotas(&lengths, max_plot_points);
+            let mut quota_iter = quotas.into_iter();
+            let mut kept_points = 0usize;
+            let mut kept_panels = Vec::new();
+            for panel in std::mem::take(&mut payload.panels) {
+                let mut kept_series = Vec::new();
+                for series in panel.series {
+                    let quota = quota_iter.next().unwrap_or(0);
+                    let (mut compacted, _, kept) = compact_scatter_series(vec![series], quota);
+                    kept_points += kept;
+                    kept_series.append(&mut compacted);
+                }
+                if !kept_series.is_empty() {
+                    let panel_point_count = kept_series
+                        .iter()
+                        .map(|series| series.points.len())
+                        .sum::<usize>();
+                    kept_panels.push(MsScatterPanelPayload {
+                        key: panel.key,
+                        label: panel.label,
+                        summary: format!(
+                            "{} Decimated points to {}.",
+                            panel.summary, panel_point_count
+                        ),
+                        series: kept_series,
+                    });
+                }
+            }
+            if kept_points == 0 {
+                return Err(format!(
+                    "{} produced no drawable panels after point-budget decimation",
+                    payload.title
+                ));
+            }
+            payload.panels = kept_panels;
+            payload.header_lines.push(warning.clone());
+            payload.summary = format!(
+                "{} Decimated points from {} to {}.",
+                payload.summary, total_points, kept_points
+            );
+            MsPlotPayload::ScatterGrid(payload)
+        }
+        MsPlotPayload::ScatterPage(mut payload) => {
+            let total_points = payload
+                .items
+                .iter()
+                .map(|item| {
+                    item.plot
+                        .series
+                        .iter()
+                        .map(|series| series.points.len())
+                        .sum::<usize>()
+                })
+                .sum::<usize>();
+            let lengths = payload
+                .items
+                .iter()
+                .flat_map(|item| item.plot.series.iter().map(|series| series.points.len()))
+                .collect::<Vec<_>>();
+            let quotas = allocate_series_point_quotas(&lengths, max_plot_points);
+            let mut quota_iter = quotas.into_iter();
+            let mut kept_points = 0usize;
+            let mut kept_items = Vec::new();
+            for mut item in std::mem::take(&mut payload.items) {
+                let mut kept_series = Vec::new();
+                for series in item.plot.series {
+                    let quota = quota_iter.next().unwrap_or(0);
+                    let (mut compacted, _, kept) = compact_scatter_series(vec![series], quota);
+                    kept_points += kept;
+                    kept_series.append(&mut compacted);
+                }
+                if !kept_series.is_empty() {
+                    item.plot.series = kept_series;
+                    item.plot.summary = format!(
+                        "{} Decimated points to {}.",
+                        item.plot.summary,
+                        item.plot
+                            .series
+                            .iter()
+                            .map(|series| series.points.len())
+                            .sum::<usize>()
+                    );
+                    kept_items.push(item);
+                }
+            }
+            if kept_points == 0 {
+                return Err(format!(
+                    "{} produced no drawable plots after point-budget decimation",
+                    payload.title
+                ));
+            }
+            payload.items = kept_items;
+            payload.header_lines.push(warning);
+            payload.summary = format!(
+                "{} Decimated points from {} to {}.",
+                payload.summary, total_points, kept_points
+            );
+            MsPlotPayload::ScatterPage(payload)
+        }
+    };
+
+    Ok(payload)
 }
 
 fn build_msexplore_plot_payload_validated(
@@ -2216,10 +2459,10 @@ fn build_msexplore_plot_payload_validated(
     build_generic_visibility_scatter(ms, selection, spec, point_budget)
 }
 
-/// Build a plot payload from a full `msexplore` request.
-pub fn build_msexplore_payload(
+fn build_msexplore_payload_internal(
     ms: &MeasurementSet,
     spec: &MsExploreSpec,
+    allow_decimation: bool,
 ) -> Result<MsPlotPayload, String> {
     spec.validate()?;
     let mut point_budget = PointBudget::limited(spec.max_plot_points);
@@ -2232,7 +2475,20 @@ pub fn build_msexplore_payload(
             &mut point_budget,
         )?;
         apply_page_header_lines(&mut payload, header_lines);
-        return Ok(payload);
+        return if allow_decimation {
+            compact_payload_to_budget(payload, &point_budget)
+        } else if point_budget.rendered_points > spec.max_plot_points {
+            Err(format!(
+                "{} would render more than {}; narrow the selection, add averaging, or raise --max-points",
+                spec.plots[0]
+                    .preset
+                    .map(MsPlotPreset::display_name)
+                    .unwrap_or("Requested plot"),
+                spec.max_plot_points
+            ))
+        } else {
+            Ok(payload)
+        };
     }
 
     let (gridrows, gridcols) = {
@@ -2277,7 +2533,7 @@ pub fn build_msexplore_payload(
         .clone()
         .unwrap_or_else(|| "MeasurementSet Multi-Plot Page".to_string());
 
-    Ok(MsPlotPayload::ScatterPage(MsScatterPagePayload {
+    let payload = MsPlotPayload::ScatterPage(MsScatterPagePayload {
         title,
         exprange: spec.exprange,
         gridrows,
@@ -2296,7 +2552,25 @@ pub fn build_msexplore_payload(
             spec.exprange
         ),
         items,
-    }))
+    });
+    if allow_decimation {
+        compact_payload_to_budget(payload, &point_budget)
+    } else if point_budget.rendered_points > spec.max_plot_points {
+        Err(format!(
+            "MeasurementSet multi-plot page would render more than {}; narrow the selection, add averaging, or raise --max-points",
+            spec.max_plot_points
+        ))
+    } else {
+        Ok(payload)
+    }
+}
+
+/// Build a plot payload from a full `msexplore` request.
+pub fn build_msexplore_payload(
+    ms: &MeasurementSet,
+    spec: &MsExploreSpec,
+) -> Result<MsPlotPayload, String> {
+    build_msexplore_payload_internal(ms, spec, true)
 }
 
 /// Open a MeasurementSet path from a full `msexplore` request and build the
@@ -2343,7 +2617,7 @@ pub fn preview_msexplore_flag_edit_for_request(
 ) -> Result<MsFlagEditPreview, String> {
     spec.validate()?;
     validate_flag_edit_request(flag_edit)?;
-    let payload = build_msexplore_payload(ms, spec)?;
+    let payload = build_msexplore_payload_internal(ms, spec, false)?;
     preview_msexplore_flag_edit_from_payload(ms, payload, flag_edit)
 }
 
@@ -8122,6 +8396,113 @@ mod tests {
                 .unwrap_err()
                 .contains("share the same x/y axis configuration")
         );
+    }
+
+    #[test]
+    fn compact_scatter_series_evenly_decimates_points() {
+        let series = vec![MsScatterSeries {
+            label: "Amplitude".to_string(),
+            color_group: "all".to_string(),
+            y_axis: MsAxis::Amplitude,
+            points: (0..5).map(|index| (index as f64, index as f64)).collect(),
+            provenance: (0..5)
+                .map(|index| MsScatterPointRef {
+                    row: index,
+                    corr: 0,
+                    chan_start: index,
+                    chan_end: index + 1,
+                })
+                .collect(),
+        }];
+
+        let (compacted, original_points, kept_points) = compact_scatter_series(series, 3);
+        assert_eq!(original_points, 5);
+        assert_eq!(kept_points, 3);
+        assert_eq!(compacted.len(), 1);
+        assert_eq!(
+            compacted[0].points,
+            vec![(0.0, 0.0), (2.0, 2.0), (4.0, 4.0)]
+        );
+        assert_eq!(
+            compacted[0]
+                .provenance
+                .iter()
+                .map(|point| point.row)
+                .collect::<Vec<_>>(),
+            vec![0, 2, 4]
+        );
+    }
+
+    #[test]
+    fn compact_payload_to_budget_downsamples_scatter_payload_and_warns() {
+        let payload = MsPlotPayload::Scatter(MsScatterPlotPayload {
+            title: "Dense plot".to_string(),
+            x_axis: MsAxis::Time,
+            y_axis: MsAxis::Amplitude,
+            secondary_y_axis: None,
+            x_label: "Time".to_string(),
+            y_label: "Amplitude".to_string(),
+            secondary_y_label: None,
+            fixed_x_bounds: None,
+            fixed_y_bounds: None,
+            secondary_fixed_y_bounds: None,
+            showlegend: true,
+            legend_position: MsLegendPosition::UpperRight,
+            showmajorgrid: true,
+            showminorgrid: false,
+            series: vec![
+                MsScatterSeries {
+                    label: "A".to_string(),
+                    color_group: "a".to_string(),
+                    y_axis: MsAxis::Amplitude,
+                    points: (0..5).map(|index| (index as f64, index as f64)).collect(),
+                    provenance: (0..5)
+                        .map(|index| MsScatterPointRef {
+                            row: index,
+                            corr: 0,
+                            chan_start: index,
+                            chan_end: index + 1,
+                        })
+                        .collect(),
+                },
+                MsScatterSeries {
+                    label: "B".to_string(),
+                    color_group: "b".to_string(),
+                    y_axis: MsAxis::Amplitude,
+                    points: (5..10).map(|index| (index as f64, index as f64)).collect(),
+                    provenance: (5..10)
+                        .map(|index| MsScatterPointRef {
+                            row: index,
+                            corr: 0,
+                            chan_start: index,
+                            chan_end: index + 1,
+                        })
+                        .collect(),
+                },
+            ],
+            header_lines: Vec::new(),
+            summary: "Dense plot summary.".to_string(),
+        });
+        let point_budget = PointBudget {
+            max_plot_points: Some(6),
+            rendered_points: 10,
+        };
+
+        let compacted = compact_payload_to_budget(payload, &point_budget).unwrap();
+        let MsPlotPayload::Scatter(compacted) = compacted else {
+            panic!("expected scatter payload");
+        };
+        assert_eq!(
+            compacted
+                .series
+                .iter()
+                .map(|series| series.points.len())
+                .sum::<usize>(),
+            6
+        );
+        assert_eq!(compacted.header_lines.len(), 1);
+        assert!(compacted.header_lines[0].contains("Downsampled plot"));
+        assert!(compacted.summary.contains("Decimated points from 10 to 6"));
     }
 
     #[test]

--- a/crates/casa-ms/src/msexplore.rs
+++ b/crates/casa-ms/src/msexplore.rs
@@ -31,6 +31,7 @@ use std::fmt;
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
 
+use casa_tables::Table;
 use casa_types::measures::doppler::DopplerRef;
 use casa_types::measures::frequency::{FrequencyRef, MFrequency};
 use casa_types::quanta::{MvAngle, MvTime};
@@ -58,7 +59,6 @@ use crate::plot::{
     ListObsPlotSpec, ListObsPlotTheme, VisibilityScatterPlotPayload, VisibilityScatterSeries,
     build_listobs_plot_payload_from_summary, build_listobs_uv_plot_payload, export_listobs_plot,
 };
-use crate::schema::main_table::VisibilityDataColumn;
 use crate::spectral_selection::{
     convert_frequency_to_frame, parse_rest_frequency_hz, velocity_ms_from_frequency_hz,
 };
@@ -3553,16 +3553,18 @@ fn build_generic_visibility_scatter(
             .any(MsAxis::uses_spectral_coordinates);
     let requested_freqframe = parse_frequency_frame(spec.transforms.freqframe.as_deref())?;
     let data_source = if needs_visibility_grid {
-        Some(PreparedDataSource::new(ms, spec.data_column)?)
+        Some(PreparedSelectedDataSource::new(
+            ms,
+            spec.data_column,
+            &row_numbers,
+        )?)
     } else {
         None
     };
-    let flag = ms.flag_column();
     let flag_row = ms.flag_row_column();
-    let weight = ms.weight_column();
-    let sigma = ms.sigma_column();
-    let weight_spectrum = WeightSpectrumColumn::new(ms.main_table()).ok();
-    let sigma_spectrum = SigmaSpectrumColumn::new(ms.main_table()).ok();
+    let selected_flags = SelectedArrayColumn::load(ms.main_table(), "FLAG", &row_numbers)?;
+    let selected_weights = SelectedArrayColumn::load(ms.main_table(), "WEIGHT", &row_numbers)?;
+    let selected_sigmas = SelectedArrayColumn::load(ms.main_table(), "SIGMA", &row_numbers)?;
     let time = TimeColumn::new(ms.main_table());
     let uvw = UvwColumn::new(ms.main_table());
     let derived_engine = if spec.x_axis.uses_derived_geometry()
@@ -3628,8 +3630,24 @@ fn build_generic_visibility_scatter(
             .iter()
             .copied()
             .any(|axis| matches!(axis, MsAxis::SigmaSpectrum));
+    let selected_weight_spectrum = if needs_weight_spectrum {
+        WeightSpectrumColumn::new(ms.main_table())
+            .ok()
+            .map(|_| SelectedArrayColumn::load(ms.main_table(), "WEIGHT_SPECTRUM", &row_numbers))
+            .transpose()?
+    } else {
+        None
+    };
+    let selected_sigma_spectrum = if needs_sigma_spectrum {
+        SigmaSpectrumColumn::new(ms.main_table())
+            .ok()
+            .map(|_| SelectedArrayColumn::load(ms.main_table(), "SIGMA_SPECTRUM", &row_numbers))
+            .transpose()?
+    } else {
+        None
+    };
 
-    for row in row_numbers {
+    for (row_slot, row) in row_numbers.iter().copied().enumerate() {
         let flag_row_value = flag_row.get(row).map_err(|error| error.to_string())?;
         if flag_row_value && !include_row_flagged_points {
             continue;
@@ -3654,7 +3672,7 @@ fn build_generic_visibility_scatter(
             Vec::new()
         };
 
-        let flags = match flag.get(row).map_err(|error| error.to_string())? {
+        let flags = match selected_flags.get(row_slot)? {
             ArrayValue::Bool(values) => {
                 values.view().into_dimensionality::<Ix2>().map_err(|_| {
                     "msexplore expects FLAG cells with shape [num_corr, num_chan]".to_string()
@@ -3669,7 +3687,7 @@ fn build_generic_visibility_scatter(
         };
         let grid = data_source
             .as_ref()
-            .map(|source| source.row(row))
+            .map(|source| source.row(row_slot))
             .transpose()?;
         let (corr_count, chan_count) = grid
             .as_ref()
@@ -3683,26 +3701,14 @@ fn build_generic_visibility_scatter(
                 chan_count
             ));
         }
-        let weight_values = float_axis_values(
-            weight.get(row).map_err(|error| error.to_string())?,
-            corr_count,
-            "WEIGHT",
-        )?;
-        let sigma_values = float_axis_values(
-            sigma.get(row).map_err(|error| error.to_string())?,
-            corr_count,
-            "SIGMA",
-        )?;
+        let weight_values =
+            float_axis_values(selected_weights.get(row_slot)?, corr_count, "WEIGHT")?;
+        let sigma_values = float_axis_values(selected_sigmas.get(row_slot)?, corr_count, "SIGMA")?;
         let weight_spectrum_grid = if needs_weight_spectrum {
             Some(
-                weight_spectrum
+                selected_weight_spectrum
                     .as_ref()
-                    .map(|column| {
-                        float_grid_from_array(
-                            column.get(row).map_err(|error| error.to_string())?,
-                            "WEIGHT_SPECTRUM",
-                        )
-                    })
+                    .map(|column| float_grid_from_array(column.get(row_slot)?, "WEIGHT_SPECTRUM"))
                     .transpose()?
                     .unwrap_or_else(|| scalar_values_to_grid(&weight_values, chan_count)),
             )
@@ -3711,14 +3717,9 @@ fn build_generic_visibility_scatter(
         };
         let sigma_spectrum_grid = if needs_sigma_spectrum {
             Some(
-                sigma_spectrum
+                selected_sigma_spectrum
                     .as_ref()
-                    .map(|column| {
-                        float_grid_from_array(
-                            column.get(row).map_err(|error| error.to_string())?,
-                            "SIGMA_SPECTRUM",
-                        )
-                    })
+                    .map(|column| float_grid_from_array(column.get(row_slot)?, "SIGMA_SPECTRUM"))
                     .transpose()?
                     .unwrap_or_else(|| scalar_values_to_grid(&sigma_values, chan_count)),
             )
@@ -4290,17 +4291,19 @@ fn build_generic_visibility_scatter_with_averaging(
             .any(MsAxis::uses_spectral_coordinates);
     let requested_freqframe = parse_frequency_frame(spec.transforms.freqframe.as_deref())?;
     let data_source = if needs_visibility_grid {
-        Some(PreparedDataSource::new(ms, spec.data_column)?)
+        Some(PreparedSelectedDataSource::new(
+            ms,
+            spec.data_column,
+            &row_numbers,
+        )?)
     } else {
         None
     };
-    let flag = ms.flag_column();
     let flag_row = ms.flag_row_column();
-    let weight = ms.weight_column();
-    let sigma = ms.sigma_column();
     let interval = IntervalColumn::new(ms.main_table());
-    let weight_spectrum = WeightSpectrumColumn::new(ms.main_table()).ok();
-    let sigma_spectrum = SigmaSpectrumColumn::new(ms.main_table()).ok();
+    let selected_flags = SelectedArrayColumn::load(ms.main_table(), "FLAG", &row_numbers)?;
+    let selected_weights = SelectedArrayColumn::load(ms.main_table(), "WEIGHT", &row_numbers)?;
+    let selected_sigmas = SelectedArrayColumn::load(ms.main_table(), "SIGMA", &row_numbers)?;
     let time = TimeColumn::new(ms.main_table());
     let uvw = UvwColumn::new(ms.main_table());
     let derived_engine = if spec.x_axis.uses_derived_geometry()
@@ -4354,6 +4357,22 @@ fn build_generic_visibility_scatter_with_averaging(
             .iter()
             .copied()
             .any(|axis| matches!(axis, MsAxis::SigmaSpectrum));
+    let selected_weight_spectrum = if needs_weight_spectrum {
+        WeightSpectrumColumn::new(ms.main_table())
+            .ok()
+            .map(|_| SelectedArrayColumn::load(ms.main_table(), "WEIGHT_SPECTRUM", &row_numbers))
+            .transpose()?
+    } else {
+        None
+    };
+    let selected_sigma_spectrum = if needs_sigma_spectrum {
+        SigmaSpectrumColumn::new(ms.main_table())
+            .ok()
+            .map(|_| SelectedArrayColumn::load(ms.main_table(), "SIGMA_SPECTRUM", &row_numbers))
+            .transpose()?
+    } else {
+        None
+    };
     let use_shared_time_scope_midpoint = spec.averaging.avgtime.is_some()
         && (spec.averaging.avgfield || spec.averaging.avgscan || spec.averaging.avgspw);
 
@@ -4420,7 +4439,7 @@ fn build_generic_visibility_scatter_with_averaging(
     let mut panels = std::collections::BTreeMap::<String, AveragedPanelAccumulator>::new();
     let mut contributing_rows = std::collections::BTreeSet::<usize>::new();
 
-    for row in row_numbers {
+    for (row_slot, row) in row_numbers.iter().copied().enumerate() {
         let flag_row_value = flag_row.get(row).map_err(|error| error.to_string())?;
         if flag_row_value && !include_row_flagged_points {
             continue;
@@ -4445,7 +4464,7 @@ fn build_generic_visibility_scatter_with_averaging(
             Vec::new()
         };
 
-        let flags = match flag.get(row).map_err(|error| error.to_string())? {
+        let flags = match selected_flags.get(row_slot)? {
             ArrayValue::Bool(values) => {
                 values.view().into_dimensionality::<Ix2>().map_err(|_| {
                     "msexplore expects FLAG cells with shape [num_corr, num_chan]".to_string()
@@ -4460,7 +4479,7 @@ fn build_generic_visibility_scatter_with_averaging(
         };
         let grid = data_source
             .as_ref()
-            .map(|source| source.row(row))
+            .map(|source| source.row(row_slot))
             .transpose()?;
         let (corr_count, chan_count) = grid
             .as_ref()
@@ -4474,26 +4493,14 @@ fn build_generic_visibility_scatter_with_averaging(
                 chan_count
             ));
         }
-        let weight_values = float_axis_values(
-            weight.get(row).map_err(|error| error.to_string())?,
-            corr_count,
-            "WEIGHT",
-        )?;
-        let sigma_values = float_axis_values(
-            sigma.get(row).map_err(|error| error.to_string())?,
-            corr_count,
-            "SIGMA",
-        )?;
+        let weight_values =
+            float_axis_values(selected_weights.get(row_slot)?, corr_count, "WEIGHT")?;
+        let sigma_values = float_axis_values(selected_sigmas.get(row_slot)?, corr_count, "SIGMA")?;
         let weight_spectrum_grid = if needs_weight_spectrum {
             Some(
-                weight_spectrum
+                selected_weight_spectrum
                     .as_ref()
-                    .map(|column| {
-                        float_grid_from_array(
-                            column.get(row).map_err(|error| error.to_string())?,
-                            "WEIGHT_SPECTRUM",
-                        )
-                    })
+                    .map(|column| float_grid_from_array(column.get(row_slot)?, "WEIGHT_SPECTRUM"))
                     .transpose()?
                     .unwrap_or_else(|| scalar_values_to_grid(&weight_values, chan_count)),
             )
@@ -4502,14 +4509,9 @@ fn build_generic_visibility_scatter_with_averaging(
         };
         let sigma_spectrum_grid = if needs_sigma_spectrum {
             Some(
-                sigma_spectrum
+                selected_sigma_spectrum
                     .as_ref()
-                    .map(|column| {
-                        float_grid_from_array(
-                            column.get(row).map_err(|error| error.to_string())?,
-                            "SIGMA_SPECTRUM",
-                        )
-                    })
+                    .map(|column| float_grid_from_array(column.get(row_slot)?, "SIGMA_SPECTRUM"))
                     .transpose()?
                     .unwrap_or_else(|| scalar_values_to_grid(&sigma_values, chan_count)),
             )
@@ -5953,124 +5955,129 @@ struct FloatGrid {
     values: Vec<f64>,
 }
 
-enum PreparedDataSource<'a> {
-    Single(crate::columns::data_columns::DataColumn<'a>),
+struct SelectedArrayColumn {
+    column: &'static str,
+    values: Vec<Option<ArrayValue>>,
+}
+
+impl SelectedArrayColumn {
+    fn load(table: &Table, column: &'static str, row_indices: &[usize]) -> Result<Self, String> {
+        let values = table
+            .get_array_cells_owned(column, row_indices)
+            .map_err(|error| error.to_string())?;
+        Ok(Self { column, values })
+    }
+
+    fn get(&self, row_slot: usize) -> Result<&ArrayValue, String> {
+        self.values
+            .get(row_slot)
+            .and_then(|value| value.as_ref())
+            .ok_or_else(|| {
+                format!(
+                    "msexplore requires {} data for selected row slot {}",
+                    self.column, row_slot
+                )
+            })
+    }
+}
+
+enum PreparedSelectedDataSource {
+    Single(SelectedArrayColumn),
     Difference {
-        left: crate::columns::data_columns::DataColumn<'a>,
-        right: crate::columns::data_columns::DataColumn<'a>,
+        left: SelectedArrayColumn,
+        right: SelectedArrayColumn,
         scalar: bool,
     },
     Ratio {
-        numerator: crate::columns::data_columns::DataColumn<'a>,
-        denominator: crate::columns::data_columns::DataColumn<'a>,
+        numerator: SelectedArrayColumn,
+        denominator: SelectedArrayColumn,
         scalar: bool,
     },
 }
 
-impl<'a> PreparedDataSource<'a> {
-    fn new(ms: &'a MeasurementSet, column: MsDataColumn) -> Result<Self, String> {
+impl PreparedSelectedDataSource {
+    fn new(
+        ms: &MeasurementSet,
+        column: MsDataColumn,
+        row_indices: &[usize],
+    ) -> Result<Self, String> {
         match column {
-            MsDataColumn::Data => Ok(Self::Single(
-                ms.data_column(VisibilityDataColumn::Data)
-                    .map_err(|error| error.to_string())?,
-            )),
-            MsDataColumn::Corrected => Ok(Self::Single(
-                ms.data_column(VisibilityDataColumn::CorrectedData)
-                    .map_err(|error| error.to_string())?,
-            )),
-            MsDataColumn::Model => Ok(Self::Single(
-                ms.data_column(VisibilityDataColumn::ModelData)
-                    .map_err(|error| error.to_string())?,
-            )),
+            MsDataColumn::Data => Ok(Self::Single(SelectedArrayColumn::load(
+                ms.main_table(),
+                "DATA",
+                row_indices,
+            )?)),
+            MsDataColumn::Corrected => Ok(Self::Single(SelectedArrayColumn::load(
+                ms.main_table(),
+                "CORRECTED_DATA",
+                row_indices,
+            )?)),
+            MsDataColumn::Model => Ok(Self::Single(SelectedArrayColumn::load(
+                ms.main_table(),
+                "MODEL_DATA",
+                row_indices,
+            )?)),
             MsDataColumn::CorrectedMinusModel => Ok(Self::Difference {
-                left: ms
-                    .data_column(VisibilityDataColumn::CorrectedData)
-                    .map_err(|error| error.to_string())?,
-                right: ms
-                    .data_column(VisibilityDataColumn::ModelData)
-                    .map_err(|error| error.to_string())?,
+                left: SelectedArrayColumn::load(ms.main_table(), "CORRECTED_DATA", row_indices)?,
+                right: SelectedArrayColumn::load(ms.main_table(), "MODEL_DATA", row_indices)?,
                 scalar: false,
             }),
             MsDataColumn::CorrectedMinusModelScalar => Ok(Self::Difference {
-                left: ms
-                    .data_column(VisibilityDataColumn::CorrectedData)
-                    .map_err(|error| error.to_string())?,
-                right: ms
-                    .data_column(VisibilityDataColumn::ModelData)
-                    .map_err(|error| error.to_string())?,
+                left: SelectedArrayColumn::load(ms.main_table(), "CORRECTED_DATA", row_indices)?,
+                right: SelectedArrayColumn::load(ms.main_table(), "MODEL_DATA", row_indices)?,
                 scalar: true,
             }),
             MsDataColumn::DataMinusModel => Ok(Self::Difference {
-                left: ms
-                    .data_column(VisibilityDataColumn::Data)
-                    .map_err(|error| error.to_string())?,
-                right: ms
-                    .data_column(VisibilityDataColumn::ModelData)
-                    .map_err(|error| error.to_string())?,
+                left: SelectedArrayColumn::load(ms.main_table(), "DATA", row_indices)?,
+                right: SelectedArrayColumn::load(ms.main_table(), "MODEL_DATA", row_indices)?,
                 scalar: false,
             }),
             MsDataColumn::DataMinusModelScalar => Ok(Self::Difference {
-                left: ms
-                    .data_column(VisibilityDataColumn::Data)
-                    .map_err(|error| error.to_string())?,
-                right: ms
-                    .data_column(VisibilityDataColumn::ModelData)
-                    .map_err(|error| error.to_string())?,
+                left: SelectedArrayColumn::load(ms.main_table(), "DATA", row_indices)?,
+                right: SelectedArrayColumn::load(ms.main_table(), "MODEL_DATA", row_indices)?,
                 scalar: true,
             }),
             MsDataColumn::CorrectedDivModel => Ok(Self::Ratio {
-                numerator: ms
-                    .data_column(VisibilityDataColumn::CorrectedData)
-                    .map_err(|error| error.to_string())?,
-                denominator: ms
-                    .data_column(VisibilityDataColumn::ModelData)
-                    .map_err(|error| error.to_string())?,
+                numerator: SelectedArrayColumn::load(
+                    ms.main_table(),
+                    "CORRECTED_DATA",
+                    row_indices,
+                )?,
+                denominator: SelectedArrayColumn::load(ms.main_table(), "MODEL_DATA", row_indices)?,
                 scalar: false,
             }),
             MsDataColumn::CorrectedDivModelScalar => Ok(Self::Ratio {
-                numerator: ms
-                    .data_column(VisibilityDataColumn::CorrectedData)
-                    .map_err(|error| error.to_string())?,
-                denominator: ms
-                    .data_column(VisibilityDataColumn::ModelData)
-                    .map_err(|error| error.to_string())?,
+                numerator: SelectedArrayColumn::load(
+                    ms.main_table(),
+                    "CORRECTED_DATA",
+                    row_indices,
+                )?,
+                denominator: SelectedArrayColumn::load(ms.main_table(), "MODEL_DATA", row_indices)?,
                 scalar: true,
             }),
             MsDataColumn::DataDivModel => Ok(Self::Ratio {
-                numerator: ms
-                    .data_column(VisibilityDataColumn::Data)
-                    .map_err(|error| error.to_string())?,
-                denominator: ms
-                    .data_column(VisibilityDataColumn::ModelData)
-                    .map_err(|error| error.to_string())?,
+                numerator: SelectedArrayColumn::load(ms.main_table(), "DATA", row_indices)?,
+                denominator: SelectedArrayColumn::load(ms.main_table(), "MODEL_DATA", row_indices)?,
                 scalar: false,
             }),
             MsDataColumn::DataDivModelScalar => Ok(Self::Ratio {
-                numerator: ms
-                    .data_column(VisibilityDataColumn::Data)
-                    .map_err(|error| error.to_string())?,
-                denominator: ms
-                    .data_column(VisibilityDataColumn::ModelData)
-                    .map_err(|error| error.to_string())?,
+                numerator: SelectedArrayColumn::load(ms.main_table(), "DATA", row_indices)?,
+                denominator: SelectedArrayColumn::load(ms.main_table(), "MODEL_DATA", row_indices)?,
                 scalar: true,
             }),
         }
     }
 
-    fn row(&self, row: usize) -> Result<ComplexGrid, String> {
+    fn row(&self, row_slot: usize) -> Result<ComplexGrid, String> {
         match self {
-            Self::Single(column) => {
-                complex_grid_from_array(column.get(row).map_err(|error| error.to_string())?)
-            }
+            Self::Single(column) => complex_grid_from_array(column.get(row_slot)?),
             Self::Difference {
                 left,
                 right,
                 scalar,
             } => {
-                let left =
-                    complex_grid_from_array(left.get(row).map_err(|error| error.to_string())?)?;
-                let right =
-                    complex_grid_from_array(right.get(row).map_err(|error| error.to_string())?)?;
+                let left = complex_grid_from_array(left.get(row_slot)?)?;
+                let right = complex_grid_from_array(right.get(row_slot)?)?;
                 combine_grids(left, right, |left, right| {
                     if *scalar {
                         Complex64::new(left.norm() - right.norm(), 0.0)
@@ -6084,12 +6091,8 @@ impl<'a> PreparedDataSource<'a> {
                 denominator,
                 scalar,
             } => {
-                let numerator = complex_grid_from_array(
-                    numerator.get(row).map_err(|error| error.to_string())?,
-                )?;
-                let denominator = complex_grid_from_array(
-                    denominator.get(row).map_err(|error| error.to_string())?,
-                )?;
+                let numerator = complex_grid_from_array(numerator.get(row_slot)?)?;
+                let denominator = complex_grid_from_array(denominator.get(row_slot)?)?;
                 combine_grids(numerator, denominator, |left, right| {
                     if *scalar {
                         if right.norm() == 0.0 {
@@ -7437,6 +7440,11 @@ impl ListObsPlotRenderStyle {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_helpers::default_value;
+    use crate::{MeasurementSetBuilder, OptionalMainColumn};
+    use casa_types::{RecordField, RecordValue};
+    use ndarray::ArrayD;
+    use num_complex::Complex32;
     use plotters::style::Color;
     use tempfile::tempdir;
 
@@ -7492,6 +7500,54 @@ mod tests {
             header_lines: vec!["Synthetic header".to_string()],
             summary: "Synthetic scatter payload".to_string(),
         }
+    }
+
+    #[test]
+    fn prepared_selected_data_source_preserves_selected_row_order() {
+        let mut ms = MeasurementSet::create_memory(
+            MeasurementSetBuilder::new().with_main_column(OptionalMainColumn::Data),
+        )
+        .expect("create in-memory MS");
+        let schema = ms.main_table().schema().expect("main schema").clone();
+
+        for amplitude in [10.0_f32, 20.0_f32, 30.0_f32] {
+            let data = ArrayValue::Complex32(
+                ArrayD::from_shape_vec(
+                    vec![1, 2],
+                    vec![
+                        Complex32::new(amplitude, 0.0),
+                        Complex32::new(amplitude + 1.0, 0.0),
+                    ],
+                )
+                .expect("data shape"),
+            );
+            let fields = schema
+                .columns()
+                .iter()
+                .map(|column| {
+                    if column.name() == "DATA" {
+                        RecordField::new("DATA", Value::Array(data.clone()))
+                    } else {
+                        RecordField::new(column.name(), default_value(column.name()))
+                    }
+                })
+                .collect::<Vec<_>>();
+            ms.main_table_mut()
+                .add_row(RecordValue::new(fields))
+                .expect("add main row");
+        }
+
+        let source =
+            PreparedSelectedDataSource::new(&ms, MsDataColumn::Data, &[2, 0]).expect("prefetch");
+        let first = source.row(0).expect("selected row 0");
+        let second = source.row(1).expect("selected row 1");
+
+        assert_eq!(first.corr_count, 1);
+        assert_eq!(first.chan_count, 2);
+        assert_eq!(first.values[0], Complex64::new(30.0, 0.0));
+        assert_eq!(first.values[1], Complex64::new(31.0, 0.0));
+        assert_eq!(second.values[0], Complex64::new(10.0, 0.0));
+        assert_eq!(second.values[1], Complex64::new(11.0, 0.0));
     }
 
     #[test]

--- a/crates/casa-ms/src/selection.rs
+++ b/crates/casa-ms/src/selection.rs
@@ -22,9 +22,10 @@
 
 use crate::error::{MsError, MsResult};
 use crate::ms::MeasurementSet;
-use crate::subtables::{get_f64, get_i32};
 use casa_tables::Table;
 use std::collections::HashSet;
+use std::sync::OnceLock;
+use std::time::Instant;
 
 /// Builder for MS row selection criteria.
 ///
@@ -150,23 +151,41 @@ impl MsSelection {
     /// If antenna names were specified, they are resolved against the ANTENNA
     /// subtable first.
     pub fn apply(&self, ms: &MeasurementSet) -> MsResult<Vec<usize>> {
+        let apply_started_at = Instant::now();
         let mut sel = self.clone();
 
         // Resolve antenna names to IDs
+        let resolve_antenna_started_at = Instant::now();
         if !sel.antenna_names.is_empty() {
             let resolved = resolve_antenna_names(ms, &sel.antenna_names)?;
             sel.antenna_ids.extend(resolved);
             sel.antenna_names.clear();
         }
+        let resolve_antenna_ns = resolve_antenna_started_at.elapsed().as_nanos() as u64;
 
         // Resolve SPW IDs to DATA_DESC_IDs
         let mut effective_ddids = Vec::new();
+        let resolve_spw_started_at = Instant::now();
         if !sel.spw_ids.is_empty() {
             effective_ddids = resolve_spw_to_ddid(ms, &sel.spw_ids)?;
         }
+        let resolve_spw_ns = resolve_spw_started_at.elapsed().as_nanos() as u64;
 
         if sel.taql_exprs.is_empty() {
-            return apply_structured_selection(&sel, ms, &effective_ddids);
+            let structured_started_at = Instant::now();
+            let rows = apply_structured_selection(&sel, ms, &effective_ddids)?;
+            log_selection_profile(
+                "apply_structured",
+                apply_started_at.elapsed().as_nanos() as u64,
+                Some(format!(
+                    "rows={} resolve_antenna={:.3}s resolve_spw={:.3}s structured={:.3}s",
+                    rows.len(),
+                    resolve_antenna_ns as f64 / 1_000_000_000.0,
+                    resolve_spw_ns as f64 / 1_000_000_000.0,
+                    structured_started_at.elapsed().as_nanos() as f64 / 1_000_000_000.0,
+                )),
+            );
+            return Ok(rows);
         }
 
         let taql = if sel.spw_ids.is_empty() {
@@ -195,8 +214,21 @@ impl MsSelection {
             }
         };
 
+        let taql_started_at = Instant::now();
         let view = ms.main_table().query(&taql)?;
-        Ok(view.row_numbers().to_vec())
+        let rows = view.row_numbers().to_vec();
+        log_selection_profile(
+            "apply_taql",
+            apply_started_at.elapsed().as_nanos() as u64,
+            Some(format!(
+                "rows={} resolve_antenna={:.3}s resolve_spw={:.3}s taql={:.3}s",
+                rows.len(),
+                resolve_antenna_ns as f64 / 1_000_000_000.0,
+                resolve_spw_ns as f64 / 1_000_000_000.0,
+                taql_started_at.elapsed().as_nanos() as f64 / 1_000_000_000.0,
+            )),
+        );
+        Ok(rows)
     }
 
     fn where_clauses(&self) -> Vec<String> {
@@ -268,6 +300,7 @@ fn apply_structured_selection(
     ms: &MeasurementSet,
     effective_ddids: &[i32],
 ) -> MsResult<Vec<usize>> {
+    let setup_started_at = Instant::now();
     let field_ids: HashSet<i32> = sel.field_ids.iter().copied().collect();
     let spw_ddids: HashSet<i32> = effective_ddids.iter().copied().collect();
     let data_desc_ids: HashSet<i32> = sel.data_desc_ids.iter().copied().collect();
@@ -283,6 +316,7 @@ fn apply_structured_selection(
     }
 
     let table = ms.main_table();
+    let load_columns_started_at = Instant::now();
     let columns = load_structured_selection_columns(
         table,
         StructuredSelectionColumnRequest {
@@ -297,8 +331,10 @@ fn apply_structured_selection(
             array: !array_ids.is_empty(),
         },
     )?;
+    let load_columns_ns = load_columns_started_at.elapsed().as_nanos() as u64;
     let mut rows = Vec::new();
 
+    let filter_rows_started_at = Instant::now();
     for row in 0..table.row_count() {
         if let Some(field_column) = columns.field.as_ref() {
             if !field_ids.contains(&field_column[row]) {
@@ -363,7 +399,58 @@ fn apply_structured_selection(
         rows.push(row);
     }
 
+    log_selection_profile(
+        "structured_selection",
+        setup_started_at.elapsed().as_nanos() as u64,
+        Some(format!(
+            "rows={} row_count={} load_columns={:.3}s filter_rows={:.3}s requested=field:{} data_desc:{} antenna:{} time:{} scan:{} state:{} observation:{} array:{}",
+            rows.len(),
+            table.row_count(),
+            load_columns_ns as f64 / 1_000_000_000.0,
+            filter_rows_started_at.elapsed().as_nanos() as f64 / 1_000_000_000.0,
+            !field_ids.is_empty(),
+            !spw_ddids.is_empty() || !data_desc_ids.is_empty(),
+            !antenna_ids.is_empty() || !baselines.is_empty(),
+            sel.time_range.is_some(),
+            !scan_numbers.is_empty(),
+            !state_ids.is_empty(),
+            !observation_ids.is_empty(),
+            !array_ids.is_empty(),
+        )),
+    );
+
     Ok(rows)
+}
+
+fn selection_profile_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| match std::env::var("CASA_RS_SELECTION_PROFILE") {
+        Ok(value) => {
+            let trimmed = value.trim();
+            !trimmed.is_empty()
+                && trimmed != "0"
+                && !trimmed.eq_ignore_ascii_case("false")
+                && !trimmed.eq_ignore_ascii_case("off")
+        }
+        Err(_) => false,
+    })
+}
+
+fn log_selection_profile(phase: &str, total_ns: u64, detail: Option<String>) {
+    if !selection_profile_enabled() {
+        return;
+    }
+    let mut line = format!(
+        "[casa-ms selection] phase={phase} dt={:.3}s",
+        total_ns as f64 / 1_000_000_000.0
+    );
+    if let Some(detail) = detail
+        && !detail.is_empty()
+    {
+        line.push(' ');
+        line.push_str(&detail);
+    }
+    eprintln!("{line}");
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -462,19 +549,45 @@ fn load_structured_selection_columns(
 }
 
 fn load_i32_column(table: &Table, column: &str) -> MsResult<Vec<i32>> {
-    let mut values = Vec::with_capacity(table.row_count());
-    for row in 0..table.row_count() {
-        values.push(get_i32(table, row, column)?);
-    }
-    Ok(values)
+    table
+        .get_scalar_cells_owned(column)?
+        .into_iter()
+        .enumerate()
+        .map(|(row, value)| match value {
+            Some(casa_types::ScalarValue::Int32(v)) => Ok(v),
+            Some(other) => Err(MsError::ColumnTypeMismatch {
+                column: column.to_string(),
+                table: "MAIN".to_string(),
+                expected: "Int32".to_string(),
+                found: format!("{:?}", other.primitive_type()),
+            }),
+            None => Err(MsError::MissingColumn {
+                column: format!("{column}[row={row}]"),
+                table: "MAIN".to_string(),
+            }),
+        })
+        .collect()
 }
 
 fn load_f64_column(table: &Table, column: &str) -> MsResult<Vec<f64>> {
-    let mut values = Vec::with_capacity(table.row_count());
-    for row in 0..table.row_count() {
-        values.push(get_f64(table, row, column)?);
-    }
-    Ok(values)
+    table
+        .get_scalar_cells_owned(column)?
+        .into_iter()
+        .enumerate()
+        .map(|(row, value)| match value {
+            Some(casa_types::ScalarValue::Float64(v)) => Ok(v),
+            Some(other) => Err(MsError::ColumnTypeMismatch {
+                column: column.to_string(),
+                table: "MAIN".to_string(),
+                expected: "Float64".to_string(),
+                found: format!("{:?}", other.primitive_type()),
+            }),
+            None => Err(MsError::MissingColumn {
+                column: format!("{column}[row={row}]"),
+                table: "MAIN".to_string(),
+            }),
+        })
+        .collect()
 }
 
 fn int_list(ids: &[i32]) -> String {

--- a/crates/casa-ms/tests/msexplore_cli.rs
+++ b/crates/casa-ms/tests/msexplore_cli.rs
@@ -328,7 +328,7 @@ fn msexplore_avgchannel_bins_channel_plot_manifest() {
 }
 
 #[test]
-fn msexplore_rejects_exports_that_exceed_max_points() {
+fn msexplore_decimates_exports_that_exceed_max_points() {
     let temp = tempdir().expect("tempdir");
     let ms_path = create_msexplore_fixture_ms(temp.path());
     let plot_path = temp.path().join("too-many-points.txt");
@@ -346,10 +346,16 @@ fn msexplore_rejects_exports_that_exceed_max_points() {
         .arg(&ms_path)
         .output()
         .expect("run msexplore");
-    assert!(!output.status.success(), "{output:?}");
-    let stderr = String::from_utf8(output.stderr).expect("utf8 stderr");
-    assert!(stderr.contains("more than 10 points"), "{stderr}");
-    assert!(stderr.contains("--max-points"), "{stderr}");
+    assert!(output.status.success(), "{output:?}");
+    let manifest = std::fs::read_to_string(&plot_path).expect("read manifest");
+    assert!(manifest.contains("Downsampled plot"), "{manifest}");
+    let plotted_rows = manifest
+        .lines()
+        .filter(|line| !line.is_empty())
+        .filter(|line| !line.starts_with('#'))
+        .filter(|line| !line.starts_with("series_key\t"))
+        .count();
+    assert_eq!(plotted_rows, 10, "{manifest}");
 }
 
 #[test]

--- a/crates/casa-tables/src/storage/canonical.rs
+++ b/crates/casa-tables/src/storage/canonical.rs
@@ -163,6 +163,22 @@ pub(crate) fn write_bool_bits(dst: &mut [u8], bit_offset: usize, values: &[bool]
     }
 }
 
+/// Pack boolean bytes into `dst` starting at `bit_offset`.
+///
+/// Non-zero input bytes are treated as `true`.
+pub(crate) fn write_bool_bits_from_bytes(dst: &mut [u8], bit_offset: usize, values: &[u8]) {
+    for (i, &value) in values.iter().enumerate() {
+        let bit = bit_offset + i;
+        let byte_idx = bit / 8;
+        let bit_idx = bit % 8;
+        if value != 0 {
+            dst[byte_idx] |= 1 << bit_idx;
+        } else {
+            dst[byte_idx] &= !(1 << bit_idx);
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Little-endian scalar reads
 // ---------------------------------------------------------------------------
@@ -319,6 +335,19 @@ mod tests {
         write_bool_bits(&mut buf, 3, &values);
         let read_back = read_bool_bits(&buf, 3, 3);
         assert_eq!(read_back, values);
+    }
+
+    #[test]
+    fn bool_byte_bit_packing_round_trip() {
+        let values = vec![1u8, 0, 7, 0, 0, 2, 9, 0, 1];
+        let byte_count = values.len().div_ceil(8);
+        let mut buf = vec![0u8; byte_count];
+        write_bool_bits_from_bytes(&mut buf, 0, &values);
+        let read_back = read_bool_bits(&buf, 0, values.len());
+        assert_eq!(
+            read_back,
+            values.iter().map(|value| *value != 0).collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/crates/casa-tables/src/storage/incremental_stman.rs
+++ b/crates/casa-tables/src/storage/incremental_stman.rs
@@ -15,7 +15,7 @@
 //! C++ equivalent: `casacore/tables/DataMan/ISMBase`, `ISMBucket`, `ISMIndex`,
 //! `ISMColumn`.
 
-use std::fs::File;
+use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
@@ -1587,14 +1587,245 @@ pub(crate) fn write_ism_file_indexed(
     write_ism_file_impl(file_path, col_descs, rows, Some(field_indices), big_endian)
 }
 
+pub(crate) fn write_ism_file_scalar_columns(
+    file_path: &Path,
+    col_descs: &[ColumnDescContents],
+    scalar_columns: &[&[Option<casa_types::ScalarValue>]],
+    big_endian: bool,
+) -> Result<Vec<u8>, StorageError> {
+    let nrrow = scalar_columns.first().map_or(0, |values| values.len());
+    if scalar_columns.len() != col_descs.len() {
+        return Err(StorageError::FormatMismatch(format!(
+            "ISM scalar column count mismatch: expected {}, got {}",
+            col_descs.len(),
+            scalar_columns.len()
+        )));
+    }
+    for values in scalar_columns.iter().skip(1) {
+        if values.len() != nrrow {
+            return Err(StorageError::FormatMismatch(
+                "ISM scalar columns have inconsistent row counts".to_string(),
+            ));
+        }
+    }
+    if col_descs
+        .iter()
+        .any(|col_desc| col_desc.is_array || col_desc.is_record())
+    {
+        return Err(StorageError::FormatMismatch(
+            "ISM scalar column writer only supports scalar non-record columns".to_string(),
+        ));
+    }
+
+    let ncol = col_descs.len();
+    let col_info: Vec<(CasacoreDataType, usize)> = col_descs
+        .iter()
+        .map(|c| {
+            let dt = CasacoreDataType::from_primitive_type(c.require_primitive_type()?, false);
+            Ok((dt, 1usize))
+        })
+        .collect::<Result<_, StorageError>>()?;
+
+    let fixed_bytes_per_row: usize = col_info
+        .iter()
+        .map(|&(dt, _)| {
+            if dt == CasacoreDataType::TpBool {
+                1
+            } else {
+                let elem = ism_element_size(dt);
+                if elem > 0 { elem } else { 12 }
+            }
+        })
+        .sum();
+    let index_overhead_per_row = ncol * 8;
+    let bytes_per_row = fixed_bytes_per_row + index_overhead_per_row;
+    let bucket_size = if bytes_per_row == 0 {
+        128u32
+    } else {
+        let target = (bytes_per_row * 32 + 4) as u32;
+        target.clamp(128, 327680)
+    };
+
+    struct BucketBuilder {
+        data: Vec<u8>,
+        col_indices: Vec<(Vec<u32>, Vec<u32>)>,
+    }
+
+    let mut buckets: Vec<BucketBuilder> = Vec::new();
+    let mut bucket_start_rows: Vec<usize> = Vec::new();
+    let mut last_values: Vec<Vec<u8>> = vec![Vec::new(); ncol];
+
+    if nrrow > 0 {
+        let mut current = BucketBuilder {
+            data: Vec::new(),
+            col_indices: (0..ncol).map(|_| (Vec::new(), Vec::new())).collect(),
+        };
+        bucket_start_rows.push(0);
+
+        for (row_idx, _) in scalar_columns[0].iter().enumerate().take(nrrow) {
+            let rel_row = (row_idx - *bucket_start_rows.last().unwrap()) as u32;
+
+            let mut new_data_estimate = 0usize;
+            for col_idx in 0..ncol {
+                let (dt, nrelem) = col_info[col_idx];
+                let temp_value = scalar_columns[col_idx][row_idx]
+                    .as_ref()
+                    .cloned()
+                    .map(casa_types::Value::Scalar);
+                let encoded = encode_value_bytes(temp_value.as_ref(), dt, nrelem, big_endian);
+                if rel_row == 0 || encoded != last_values[col_idx] {
+                    new_data_estimate += encoded.len();
+                }
+            }
+
+            let current_index_size: usize = current
+                .col_indices
+                .iter()
+                .map(|(row_nrs, _)| 4 + (row_nrs.len() + 1) * 4 + (row_nrs.len() + 1) * 4)
+                .sum();
+            let total_estimate =
+                4 + current.data.len() + new_data_estimate + current_index_size + ncol * 12;
+
+            if rel_row > 0 && total_estimate > bucket_size as usize {
+                buckets.push(current);
+                current = BucketBuilder {
+                    data: Vec::new(),
+                    col_indices: (0..ncol).map(|_| (Vec::new(), Vec::new())).collect(),
+                };
+                bucket_start_rows.push(row_idx);
+                for col_idx in 0..ncol {
+                    let (dt, nrelem) = col_info[col_idx];
+                    let bytes = if last_values[col_idx].is_empty() {
+                        let temp_value = scalar_columns[col_idx][row_idx]
+                            .as_ref()
+                            .cloned()
+                            .map(casa_types::Value::Scalar);
+                        encode_value_bytes(temp_value.as_ref(), dt, nrelem, big_endian)
+                    } else {
+                        last_values[col_idx].clone()
+                    };
+                    let offset = current.data.len() as u32;
+                    current.data.extend_from_slice(&bytes);
+                    current.col_indices[col_idx].0.push(0);
+                    current.col_indices[col_idx].1.push(offset);
+                }
+                for col_idx in 0..ncol {
+                    let (dt, nrelem) = col_info[col_idx];
+                    let temp_value = scalar_columns[col_idx][row_idx]
+                        .as_ref()
+                        .cloned()
+                        .map(casa_types::Value::Scalar);
+                    let encoded = encode_value_bytes(temp_value.as_ref(), dt, nrelem, big_endian);
+                    if encoded != last_values[col_idx] {
+                        let offset = current.data.len() as u32;
+                        current.data.extend_from_slice(&encoded);
+                        let idx = &mut current.col_indices[col_idx];
+                        idx.0[0] = 0;
+                        idx.1[0] = offset;
+                        last_values[col_idx] = encoded;
+                    }
+                }
+                continue;
+            }
+
+            for col_idx in 0..ncol {
+                let (dt, nrelem) = col_info[col_idx];
+                let temp_value = scalar_columns[col_idx][row_idx]
+                    .as_ref()
+                    .cloned()
+                    .map(casa_types::Value::Scalar);
+                let encoded = encode_value_bytes(temp_value.as_ref(), dt, nrelem, big_endian);
+
+                if rel_row == 0 || encoded != last_values[col_idx] {
+                    let offset = current.data.len() as u32;
+                    current.data.extend_from_slice(&encoded);
+                    current.col_indices[col_idx].0.push(rel_row);
+                    current.col_indices[col_idx].1.push(offset);
+                    last_values[col_idx] = encoded;
+                }
+            }
+        }
+
+        buckets.push(current);
+    }
+
+    let nr_buckets = buckets.len();
+    let mut raw_buckets: Vec<Vec<u8>> = Vec::with_capacity(nr_buckets);
+    for bucket in &buckets {
+        let mut raw = vec![0u8; bucket_size as usize];
+        let data_len = bucket.data.len().min(bucket_size as usize - 4);
+        raw[4..4 + data_len].copy_from_slice(&bucket.data[..data_len]);
+
+        let mut index_area = Vec::new();
+        for (row_nrs, offsets) in &bucket.col_indices {
+            let n = row_nrs.len() as u32;
+            if big_endian {
+                index_area.extend_from_slice(&n.to_be_bytes());
+                for &r in row_nrs {
+                    index_area.extend_from_slice(&r.to_be_bytes());
+                }
+                for &o in offsets {
+                    index_area.extend_from_slice(&o.to_be_bytes());
+                }
+            } else {
+                index_area.extend_from_slice(&n.to_le_bytes());
+                for &r in row_nrs {
+                    index_area.extend_from_slice(&r.to_le_bytes());
+                }
+                for &o in offsets {
+                    index_area.extend_from_slice(&o.to_le_bytes());
+                }
+            }
+        }
+
+        let index_start = bucket_size as usize - index_area.len();
+        let index_offset = index_start as u32;
+        if big_endian {
+            raw[0..4].copy_from_slice(&index_offset.to_be_bytes());
+        } else {
+            raw[0..4].copy_from_slice(&index_offset.to_le_bytes());
+        }
+        if index_start + index_area.len() <= raw.len() {
+            raw[index_start..index_start + index_area.len()].copy_from_slice(&index_area);
+        }
+        raw_buckets.push(raw);
+    }
+
+    let mut ism_rows: Vec<u64> = Vec::with_capacity(nr_buckets + 1);
+    let mut ism_bucket_nrs: Vec<u32> = Vec::with_capacity(nr_buckets);
+    for (i, &start) in bucket_start_rows.iter().enumerate() {
+        ism_rows.push(start as u64);
+        ism_bucket_nrs.push(i as u32);
+    }
+    ism_rows.push(nrrow as u64);
+
+    let index_data = serialize_ism_index(&ism_rows, &ism_bucket_nrs, big_endian);
+    let header_buf = serialize_ism_header(bucket_size, nr_buckets as u32, big_endian);
+
+    let mut file = File::create(file_path)?;
+    file.write_all(&header_buf)?;
+    for raw in &raw_buckets {
+        file.write_all(raw)?;
+    }
+    file.write_all(&index_data)?;
+
+    serialize_ism_dm_blob("ISM")
+}
+
 fn row_value_at_index<'a>(
     row: &'a casa_types::RecordValue,
     field_index: usize,
     field_name: &str,
 ) -> Option<&'a casa_types::Value> {
-    let field = row.fields().get(field_index)?;
-    debug_assert_eq!(field.name, field_name);
-    Some(&field.value)
+    if let Some(field) = row.fields().get(field_index) {
+        if field.name == field_name {
+            return Some(&field.value);
+        }
+    }
+    row.fields()
+        .iter()
+        .find(|field| field.name == field_name)
+        .map(|field| &field.value)
 }
 
 fn row_value_for_column<'a>(
@@ -1850,6 +2081,213 @@ fn write_ism_file_impl(
     let dm_blob = serialize_ism_dm_blob("ISM")?;
 
     Ok(dm_blob)
+}
+
+pub(crate) fn save_ism_file_scalar_columns_rows_in_place(
+    file_path: &Path,
+    col_descs: &[ColumnDescContents],
+    scalar_columns: &[&[Option<casa_types::ScalarValue>]],
+    changed_rows: &[usize],
+    big_endian: bool,
+) -> Result<bool, StorageError> {
+    let nrrow = scalar_columns.first().map_or(0, |values| values.len());
+    if scalar_columns.len() != col_descs.len() {
+        return Err(StorageError::FormatMismatch(format!(
+            "ISM scalar column count mismatch: expected {}, got {}",
+            col_descs.len(),
+            scalar_columns.len()
+        )));
+    }
+    for values in scalar_columns.iter().skip(1) {
+        if values.len() != nrrow {
+            return Err(StorageError::FormatMismatch(
+                "ISM scalar columns have inconsistent row counts".to_string(),
+            ));
+        }
+    }
+    if changed_rows.is_empty() || nrrow == 0 {
+        return Ok(false);
+    }
+    if col_descs
+        .iter()
+        .any(|col_desc| col_desc.is_array || col_desc.is_record())
+    {
+        return Ok(false);
+    }
+
+    let col_info: Vec<(CasacoreDataType, usize)> = col_descs
+        .iter()
+        .map(|c| {
+            let dt = CasacoreDataType::from_primitive_type(c.require_primitive_type()?, false);
+            Ok((dt, 1usize))
+        })
+        .collect::<Result<_, StorageError>>()?;
+
+    let mut file = OpenOptions::new().read(true).write(true).open(file_path)?;
+    let header = parse_ism_header(&mut file)?;
+    if header.big_endian != big_endian {
+        return Err(StorageError::FormatMismatch(format!(
+            "ISM endian mismatch for sparse save: file={}, requested={}",
+            header.big_endian, big_endian
+        )));
+    }
+    let index = parse_ism_index(&mut file, &header)?;
+    if index.rows.len() < 2 || index.bucket_nrs.is_empty() {
+        return Ok(false);
+    }
+
+    let mut changed_intervals = Vec::new();
+    let mut last_interval = None;
+    for &row_idx in changed_rows {
+        if row_idx >= nrrow {
+            continue;
+        }
+        let interval = index.rows.partition_point(|&start| start <= row_idx as u64);
+        if interval == 0 {
+            continue;
+        }
+        let interval_idx = interval - 1;
+        if interval_idx >= index.bucket_nrs.len() {
+            continue;
+        }
+        if last_interval != Some(interval_idx) {
+            changed_intervals.push(interval_idx);
+            last_interval = Some(interval_idx);
+        }
+    }
+    if changed_intervals.is_empty() {
+        return Ok(false);
+    }
+
+    let mut patched_buckets = Vec::with_capacity(changed_intervals.len());
+    for interval_idx in changed_intervals {
+        let bucket_start = index.rows[interval_idx] as usize;
+        let bucket_end = index.rows[interval_idx + 1] as usize;
+        let bucket_nr = index.bucket_nrs[interval_idx];
+        let Some(raw) = build_ism_scalar_bucket_for_row_range(
+            &col_info,
+            scalar_columns,
+            bucket_start,
+            bucket_end,
+            header.bucket_size,
+            big_endian,
+        )?
+        else {
+            return Ok(false);
+        };
+        patched_buckets.push((bucket_nr, raw));
+    }
+
+    for (bucket_nr, raw) in patched_buckets {
+        let offset = ISM_HEADER_SIZE + (bucket_nr as u64) * (header.bucket_size as u64);
+        file.seek(SeekFrom::Start(offset))?;
+        file.write_all(&raw)?;
+    }
+
+    Ok(true)
+}
+
+fn build_ism_scalar_bucket_for_row_range(
+    col_info: &[(CasacoreDataType, usize)],
+    scalar_columns: &[&[Option<casa_types::ScalarValue>]],
+    row_start: usize,
+    row_end: usize,
+    bucket_size: u32,
+    big_endian: bool,
+) -> Result<Option<Vec<u8>>, StorageError> {
+    if row_end <= row_start {
+        return Ok(Some(vec![0u8; bucket_size as usize]));
+    }
+
+    let ncol = scalar_columns.len();
+    let mut data = Vec::new();
+    let mut col_indices: Vec<(Vec<u32>, Vec<u32>)> =
+        (0..ncol).map(|_| (Vec::new(), Vec::new())).collect();
+    let mut last_values: Vec<Vec<u8>> = vec![Vec::new(); ncol];
+
+    for (row_idx, _) in scalar_columns[0]
+        .iter()
+        .enumerate()
+        .take(row_end)
+        .skip(row_start)
+    {
+        let rel_row = (row_idx - row_start) as u32;
+        for col_idx in 0..ncol {
+            let (dt, nrelem) = col_info[col_idx];
+            let temp_value = scalar_columns[col_idx][row_idx]
+                .as_ref()
+                .cloned()
+                .map(casa_types::Value::Scalar);
+            let encoded = encode_value_bytes(temp_value.as_ref(), dt, nrelem, big_endian);
+            if rel_row == 0 || encoded != last_values[col_idx] {
+                let offset = data.len() as u32;
+                data.extend_from_slice(&encoded);
+                col_indices[col_idx].0.push(rel_row);
+                col_indices[col_idx].1.push(offset);
+                last_values[col_idx] = encoded;
+            }
+        }
+    }
+
+    serialize_ism_bucket(bucket_size, &data, &col_indices, big_endian)
+}
+
+fn serialize_ism_bucket(
+    bucket_size: u32,
+    data: &[u8],
+    col_indices: &[(Vec<u32>, Vec<u32>)],
+    big_endian: bool,
+) -> Result<Option<Vec<u8>>, StorageError> {
+    if bucket_size < 4 {
+        return Err(StorageError::FormatMismatch(
+            "ISM bucket size too small".to_string(),
+        ));
+    }
+
+    let mut index_area = Vec::new();
+    for (row_nrs, offsets) in col_indices {
+        if row_nrs.len() != offsets.len() {
+            return Err(StorageError::FormatMismatch(
+                "ISM bucket row/offset index length mismatch".to_string(),
+            ));
+        }
+        let n = row_nrs.len() as u32;
+        if big_endian {
+            index_area.extend_from_slice(&n.to_be_bytes());
+            for &r in row_nrs {
+                index_area.extend_from_slice(&r.to_be_bytes());
+            }
+            for &o in offsets {
+                index_area.extend_from_slice(&o.to_be_bytes());
+            }
+        } else {
+            index_area.extend_from_slice(&n.to_le_bytes());
+            for &r in row_nrs {
+                index_area.extend_from_slice(&r.to_le_bytes());
+            }
+            for &o in offsets {
+                index_area.extend_from_slice(&o.to_le_bytes());
+            }
+        }
+    }
+
+    let bucket_size = bucket_size as usize;
+    if 4 + data.len() + index_area.len() > bucket_size {
+        return Ok(None);
+    }
+
+    let mut raw = vec![0u8; bucket_size];
+    raw[4..4 + data.len()].copy_from_slice(data);
+
+    let index_start = bucket_size - index_area.len();
+    let index_offset = index_start as u32;
+    if big_endian {
+        raw[0..4].copy_from_slice(&index_offset.to_be_bytes());
+    } else {
+        raw[0..4].copy_from_slice(&index_offset.to_le_bytes());
+    }
+    raw[index_start..].copy_from_slice(&index_area);
+    Ok(Some(raw))
 }
 
 // ---------------------------------------------------------------------------
@@ -2115,6 +2553,103 @@ mod tests {
                 val,
                 casa_types::Value::Scalar(casa_types::ScalarValue::Int32(expected)),
                 "row {rel_row}"
+            );
+        }
+    }
+
+    #[test]
+    fn scalar_column_writer_matches_row_writer_for_scalar_columns() {
+        use casa_types::{RecordField, RecordValue, ScalarValue, Value};
+        use tempfile::TempDir;
+
+        let schema = vec![
+            ColumnDescContents {
+                class_name: "ScalarColumnDesc".to_string(),
+                col_name: "flag_row".to_string(),
+                comment: String::new(),
+                data_manager_type: String::new(),
+                data_manager_group: String::new(),
+                shape: vec![],
+                data_type: CasacoreDataType::TpBool,
+                option: 0,
+                nrdim: 0,
+                max_length: 0,
+                keywords: RecordValue::default(),
+                is_array: false,
+                primitive_type: Some(casa_types::PrimitiveType::Bool),
+            },
+            ColumnDescContents {
+                class_name: "ScalarColumnDesc".to_string(),
+                col_name: "scan".to_string(),
+                comment: String::new(),
+                data_manager_type: String::new(),
+                data_manager_group: String::new(),
+                shape: vec![],
+                data_type: CasacoreDataType::TpInt,
+                option: 0,
+                nrdim: 0,
+                max_length: 0,
+                keywords: RecordValue::default(),
+                is_array: false,
+                primitive_type: Some(casa_types::PrimitiveType::Int32),
+            },
+        ];
+
+        let rows = vec![
+            RecordValue::new(vec![
+                RecordField::new("flag_row", Value::Scalar(ScalarValue::Bool(false))),
+                RecordField::new("scan", Value::Scalar(ScalarValue::Int32(1))),
+            ]),
+            RecordValue::new(vec![
+                RecordField::new("flag_row", Value::Scalar(ScalarValue::Bool(false))),
+                RecordField::new("scan", Value::Scalar(ScalarValue::Int32(1))),
+            ]),
+            RecordValue::new(vec![
+                RecordField::new("flag_row", Value::Scalar(ScalarValue::Bool(true))),
+                RecordField::new("scan", Value::Scalar(ScalarValue::Int32(2))),
+            ]),
+            RecordValue::new(vec![
+                RecordField::new("flag_row", Value::Scalar(ScalarValue::Bool(true))),
+                RecordField::new("scan", Value::Scalar(ScalarValue::Int32(2))),
+            ]),
+        ];
+
+        let flag_values = vec![
+            Some(ScalarValue::Bool(false)),
+            Some(ScalarValue::Bool(false)),
+            Some(ScalarValue::Bool(true)),
+            Some(ScalarValue::Bool(true)),
+        ];
+        let scan_values = vec![
+            Some(ScalarValue::Int32(1)),
+            Some(ScalarValue::Int32(1)),
+            Some(ScalarValue::Int32(2)),
+            Some(ScalarValue::Int32(2)),
+        ];
+        let scalar_columns = vec![flag_values.as_slice(), scan_values.as_slice()];
+
+        for big_endian in [true, false] {
+            let dir = TempDir::new().expect("tempdir");
+            let row_path = dir.path().join(if big_endian {
+                "row_be.ism"
+            } else {
+                "row_le.ism"
+            });
+            let scalar_path = dir.path().join(if big_endian {
+                "scalar_be.ism"
+            } else {
+                "scalar_le.ism"
+            });
+
+            let row_dm = write_ism_file(&row_path, &schema, &rows, big_endian).expect("row writer");
+            let scalar_dm =
+                write_ism_file_scalar_columns(&scalar_path, &schema, &scalar_columns, big_endian)
+                    .expect("scalar writer");
+
+            assert_eq!(row_dm, scalar_dm);
+            assert_eq!(
+                std::fs::read(&row_path).expect("read row file"),
+                std::fs::read(&scalar_path).expect("read scalar file")
             );
         }
     }

--- a/crates/casa-tables/src/storage/mod.rs
+++ b/crates/casa-tables/src/storage/mod.rs
@@ -36,7 +36,8 @@ use self::incremental_stman::{
 use self::standard_stman::{read_ssm_file, write_ssm_file, write_ssm_file_indexed};
 use self::stman_aipsio::scalar_value_is_default;
 use self::stman_aipsio::{
-    StManColumnData, StManColumnInfo, extract_row_value, read_stman_file, write_stman_file,
+    StManColumnData, StManColumnInfo, extract_row_value, read_stman_array_column_rows,
+    read_stman_file, read_stman_scalar_column, write_stman_file,
 };
 pub(crate) use self::table_control::RefTableDatContents;
 use self::virtual_engine::{VirtualContext, is_virtual_engine, lookup_engine};
@@ -951,6 +952,31 @@ impl CompositeStorage {
         }
     }
 
+    pub(crate) fn load_scalar_column_with_row_hint(
+        &self,
+        table_path: &Path,
+        column: &str,
+        row_hint: Option<u64>,
+    ) -> Result<Vec<Option<ScalarValue>>, StorageError> {
+        let control_path = table_path.join(TABLE_CONTROL_FILE);
+        if !table_path.exists() {
+            return Err(StorageError::MissingPath(table_path.to_path_buf()));
+        }
+        if !control_path.exists() {
+            return Err(StorageError::MissingControlFile(control_path));
+        }
+
+        match read_table_dat_dispatch(&control_path)? {
+            TableDatResult::Plain(table_dat) => {
+                self.load_plain_scalar_column(table_path, &table_dat, column, row_hint)
+            }
+            TableDatResult::Ref(_) | TableDatResult::Concat(_) => {
+                let snapshot = self.load_with_row_hint(table_path, row_hint)?;
+                scalar_column_from_snapshot(&snapshot, column)
+            }
+        }
+    }
+
     pub(crate) fn load_array_column_with_row_hint(
         &self,
         table_path: &Path,
@@ -972,6 +998,41 @@ impl CompositeStorage {
             TableDatResult::Ref(_) | TableDatResult::Concat(_) => {
                 let snapshot = self.load_with_row_hint(table_path, row_hint)?;
                 array_column_from_snapshot(&snapshot, column)
+            }
+        }
+    }
+
+    pub(crate) fn load_array_column_rows_with_row_hint(
+        &self,
+        table_path: &Path,
+        column: &str,
+        selected_rows: &[usize],
+        row_hint: Option<u64>,
+    ) -> Result<Vec<Option<ArrayValue>>, StorageError> {
+        if selected_rows.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let control_path = table_path.join(TABLE_CONTROL_FILE);
+        if !table_path.exists() {
+            return Err(StorageError::MissingPath(table_path.to_path_buf()));
+        }
+        if !control_path.exists() {
+            return Err(StorageError::MissingControlFile(control_path));
+        }
+
+        match read_table_dat_dispatch(&control_path)? {
+            TableDatResult::Plain(table_dat) => self.load_plain_array_column_rows(
+                table_path,
+                &table_dat,
+                column,
+                selected_rows,
+                row_hint,
+            ),
+            TableDatResult::Ref(_) | TableDatResult::Concat(_) => {
+                let snapshot = self.load_with_row_hint(table_path, row_hint)?;
+                let values = array_column_from_snapshot(&snapshot, column)?;
+                Ok(select_array_rows(&values, selected_rows))
             }
         }
     }
@@ -1188,6 +1249,112 @@ impl CompositeStorage {
         table_dat: &TableDatContents,
         row_hint: Option<u64>,
     ) -> Result<ScalarColumnSnapshot, StorageError> {
+        self.load_plain_scalar_columns_filtered(table_path, table_dat, row_hint, None)
+    }
+
+    fn load_plain_scalar_column(
+        &self,
+        table_path: &Path,
+        table_dat: &TableDatContents,
+        column: &str,
+        row_hint: Option<u64>,
+    ) -> Result<Vec<Option<ScalarValue>>, StorageError> {
+        if table_dat
+            .column_set
+            .data_managers
+            .iter()
+            .any(|dm| is_virtual_engine(&dm.type_name))
+        {
+            let snapshot = self.load_plain_table(table_path, table_dat, row_hint)?;
+            return scalar_column_from_snapshot(&snapshot, column);
+        }
+
+        let desc_idx = table_dat
+            .table_desc
+            .columns
+            .iter()
+            .position(|desc| desc.col_name == column)
+            .ok_or_else(|| {
+                StorageError::FormatMismatch(format!("scalar column '{column}' not found"))
+            })?;
+        let col_desc = &table_dat.table_desc.columns[desc_idx];
+        if col_desc.is_array || col_desc.is_record() {
+            return Err(StorageError::FormatMismatch(format!(
+                "column '{column}' is not a scalar column"
+            )));
+        }
+
+        let dm_seq_nr = table_dat
+            .column_set
+            .columns
+            .iter()
+            .find(|entry| entry.original_name == column)
+            .ok_or_else(|| {
+                StorageError::FormatMismatch(format!(
+                    "scalar column '{column}' missing ColumnSet binding"
+                ))
+            })?
+            .dm_seq_nr;
+        let dm = table_dat
+            .column_set
+            .data_managers
+            .iter()
+            .find(|dm| dm.seq_nr == dm_seq_nr)
+            .ok_or_else(|| {
+                StorageError::FormatMismatch(format!(
+                    "scalar column '{column}' missing data manager {dm_seq_nr}"
+                ))
+            })?;
+        let data_path = table_path.join(format!("{}{}", TABLE_DATA_FILE_PREFIX, dm.seq_nr));
+
+        if dm.type_name == "StManAipsIO" {
+            if !data_path.is_file() {
+                return Err(StorageError::MissingDataFile(data_path));
+            }
+            let bound_cols: Vec<(usize, &_)> = table_dat
+                .column_set
+                .columns
+                .iter()
+                .enumerate()
+                .filter(|(_, pc)| pc.dm_seq_nr == dm.seq_nr)
+                .collect();
+            let target_col_idx = bound_cols
+                .iter()
+                .position(|(candidate_desc_idx, _)| *candidate_desc_idx == desc_idx)
+                .ok_or_else(|| {
+                    StorageError::FormatMismatch(format!(
+                        "scalar column '{column}' missing StManAipsIO binding index"
+                    ))
+                })?;
+            let dm_columns: Vec<_> = bound_cols
+                .iter()
+                .map(|(candidate_desc_idx, _)| {
+                    table_dat.table_desc.columns[*candidate_desc_idx].clone()
+                })
+                .collect();
+            if let Some(values) = read_stman_scalar_column(
+                &data_path,
+                &dm_columns,
+                target_col_idx,
+                ByteOrder::BigEndian,
+            )? {
+                return Ok(values);
+            }
+        }
+
+        let snapshot = self.load_plain_scalar_columns(table_path, table_dat, row_hint)?;
+        snapshot.columns.get(column).cloned().ok_or_else(|| {
+            StorageError::FormatMismatch(format!("scalar column '{column}' not found"))
+        })
+    }
+
+    fn load_plain_scalar_columns_filtered(
+        &self,
+        table_path: &Path,
+        table_dat: &TableDatContents,
+        row_hint: Option<u64>,
+        requested_columns: Option<&HashSet<&str>>,
+    ) -> Result<ScalarColumnSnapshot, StorageError> {
         let nrrow = table_dat
             .nrrow
             .max(table_dat.column_set.nrrow)
@@ -1207,13 +1374,27 @@ impl CompositeStorage {
 
         for dm in &table_dat.column_set.data_managers {
             let data_path = table_path.join(format!("{}{}", TABLE_DATA_FILE_PREFIX, dm.seq_nr));
-            let bound_cols: Vec<(usize, &_)> = table_dat
+            let all_bound_cols: Vec<(usize, &_)> = table_dat
                 .column_set
                 .columns
                 .iter()
                 .enumerate()
                 .filter(|(_, pc)| pc.dm_seq_nr == dm.seq_nr)
                 .collect();
+            if all_bound_cols.is_empty() {
+                continue;
+            }
+            let bound_cols: Vec<(usize, &_)> = all_bound_cols
+                .iter()
+                .copied()
+                .filter(|(_, pc)| {
+                    requested_columns
+                        .is_none_or(|requested| requested.contains(pc.original_name.as_str()))
+                })
+                .collect();
+            if bound_cols.is_empty() {
+                continue;
+            }
 
             match dm.type_name.as_str() {
                 "StManAipsIO" => {
@@ -1223,7 +1404,8 @@ impl CompositeStorage {
                     collect_stman_scalar_columns(
                         &data_path,
                         &table_dat.table_desc.columns,
-                        &bound_cols,
+                        &all_bound_cols,
+                        requested_columns,
                         nrrow,
                         ByteOrder::BigEndian,
                         &mut columns,
@@ -1417,6 +1599,117 @@ impl CompositeStorage {
             dm_info: Vec::new(),
         };
         array_column_from_snapshot(&snapshot, column)
+    }
+
+    fn load_plain_array_column_rows(
+        &self,
+        table_path: &Path,
+        table_dat: &TableDatContents,
+        column: &str,
+        selected_rows: &[usize],
+        row_hint: Option<u64>,
+    ) -> Result<Vec<Option<ArrayValue>>, StorageError> {
+        let desc_idx = table_dat
+            .table_desc
+            .columns
+            .iter()
+            .position(|desc| desc.col_name == column)
+            .ok_or_else(|| {
+                StorageError::FormatMismatch(format!("array column '{column}' not found"))
+            })?;
+        let col_desc = &table_dat.table_desc.columns[desc_idx];
+        if !col_desc.is_array {
+            return Err(StorageError::FormatMismatch(format!(
+                "column '{column}' is not an array column"
+            )));
+        }
+
+        if table_dat
+            .column_set
+            .data_managers
+            .iter()
+            .any(|dm| is_virtual_engine(&dm.type_name))
+        {
+            let snapshot = self.load_plain_table(table_path, table_dat, row_hint)?;
+            let values = array_column_from_snapshot(&snapshot, column)?;
+            return Ok(select_array_rows(&values, selected_rows));
+        }
+
+        let dm_seq_nr = table_dat
+            .column_set
+            .columns
+            .iter()
+            .find(|entry| entry.original_name == column)
+            .ok_or_else(|| {
+                StorageError::FormatMismatch(format!(
+                    "array column '{column}' missing ColumnSet binding"
+                ))
+            })?
+            .dm_seq_nr;
+        let dm = table_dat
+            .column_set
+            .data_managers
+            .iter()
+            .find(|dm| dm.seq_nr == dm_seq_nr)
+            .ok_or_else(|| {
+                StorageError::FormatMismatch(format!(
+                    "array column '{column}' missing data manager {dm_seq_nr}"
+                ))
+            })?;
+        let data_path = table_path.join(format!("{}{}", TABLE_DATA_FILE_PREFIX, dm.seq_nr));
+        let bound_cols: Vec<(usize, &_)> = table_dat
+            .column_set
+            .columns
+            .iter()
+            .enumerate()
+            .filter(|(_, pc)| pc.dm_seq_nr == dm.seq_nr)
+            .collect();
+
+        match dm.type_name.as_str() {
+            "StManAipsIO" => {
+                let group_col_descs: Vec<_> = bound_cols
+                    .iter()
+                    .map(|(bound_desc_idx, _)| {
+                        table_dat.table_desc.columns[*bound_desc_idx].clone()
+                    })
+                    .collect();
+                let Some(target_col_idx) = bound_cols
+                    .iter()
+                    .position(|(bound_desc_idx, _)| *bound_desc_idx == desc_idx)
+                else {
+                    return Err(StorageError::FormatMismatch(format!(
+                        "array column '{column}' missing StManAipsIO column binding"
+                    )));
+                };
+                if let Some(values) = read_stman_array_column_rows(
+                    &data_path,
+                    &group_col_descs,
+                    target_col_idx,
+                    selected_rows,
+                    ByteOrder::BigEndian,
+                )? {
+                    return Ok(values);
+                }
+                let values =
+                    self.load_plain_array_column(table_path, table_dat, column, row_hint)?;
+                Ok(select_array_rows(&values, selected_rows))
+            }
+            "TiledColumnStMan" | "TiledShapeStMan" | "TiledCellStMan" | "TiledDataStMan" => {
+                tiled_stman::load_tiled_column_rows(
+                    table_path,
+                    dm,
+                    &table_dat.table_desc.columns,
+                    &bound_cols,
+                    desc_idx,
+                    selected_rows,
+                )
+            }
+            _ => {
+                let values =
+                    self.load_plain_array_column(table_path, table_dat, column, row_hint)?;
+                Ok(select_array_rows(&values, selected_rows))
+            }
+        }
     }
 
     fn load_plain_table_metadata(
@@ -1923,6 +2216,10 @@ impl CompositeStorage {
                     | DataManagerKind::TiledCellStMan
                     | DataManagerKind::TiledDataStMan
             ) && group_col_descs.len() == 1;
+            let use_direct_indexed_rows = matches!(
+                group.dm_kind,
+                DataManagerKind::StandardStMan | DataManagerKind::IncrementalStMan
+            ) && group_col_indices.is_some();
             let group_col_index = group_col_indices
                 .as_ref()
                 .and_then(|indices| (indices.len() == 1).then_some(indices[0]));
@@ -1933,7 +2230,7 @@ impl CompositeStorage {
                     group_col_index,
                 )
             });
-            let group_rows = if group_values.is_none() {
+            let group_rows = if group_values.is_none() && !use_direct_indexed_rows {
                 Some(project_rows_for_group(
                     filtered_rows,
                     &group_col_descs,
@@ -1942,9 +2239,6 @@ impl CompositeStorage {
             } else {
                 None
             };
-            let projected_group_col_indices = group_col_indices
-                .as_ref()
-                .map(|_| (0..group_col_descs.len()).collect::<Vec<_>>());
             if let Some(profiler) = profiler.as_mut() {
                 profiler.mark_with_detail(
                     "group_projection",
@@ -1957,6 +2251,8 @@ impl CompositeStorage {
                         group_col_indices.is_some(),
                         if group_values.is_some() {
                             "borrowed_values"
+                        } else if use_direct_indexed_rows {
+                            "direct_rows"
                         } else {
                             "projected_rows"
                         }
@@ -1974,16 +2270,12 @@ impl CompositeStorage {
                     )?;
                 }
                 DataManagerKind::StandardStMan => {
-                    let dm_data = if let Some(projected_group_col_indices) =
-                        projected_group_col_indices.as_ref()
-                    {
+                    let dm_data = if let Some(group_col_indices) = group_col_indices.as_ref() {
                         write_ssm_file_indexed(
                             &data_path,
                             &group_col_descs,
-                            group_rows
-                                .as_ref()
-                                .expect("row projection for StandardStMan"),
-                            projected_group_col_indices,
+                            filtered_rows,
+                            group_col_indices,
                             big_endian,
                         )?
                     } else {
@@ -2007,16 +2299,12 @@ impl CompositeStorage {
                     }
                 }
                 DataManagerKind::IncrementalStMan => {
-                    let dm_data = if let Some(projected_group_col_indices) =
-                        projected_group_col_indices.as_ref()
-                    {
+                    let dm_data = if let Some(group_col_indices) = group_col_indices.as_ref() {
                         write_ism_file_indexed(
                             &data_path,
                             &group_col_descs,
-                            group_rows
-                                .as_ref()
-                                .expect("row projection for IncrementalStMan"),
-                            projected_group_col_indices,
+                            filtered_rows,
+                            group_col_indices,
                             big_endian,
                         )?
                     } else {
@@ -2174,10 +2462,39 @@ fn array_column_from_snapshot(
         .collect()
 }
 
+fn scalar_column_from_snapshot(
+    snapshot: &StorageSnapshot,
+    column: &str,
+) -> Result<Vec<Option<ScalarValue>>, StorageError> {
+    snapshot
+        .rows
+        .iter()
+        .map(|row| match row.get(column) {
+            Some(Value::Scalar(value)) => Ok(Some(value.clone())),
+            Some(other) => Err(StorageError::FormatMismatch(format!(
+                "column '{column}' expected scalar value, found {:?}",
+                other.kind()
+            ))),
+            None => Ok(None),
+        })
+        .collect()
+}
+
+fn select_array_rows(
+    values: &[Option<ArrayValue>],
+    selected_rows: &[usize],
+) -> Vec<Option<ArrayValue>> {
+    selected_rows
+        .iter()
+        .map(|&row_idx| values.get(row_idx).cloned().unwrap_or(None))
+        .collect()
+}
+
 fn collect_stman_scalar_columns(
     data_path: &Path,
     all_col_descs: &[table_control::ColumnDescContents],
     bound_cols: &[(usize, &table_control::PlainColumnEntry)],
+    requested_columns: Option<&HashSet<&str>>,
     nrrow: usize,
     byte_order: ByteOrder,
     columns: &mut HashMap<String, Vec<Option<ScalarValue>>>,
@@ -2203,6 +2520,11 @@ fn collect_stman_scalar_columns(
             break;
         }
         let col_desc = &all_col_descs[*desc_idx];
+        if requested_columns
+            .is_some_and(|requested| !requested.contains(col_desc.col_name.as_str()))
+        {
+            continue;
+        }
         if col_desc.is_array || col_desc.is_record() {
             continue;
         }

--- a/crates/casa-tables/src/storage/standard_stman.rs
+++ b/crates/casa-tables/src/storage/standard_stman.rs
@@ -1301,9 +1301,15 @@ fn row_value_at_index<'a>(
     field_index: usize,
     field_name: &str,
 ) -> Option<&'a casa_types::Value> {
-    let field = row.fields().get(field_index)?;
-    debug_assert_eq!(field.name, field_name);
-    Some(&field.value)
+    if let Some(field) = row.fields().get(field_index) {
+        if field.name == field_name {
+            return Some(&field.value);
+        }
+    }
+    row.fields()
+        .iter()
+        .find(|field| field.name == field_name)
+        .map(|field| &field.value)
 }
 
 fn write_ssm_file_impl(

--- a/crates/casa-tables/src/storage/stman_aipsio.rs
+++ b/crates/casa-tables/src/storage/stman_aipsio.rs
@@ -858,7 +858,7 @@ fn parse_sparse_column_layouts(
     }
 
     let mut layouts = Vec::with_capacity(ncol);
-    for (col_desc, data_type) in columns.iter().zip(data_types.into_iter()) {
+    for (col_desc, data_type) in columns.iter().zip(data_types) {
         let column_header = read_object_header(&mut file)?;
         let layout = match column_header.type_name.as_str() {
             "StManColumnIndArrayAipsIO" => {

--- a/crates/casa-tables/src/storage/stman_aipsio.rs
+++ b/crates/casa-tables/src/storage/stman_aipsio.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #![allow(dead_code)]
 
-use std::path::Path;
+use std::collections::HashMap;
+use std::fs::OpenOptions;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
 
 use casa_aipsio::{AipsIo, AipsOpenOption, ByteOrder};
 use casa_types::{ArrayValue, PrimitiveType, RecordValue, ScalarValue, Value};
@@ -55,6 +58,49 @@ pub(crate) enum ColumnRawData {
     Complex32(Vec<casa_types::Complex32>),
     Complex64(Vec<casa_types::Complex64>),
     String(Vec<String>),
+}
+
+#[derive(Debug, Clone)]
+struct ExtentLayout {
+    row_start: usize,
+    row_count: usize,
+    values_start: u64,
+    row_width_bytes: usize,
+}
+
+#[derive(Debug, Clone)]
+struct BitExtentLayout {
+    row_start: usize,
+    row_count: usize,
+    values_start: u64,
+}
+
+#[derive(Debug, Clone)]
+enum SparseColumnLayout {
+    ScalarBoolPacked {
+        extents: Vec<BitExtentLayout>,
+    },
+    ScalarFixed {
+        data_type: CasacoreDataType,
+        extents: Vec<ExtentLayout>,
+    },
+    DirectArrayFixed {
+        data_type: CasacoreDataType,
+        extents: Vec<ExtentLayout>,
+    },
+    IndirectArrayOffsetsU32 {
+        data_type: CasacoreDataType,
+        extents: Vec<ExtentLayout>,
+    },
+}
+
+#[derive(Debug, Clone)]
+struct ObjectHeader {
+    len: u32,
+    type_name: String,
+    version: u32,
+    payload_start: u64,
+    object_end: u64,
 }
 
 // ---------------------------------------------------------------------------
@@ -218,6 +264,7 @@ fn read_stman_array_column(
 
 /// Marker value for file offsets > 2GB in indirect AipsIO columns.
 const LARGE_OFFSET_MARKER: u32 = 2u32 * 1024 * 1024 * 1024 + 1;
+const AIPSIO_TOP_LEVEL_MAGIC: u32 = 0xbebebebe;
 
 /// Read a variable-shape (indirect) array column.
 ///
@@ -513,6 +560,758 @@ fn empty_column_data(dt: CasacoreDataType) -> ColumnRawData {
         CasacoreDataType::TpInt64 => ColumnRawData::Int64(vec![]),
         _ => ColumnRawData::Int32(vec![]),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Sparse patch path
+// ---------------------------------------------------------------------------
+
+pub(crate) fn save_stman_file_rows_in_place(
+    path: &Path,
+    columns: &[ColumnDescContents],
+    changed_values: &HashMap<&str, Vec<(usize, Option<Value>)>>,
+    byte_order: ByteOrder,
+) -> Result<bool, StorageError> {
+    if changed_values.is_empty() {
+        return Ok(true);
+    }
+
+    let layouts = parse_sparse_column_layouts(path, columns, byte_order)?;
+    if layouts.len() != columns.len() {
+        return Ok(false);
+    }
+
+    let mut main_file = OpenOptions::new().read(true).write(true).open(path)?;
+    let array_file_path = indirect_array_file_path(path);
+    let array_file_len = if array_file_path.exists() {
+        Some(std::fs::metadata(&array_file_path)?.len())
+    } else {
+        None
+    };
+    let mut array_writer: Option<StManArrayFileWriter> = None;
+
+    for (col_index, col_desc) in columns.iter().enumerate() {
+        let Some(row_values) = changed_values.get(col_desc.col_name.as_str()) else {
+            continue;
+        };
+        let Some(layout) = layouts[col_index].as_ref() else {
+            return Ok(false);
+        };
+        match layout {
+            SparseColumnLayout::ScalarBoolPacked { extents } => {
+                for &(row_index, ref value) in row_values {
+                    let Some(Value::Scalar(ScalarValue::Bool(flag))) = value else {
+                        return Ok(false);
+                    };
+                    let (byte_pos, bit_index) = locate_bit_extent_slot(extents, row_index)?;
+                    main_file.seek(SeekFrom::Start(byte_pos))?;
+                    let mut current = [0u8; 1];
+                    main_file.read_exact(&mut current)?;
+                    if *flag {
+                        current[0] |= 1 << bit_index;
+                    } else {
+                        current[0] &= !(1 << bit_index);
+                    }
+                    main_file.seek(SeekFrom::Start(byte_pos))?;
+                    main_file.write_all(&current)?;
+                }
+            }
+            SparseColumnLayout::IndirectArrayOffsetsU32 { data_type, extents } => {
+                let existing_len = array_file_len.unwrap_or(0);
+                if existing_len >= LARGE_OFFSET_MARKER as u64 {
+                    return Ok(false);
+                }
+                let writer = match array_writer.as_mut() {
+                    Some(writer) => writer,
+                    None => {
+                        array_writer = Some(StManArrayFileWriter::open_append(
+                            &array_file_path,
+                            byte_order == ByteOrder::BigEndian,
+                        )?);
+                        array_writer.as_mut().expect("writer just created")
+                    }
+                };
+                for &(row_index, ref value) in row_values {
+                    let offset = match value {
+                        Some(value @ Value::Array(_)) => writer.write_array(value, *data_type)?,
+                        None => 0,
+                        _ => return Ok(false),
+                    };
+                    let offset_u32 = u32::try_from(offset).map_err(|_| {
+                        StorageError::FormatMismatch(format!(
+                            "sparse StManAipsIO offset exceeds u32 for column {} row {}",
+                            col_desc.col_name, row_index
+                        ))
+                    })?;
+                    let slot = locate_extent_slot(extents, row_index)?;
+                    main_file.seek(SeekFrom::Start(slot))?;
+                    main_file.write_all(&offset_u32.to_be_bytes())?;
+                }
+            }
+            SparseColumnLayout::ScalarFixed { data_type, extents } => {
+                for &(row_index, ref value) in row_values {
+                    let Some(Value::Scalar(scalar)) = value else {
+                        return Ok(false);
+                    };
+                    let encoded = encode_fixed_scalar_value(*data_type, scalar)?;
+                    let slot = locate_extent_slot(extents, row_index)?;
+                    main_file.seek(SeekFrom::Start(slot))?;
+                    main_file.write_all(&encoded)?;
+                }
+            }
+            SparseColumnLayout::DirectArrayFixed { data_type, extents } => {
+                for &(row_index, ref value) in row_values {
+                    let Some(Value::Array(array)) = value else {
+                        return Ok(false);
+                    };
+                    let encoded = encode_fixed_array_row(*data_type, array)?;
+                    let slot = locate_extent_slot(extents, row_index)?;
+                    main_file.seek(SeekFrom::Start(slot))?;
+                    main_file.write_all(&encoded)?;
+                }
+            }
+        }
+    }
+
+    if let Some(writer) = array_writer.as_mut() {
+        writer.finish()?;
+    }
+    main_file.flush()?;
+    Ok(true)
+}
+
+pub(crate) fn read_stman_array_column_rows(
+    path: &Path,
+    columns: &[ColumnDescContents],
+    target_col_idx: usize,
+    selected_rows: &[usize],
+    byte_order: ByteOrder,
+) -> Result<Option<Vec<Option<ArrayValue>>>, StorageError> {
+    if selected_rows.is_empty() {
+        return Ok(Some(Vec::new()));
+    }
+    let layouts = parse_sparse_column_layouts(path, columns, byte_order)?;
+    let Some(SparseColumnLayout::IndirectArrayOffsetsU32 { data_type, extents }) = layouts
+        .get(target_col_idx)
+        .and_then(|layout| layout.as_ref())
+    else {
+        return Ok(None);
+    };
+
+    let array_file_path = indirect_array_file_path(path);
+    if std::fs::metadata(&array_file_path)
+        .map(|meta| meta.len())
+        .unwrap_or(0)
+        >= LARGE_OFFSET_MARKER as u64
+    {
+        return Ok(None);
+    }
+
+    let mut main_file = std::fs::File::open(path)?;
+    let mut requests: Vec<(usize, usize)> = selected_rows
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(out_idx, row_index)| (row_index, out_idx))
+        .collect();
+    requests.sort_unstable_by_key(|&(row_index, _)| row_index);
+
+    let mut offsets = vec![0u32; selected_rows.len()];
+    for (row_index, out_idx) in requests {
+        let slot = locate_extent_slot(extents, row_index)?;
+        main_file.seek(SeekFrom::Start(slot))?;
+        offsets[out_idx] = read_be_u32(&mut main_file)?;
+    }
+
+    let mut reader =
+        StManArrayFileReader::open(&array_file_path, byte_order == ByteOrder::BigEndian)?;
+    let mut values = Vec::with_capacity(offsets.len());
+    for offset in offsets {
+        let value = reader
+            .read_array_at(offset as i64, *data_type)?
+            .map(|value| match value {
+                Value::Array(array) => Ok(array),
+                other => Err(StorageError::FormatMismatch(format!(
+                    "expected array value in indirect StManAipsIO column, found {:?}",
+                    other.kind()
+                ))),
+            })
+            .transpose()?;
+        values.push(value);
+    }
+
+    Ok(Some(values))
+}
+
+pub(crate) fn read_stman_scalar_column(
+    path: &Path,
+    columns: &[ColumnDescContents],
+    target_col_idx: usize,
+    byte_order: ByteOrder,
+) -> Result<Option<Vec<Option<ScalarValue>>>, StorageError> {
+    let layouts = parse_sparse_column_layouts(path, columns, byte_order)?;
+    let Some(layout) = layouts
+        .get(target_col_idx)
+        .and_then(|layout| layout.as_ref())
+    else {
+        return Ok(None);
+    };
+    let column = columns.get(target_col_idx).ok_or_else(|| {
+        StorageError::FormatMismatch(format!(
+            "target StManAipsIO scalar column index {target_col_idx} is out of range"
+        ))
+    })?;
+
+    let mut file = std::fs::File::open(path)?;
+    let mut values = Vec::new();
+    match layout {
+        SparseColumnLayout::ScalarBoolPacked { extents } => {
+            for extent in extents {
+                file.seek(SeekFrom::Start(extent.values_start))?;
+                let mut packed = vec![0u8; extent.row_count.div_ceil(8)];
+                file.read_exact(&mut packed)?;
+                for row_offset in 0..extent.row_count {
+                    let byte = packed[row_offset / 8];
+                    let flag = ((byte >> (row_offset % 8)) & 1) != 0;
+                    let scalar = ScalarValue::Bool(flag);
+                    if (column.option & 2) != 0
+                        && scalar_value_is_default(
+                            &Value::Scalar(scalar.clone()),
+                            column.require_primitive_type()?,
+                        )
+                    {
+                        values.push(None);
+                    } else {
+                        values.push(Some(scalar));
+                    }
+                }
+            }
+        }
+        SparseColumnLayout::ScalarFixed { data_type, extents } => {
+            for extent in extents {
+                file.seek(SeekFrom::Start(extent.values_start))?;
+                let mut raw = vec![0u8; extent.row_count * extent.row_width_bytes];
+                file.read_exact(&mut raw)?;
+                for chunk in raw.chunks_exact(extent.row_width_bytes) {
+                    let scalar = decode_fixed_scalar_value(*data_type, chunk)?;
+                    if (column.option & 2) != 0
+                        && scalar_value_is_default(
+                            &Value::Scalar(scalar.clone()),
+                            column.require_primitive_type()?,
+                        )
+                    {
+                        values.push(None);
+                    } else {
+                        values.push(Some(scalar));
+                    }
+                }
+            }
+        }
+        _ => return Ok(None),
+    }
+    Ok(Some(values))
+}
+
+fn parse_sparse_column_layouts(
+    path: &Path,
+    columns: &[ColumnDescContents],
+    byte_order: ByteOrder,
+) -> Result<Vec<Option<SparseColumnLayout>>, StorageError> {
+    if byte_order != ByteOrder::BigEndian {
+        return Ok(vec![None; columns.len()]);
+    }
+
+    let mut file = std::fs::File::open(path)?;
+    let magic = read_be_u32(&mut file)?;
+    if magic != AIPSIO_TOP_LEVEL_MAGIC {
+        return Err(StorageError::FormatMismatch(format!(
+            "StManAipsIO file missing top-level magic: {magic:#x}"
+        )));
+    }
+    let top = read_object_header(&mut file)?;
+    if top.type_name != "StManAipsIO" {
+        return Err(StorageError::FormatMismatch(format!(
+            "expected StManAipsIO top-level object, found {}",
+            top.type_name
+        )));
+    }
+
+    let _name = read_be_string(&mut file)?;
+    let _seq_nr = read_be_u32(&mut file)?;
+    let _uniq_nr = read_be_u32(&mut file)?;
+    let nrrow = read_be_u32(&mut file)? as usize;
+    let ncol = read_be_u32(&mut file)? as usize;
+    if ncol != columns.len() {
+        return Err(StorageError::FormatMismatch(format!(
+            "StManAipsIO column count mismatch: file has {ncol}, expected {}",
+            columns.len()
+        )));
+    }
+
+    let mut data_types = Vec::with_capacity(ncol);
+    for _ in 0..ncol {
+        let dt_i32 = read_be_i32(&mut file)?;
+        let dt = CasacoreDataType::from_i32(dt_i32).ok_or_else(|| {
+            StorageError::FormatMismatch(format!("unknown StManAipsIO dtype tag: {dt_i32}"))
+        })?;
+        data_types.push(dt);
+    }
+
+    let mut layouts = Vec::with_capacity(ncol);
+    for (col_desc, data_type) in columns.iter().zip(data_types.into_iter()) {
+        let column_header = read_object_header(&mut file)?;
+        let layout = match column_header.type_name.as_str() {
+            "StManColumnIndArrayAipsIO" => {
+                let _compat_dtype = read_be_i32(&mut file)?;
+                let _seqnr = read_be_i32(&mut file)?;
+                let inner = read_object_header(&mut file)?;
+                if inner.type_name != "StManColumnAipsIO" {
+                    None
+                } else {
+                    let stored_nrrow = read_be_u32(&mut file)? as usize;
+                    if stored_nrrow != nrrow {
+                        None
+                    } else {
+                        parse_indirect_offsets_layout(&mut file, stored_nrrow, data_type)?
+                    }
+                }
+            }
+            "StManColumnAipsIO" => {
+                let stored_nrrow = read_be_u32(&mut file)? as usize;
+                if stored_nrrow != nrrow {
+                    None
+                } else {
+                    parse_scalar_layout(&mut file, stored_nrrow, data_type)?
+                }
+            }
+            "StManColumnArrayAipsIO" => {
+                let inner = read_object_header(&mut file)?;
+                if inner.type_name != "StManColumnAipsIO" {
+                    None
+                } else {
+                    let stored_nrrow = read_be_u32(&mut file)? as usize;
+                    if stored_nrrow != nrrow {
+                        None
+                    } else {
+                        parse_direct_array_layout(&mut file, stored_nrrow, col_desc, data_type)?
+                    }
+                }
+            }
+            _ => None,
+        };
+        file.seek(SeekFrom::Start(column_header.object_end))?;
+        layouts.push(layout);
+    }
+
+    file.seek(SeekFrom::Start(top.object_end))?;
+    Ok(layouts)
+}
+
+fn parse_indirect_offsets_layout(
+    file: &mut std::fs::File,
+    nrrow: usize,
+    data_type: CasacoreDataType,
+) -> Result<Option<SparseColumnLayout>, StorageError> {
+    let mut extents = Vec::new();
+    let mut row_start = 0usize;
+    while row_start < nrrow {
+        let raw_count = read_be_u32(file)? as usize;
+        let row_count = if raw_count == 0 {
+            nrrow - row_start
+        } else {
+            raw_count
+        };
+        let values_start = file.stream_position()?;
+        file.seek(SeekFrom::Current(
+            (row_count * std::mem::size_of::<u32>()) as i64,
+        ))?;
+        extents.push(ExtentLayout {
+            row_start,
+            row_count,
+            values_start,
+            row_width_bytes: std::mem::size_of::<u32>(),
+        });
+        row_start += row_count;
+    }
+    Ok(Some(SparseColumnLayout::IndirectArrayOffsetsU32 {
+        data_type,
+        extents,
+    }))
+}
+
+fn parse_scalar_layout(
+    file: &mut std::fs::File,
+    nrrow: usize,
+    data_type: CasacoreDataType,
+) -> Result<Option<SparseColumnLayout>, StorageError> {
+    if data_type == CasacoreDataType::TpBool {
+        let mut extents = Vec::new();
+        let mut row_start = 0usize;
+        while row_start < nrrow {
+            let raw_count = read_be_u32(file)? as usize;
+            let row_count = if raw_count == 0 {
+                nrrow - row_start
+            } else {
+                raw_count
+            };
+            let stored_count = read_be_u32(file)? as usize;
+            if stored_count != row_count {
+                return Ok(None);
+            }
+            let values_start = file.stream_position()?;
+            let packed_bytes = row_count.div_ceil(8);
+            file.seek(SeekFrom::Current(packed_bytes as i64))?;
+            extents.push(BitExtentLayout {
+                row_start,
+                row_count,
+                values_start,
+            });
+            row_start += row_count;
+        }
+        return Ok(Some(SparseColumnLayout::ScalarBoolPacked { extents }));
+    }
+
+    let Some(row_width_bytes) = scalar_fixed_width_bytes(data_type) else {
+        return Ok(None);
+    };
+    let mut extents = Vec::new();
+    let mut row_start = 0usize;
+    while row_start < nrrow {
+        let raw_count = read_be_u32(file)? as usize;
+        let row_count = if raw_count == 0 {
+            nrrow - row_start
+        } else {
+            raw_count
+        };
+        let stored_count = read_be_u32(file)? as usize;
+        if stored_count != row_count {
+            return Ok(None);
+        }
+        let values_start = file.stream_position()?;
+        file.seek(SeekFrom::Current((row_count * row_width_bytes) as i64))?;
+        extents.push(ExtentLayout {
+            row_start,
+            row_count,
+            values_start,
+            row_width_bytes,
+        });
+        row_start += row_count;
+    }
+    Ok(Some(SparseColumnLayout::ScalarFixed { data_type, extents }))
+}
+
+fn parse_direct_array_layout(
+    file: &mut std::fs::File,
+    nrrow: usize,
+    col_desc: &ColumnDescContents,
+    data_type: CasacoreDataType,
+) -> Result<Option<SparseColumnLayout>, StorageError> {
+    let Some(elem_width) = scalar_fixed_width_bytes(data_type) else {
+        return Ok(None);
+    };
+    let elements_per_row: usize = col_desc.shape.iter().map(|&dim| dim as usize).product();
+    if elements_per_row == 0 {
+        return Ok(None);
+    }
+    let row_width_bytes = elements_per_row.checked_mul(elem_width).ok_or_else(|| {
+        StorageError::FormatMismatch("direct-array row width overflow".to_string())
+    })?;
+    let mut extents = Vec::new();
+    let mut row_start = 0usize;
+    while row_start < nrrow {
+        let raw_count = read_be_u32(file)? as usize;
+        let row_count = if raw_count == 0 {
+            nrrow - row_start
+        } else {
+            raw_count
+        };
+        let total_elements = read_be_u32(file)? as usize;
+        if total_elements != row_count * elements_per_row {
+            return Ok(None);
+        }
+        let values_start = file.stream_position()?;
+        file.seek(SeekFrom::Current((row_count * row_width_bytes) as i64))?;
+        extents.push(ExtentLayout {
+            row_start,
+            row_count,
+            values_start,
+            row_width_bytes,
+        });
+        row_start += row_count;
+    }
+    Ok(Some(SparseColumnLayout::DirectArrayFixed {
+        data_type,
+        extents,
+    }))
+}
+
+fn read_object_header(file: &mut std::fs::File) -> Result<ObjectHeader, StorageError> {
+    let len_pos = file.stream_position()?;
+    let len = read_be_u32(file)?;
+    let type_name = read_be_string(file)?;
+    let version = read_be_u32(file)?;
+    let payload_start = file.stream_position()?;
+    let object_end = len_pos + len as u64;
+    Ok(ObjectHeader {
+        len,
+        type_name,
+        version,
+        payload_start,
+        object_end,
+    })
+}
+
+fn locate_extent_slot(extents: &[ExtentLayout], row_index: usize) -> Result<u64, StorageError> {
+    for extent in extents {
+        if row_index >= extent.row_start && row_index < extent.row_start + extent.row_count {
+            return Ok(extent.values_start
+                + ((row_index - extent.row_start) * extent.row_width_bytes) as u64);
+        }
+    }
+    Err(StorageError::FormatMismatch(format!(
+        "row {row_index} is outside sparse-patch extents"
+    )))
+}
+
+fn locate_bit_extent_slot(
+    extents: &[BitExtentLayout],
+    row_index: usize,
+) -> Result<(u64, usize), StorageError> {
+    for extent in extents {
+        if row_index >= extent.row_start && row_index < extent.row_start + extent.row_count {
+            let row_offset = row_index - extent.row_start;
+            return Ok((
+                extent.values_start + (row_offset / 8) as u64,
+                row_offset % 8,
+            ));
+        }
+    }
+    Err(StorageError::FormatMismatch(format!(
+        "row {row_index} is outside sparse-patch bit extents"
+    )))
+}
+
+fn scalar_fixed_width_bytes(data_type: CasacoreDataType) -> Option<usize> {
+    match data_type {
+        CasacoreDataType::TpBool | CasacoreDataType::TpUChar | CasacoreDataType::TpChar => Some(1),
+        CasacoreDataType::TpShort | CasacoreDataType::TpUShort => Some(2),
+        CasacoreDataType::TpInt | CasacoreDataType::TpUInt | CasacoreDataType::TpFloat => Some(4),
+        CasacoreDataType::TpDouble | CasacoreDataType::TpInt64 | CasacoreDataType::TpComplex => {
+            Some(8)
+        }
+        CasacoreDataType::TpDComplex => Some(16),
+        _ => None,
+    }
+}
+
+fn decode_fixed_scalar_value(
+    data_type: CasacoreDataType,
+    bytes: &[u8],
+) -> Result<ScalarValue, StorageError> {
+    let scalar = match data_type {
+        CasacoreDataType::TpUChar | CasacoreDataType::TpChar => {
+            ScalarValue::UInt8(*bytes.first().ok_or_else(|| {
+                StorageError::FormatMismatch("missing u8 scalar bytes".to_string())
+            })?)
+        }
+        CasacoreDataType::TpShort => {
+            ScalarValue::Int16(i16::from_be_bytes(bytes.try_into().map_err(|_| {
+                StorageError::FormatMismatch("invalid i16 scalar width".to_string())
+            })?))
+        }
+        CasacoreDataType::TpUShort => {
+            ScalarValue::UInt16(u16::from_be_bytes(bytes.try_into().map_err(|_| {
+                StorageError::FormatMismatch("invalid u16 scalar width".to_string())
+            })?))
+        }
+        CasacoreDataType::TpInt => {
+            ScalarValue::Int32(i32::from_be_bytes(bytes.try_into().map_err(|_| {
+                StorageError::FormatMismatch("invalid i32 scalar width".to_string())
+            })?))
+        }
+        CasacoreDataType::TpUInt => {
+            ScalarValue::UInt32(u32::from_be_bytes(bytes.try_into().map_err(|_| {
+                StorageError::FormatMismatch("invalid u32 scalar width".to_string())
+            })?))
+        }
+        CasacoreDataType::TpInt64 => {
+            ScalarValue::Int64(i64::from_be_bytes(bytes.try_into().map_err(|_| {
+                StorageError::FormatMismatch("invalid i64 scalar width".to_string())
+            })?))
+        }
+        CasacoreDataType::TpFloat => {
+            ScalarValue::Float32(f32::from_be_bytes(bytes.try_into().map_err(|_| {
+                StorageError::FormatMismatch("invalid f32 scalar width".to_string())
+            })?))
+        }
+        CasacoreDataType::TpDouble => {
+            ScalarValue::Float64(f64::from_be_bytes(bytes.try_into().map_err(|_| {
+                StorageError::FormatMismatch("invalid f64 scalar width".to_string())
+            })?))
+        }
+        CasacoreDataType::TpComplex => {
+            if bytes.len() != 8 {
+                return Err(StorageError::FormatMismatch(
+                    "invalid complex32 scalar width".to_string(),
+                ));
+            }
+            ScalarValue::Complex32(casa_types::Complex32 {
+                re: f32::from_be_bytes(bytes[0..4].try_into().expect("slice width checked")),
+                im: f32::from_be_bytes(bytes[4..8].try_into().expect("slice width checked")),
+            })
+        }
+        CasacoreDataType::TpDComplex => {
+            if bytes.len() != 16 {
+                return Err(StorageError::FormatMismatch(
+                    "invalid complex64 scalar width".to_string(),
+                ));
+            }
+            ScalarValue::Complex64(casa_types::Complex64 {
+                re: f64::from_be_bytes(bytes[0..8].try_into().expect("slice width checked")),
+                im: f64::from_be_bytes(bytes[8..16].try_into().expect("slice width checked")),
+            })
+        }
+        other => {
+            return Err(StorageError::FormatMismatch(format!(
+                "unsupported direct StManAipsIO scalar decode for {other:?}"
+            )));
+        }
+    };
+    Ok(scalar)
+}
+
+fn encode_fixed_scalar_value(
+    data_type: CasacoreDataType,
+    value: &ScalarValue,
+) -> Result<Vec<u8>, StorageError> {
+    let bytes = match (data_type, value) {
+        (CasacoreDataType::TpBool, ScalarValue::Bool(v)) => vec![u8::from(*v)],
+        (CasacoreDataType::TpUChar, ScalarValue::UInt8(v))
+        | (CasacoreDataType::TpChar, ScalarValue::UInt8(v)) => vec![*v],
+        (CasacoreDataType::TpShort, ScalarValue::Int16(v)) => v.to_be_bytes().to_vec(),
+        (CasacoreDataType::TpUShort, ScalarValue::UInt16(v)) => v.to_be_bytes().to_vec(),
+        (CasacoreDataType::TpInt, ScalarValue::Int32(v)) => v.to_be_bytes().to_vec(),
+        (CasacoreDataType::TpUInt, ScalarValue::UInt32(v)) => v.to_be_bytes().to_vec(),
+        (CasacoreDataType::TpInt64, ScalarValue::Int64(v)) => v.to_be_bytes().to_vec(),
+        (CasacoreDataType::TpFloat, ScalarValue::Float32(v)) => v.to_be_bytes().to_vec(),
+        (CasacoreDataType::TpDouble, ScalarValue::Float64(v)) => v.to_be_bytes().to_vec(),
+        (CasacoreDataType::TpComplex, ScalarValue::Complex32(v)) => {
+            let mut bytes = Vec::with_capacity(8);
+            bytes.extend_from_slice(&v.re.to_be_bytes());
+            bytes.extend_from_slice(&v.im.to_be_bytes());
+            bytes
+        }
+        (CasacoreDataType::TpDComplex, ScalarValue::Complex64(v)) => {
+            let mut bytes = Vec::with_capacity(16);
+            bytes.extend_from_slice(&v.re.to_be_bytes());
+            bytes.extend_from_slice(&v.im.to_be_bytes());
+            bytes
+        }
+        _ => {
+            return Err(StorageError::FormatMismatch(format!(
+                "unsupported sparse scalar patch for type {data_type:?} value {value:?}"
+            )));
+        }
+    };
+    Ok(bytes)
+}
+
+fn encode_fixed_array_row(
+    data_type: CasacoreDataType,
+    value: &ArrayValue,
+) -> Result<Vec<u8>, StorageError> {
+    let mut encoded = Vec::new();
+    match (data_type, value) {
+        (CasacoreDataType::TpBool, _) | (_, ArrayValue::String(_)) => {
+            return Err(StorageError::FormatMismatch(format!(
+                "unsupported sparse direct-array patch for {data_type:?}"
+            )));
+        }
+        (CasacoreDataType::TpUChar, ArrayValue::UInt8(arr))
+        | (CasacoreDataType::TpChar, ArrayValue::UInt8(arr)) => {
+            encoded.extend(fortran_flat_iter(arr))
+        }
+        (CasacoreDataType::TpShort, ArrayValue::Int16(arr)) => {
+            for value in fortran_flat_iter(arr) {
+                encoded.extend_from_slice(&value.to_be_bytes());
+            }
+        }
+        (CasacoreDataType::TpUShort, ArrayValue::UInt16(arr)) => {
+            for value in fortran_flat_iter(arr) {
+                encoded.extend_from_slice(&value.to_be_bytes());
+            }
+        }
+        (CasacoreDataType::TpInt, ArrayValue::Int32(arr)) => {
+            for value in fortran_flat_iter(arr) {
+                encoded.extend_from_slice(&value.to_be_bytes());
+            }
+        }
+        (CasacoreDataType::TpUInt, ArrayValue::UInt32(arr)) => {
+            for value in fortran_flat_iter(arr) {
+                encoded.extend_from_slice(&value.to_be_bytes());
+            }
+        }
+        (CasacoreDataType::TpInt64, ArrayValue::Int64(arr)) => {
+            for value in fortran_flat_iter(arr) {
+                encoded.extend_from_slice(&value.to_be_bytes());
+            }
+        }
+        (CasacoreDataType::TpFloat, ArrayValue::Float32(arr)) => {
+            for value in fortran_flat_iter(arr) {
+                encoded.extend_from_slice(&value.to_be_bytes());
+            }
+        }
+        (CasacoreDataType::TpDouble, ArrayValue::Float64(arr)) => {
+            for value in fortran_flat_iter(arr) {
+                encoded.extend_from_slice(&value.to_be_bytes());
+            }
+        }
+        (CasacoreDataType::TpComplex, ArrayValue::Complex32(arr)) => {
+            for value in fortran_flat_iter(arr) {
+                encoded.extend_from_slice(&value.re.to_be_bytes());
+                encoded.extend_from_slice(&value.im.to_be_bytes());
+            }
+        }
+        (CasacoreDataType::TpDComplex, ArrayValue::Complex64(arr)) => {
+            for value in fortran_flat_iter(arr) {
+                encoded.extend_from_slice(&value.re.to_be_bytes());
+                encoded.extend_from_slice(&value.im.to_be_bytes());
+            }
+        }
+        _ => {
+            return Err(StorageError::FormatMismatch(format!(
+                "unsupported sparse direct-array patch for type {data_type:?}"
+            )));
+        }
+    }
+    Ok(encoded)
+}
+
+fn indirect_array_file_path(path: &Path) -> PathBuf {
+    let mut array_path = path.as_os_str().to_os_string();
+    array_path.push("i");
+    PathBuf::from(array_path)
+}
+
+fn read_be_u32(file: &mut std::fs::File) -> Result<u32, StorageError> {
+    let mut bytes = [0u8; 4];
+    file.read_exact(&mut bytes)?;
+    Ok(u32::from_be_bytes(bytes))
+}
+
+fn read_be_i32(file: &mut std::fs::File) -> Result<i32, StorageError> {
+    let mut bytes = [0u8; 4];
+    file.read_exact(&mut bytes)?;
+    Ok(i32::from_be_bytes(bytes))
+}
+
+fn read_be_string(file: &mut std::fs::File) -> Result<String, StorageError> {
+    let length = read_be_u32(file)? as usize;
+    let mut bytes = vec![0u8; length];
+    file.read_exact(&mut bytes)?;
+    String::from_utf8(bytes).map_err(|error| {
+        StorageError::FormatMismatch(format!("invalid UTF-8 in AipsIO string: {error}"))
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/casa-tables/src/storage/stman_array_file.rs
+++ b/crates/casa-tables/src/storage/stman_array_file.rs
@@ -31,7 +31,7 @@
 //! - `casacore::StManArrayFile`  (`StArrayFile.h / StArrayFile.cc`)
 //! - `casacore::StIndArray`      (`StIndArray.h / StIndArray.cc`)
 
-use std::fs::File;
+use std::fs::{File, OpenOptions};
 use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
@@ -503,6 +503,27 @@ impl StManArrayFileWriter {
 
         Ok(Self {
             file,
+            bo,
+            version,
+            file_length,
+        })
+    }
+
+    /// Open an existing array file and append new array records.
+    pub(crate) fn open_append(path: &Path, big_endian: bool) -> Result<Self, StorageError> {
+        let bo = if big_endian {
+            ArrayFileByteOrder::Big
+        } else {
+            ArrayFileByteOrder::Little
+        };
+        let mut raw = OpenOptions::new().read(true).write(true).open(path)?;
+        let version = read_u32(&mut raw, bo)?;
+        let file_length = read_i64(&mut raw, bo)?;
+        let mut pad = [0u8; 4];
+        raw.read_exact(&mut pad)?;
+        raw.seek(SeekFrom::Start(file_length as u64))?;
+        Ok(Self {
+            file: BufWriter::new(raw),
             bo,
             version,
             file_length,

--- a/crates/casa-tables/src/storage/tiled_stman.rs
+++ b/crates/casa-tables/src/storage/tiled_stman.rs
@@ -1129,6 +1129,102 @@ pub(crate) fn load_tiled_columns(
     }
 }
 
+pub(crate) fn load_tiled_column_rows(
+    table_path: &Path,
+    dm: &DataManagerEntry,
+    all_col_descs: &[ColumnDescContents],
+    bound_cols: &[(usize, &super::table_control::PlainColumnEntry)],
+    target_desc_idx: usize,
+    selected_rows: &[usize],
+) -> Result<Vec<Option<ArrayValue>>, StorageError> {
+    let header_path = table_path.join(format!("table.f{}", dm.seq_nr));
+    let (variant, header) = read_tiled_header(&header_path)?;
+    let Some(target_col_idx) = bound_cols
+        .iter()
+        .position(|(desc_idx, _)| *desc_idx == target_desc_idx)
+    else {
+        return Err(StorageError::FormatMismatch(format!(
+            "tiled column desc index {target_desc_idx} not bound to data manager {}",
+            dm.seq_nr
+        )));
+    };
+    if target_col_idx >= header.col_data_types.len() {
+        return Err(StorageError::FormatMismatch(format!(
+            "tiled column index {target_col_idx} out of range for data manager {}",
+            dm.seq_nr
+        )));
+    }
+    let col_desc = &all_col_descs[target_desc_idx];
+    let dt = header.col_data_types[target_col_idx];
+    let elem_size = tile_element_size(dt);
+    if elem_size == 0 {
+        return Ok(vec![None; selected_rows.len()]);
+    }
+
+    match variant {
+        TiledVariant::Column { .. } => load_tiled_column_rows_column_variant(
+            table_path,
+            dm.seq_nr,
+            &header,
+            target_col_idx,
+            col_desc,
+            dt,
+            elem_size,
+            selected_rows,
+        ),
+        TiledVariant::Shape {
+            nr_used_row_map,
+            ref row_map,
+            ref cube_map,
+            ref pos_map,
+            ..
+        } => load_tiled_column_rows_shape_variant(
+            table_path,
+            dm.seq_nr,
+            &header,
+            target_col_idx,
+            col_desc,
+            dt,
+            elem_size,
+            selected_rows,
+            &ShapeRowMapping {
+                nr_used_row_map,
+                row_map,
+                cube_map,
+                pos_map,
+            },
+        ),
+        TiledVariant::Cell { .. } => load_tiled_column_rows_cell_variant(
+            table_path,
+            dm.seq_nr,
+            &header,
+            target_col_idx,
+            col_desc,
+            dt,
+            elem_size,
+            selected_rows,
+        ),
+        TiledVariant::Data {
+            ref row_map,
+            ref cube_map,
+            ref pos_map,
+            ..
+        } => load_tiled_column_rows_data_variant(
+            table_path,
+            dm.seq_nr,
+            &header,
+            target_col_idx,
+            col_desc,
+            dt,
+            elem_size,
+            selected_rows,
+            row_map,
+            cube_map,
+            pos_map,
+        ),
+    }
+}
+
 /// Load columns from a `TiledColumnStMan` (single hypercube for all rows).
 fn load_tiled_column_stman(
     table_path: &Path,
@@ -1198,6 +1294,56 @@ fn load_tiled_column_stman(
     }
 
     Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn load_tiled_column_rows_column_variant(
+    table_path: &Path,
+    dm_seq_nr: u32,
+    header: &TiledStManHeader,
+    target_col_idx: usize,
+    col_desc: &ColumnDescContents,
+    dt: CasacoreDataType,
+    elem_size: usize,
+    selected_rows: &[usize],
+) -> Result<Vec<Option<ArrayValue>>, StorageError> {
+    if header.cubes.is_empty() {
+        return Ok(vec![None; selected_rows.len()]);
+    }
+    let cube = &header.cubes[0];
+    if cube.file_seq_nr < 0 || cube.cube_shape.is_empty() {
+        return Ok(vec![None; selected_rows.len()]);
+    }
+    let tsm_file_name = tsm_data_path(table_path, dm_seq_nr, cube.file_seq_nr as u32);
+    let file_data = std::fs::read(&tsm_file_name).map_err(|e| {
+        StorageError::FormatMismatch(format!("cannot read {}: {e}", tsm_file_name.display()))
+    })?;
+    let (bucket_size, col_offsets) = compute_tile_layout(&header.col_data_types, &cube.tile_shape);
+    let cube_raw = reconstruct_cube_column(
+        &file_data,
+        cube.file_offset as usize,
+        &cube.cube_shape,
+        &cube.tile_shape,
+        col_offsets[target_col_idx],
+        bucket_size,
+        dt,
+        elem_size,
+    )?;
+    extract_selected_rows_from_cube_raw(
+        &cube_raw,
+        &cube.cube_shape,
+        selected_rows
+            .iter()
+            .enumerate()
+            .map(|(out_idx, &row_idx)| SelectedCubeRow {
+                out_idx,
+                pos_in_cube: row_idx,
+            }),
+        col_desc,
+        dt,
+        header.big_endian,
+        selected_rows.len(),
+    )
 }
 
 /// Row-to-cube mapping tables extracted from `TiledShapeStMan` variant data.
@@ -1380,6 +1526,68 @@ fn load_tiled_shape_stman(
     Ok(())
 }
 
+#[derive(Clone, Copy, Debug)]
+struct SelectedCubeRow {
+    out_idx: usize,
+    pos_in_cube: usize,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn load_tiled_column_rows_shape_variant(
+    table_path: &Path,
+    dm_seq_nr: u32,
+    header: &TiledStManHeader,
+    target_col_idx: usize,
+    col_desc: &ColumnDescContents,
+    dt: CasacoreDataType,
+    elem_size: usize,
+    selected_rows: &[usize],
+    mapping: &ShapeRowMapping<'_>,
+) -> Result<Vec<Option<ArrayValue>>, StorageError> {
+    let n_intervals = mapping.nr_used_row_map as usize;
+    if n_intervals == 0 {
+        return Ok(vec![None; selected_rows.len()]);
+    }
+
+    let mut patches_by_cube: std::collections::BTreeMap<usize, Vec<SelectedCubeRow>> =
+        std::collections::BTreeMap::new();
+    for (out_idx, &row_idx) in selected_rows.iter().enumerate() {
+        let interval = mapping.row_map[..n_intervals].partition_point(|&rm| rm < row_idx as u32);
+        if interval >= n_intervals {
+            continue;
+        }
+        let cube_idx = mapping.cube_map[interval] as usize;
+        if cube_idx == 0 || cube_idx >= header.cubes.len() {
+            continue;
+        }
+        let diff = mapping.row_map[interval] as usize - row_idx;
+        let Some(pos_in_cube) = (mapping.pos_map[interval] as usize).checked_sub(diff) else {
+            return Err(StorageError::FormatMismatch(format!(
+                "invalid TiledShapeStMan row map for row {row_idx}: interval {interval} has pos {} < diff {diff}",
+                mapping.pos_map[interval]
+            )));
+        };
+        patches_by_cube
+            .entry(cube_idx)
+            .or_default()
+            .push(SelectedCubeRow {
+                out_idx,
+                pos_in_cube,
+            });
+    }
+    load_selected_rows_from_touched_cubes(
+        table_path,
+        dm_seq_nr,
+        header,
+        target_col_idx,
+        col_desc,
+        dt,
+        elem_size,
+        selected_rows.len(),
+        patches_by_cube,
+    )
+}
+
 /// Load columns from a `TiledDataStMan` (user-controlled hypercube assignment).
 ///
 /// Uses binary search in `row_map` to find the chunk index for each row.
@@ -1537,6 +1745,63 @@ fn load_tiled_data_stman(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
+fn load_tiled_column_rows_data_variant(
+    table_path: &Path,
+    dm_seq_nr: u32,
+    header: &TiledStManHeader,
+    target_col_idx: usize,
+    col_desc: &ColumnDescContents,
+    dt: CasacoreDataType,
+    elem_size: usize,
+    selected_rows: &[usize],
+    row_map: &[u64],
+    cube_map: &[u32],
+    pos_map: &[u32],
+) -> Result<Vec<Option<ArrayValue>>, StorageError> {
+    let mut patches_by_cube: std::collections::BTreeMap<usize, Vec<SelectedCubeRow>> =
+        std::collections::BTreeMap::new();
+    let n_chunks = row_map.len();
+    for (out_idx, &row_idx) in selected_rows.iter().enumerate() {
+        let chunk = match row_map.binary_search(&(row_idx as u64)) {
+            Ok(i) => i,
+            Err(i) => {
+                if i == 0 {
+                    continue;
+                }
+                i - 1
+            }
+        };
+        if chunk >= n_chunks {
+            continue;
+        }
+        let cube_idx = cube_map[chunk] as usize;
+        if cube_idx >= header.cubes.len() {
+            continue;
+        }
+        let chunk_start = row_map[chunk] as usize;
+        let pos_in_cube = pos_map[chunk] as usize + (row_idx - chunk_start);
+        patches_by_cube
+            .entry(cube_idx)
+            .or_default()
+            .push(SelectedCubeRow {
+                out_idx,
+                pos_in_cube,
+            });
+    }
+    load_selected_rows_from_touched_cubes(
+        table_path,
+        dm_seq_nr,
+        header,
+        target_col_idx,
+        col_desc,
+        dt,
+        elem_size,
+        selected_rows.len(),
+        patches_by_cube,
+    )
+}
+
 /// Load columns from a `TiledCellStMan` (one hypercube per row).
 fn load_tiled_cell_stman(
     table_path: &Path,
@@ -1595,6 +1860,168 @@ fn load_tiled_cell_stman(
     }
 
     Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn load_tiled_column_rows_cell_variant(
+    table_path: &Path,
+    dm_seq_nr: u32,
+    header: &TiledStManHeader,
+    target_col_idx: usize,
+    col_desc: &ColumnDescContents,
+    dt: CasacoreDataType,
+    elem_size: usize,
+    selected_rows: &[usize],
+) -> Result<Vec<Option<ArrayValue>>, StorageError> {
+    let mut outputs = vec![None; selected_rows.len()];
+    let mut file_cache: std::collections::HashMap<u32, Vec<u8>> = std::collections::HashMap::new();
+
+    for (out_idx, &row_idx) in selected_rows.iter().enumerate() {
+        let Some(cube) = header.cubes.get(row_idx) else {
+            continue;
+        };
+        if cube.file_seq_nr < 0 || cube.cube_shape.is_empty() {
+            continue;
+        }
+        let file_seq_nr = cube.file_seq_nr as u32;
+        let file_data = match file_cache.entry(file_seq_nr) {
+            std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                let path = tsm_data_path(table_path, dm_seq_nr, file_seq_nr);
+                let data = std::fs::read(&path).map_err(|err| {
+                    StorageError::FormatMismatch(format!("cannot read {}: {err}", path.display()))
+                })?;
+                entry.insert(data)
+            }
+        };
+        let (bucket_size, col_offsets) =
+            compute_tile_layout(&header.col_data_types, &cube.tile_shape);
+        let raw = reconstruct_cube_column(
+            file_data,
+            cube.file_offset as usize,
+            &cube.cube_shape,
+            &cube.tile_shape,
+            col_offsets[target_col_idx],
+            bucket_size,
+            dt,
+            elem_size,
+        )?;
+        let mut decoded = extract_selected_rows_from_cube_raw(
+            &raw,
+            &cube.cube_shape,
+            std::iter::once(SelectedCubeRow {
+                out_idx: 0,
+                pos_in_cube: 0,
+            }),
+            col_desc,
+            dt,
+            header.big_endian,
+            1,
+        )?;
+        outputs[out_idx] = decoded.pop().flatten();
+    }
+    Ok(outputs)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn load_selected_rows_from_touched_cubes(
+    table_path: &Path,
+    dm_seq_nr: u32,
+    header: &TiledStManHeader,
+    target_col_idx: usize,
+    col_desc: &ColumnDescContents,
+    dt: CasacoreDataType,
+    elem_size: usize,
+    output_len: usize,
+    patches_by_cube: std::collections::BTreeMap<usize, Vec<SelectedCubeRow>>,
+) -> Result<Vec<Option<ArrayValue>>, StorageError> {
+    let mut outputs = vec![None; output_len];
+    let mut file_cache: std::collections::HashMap<u32, Vec<u8>> = std::collections::HashMap::new();
+
+    for (cube_idx, patches) in patches_by_cube {
+        let Some(cube) = header.cubes.get(cube_idx) else {
+            continue;
+        };
+        if cube.file_seq_nr < 0 || cube.cube_shape.is_empty() {
+            continue;
+        }
+        let file_seq_nr = cube.file_seq_nr as u32;
+        let file_data = match file_cache.entry(file_seq_nr) {
+            std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                let path = tsm_data_path(table_path, dm_seq_nr, file_seq_nr);
+                let data = std::fs::read(&path).map_err(|err| {
+                    StorageError::FormatMismatch(format!("cannot read {}: {err}", path.display()))
+                })?;
+                entry.insert(data)
+            }
+        };
+        let (bucket_size, col_offsets) =
+            compute_tile_layout(&header.col_data_types, &cube.tile_shape);
+        let cube_raw = reconstruct_cube_column(
+            file_data,
+            cube.file_offset as usize,
+            &cube.cube_shape,
+            &cube.tile_shape,
+            col_offsets[target_col_idx],
+            bucket_size,
+            dt,
+            elem_size,
+        )?;
+        let decoded = extract_selected_rows_from_cube_raw(
+            &cube_raw,
+            &cube.cube_shape,
+            patches.iter().copied(),
+            col_desc,
+            dt,
+            header.big_endian,
+            output_len,
+        )?;
+        for (out_idx, value) in decoded.into_iter().enumerate() {
+            if value.is_some() {
+                outputs[out_idx] = value;
+            }
+        }
+    }
+
+    Ok(outputs)
+}
+
+fn extract_selected_rows_from_cube_raw(
+    cube_raw: &[u8],
+    cube_shape: &[usize],
+    selected_rows: impl IntoIterator<Item = SelectedCubeRow>,
+    col_desc: &ColumnDescContents,
+    dt: CasacoreDataType,
+    big_endian: bool,
+    output_len: usize,
+) -> Result<Vec<Option<ArrayValue>>, StorageError> {
+    let cell_ndim = cube_shape.len().saturating_sub(1);
+    let cell_shape: Vec<usize> = cube_shape[..cell_ndim].to_vec();
+    let cell_nelem: usize = cell_shape.iter().product();
+    let elem_size = tile_element_size(dt);
+    let row_bytes = cell_nelem * elem_size;
+    let mut outputs = vec![None; output_len];
+
+    for selected in selected_rows {
+        let start = selected.pos_in_cube * row_bytes;
+        let end = start + row_bytes;
+        if end > cube_raw.len() {
+            continue;
+        }
+        let value = decode_array_value(&cube_raw[start..end], &cell_shape, dt, big_endian)?;
+        match value {
+            Value::Array(array) => outputs[selected.out_idx] = Some(array),
+            other => {
+                return Err(StorageError::FormatMismatch(format!(
+                    "tiled array column {} decoded as non-array value {:?}",
+                    col_desc.col_name, other
+                )));
+            }
+        }
+    }
+
+    Ok(outputs)
 }
 
 /// Construct the path to a TSM data file.
@@ -1726,6 +2153,298 @@ pub(crate) fn save_tiled_single_column_values(
             )
         }
     }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SingleColumnCubeRowPatch {
+    global_row_idx: usize,
+    pos_in_cube: usize,
+}
+
+pub(crate) fn save_tiled_single_column_rows_in_place(
+    table_path: &Path,
+    dm_seq_nr: u32,
+    col_desc: &ColumnDescContents,
+    values: &[Option<&Value>],
+    changed_rows: &[usize],
+    options: SingleColumnTiledSaveOptions<'_>,
+) -> Result<bool, StorageError> {
+    if changed_rows.is_empty() {
+        return Ok(true);
+    }
+    match options.dm_type_name {
+        "TiledColumnStMan" => save_single_column_tiled_column_rows_in_place(
+            table_path,
+            dm_seq_nr,
+            col_desc,
+            values,
+            changed_rows,
+            options.big_endian,
+        ),
+        "TiledShapeStMan" => save_single_column_tiled_shape_rows_in_place(
+            table_path,
+            dm_seq_nr,
+            col_desc,
+            values,
+            changed_rows,
+            options.big_endian,
+        ),
+        _ => Ok(false),
+    }
+}
+
+fn save_single_column_tiled_column_rows_in_place(
+    table_path: &Path,
+    dm_seq_nr: u32,
+    col_desc: &ColumnDescContents,
+    values: &[Option<&Value>],
+    changed_rows: &[usize],
+    big_endian: bool,
+) -> Result<bool, StorageError> {
+    let header_path = table_path.join(format!("table.f{dm_seq_nr}"));
+    let (variant, header) = read_tiled_header(&header_path)?;
+    if !matches!(variant, TiledVariant::Column { .. }) || header.col_data_types.len() != 1 {
+        return Ok(false);
+    }
+    let Some(cube) = header.cubes.first() else {
+        return Ok(false);
+    };
+    if cube.file_seq_nr < 0 || cube.cube_shape.is_empty() {
+        return Ok(false);
+    }
+    let row_axis = cube.cube_shape.len() - 1;
+    let row_count = cube.cube_shape[row_axis];
+    let row_patches: Vec<_> = changed_rows
+        .iter()
+        .copied()
+        .filter(|&row_idx| row_idx < values.len() && row_idx < row_count)
+        .map(|row_idx| SingleColumnCubeRowPatch {
+            global_row_idx: row_idx,
+            pos_in_cube: row_idx,
+        })
+        .collect();
+    if row_patches.is_empty() {
+        return Ok(true);
+    }
+    patch_single_column_tiled_cube_rows(
+        table_path,
+        dm_seq_nr,
+        col_desc,
+        values,
+        big_endian,
+        header.col_data_types[0],
+        cube,
+        &row_patches,
+    )?;
+    Ok(true)
+}
+
+fn save_single_column_tiled_shape_rows_in_place(
+    table_path: &Path,
+    dm_seq_nr: u32,
+    col_desc: &ColumnDescContents,
+    values: &[Option<&Value>],
+    changed_rows: &[usize],
+    big_endian: bool,
+) -> Result<bool, StorageError> {
+    let header_path = table_path.join(format!("table.f{dm_seq_nr}"));
+    let (variant, header) = read_tiled_header(&header_path)?;
+    let TiledVariant::Shape {
+        nr_used_row_map,
+        row_map,
+        cube_map,
+        pos_map,
+        ..
+    } = variant
+    else {
+        return Ok(false);
+    };
+    if header.col_data_types.len() != 1 {
+        return Ok(false);
+    }
+    let n_intervals = nr_used_row_map as usize;
+    if n_intervals == 0 {
+        return Ok(false);
+    }
+
+    let mut patches_by_cube: std::collections::BTreeMap<usize, Vec<SingleColumnCubeRowPatch>> =
+        std::collections::BTreeMap::new();
+    for &row_idx in changed_rows {
+        if row_idx >= values.len() {
+            continue;
+        }
+        let interval = row_map[..n_intervals].partition_point(|&rm| rm < row_idx as u32);
+        if interval >= n_intervals {
+            continue;
+        }
+        let cube_idx = cube_map[interval] as usize;
+        if cube_idx == 0 || cube_idx >= header.cubes.len() {
+            continue;
+        }
+        let diff = row_map[interval] as usize - row_idx;
+        let Some(pos_in_cube) = (pos_map[interval] as usize).checked_sub(diff) else {
+            return Err(StorageError::FormatMismatch(format!(
+                "invalid TiledShapeStMan row map for row {row_idx}: interval {interval} has pos {} < diff {diff}",
+                pos_map[interval]
+            )));
+        };
+        patches_by_cube
+            .entry(cube_idx)
+            .or_default()
+            .push(SingleColumnCubeRowPatch {
+                global_row_idx: row_idx,
+                pos_in_cube,
+            });
+    }
+    if patches_by_cube.is_empty() {
+        return Ok(true);
+    }
+
+    for (cube_idx, row_patches) in patches_by_cube {
+        let cube = &header.cubes[cube_idx];
+        if cube.file_seq_nr < 0 || cube.cube_shape.is_empty() {
+            continue;
+        }
+        patch_single_column_tiled_cube_rows(
+            table_path,
+            dm_seq_nr,
+            col_desc,
+            values,
+            big_endian,
+            header.col_data_types[0],
+            cube,
+            &row_patches,
+        )?;
+    }
+    Ok(true)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn patch_single_column_tiled_cube_rows(
+    table_path: &Path,
+    dm_seq_nr: u32,
+    col_desc: &ColumnDescContents,
+    values: &[Option<&Value>],
+    big_endian: bool,
+    col_data_type: CasacoreDataType,
+    cube: &TsmCubeInfo,
+    row_patches: &[SingleColumnCubeRowPatch],
+) -> Result<(), StorageError> {
+    let ndim = cube.cube_shape.len();
+    if ndim == 0 {
+        return Ok(());
+    }
+    let row_axis = ndim - 1;
+    if row_axis == 0 {
+        return Err(StorageError::FormatMismatch(format!(
+            "single-column tiled sparse save requires array cells for {}",
+            col_desc.col_name
+        )));
+    }
+
+    let cell_shape = &cube.cube_shape[..row_axis];
+    let tile_cell_shape = &cube.tile_shape[..row_axis];
+    let row_tile_len = cube.tile_shape[row_axis].max(1);
+    let row_block_pixels: usize = tile_cell_shape.iter().product();
+    let elem_size = tile_element_size(col_data_type);
+    let expected_row_bytes = cell_shape.iter().product::<usize>() * elem_size;
+    let row_block_bytes = row_block_pixels * elem_size;
+    let nrpixels: usize = cube.tile_shape.iter().product();
+    let (bucket_size, col_offsets) =
+        compute_tile_layout(std::slice::from_ref(&col_data_type), &cube.tile_shape);
+    let col_offset = col_offsets[0];
+    let tiles_per_dim: Vec<usize> = cube
+        .cube_shape
+        .iter()
+        .zip(cube.tile_shape.iter())
+        .map(|(&cube_len, &tile_len)| cube_len.div_ceil(tile_len))
+        .collect();
+    let cell_tiles_per_dim = &tiles_per_dim[..row_axis];
+    let cell_tile_total = cell_tiles_per_dim.iter().product::<usize>().max(1);
+
+    let mut patches_by_row_tile: std::collections::BTreeMap<usize, Vec<SingleColumnCubeRowPatch>> =
+        std::collections::BTreeMap::new();
+    for &patch in row_patches {
+        patches_by_row_tile
+            .entry(patch.pos_in_cube / row_tile_len)
+            .or_default()
+            .push(patch);
+    }
+
+    let tsm_path = tsm_data_path(table_path, dm_seq_nr, cube.file_seq_nr as u32);
+    let mut file = OpenOptions::new().read(true).write(true).open(&tsm_path)?;
+    let tile_storage_len = tile_storage_bytes(col_data_type, nrpixels);
+    for (row_tile_idx, row_tile_patches) in patches_by_row_tile {
+        if row_tile_idx >= tiles_per_dim[row_axis] {
+            continue;
+        }
+        for cell_tile_linear in 0..cell_tile_total {
+            let cell_tile_pos = if cell_tiles_per_dim.is_empty() {
+                Vec::new()
+            } else {
+                linear_to_nd(cell_tile_linear, cell_tiles_per_dim)
+            };
+            let mut tile_pos = cell_tile_pos.clone();
+            tile_pos.push(row_tile_idx);
+            let tile_idx = nd_to_linear(&tile_pos, &tiles_per_dim);
+            let tile_start = cube.file_offset as usize + tile_idx * bucket_size + col_offset;
+            let mut packed_tile = vec![0u8; tile_storage_len];
+            file.seek(SeekFrom::Start(tile_start as u64))?;
+            file.read_exact(&mut packed_tile)?;
+            let mut unpacked_tile = read_tile_storage(&packed_tile, col_data_type, nrpixels);
+
+            let cell_cube_start: Vec<usize> = (0..row_axis)
+                .map(|dim| cell_tile_pos.get(dim).copied().unwrap_or(0) * cube.tile_shape[dim])
+                .collect();
+            let actual_cell_extent: Vec<usize> = (0..row_axis)
+                .map(|dim| {
+                    std::cmp::min(cube.tile_shape[dim], cell_shape[dim] - cell_cube_start[dim])
+                })
+                .collect();
+
+            for patch in &row_tile_patches {
+                let local_row = patch.pos_in_cube % row_tile_len;
+                let row_slice_start = local_row * row_block_bytes;
+                let row_slice_end = row_slice_start + row_block_bytes;
+                let row_tile = &mut unpacked_tile[row_slice_start..row_slice_end];
+                let encoded_row = match values.get(patch.global_row_idx).copied().flatten() {
+                    Some(value) => {
+                        let (encoded, dt) = encode_array_value(value, big_endian)?;
+                        if dt != col_data_type {
+                            return Err(StorageError::FormatMismatch(format!(
+                                "tiled sparse save column {} expected {:?} but encoded {:?}",
+                                col_desc.col_name, col_data_type, dt
+                            )));
+                        }
+                        if encoded.len() != expected_row_bytes {
+                            return Err(StorageError::FormatMismatch(format!(
+                                "tiled sparse save column {} expected {expected_row_bytes} row bytes but encoded {}",
+                                col_desc.col_name,
+                                encoded.len()
+                            )));
+                        }
+                        encoded
+                    }
+                    None => vec![0u8; expected_row_bytes],
+                };
+                copy_cube_to_tile(
+                    &encoded_row,
+                    cell_shape,
+                    row_tile,
+                    tile_cell_shape,
+                    &cell_cube_start,
+                    &actual_cell_extent,
+                    elem_size,
+                );
+            }
+
+            write_tile_storage(&mut packed_tile, col_data_type, &unpacked_tile, nrpixels);
+            file.seek(SeekFrom::Start(tile_start as u64))?;
+            file.write_all(&packed_tile)?;
+        }
+    }
+
+    Ok(())
 }
 
 fn format_shape(shape: &[usize]) -> String {

--- a/crates/casa-tables/src/storage/tiled_stman.rs
+++ b/crates/casa-tables/src/storage/tiled_stman.rs
@@ -195,14 +195,7 @@ fn read_tile_storage(src: &[u8], dt: CasacoreDataType, nrpixels: usize) -> Vec<u
 
 fn write_tile_storage(dst: &mut [u8], dt: CasacoreDataType, unpacked: &[u8], nrpixels: usize) {
     match dt {
-        CasacoreDataType::TpBool => {
-            let values: Vec<bool> = unpacked
-                .iter()
-                .take(nrpixels)
-                .map(|&value| value != 0)
-                .collect();
-            write_bool_bits(dst, 0, &values);
-        }
+        CasacoreDataType::TpBool => write_bool_bits_from_bytes(dst, 0, &unpacked[..nrpixels]),
         _ => dst.copy_from_slice(unpacked),
     }
 }

--- a/crates/casa-tables/src/table/columns.rs
+++ b/crates/casa-tables/src/table/columns.rs
@@ -564,6 +564,67 @@ impl Table {
         }
     }
 
+    /// Returns owned array values for the selected rows in `column`.
+    ///
+    /// The output preserves the order of `row_indices`. Missing cells are
+    /// returned as `None`.
+    pub fn get_array_cells_owned(
+        &self,
+        column: &str,
+        row_indices: &[usize],
+    ) -> Result<Vec<Option<ArrayValue>>, TableError> {
+        self.require_column(column)?;
+        for &row_index in row_indices {
+            if row_index >= self.row_count() {
+                return Err(TableError::RowOutOfBounds {
+                    row_index,
+                    row_count: self.row_count(),
+                });
+            }
+        }
+        if let Some(values) = self.inner.array_cells_owned(row_indices, column)? {
+            return Ok(values);
+        }
+        row_indices
+            .iter()
+            .map(|&row_index| match self.cell(row_index, column)? {
+                Some(Value::Array(array)) => Ok(Some(array.clone())),
+                Some(value) => Err(TableError::ColumnTypeMismatch {
+                    row_index,
+                    column: column.to_string(),
+                    expected: "array",
+                    found: value.kind(),
+                }),
+                None => Ok(None),
+            })
+            .collect()
+    }
+
+    /// Returns owned scalar values for every row in `column`.
+    ///
+    /// Missing cells are returned as `None`.
+    pub fn get_scalar_cells_owned(
+        &self,
+        column: &str,
+    ) -> Result<Vec<Option<ScalarValue>>, TableError> {
+        self.require_column(column)?;
+        if let Some(values) = self.inner.scalar_cells_owned(column)? {
+            return Ok(values);
+        }
+        (0..self.row_count())
+            .map(|row_index| match self.cell(row_index, column)? {
+                Some(Value::Scalar(scalar)) => Ok(Some(scalar.clone())),
+                Some(value) => Err(TableError::ColumnTypeMismatch {
+                    row_index,
+                    column: column.to_string(),
+                    expected: "scalar",
+                    found: value.kind(),
+                }),
+                None => Ok(None),
+            })
+            .collect()
+    }
+
     /// Returns a reference to the scalar value in a cell without cloning.
     pub fn get_scalar_cell(
         &self,
@@ -600,6 +661,59 @@ impl Table {
                 column: column.to_string(),
             }),
         }
+    }
+
+    /// Updates a scalar cell while preserving lazy column-backed state when possible.
+    ///
+    /// This is an advanced path for callers that already know the replacement
+    /// value satisfies the schema. When the table is still in lazy mode, it
+    /// updates the cached scalar column rather than forcing full-row
+    /// materialization. If rows are already loaded, it mutates the row in
+    /// memory directly.
+    pub fn set_scalar_cell_assuming_valid(
+        &mut self,
+        row_index: usize,
+        column: &str,
+        value: ScalarValue,
+    ) -> Result<(), TableError> {
+        self.require_column(column)?;
+        self.require_row_index_without_loading_rows(row_index)?;
+        let Some(value) = self
+            .inner
+            .set_cached_scalar_cell(row_index, column, value)?
+        else {
+            return Ok(());
+        };
+        self.set_cell_impl(row_index, column, Value::Scalar(value))
+    }
+
+    /// Updates an array cell while preserving lazy column-backed state when possible.
+    ///
+    /// This is an advanced path for callers that already know the replacement
+    /// value satisfies the schema. When the table is still in lazy mode, it
+    /// updates the cached array column rather than forcing full-row
+    /// materialization. If rows are already loaded, it mutates the row in
+    /// memory directly.
+    pub fn set_array_cell_assuming_valid(
+        &mut self,
+        row_index: usize,
+        column: &str,
+        value: ArrayValue,
+    ) -> Result<(), TableError> {
+        self.require_column(column)?;
+        self.require_row_index_without_loading_rows(row_index)?;
+        let Some(value) = self.inner.set_cached_array_cell(row_index, column, value)? else {
+            return Ok(());
+        };
+        self.set_cell_impl(row_index, column, Value::Array(value))
+    }
+
+    /// Reserves sparse lazy-update capacity for repeated array-cell writes.
+    ///
+    /// This is useful when a caller knows it will update many rows of the same
+    /// array column while keeping the table in lazy disk-backed mode.
+    pub fn reserve_array_cell_updates(&mut self, column: &str, additional: usize) {
+        self.inner.reserve_pending_array_cells(column, additional);
     }
 
     /// Returns the table-level keyword record.
@@ -654,6 +768,16 @@ impl Table {
         {
             return Err(TableError::SchemaColumnUnknown {
                 column: column.to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    fn require_row_index_without_loading_rows(&self, row_index: usize) -> Result<(), TableError> {
+        if row_index >= self.row_count() {
+            return Err(TableError::RowOutOfBounds {
+                row_index,
+                row_count: self.row_count(),
             });
         }
         Ok(())

--- a/crates/casa-tables/src/table/io.rs
+++ b/crates/casa-tables/src/table/io.rs
@@ -3,6 +3,7 @@ use super::*;
 #[cfg(unix)]
 use crate::lock::read_sync_data_from_table_dir;
 use crate::storage::StorageProfiler;
+use casa_types::ScalarValue;
 
 impl Table {
     /// Opens an existing table from disk.
@@ -256,6 +257,326 @@ impl Table {
         )?;
         if let Some(profiler) = profiler.as_mut() {
             profiler.mark("storage_save");
+        }
+        Ok(())
+    }
+
+    /// Rewrites only the existing data-manager groups that contain `changed_columns`.
+    ///
+    /// This is a narrow in-place optimization for schema-stable disk-backed
+    /// tables. It preserves untouched `table.f*` payloads and rewrites only
+    /// the groups that contain one or more changed columns, updating `table.dat`
+    /// when the rewritten storage manager carries a data blob (for example
+    /// `StandardStMan` / `IncrementalStMan`).
+    ///
+    /// Callers must ensure that:
+    /// - the table schema and column-keyword layout are unchanged
+    /// - all modified values already satisfy the schema
+    /// - the table was opened from disk and still points at its source path
+    ///
+    /// If those conditions do not hold, use the normal save path instead.
+    pub fn save_selected_columns_in_place_assuming_valid(
+        &self,
+        changed_columns: &[&str],
+    ) -> Result<(), TableError> {
+        self.save_selected_rows_in_place_assuming_valid(changed_columns, &[])
+    }
+
+    /// Saves only the affected storage-manager groups for the given columns,
+    /// using row hints when available to avoid rewriting untouched tiled rows.
+    ///
+    /// `changed_rows` may be empty, in which case the save falls back to
+    /// column-only invalidation semantics.
+    pub fn save_selected_rows_in_place_assuming_valid(
+        &self,
+        changed_columns: &[&str],
+        changed_rows: &[usize],
+    ) -> Result<(), TableError> {
+        if changed_columns.is_empty() {
+            return Ok(());
+        }
+        if self.kind != TableKind::Plain {
+            return Err(TableError::Storage(
+                "partial in-place save requires a plain disk-backed table".to_string(),
+            ));
+        }
+        if !self.virtual_columns.is_empty() || !self.virtual_bindings.is_empty() {
+            return Err(TableError::Storage(
+                "partial in-place save does not support virtual columns".to_string(),
+            ));
+        }
+
+        let source_path = self
+            .source_path
+            .as_ref()
+            .ok_or_else(|| TableError::Storage("table has no source path".to_string()))?;
+        let changed_rows = if changed_rows.is_empty() {
+            None
+        } else {
+            let mut rows: Vec<usize> = changed_rows
+                .iter()
+                .copied()
+                .filter(|&row_idx| row_idx < self.row_count())
+                .collect();
+            rows.sort_unstable();
+            rows.dedup();
+            Some(rows)
+        };
+        let changed_set: std::collections::HashSet<&str> =
+            changed_columns.iter().copied().collect();
+        let affected_groups: Vec<_> = self
+            .dm_info
+            .iter()
+            .filter(|dm| {
+                dm.columns
+                    .iter()
+                    .any(|column| changed_set.contains(column.as_str()))
+            })
+            .cloned()
+            .collect();
+        if affected_groups.is_empty() {
+            return Ok(());
+        }
+
+        let control_path = source_path.join(crate::storage::TABLE_CONTROL_FILE);
+        let mut table_dat =
+            match crate::storage::table_control::read_table_dat_dispatch(&control_path)? {
+                crate::storage::table_control::TableDatResult::Plain(table_dat) => table_dat,
+                _ => {
+                    return Err(TableError::Storage(
+                        "partial in-place save only supports plain tables".to_string(),
+                    ));
+                }
+            };
+
+        let mut profiler = StorageProfiler::start(format!(
+            "Table::save_selected_columns_in_place path={}",
+            source_path.display()
+        ));
+        if let Some(profiler) = profiler.as_mut() {
+            profiler.mark_with_detail(
+                "start",
+                Some(format!(
+                    "rows={} changed_columns={} affected_groups={} changed_rows={}",
+                    self.row_count(),
+                    changed_columns.len(),
+                    affected_groups.len(),
+                    changed_rows.as_ref().map_or(0, |rows| rows.len())
+                )),
+            );
+        }
+
+        for group in affected_groups {
+            let data_path = source_path.join(format!(
+                "{}{}",
+                crate::storage::TABLE_DATA_FILE_PREFIX,
+                group.seq_nr
+            ));
+            let group_col_set: std::collections::HashSet<&str> =
+                group.columns.iter().map(|column| column.as_str()).collect();
+            let group_col_descs: Vec<_> = table_dat
+                .table_desc
+                .columns
+                .iter()
+                .filter(|desc| group_col_set.contains(desc.col_name.as_str()))
+                .cloned()
+                .collect();
+            if group_col_descs.is_empty() {
+                return Err(TableError::Storage(format!(
+                    "data manager group {} has no columns in current table.dat",
+                    group.seq_nr
+                )));
+            }
+
+            match group.dm_type.as_str() {
+                "StManAipsIO" => {
+                    let group_changed_columns: Vec<&str> = group_col_descs
+                        .iter()
+                        .filter_map(|desc| {
+                            changed_set
+                                .contains(desc.col_name.as_str())
+                                .then_some(desc.col_name.as_str())
+                        })
+                        .collect();
+                    let sparse_saved = match changed_rows.as_ref() {
+                        Some(rows) => {
+                            let sparse_values = collect_sparse_column_values_from_current_cells(
+                                self,
+                                rows,
+                                &group_col_descs,
+                                &group_changed_columns,
+                            )?;
+                            crate::storage::stman_aipsio::save_stman_file_rows_in_place(
+                                &data_path,
+                                &group_col_descs,
+                                &sparse_values,
+                                casa_aipsio::ByteOrder::BigEndian,
+                            )?
+                        }
+                        None => false,
+                    };
+                    if !sparse_saved {
+                        let rows = build_group_rows_from_current_cells(
+                            self,
+                            self.row_count(),
+                            &group_col_descs,
+                        )?;
+                        crate::storage::stman_aipsio::write_stman_file(
+                            &data_path,
+                            &group_col_descs,
+                            &rows,
+                            casa_aipsio::ByteOrder::BigEndian,
+                        )?;
+                    }
+                }
+                "StandardStMan" => {
+                    let rows = build_group_rows_from_current_cells(
+                        self,
+                        self.row_count(),
+                        &group_col_descs,
+                    )?;
+                    let dm_data = crate::storage::standard_stman::write_ssm_file(
+                        &data_path,
+                        &group_col_descs,
+                        &rows,
+                        table_dat.big_endian,
+                    )?;
+                    if let Some(entry) = table_dat
+                        .column_set
+                        .data_managers
+                        .iter_mut()
+                        .find(|entry| entry.seq_nr == group.seq_nr)
+                    {
+                        entry.data = dm_data;
+                    }
+                }
+                "IncrementalStMan" => {
+                    let sparse_saved = if let (Some(rows), Some(scalar_group_columns)) = (
+                        changed_rows.as_ref(),
+                        borrow_scalar_group_columns_from_current_cells(self, &group_col_descs)?,
+                    ) {
+                        crate::storage::incremental_stman::save_ism_file_scalar_columns_rows_in_place(
+                            &data_path,
+                            &group_col_descs,
+                            &scalar_group_columns,
+                            rows,
+                            table_dat.big_endian,
+                        )?
+                    } else {
+                        false
+                    };
+                    let dm_data = if sparse_saved {
+                        None
+                    } else if let Some(scalar_group_columns) =
+                        borrow_scalar_group_columns_from_current_cells(self, &group_col_descs)?
+                    {
+                        Some(
+                            crate::storage::incremental_stman::write_ism_file_scalar_columns(
+                                &data_path,
+                                &group_col_descs,
+                                &scalar_group_columns,
+                                table_dat.big_endian,
+                            )?,
+                        )
+                    } else {
+                        let rows = build_group_rows_from_current_cells(
+                            self,
+                            self.row_count(),
+                            &group_col_descs,
+                        )?;
+                        Some(crate::storage::incremental_stman::write_ism_file(
+                            &data_path,
+                            &group_col_descs,
+                            &rows,
+                            table_dat.big_endian,
+                        )?)
+                    };
+                    if let Some(dm_data) = dm_data {
+                        if let Some(entry) = table_dat
+                            .column_set
+                            .data_managers
+                            .iter_mut()
+                            .find(|entry| entry.seq_nr == group.seq_nr)
+                        {
+                            entry.data = dm_data;
+                        }
+                    }
+                }
+                "TiledColumnStMan" | "TiledShapeStMan" | "TiledCellStMan" | "TiledDataStMan" => {
+                    if group_col_descs.len() != 1 {
+                        return Err(TableError::Storage(format!(
+                            "partial in-place save only supports single-column tiled groups; seq {} has {} columns",
+                            group.seq_nr,
+                            group_col_descs.len()
+                        )));
+                    }
+                    let values = collect_column_values_from_current_cells(
+                        self,
+                        self.row_count(),
+                        &group_col_descs[0],
+                    )?;
+                    let value_refs: Vec<_> = values.iter().map(|value| value.as_ref()).collect();
+                    let dm_name = if group_col_descs[0].data_manager_group.is_empty() {
+                        group_col_descs[0].col_name.as_str()
+                    } else {
+                        group_col_descs[0].data_manager_group.as_str()
+                    };
+                    let sparse_saved = match changed_rows.as_ref() {
+                        Some(rows) => {
+                            crate::storage::tiled_stman::save_tiled_single_column_rows_in_place(
+                                source_path,
+                                group.seq_nr,
+                                &group_col_descs[0],
+                                &value_refs,
+                                rows,
+                                crate::storage::tiled_stman::SingleColumnTiledSaveOptions {
+                                    dm_type_name: &group.dm_type,
+                                    big_endian: table_dat.big_endian,
+                                    default_tile_shape: None,
+                                    dm_name,
+                                },
+                            )?
+                        }
+                        None => false,
+                    };
+                    if !sparse_saved {
+                        crate::storage::tiled_stman::save_tiled_single_column_values(
+                            source_path,
+                            group.seq_nr,
+                            &group_col_descs[0],
+                            &value_refs,
+                            crate::storage::tiled_stman::SingleColumnTiledSaveOptions {
+                                dm_type_name: &group.dm_type,
+                                big_endian: table_dat.big_endian,
+                                default_tile_shape: None,
+                                dm_name,
+                            },
+                        )?;
+                    }
+                }
+                other => {
+                    return Err(TableError::Storage(format!(
+                        "partial in-place save does not support data manager type {other}"
+                    )));
+                }
+            }
+
+            if let Some(profiler) = profiler.as_mut() {
+                profiler.mark_with_detail(
+                    "group_save",
+                    Some(format!(
+                        "seq={} dm={} cols={}",
+                        group.seq_nr,
+                        group.dm_type,
+                        group.columns.len()
+                    )),
+                );
+            }
+        }
+
+        crate::storage::table_control::write_table_dat(&control_path, &table_dat)?;
+        if let Some(profiler) = profiler.as_mut() {
+            profiler.mark("write_control_file");
         }
         Ok(())
     }
@@ -538,5 +859,115 @@ impl Table {
             opts.tile_shape.as_deref(),
         )?;
         Ok(())
+    }
+}
+
+fn build_group_rows_from_current_cells(
+    table: &Table,
+    row_count: usize,
+    col_descs: &[crate::storage::table_control::ColumnDescContents],
+) -> Result<Vec<RecordValue>, TableError> {
+    (0..row_count)
+        .map(|row_index| {
+            let mut fields = Vec::with_capacity(col_descs.len());
+            for col_desc in col_descs {
+                if let Some(value) = current_value_for_column(table, row_index, col_desc)? {
+                    fields.push(RecordField::new(col_desc.col_name.clone(), value));
+                }
+            }
+            Ok(RecordValue::new(fields))
+        })
+        .collect()
+}
+
+fn collect_column_values_from_current_cells(
+    table: &Table,
+    row_count: usize,
+    col_desc: &crate::storage::table_control::ColumnDescContents,
+) -> Result<Vec<Option<Value>>, TableError> {
+    (0..row_count)
+        .map(|row_index| current_value_for_column(table, row_index, col_desc))
+        .collect()
+}
+
+type SparseCurrentColumnValues<'a> =
+    std::collections::HashMap<&'a str, Vec<(usize, Option<Value>)>>;
+
+fn collect_sparse_column_values_from_current_cells<'a>(
+    table: &Table,
+    row_indices: &[usize],
+    col_descs: &[crate::storage::table_control::ColumnDescContents],
+    changed_columns: &[&'a str],
+) -> Result<SparseCurrentColumnValues<'a>, TableError> {
+    let mut patches = std::collections::HashMap::with_capacity(changed_columns.len());
+    for &column in changed_columns {
+        let Some(col_desc) = col_descs.iter().find(|desc| desc.col_name == column) else {
+            continue;
+        };
+        if !col_desc.is_array
+            && let Some(pending_values) = table.inner.pending_scalar_cell_values(column)
+        {
+            let values = pending_values
+                .into_iter()
+                .map(|(row_index, value)| (row_index, Some(Value::Scalar(value))))
+                .collect();
+            patches.insert(column, values);
+            continue;
+        }
+        let mut values = Vec::with_capacity(row_indices.len());
+        for &row_index in row_indices {
+            values.push((
+                row_index,
+                current_value_for_column(table, row_index, col_desc)?,
+            ));
+        }
+        patches.insert(column, values);
+    }
+    Ok(patches)
+}
+
+fn borrow_scalar_group_columns_from_current_cells<'a>(
+    table: &'a Table,
+    col_descs: &[crate::storage::table_control::ColumnDescContents],
+) -> Result<Option<Vec<&'a [Option<ScalarValue>]>>, TableError> {
+    let mut values = Vec::with_capacity(col_descs.len());
+    for col_desc in col_descs {
+        if col_desc.is_array || col_desc.is_record() {
+            return Ok(None);
+        }
+        if table.inner.has_pending_scalar_cells(&col_desc.col_name) {
+            return Ok(None);
+        }
+        let Some(column_values) = table.inner.scalar_column_values(&col_desc.col_name)? else {
+            return Ok(None);
+        };
+        values.push(column_values);
+    }
+    Ok(Some(values))
+}
+
+fn current_value_for_column(
+    table: &Table,
+    row_index: usize,
+    col_desc: &crate::storage::table_control::ColumnDescContents,
+) -> Result<Option<Value>, TableError> {
+    if col_desc.is_record() {
+        return Err(TableError::Storage(format!(
+            "partial in-place save does not support record column {}",
+            col_desc.col_name
+        )));
+    }
+    if col_desc.is_array {
+        match table.get_array_cell(row_index, &col_desc.col_name) {
+            Ok(value) => Ok(Some(Value::Array(value.clone()))),
+            Err(TableError::ColumnNotFound { .. }) => Ok(None),
+            Err(err) => Err(err),
+        }
+    } else {
+        match table.get_scalar_cell(row_index, &col_desc.col_name) {
+            Ok(value) => Ok(Some(Value::Scalar(value.clone()))),
+            Err(TableError::ColumnNotFound { .. }) => Ok(None),
+            Err(err) => Err(err),
+        }
     }
 }

--- a/crates/casa-tables/src/table/tests.rs
+++ b/crates/casa-tables/src/table/tests.rs
@@ -1145,6 +1145,542 @@ fn lazy_disk_open_reads_cells_without_materializing_rows() {
 }
 
 #[test]
+fn lazy_disk_open_reads_scalar_column_owned_without_materializing_rows() {
+    let schema = TableSchema::new(vec![
+        ColumnSchema::scalar("id", PrimitiveType::Int32),
+        ColumnSchema::scalar("scan", PrimitiveType::Int32),
+        ColumnSchema::array_fixed("data", PrimitiveType::Int32, vec![2]),
+    ])
+    .expect("schema");
+
+    for dm in [
+        DataManagerKind::StManAipsIO,
+        DataManagerKind::StandardStMan,
+        DataManagerKind::IncrementalStMan,
+    ] {
+        let mut table = Table::with_schema(schema.clone());
+        table
+            .add_row(RecordValue::new(vec![
+                RecordField::new("id", Value::Scalar(ScalarValue::Int32(1))),
+                RecordField::new("scan", Value::Scalar(ScalarValue::Int32(10))),
+                RecordField::new("data", Value::Array(ArrayValue::from_i32_vec(vec![7, 9]))),
+            ]))
+            .expect("push row 0");
+        table
+            .add_row(RecordValue::new(vec![
+                RecordField::new("id", Value::Scalar(ScalarValue::Int32(2))),
+                RecordField::new("scan", Value::Scalar(ScalarValue::Int32(20))),
+                RecordField::new("data", Value::Array(ArrayValue::from_i32_vec(vec![11, 13]))),
+            ]))
+            .expect("push row 1");
+
+        let root = unique_test_dir(&format!("lazy_scalar_column_owned_{dm:?}"));
+        std::fs::create_dir_all(&root).expect("create test dir");
+        table
+            .save(TableOptions::new(&root).with_data_manager(dm))
+            .expect("save disk-backed table");
+
+        let reopened = Table::open(TableOptions::new(&root)).expect("open lazy table");
+        assert!(!reopened.inner.has_loaded_rows());
+
+        let values = reopened
+            .get_scalar_cells_owned("scan")
+            .expect("read scalar column");
+        assert_eq!(
+            values,
+            vec![Some(ScalarValue::Int32(10)), Some(ScalarValue::Int32(20))]
+        );
+        assert!(
+            !reopened.inner.has_loaded_rows(),
+            "owned scalar column reads should not force row materialization for {dm:?}"
+        );
+
+        std::fs::remove_dir_all(&root).expect("cleanup test dir");
+    }
+}
+
+#[test]
+fn lazy_disk_open_mutates_and_partially_saves_without_materializing_rows() {
+    let schema = TableSchema::new(vec![
+        ColumnSchema::scalar("id", PrimitiveType::Int32),
+        ColumnSchema::scalar("scan", PrimitiveType::Int32),
+        ColumnSchema::array_fixed("data", PrimitiveType::Int32, vec![2]),
+    ])
+    .expect("schema");
+
+    for dm in [
+        DataManagerKind::StManAipsIO,
+        DataManagerKind::StandardStMan,
+        DataManagerKind::IncrementalStMan,
+    ] {
+        let mut table = Table::with_schema(schema.clone());
+        table
+            .add_row(RecordValue::new(vec![
+                RecordField::new("id", Value::Scalar(ScalarValue::Int32(1))),
+                RecordField::new("scan", Value::Scalar(ScalarValue::Int32(10))),
+                RecordField::new("data", Value::Array(ArrayValue::from_i32_vec(vec![7, 9]))),
+            ]))
+            .expect("push row");
+        table
+            .add_row(RecordValue::new(vec![
+                RecordField::new("id", Value::Scalar(ScalarValue::Int32(2))),
+                RecordField::new("scan", Value::Scalar(ScalarValue::Int32(20))),
+                RecordField::new("data", Value::Array(ArrayValue::from_i32_vec(vec![11, 13]))),
+            ]))
+            .expect("push row");
+
+        let root = unique_test_dir(&format!("lazy_partial_save_{dm:?}"));
+        std::fs::create_dir_all(&root).expect("create test dir");
+        table
+            .save(TableOptions::new(&root).with_data_manager(dm))
+            .expect("save disk-backed table");
+
+        let mut reopened = Table::open(TableOptions::new(&root)).expect("open lazy table");
+        assert!(!reopened.inner.has_loaded_rows());
+        assert_eq!(
+            reopened
+                .get_scalar_cell(0, "id")
+                .expect("prefetch id row 0"),
+            &ScalarValue::Int32(1)
+        );
+        assert_eq!(
+            reopened
+                .get_scalar_cell(1, "scan")
+                .expect("prefetch scan row 1"),
+            &ScalarValue::Int32(20)
+        );
+
+        reopened
+            .set_scalar_cell_assuming_valid(1, "id", ScalarValue::Int32(22))
+            .expect("set scalar cell lazily");
+        reopened
+            .set_array_cell_assuming_valid(0, "data", ArrayValue::from_i32_vec(vec![70, 90]))
+            .expect("set array cell lazily");
+        assert!(
+            !reopened.inner.has_loaded_rows(),
+            "lazy mutation should not force row materialization for {dm:?}"
+        );
+        assert!(
+            !reopened.inner.has_loaded_array_column("data"),
+            "lazy array mutation should not force full array-column loads for {dm:?}"
+        );
+        assert!(
+            reopened.inner.has_pending_array_cells("data"),
+            "lazy array mutation should keep pending sparse cells for {dm:?}"
+        );
+
+        reopened
+            .save_selected_columns_in_place_assuming_valid(&["id", "data"])
+            .expect("partial save");
+        assert!(
+            !reopened.inner.has_loaded_rows(),
+            "partial save should not force row materialization for {dm:?}"
+        );
+
+        let verify = Table::open(TableOptions::new(&root)).expect("reopen after partial save");
+        assert!(!verify.inner.has_loaded_rows());
+        assert_eq!(
+            verify.get_scalar_cell(0, "id").expect("id row 0"),
+            &ScalarValue::Int32(1)
+        );
+        assert_eq!(
+            verify.get_scalar_cell(1, "id").expect("id row 1"),
+            &ScalarValue::Int32(22)
+        );
+        assert_eq!(
+            verify.get_scalar_cell(0, "scan").expect("scan row 0"),
+            &ScalarValue::Int32(10)
+        );
+        assert_eq!(
+            verify.get_scalar_cell(1, "scan").expect("scan row 1"),
+            &ScalarValue::Int32(20)
+        );
+        assert_eq!(
+            verify.get_array_cell(0, "data").expect("data row 0"),
+            &ArrayValue::from_i32_vec(vec![70, 90])
+        );
+        assert_eq!(
+            verify.get_array_cell(1, "data").expect("data row 1"),
+            &ArrayValue::from_i32_vec(vec![11, 13])
+        );
+
+        std::fs::remove_dir_all(&root).expect("cleanup test dir");
+    }
+}
+
+#[test]
+fn lazy_disk_open_reads_selected_array_cells_without_loading_full_tiled_column() {
+    let schema = TableSchema::new(vec![ColumnSchema::array_fixed(
+        "data",
+        PrimitiveType::Float32,
+        vec![2, 2],
+    )])
+    .expect("schema");
+
+    let mut table = Table::with_schema(schema);
+    for row_idx in 0..6 {
+        table
+            .add_row(RecordValue::new(vec![RecordField::new(
+                "data",
+                Value::Array(ArrayValue::Float32(
+                    ArrayD::from_shape_vec(
+                        vec![2, 2],
+                        vec![
+                            row_idx as f32,
+                            row_idx as f32 + 10.0,
+                            row_idx as f32 + 20.0,
+                            row_idx as f32 + 30.0,
+                        ],
+                    )
+                    .expect("shape data"),
+                )),
+            )]))
+            .expect("push row");
+    }
+
+    let root = unique_test_dir("lazy_selected_array_rows_tiled_shape");
+    std::fs::create_dir_all(&root).expect("create test dir");
+    table
+        .save(TableOptions::new(&root).with_data_manager(DataManagerKind::TiledShapeStMan))
+        .expect("save tiled-shape table");
+
+    let reopened = Table::open(TableOptions::new(&root)).expect("open lazy table");
+    assert!(!reopened.inner.has_loaded_rows());
+    assert!(!reopened.inner.has_loaded_array_column("data"));
+
+    let selected = reopened
+        .get_array_cells_owned("data", &[5, 2, 4])
+        .expect("read selected array cells");
+    assert_eq!(
+        selected,
+        vec![
+            Some(ArrayValue::Float32(
+                ArrayD::from_shape_vec(vec![2, 2], vec![5.0, 15.0, 25.0, 35.0]).unwrap()
+            )),
+            Some(ArrayValue::Float32(
+                ArrayD::from_shape_vec(vec![2, 2], vec![2.0, 12.0, 22.0, 32.0]).unwrap()
+            )),
+            Some(ArrayValue::Float32(
+                ArrayD::from_shape_vec(vec![2, 2], vec![4.0, 14.0, 24.0, 34.0]).unwrap()
+            )),
+        ]
+    );
+    assert!(
+        !reopened.inner.has_loaded_rows(),
+        "selected array reads should not force row materialization"
+    );
+    assert!(
+        !reopened.inner.has_loaded_array_column("data"),
+        "selected array reads should not populate the full array-column cache"
+    );
+
+    std::fs::remove_dir_all(&root).expect("cleanup test dir");
+}
+
+#[test]
+fn partial_save_with_changed_rows_patches_stman_aipsio_indirect_arrays() {
+    let schema = TableSchema::new(vec![
+        ColumnSchema::scalar("flag_row", PrimitiveType::Bool),
+        ColumnSchema::array_variable("data", PrimitiveType::Float32, Some(2)),
+    ])
+    .expect("schema");
+
+    let mut table = Table::with_schema(schema);
+    table
+        .add_row(RecordValue::new(vec![
+            RecordField::new("flag_row", Value::Scalar(ScalarValue::Bool(false))),
+            RecordField::new(
+                "data",
+                Value::Array(ArrayValue::Float32(
+                    ndarray::Array2::from_shape_vec((2, 2), vec![1.0, 2.0, 3.0, 4.0])
+                        .expect("row 0 shape")
+                        .into_dyn(),
+                )),
+            ),
+        ]))
+        .expect("add row 0");
+    table
+        .add_row(RecordValue::new(vec![
+            RecordField::new("flag_row", Value::Scalar(ScalarValue::Bool(false))),
+            RecordField::new(
+                "data",
+                Value::Array(ArrayValue::Float32(
+                    ndarray::Array2::from_shape_vec((1, 3), vec![5.0, 6.0, 7.0])
+                        .expect("row 1 shape")
+                        .into_dyn(),
+                )),
+            ),
+        ]))
+        .expect("add row 1");
+
+    let root = unique_test_dir("partial_save_changed_rows_stman_aipsio_indirect");
+    std::fs::create_dir_all(&root).expect("create test dir");
+    table
+        .save(TableOptions::new(&root).with_data_manager(DataManagerKind::StManAipsIO))
+        .expect("save disk-backed table");
+
+    let mut reopened = Table::open(TableOptions::new(&root)).expect("open lazy table");
+    reopened
+        .set_scalar_cell_assuming_valid(1, "flag_row", ScalarValue::Bool(true))
+        .expect("set flag_row");
+    reopened
+        .set_array_cell_assuming_valid(
+            1,
+            "data",
+            ArrayValue::Float32(
+                ndarray::Array2::from_shape_vec((1, 3), vec![50.0, 60.0, 70.0])
+                    .expect("updated row 1 shape")
+                    .into_dyn(),
+            ),
+        )
+        .expect("set indirect data");
+    assert!(!reopened.inner.has_loaded_rows());
+    assert!(reopened.inner.has_pending_array_cells("data"));
+
+    reopened
+        .save_selected_rows_in_place_assuming_valid(&["flag_row", "data"], &[1])
+        .expect("partial sparse save");
+
+    let verify = Table::open(TableOptions::new(&root)).expect("reopen after partial save");
+    assert_eq!(
+        verify.get_scalar_cell(0, "flag_row").expect("row 0 flag"),
+        &ScalarValue::Bool(false)
+    );
+    assert_eq!(
+        verify.get_scalar_cell(1, "flag_row").expect("row 1 flag"),
+        &ScalarValue::Bool(true)
+    );
+    assert_eq!(
+        verify.get_array_cell(0, "data").expect("row 0 data"),
+        &ArrayValue::Float32(
+            ndarray::Array2::from_shape_vec((2, 2), vec![1.0, 2.0, 3.0, 4.0])
+                .expect("verify row 0 shape")
+                .into_dyn(),
+        )
+    );
+    assert_eq!(
+        verify.get_array_cell(1, "data").expect("row 1 data"),
+        &ArrayValue::Float32(
+            ndarray::Array2::from_shape_vec((1, 3), vec![50.0, 60.0, 70.0])
+                .expect("verify row 1 shape")
+                .into_dyn(),
+        )
+    );
+
+    std::fs::remove_dir_all(&root).expect("cleanup test dir");
+}
+
+#[test]
+fn lazy_disk_open_reads_selected_indirect_array_cells_without_loading_full_stman_column() {
+    let schema = TableSchema::new(vec![ColumnSchema::array_variable(
+        "data",
+        PrimitiveType::Float32,
+        Some(2),
+    )])
+    .expect("schema");
+
+    let mut table = Table::with_schema(schema);
+    for row in [
+        ndarray::Array2::from_shape_vec((2, 2), vec![1.0, 2.0, 3.0, 4.0]).expect("row 0 shape"),
+        ndarray::Array2::from_shape_vec((1, 3), vec![5.0, 6.0, 7.0]).expect("row 1 shape"),
+        ndarray::Array2::from_shape_vec((1, 2), vec![8.0, 9.0]).expect("row 2 shape"),
+    ] {
+        table
+            .add_row(RecordValue::new(vec![RecordField::new(
+                "data",
+                Value::Array(ArrayValue::Float32(row.into_dyn())),
+            )]))
+            .expect("add row");
+    }
+
+    let root = unique_test_dir("lazy_selected_rows_stman_indirect");
+    std::fs::create_dir_all(&root).expect("create test dir");
+    table
+        .save(TableOptions::new(&root).with_data_manager(DataManagerKind::StManAipsIO))
+        .expect("save disk-backed table");
+
+    let reopened = Table::open(TableOptions::new(&root)).expect("open lazy table");
+    let values = reopened
+        .get_array_cells_owned("data", &[2, 1])
+        .expect("selected indirect array rows");
+
+    assert_eq!(
+        values,
+        vec![
+            Some(ArrayValue::Float32(
+                ndarray::Array2::from_shape_vec((1, 2), vec![8.0, 9.0])
+                    .expect("verify row 2 shape")
+                    .into_dyn(),
+            )),
+            Some(ArrayValue::Float32(
+                ndarray::Array2::from_shape_vec((1, 3), vec![5.0, 6.0, 7.0])
+                    .expect("verify row 1 shape")
+                    .into_dyn(),
+            )),
+        ]
+    );
+    assert!(!reopened.inner.has_loaded_rows());
+    assert!(!reopened.inner.has_loaded_array_column("data"));
+
+    std::fs::remove_dir_all(&root).expect("cleanup test dir");
+}
+
+#[test]
+fn partial_save_with_changed_rows_patches_only_touched_tiled_rows() {
+    let schema = TableSchema::new(vec![ColumnSchema::array_fixed(
+        "data",
+        PrimitiveType::Float32,
+        vec![4, 1],
+    )])
+    .expect("schema");
+
+    let mut table = Table::with_schema(schema);
+    for row_idx in 0..4 {
+        table
+            .add_row(RecordValue::new(vec![RecordField::new(
+                "data",
+                Value::Array(ArrayValue::Float32(
+                    ArrayD::from_shape_vec(
+                        vec![4, 1],
+                        vec![
+                            row_idx as f32,
+                            row_idx as f32 + 10.0,
+                            row_idx as f32 + 20.0,
+                            row_idx as f32 + 30.0,
+                        ],
+                    )
+                    .expect("shape data"),
+                )),
+            )]))
+            .expect("push row");
+    }
+
+    let root = unique_test_dir("partial_save_changed_rows_tiled_shape");
+    std::fs::create_dir_all(&root).expect("create test dir");
+    table
+        .save(TableOptions::new(&root).with_data_manager(DataManagerKind::TiledShapeStMan))
+        .expect("save tiled-shape table");
+
+    let mut reopened = Table::open(TableOptions::new(&root)).expect("open tiled-shape table");
+    reopened
+        .set_array_cell_assuming_valid(
+            2,
+            "data",
+            ArrayValue::Float32(
+                ArrayD::from_shape_vec(vec![4, 1], vec![200.0, 210.0, 220.0, 230.0])
+                    .expect("shape updated data"),
+            ),
+        )
+        .expect("set array cell lazily");
+    reopened
+        .save_selected_rows_in_place_assuming_valid(&["data"], &[2])
+        .expect("partial save with row hint");
+
+    let verify = Table::open(TableOptions::new(&root)).expect("reopen after sparse partial save");
+    assert_eq!(
+        verify.get_array_cell(0, "data").expect("data row 0"),
+        &ArrayValue::Float32(
+            ArrayD::from_shape_vec(vec![4, 1], vec![0.0, 10.0, 20.0, 30.0]).unwrap()
+        )
+    );
+    assert_eq!(
+        verify.get_array_cell(1, "data").expect("data row 1"),
+        &ArrayValue::Float32(
+            ArrayD::from_shape_vec(vec![4, 1], vec![1.0, 11.0, 21.0, 31.0]).unwrap()
+        )
+    );
+    assert_eq!(
+        verify.get_array_cell(2, "data").expect("data row 2"),
+        &ArrayValue::Float32(
+            ArrayD::from_shape_vec(vec![4, 1], vec![200.0, 210.0, 220.0, 230.0]).unwrap()
+        )
+    );
+    assert_eq!(
+        verify.get_array_cell(3, "data").expect("data row 3"),
+        &ArrayValue::Float32(
+            ArrayD::from_shape_vec(vec![4, 1], vec![3.0, 13.0, 23.0, 33.0]).unwrap()
+        )
+    );
+
+    std::fs::remove_dir_all(&root).expect("cleanup test dir");
+}
+
+#[test]
+fn partial_save_with_changed_rows_patches_only_touched_incremental_rows() {
+    let schema = TableSchema::new(vec![
+        ColumnSchema::scalar("id", PrimitiveType::Int32),
+        ColumnSchema::scalar("scan", PrimitiveType::Int32),
+        ColumnSchema::scalar("state", PrimitiveType::Int32),
+    ])
+    .expect("schema");
+
+    let mut table = Table::with_schema(schema);
+    for row_idx in 0..80 {
+        table
+            .add_row(RecordValue::new(vec![
+                RecordField::new("id", Value::Scalar(ScalarValue::Int32(row_idx))),
+                RecordField::new(
+                    "scan",
+                    Value::Scalar(ScalarValue::Int32((row_idx / 8) * 10)),
+                ),
+                RecordField::new("state", Value::Scalar(ScalarValue::Int32(row_idx % 3))),
+            ]))
+            .expect("push row");
+    }
+
+    let root = unique_test_dir("partial_save_changed_rows_incremental");
+    std::fs::create_dir_all(&root).expect("create test dir");
+    table
+        .save(TableOptions::new(&root).with_data_manager(DataManagerKind::IncrementalStMan))
+        .expect("save incremental table");
+
+    let mut reopened = Table::open(TableOptions::new(&root)).expect("open incremental table");
+    assert!(!reopened.inner.has_loaded_rows());
+    reopened
+        .set_scalar_cell_assuming_valid(2, "id", ScalarValue::Int32(2002))
+        .expect("set row 2 id");
+    reopened
+        .set_scalar_cell_assuming_valid(41, "scan", ScalarValue::Int32(9041))
+        .expect("set row 41 scan");
+    reopened
+        .save_selected_rows_in_place_assuming_valid(&["id", "scan"], &[2, 41])
+        .expect("sparse incremental partial save");
+    assert!(
+        !reopened.inner.has_loaded_rows(),
+        "sparse incremental save should not force row materialization"
+    );
+
+    let verify =
+        Table::open(TableOptions::new(&root)).expect("reopen after sparse incremental save");
+    assert_eq!(
+        verify.get_scalar_cell(1, "id").expect("id row 1"),
+        &ScalarValue::Int32(1)
+    );
+    assert_eq!(
+        verify.get_scalar_cell(2, "id").expect("id row 2"),
+        &ScalarValue::Int32(2002)
+    );
+    assert_eq!(
+        verify.get_scalar_cell(40, "scan").expect("scan row 40"),
+        &ScalarValue::Int32(50)
+    );
+    assert_eq!(
+        verify.get_scalar_cell(41, "scan").expect("scan row 41"),
+        &ScalarValue::Int32(9041)
+    );
+    assert_eq!(
+        verify.get_scalar_cell(42, "scan").expect("scan row 42"),
+        &ScalarValue::Int32(50)
+    );
+    assert_eq!(
+        verify.get_scalar_cell(41, "state").expect("state row 41"),
+        &ScalarValue::Int32(2)
+    );
+
+    std::fs::remove_dir_all(&root).expect("cleanup test dir");
+}
+
+#[test]
 fn get_scalar_cell_rejects_non_scalar() {
     let table = Table::from_rows(vec![RecordValue::new(vec![RecordField::new(
         "data",

--- a/crates/casa-tables/src/table_impl.rs
+++ b/crates/casa-tables/src/table_impl.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use casa_types::{ArrayValue, RecordValue, ScalarValue, Value};
 
 use crate::schema::{ColumnType, TableSchema};
-use crate::storage::CompositeStorage;
+use crate::storage::{CompositeStorage, StorageProfiler};
 use crate::table::TableError;
 
 #[derive(Debug, Clone)]
@@ -25,6 +25,72 @@ struct LoadedRows {
 #[derive(Debug)]
 struct LoadedScalarColumns {
     columns: HashMap<String, Vec<Option<ScalarValue>>>,
+}
+
+#[derive(Debug, Default)]
+struct PendingScalarCells {
+    by_column: HashMap<String, HashMap<usize, ScalarValue>>,
+}
+
+#[derive(Debug)]
+struct PendingArrayColumn {
+    rows: Vec<(usize, ArrayValue)>,
+    sorted: bool,
+}
+
+impl Default for PendingArrayColumn {
+    fn default() -> Self {
+        Self {
+            rows: Vec::new(),
+            sorted: true,
+        }
+    }
+}
+
+impl PendingArrayColumn {
+    fn insert(&mut self, row_index: usize, value: ArrayValue) {
+        if let Some((last_row_index, last_value)) = self.rows.last_mut()
+            && *last_row_index == row_index
+        {
+            *last_value = value;
+            return;
+        }
+
+        let keeps_sorted = self
+            .rows
+            .last()
+            .is_none_or(|(last_row_index, _)| *last_row_index <= row_index);
+        self.sorted &= keeps_sorted;
+        self.rows.push((row_index, value));
+    }
+
+    fn get(&self, row_index: usize) -> Option<&ArrayValue> {
+        if self.sorted {
+            let found = self
+                .rows
+                .partition_point(|(candidate, _)| *candidate <= row_index);
+            if found == 0 {
+                return None;
+            }
+            let (candidate, value) = &self.rows[found - 1];
+            return (*candidate == row_index).then_some(value);
+        }
+
+        self.rows
+            .iter()
+            .rev()
+            .find(|(candidate, _)| *candidate == row_index)
+            .map(|(_, value)| value)
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        self.rows.reserve(additional);
+    }
+}
+
+#[derive(Debug, Default)]
+struct PendingArrayCells {
+    by_column: HashMap<String, PendingArrayColumn>,
 }
 
 pub(crate) enum LazyScalarLookup<'a> {
@@ -67,7 +133,9 @@ fn eager_loaded_rows(
 pub(crate) struct TableImpl {
     loaded_rows: OnceCell<LoadedRows>,
     loaded_scalar_columns: OnceCell<LoadedScalarColumns>,
+    pending_scalar_cells: PendingScalarCells,
     loaded_array_columns: HashMap<String, OnceCell<Vec<Option<ArrayValue>>>>,
+    pending_array_cells: PendingArrayCells,
     lazy_rows: Option<LazyRowsSource>,
     persisted_row_count: usize,
     keywords: RecordValue,
@@ -87,7 +155,9 @@ impl TableImpl {
         Self {
             loaded_rows,
             loaded_scalar_columns: OnceCell::new(),
+            pending_scalar_cells: PendingScalarCells::default(),
             loaded_array_columns: HashMap::new(),
+            pending_array_cells: PendingArrayCells::default(),
             lazy_rows: None,
             persisted_row_count: 0,
             keywords: RecordValue::default(),
@@ -105,7 +175,9 @@ impl TableImpl {
         Self {
             loaded_rows,
             loaded_scalar_columns: OnceCell::new(),
+            pending_scalar_cells: PendingScalarCells::default(),
             loaded_array_columns: HashMap::new(),
+            pending_array_cells: PendingArrayCells::default(),
             lazy_rows: None,
             persisted_row_count,
             keywords: RecordValue::default(),
@@ -129,7 +201,9 @@ impl TableImpl {
         Self {
             loaded_rows,
             loaded_scalar_columns: OnceCell::new(),
+            pending_scalar_cells: PendingScalarCells::default(),
             loaded_array_columns: lazy_array_column_store(schema.as_ref()),
+            pending_array_cells: PendingArrayCells::default(),
             lazy_rows: None,
             persisted_row_count,
             keywords,
@@ -148,7 +222,9 @@ impl TableImpl {
         Self {
             loaded_rows: OnceCell::new(),
             loaded_scalar_columns: OnceCell::new(),
+            pending_scalar_cells: PendingScalarCells::default(),
             loaded_array_columns: lazy_array_column_store(schema.as_ref()),
+            pending_array_cells: PendingArrayCells::default(),
             lazy_rows: Some(LazyRowsSource {
                 path,
                 row_count_hint: row_count,
@@ -161,6 +237,10 @@ impl TableImpl {
     }
 
     fn load_rows_now(source: &LazyRowsSource) -> Result<LoadedRows, TableError> {
+        let mut profiler = StorageProfiler::start(format!(
+            "table_impl::load_rows_now path={}",
+            source.path.display()
+        ));
         let storage = CompositeStorage;
         let snapshot = storage
             .load_with_row_hint(&source.path, Some(source.row_count_hint as u64))
@@ -170,10 +250,34 @@ impl TableImpl {
                     source.path.display()
                 ))
             })?;
-        Ok(eager_loaded_rows(snapshot.rows, snapshot.undefined_cells))
+        if let Some(profiler) = profiler.as_mut() {
+            profiler.mark_with_detail(
+                "storage_load_complete",
+                Some(format!(
+                    "row_count_hint={} rows={}",
+                    source.row_count_hint, snapshot.row_count
+                )),
+            );
+        }
+        let loaded = eager_loaded_rows(snapshot.rows, snapshot.undefined_cells);
+        if let Some(profiler) = profiler.as_mut() {
+            profiler.mark_with_detail(
+                "eager_loaded_rows",
+                Some(format!(
+                    "rows={} undefined_rows={}",
+                    loaded.rows.len(),
+                    loaded.undefined_cells.len()
+                )),
+            );
+        }
+        Ok(loaded)
     }
 
     fn load_scalar_columns_now(source: &LazyRowsSource) -> Result<LoadedScalarColumns, TableError> {
+        let mut profiler = StorageProfiler::start(format!(
+            "table_impl::load_scalar_columns_now path={}",
+            source.path.display()
+        ));
         let storage = CompositeStorage;
         let snapshot = storage
             .load_scalar_columns_with_row_hint(&source.path, Some(source.row_count_hint as u64))
@@ -183,6 +287,16 @@ impl TableImpl {
                     source.path.display()
                 ))
             })?;
+        if let Some(profiler) = profiler.as_mut() {
+            profiler.mark_with_detail(
+                "storage_load_complete",
+                Some(format!(
+                    "row_count_hint={} columns={}",
+                    source.row_count_hint,
+                    snapshot.columns.len()
+                )),
+            );
+        }
         Ok(LoadedScalarColumns {
             columns: snapshot.columns,
         })
@@ -192,8 +306,12 @@ impl TableImpl {
         source: &LazyRowsSource,
         column: &str,
     ) -> Result<Vec<Option<ArrayValue>>, TableError> {
+        let mut profiler = StorageProfiler::start(format!(
+            "table_impl::load_array_column_now path={} column={column}",
+            source.path.display()
+        ));
         let storage = CompositeStorage;
-        storage
+        let values = storage
             .load_array_column_with_row_hint(
                 &source.path,
                 column,
@@ -204,7 +322,55 @@ impl TableImpl {
                     "failed to load array column '{column}' for table {}: {err}",
                     source.path.display()
                 ))
-            })
+            })?;
+        if let Some(profiler) = profiler.as_mut() {
+            profiler.mark_with_detail(
+                "storage_load_complete",
+                Some(format!(
+                    "row_count_hint={} values={}",
+                    source.row_count_hint,
+                    values.len()
+                )),
+            );
+        }
+        Ok(values)
+    }
+
+    fn load_array_column_rows_now(
+        source: &LazyRowsSource,
+        column: &str,
+        row_indices: &[usize],
+    ) -> Result<Vec<Option<ArrayValue>>, TableError> {
+        let mut profiler = StorageProfiler::start(format!(
+            "table_impl::load_array_column_rows_now path={} column={column}",
+            source.path.display()
+        ));
+        let storage = CompositeStorage;
+        let values = storage
+            .load_array_column_rows_with_row_hint(
+                &source.path,
+                column,
+                row_indices,
+                Some(source.row_count_hint as u64),
+            )
+            .map_err(|err| {
+                TableError::Storage(format!(
+                    "failed to load selected rows for array column '{column}' from table {}: {err}",
+                    source.path.display()
+                ))
+            })?;
+        if let Some(profiler) = profiler.as_mut() {
+            profiler.mark_with_detail(
+                "storage_load_complete",
+                Some(format!(
+                    "row_count_hint={} requested_rows={} values={}",
+                    source.row_count_hint,
+                    row_indices.len(),
+                    values.len()
+                )),
+            );
+        }
+        Ok(values)
     }
 
     fn ensure_loaded(&self) -> Result<&LoadedRows, TableError> {
@@ -239,6 +405,30 @@ impl TableImpl {
             self.loaded_rows
                 .set(loaded)
                 .expect("initialize mutable row store");
+        }
+        if !self.pending_array_cells.by_column.is_empty() {
+            let pending = std::mem::take(&mut self.pending_array_cells.by_column);
+            if let Some(loaded) = self.loaded_rows.get_mut() {
+                for (column, rows) in pending {
+                    for (row_index, value) in rows.rows {
+                        if let Some(row) = loaded.rows.get_mut(row_index) {
+                            row.upsert(column.clone(), Value::Array(value));
+                        }
+                    }
+                }
+            }
+        }
+        if !self.pending_scalar_cells.by_column.is_empty() {
+            let pending = std::mem::take(&mut self.pending_scalar_cells.by_column);
+            if let Some(loaded) = self.loaded_rows.get_mut() {
+                for (column, rows) in pending {
+                    for (row_index, value) in rows {
+                        if let Some(row) = loaded.rows.get_mut(row_index) {
+                            row.upsert(column.clone(), Value::Scalar(value));
+                        }
+                    }
+                }
+            }
         }
         Ok(self
             .loaded_rows
@@ -297,6 +487,12 @@ impl TableImpl {
             return Ok(LazyScalarLookup::Unknown);
         };
 
+        if let Some(overrides) = self.pending_scalar_cells.by_column.get(column)
+            && let Some(value) = overrides.get(&row_index)
+        {
+            return Ok(LazyScalarLookup::Hit(value));
+        }
+
         if self.loaded_scalar_columns.get().is_none() {
             let loaded = Self::load_scalar_columns_now(source)?;
             let _ = self.loaded_scalar_columns.set(loaded);
@@ -312,6 +508,100 @@ impl TableImpl {
             Some(Some(value)) => Ok(LazyScalarLookup::Hit(value)),
             Some(None) | None => Ok(LazyScalarLookup::Missing),
         }
+    }
+
+    pub(crate) fn scalar_column_values(
+        &self,
+        column: &str,
+    ) -> Result<Option<&[Option<ScalarValue>]>, TableError> {
+        if self.loaded_rows.get().is_some() {
+            return Ok(None);
+        }
+
+        let Some(source) = &self.lazy_rows else {
+            return Ok(None);
+        };
+
+        if self.loaded_scalar_columns.get().is_none() {
+            let loaded = Self::load_scalar_columns_now(source)?;
+            let _ = self.loaded_scalar_columns.set(loaded);
+        }
+
+        Ok(self
+            .loaded_scalar_columns
+            .get()
+            .and_then(|columns| columns.columns.get(column).map(|values| values.as_slice())))
+    }
+
+    pub(crate) fn scalar_cells_owned(
+        &self,
+        column: &str,
+    ) -> Result<Option<Vec<Option<ScalarValue>>>, TableError> {
+        if let Some(loaded) = self.loaded_rows.get() {
+            let values = loaded
+                .rows
+                .iter()
+                .map(|row| match row.get(column) {
+                    Some(Value::Scalar(scalar)) => Some(scalar.clone()),
+                    _ => None,
+                })
+                .collect();
+            return Ok(Some(values));
+        }
+
+        if let Some(columns) = self.loaded_scalar_columns.get()
+            && let Some(values) = columns.columns.get(column)
+        {
+            let mut values = values.clone();
+            if let Some(overrides) = self.pending_scalar_cells.by_column.get(column) {
+                for (&row_index, value) in overrides {
+                    if let Some(cell) = values.get_mut(row_index) {
+                        *cell = Some(value.clone());
+                    }
+                }
+            }
+            return Ok(Some(values));
+        }
+
+        let Some(source) = &self.lazy_rows else {
+            return Ok(None);
+        };
+
+        let mut profiler = StorageProfiler::start(format!(
+            "table_impl::scalar_cells_owned path={} column={column}",
+            source.path.display()
+        ));
+        let storage = CompositeStorage;
+        let mut values = storage
+            .load_scalar_column_with_row_hint(
+                &source.path,
+                column,
+                Some(source.row_count_hint as u64),
+            )
+            .map_err(|err| {
+                TableError::Storage(format!(
+                    "failed to load scalar column '{column}' for table {}: {err}",
+                    source.path.display()
+                ))
+            })?;
+        if let Some(profiler) = profiler.as_mut() {
+            profiler.mark_with_detail(
+                "storage_load_complete",
+                Some(format!(
+                    "row_count_hint={} values={}",
+                    source.row_count_hint,
+                    values.len()
+                )),
+            );
+        }
+        if let Some(overrides) = self.pending_scalar_cells.by_column.get(column) {
+            for (&row_index, value) in overrides {
+                if let Some(cell) = values.get_mut(row_index) {
+                    *cell = Some(value.clone());
+                }
+            }
+        }
+        Ok(Some(values))
     }
 
     pub(crate) fn array_cell(
@@ -333,6 +623,11 @@ impl TableImpl {
         let Some(source) = &self.lazy_rows else {
             return Ok(LazyArrayLookup::Unknown);
         };
+        if let Some(overrides) = self.pending_array_cells.by_column.get(column)
+            && let Some(value) = overrides.get(row_index)
+        {
+            return Ok(LazyArrayLookup::Hit(value));
+        }
         let Some(cached_column) = self.loaded_array_columns.get(column) else {
             return Ok(LazyArrayLookup::Unknown);
         };
@@ -349,6 +644,51 @@ impl TableImpl {
         }
     }
 
+    pub(crate) fn array_cells_owned(
+        &self,
+        row_indices: &[usize],
+        column: &str,
+    ) -> Result<Option<Vec<Option<ArrayValue>>>, TableError> {
+        if let Some(loaded) = self.loaded_rows.get() {
+            let values = row_indices
+                .iter()
+                .map(|&row_index| {
+                    loaded
+                        .rows
+                        .get(row_index)
+                        .and_then(|row| match row.get(column) {
+                            Some(Value::Array(array)) => Some(array.clone()),
+                            _ => None,
+                        })
+                })
+                .collect();
+            return Ok(Some(values));
+        }
+
+        let Some(source) = &self.lazy_rows else {
+            return Ok(None);
+        };
+        let mut values = if let Some(cached_column) = self.loaded_array_columns.get(column)
+            && let Some(cached_values) = cached_column.get()
+        {
+            row_indices
+                .iter()
+                .map(|&row_index| cached_values.get(row_index).cloned().unwrap_or(None))
+                .collect()
+        } else {
+            Self::load_array_column_rows_now(source, column, row_indices)?
+        };
+        if let Some(overrides) = self.pending_array_cells.by_column.get(column) {
+            for (out_idx, &row_index) in row_indices.iter().enumerate() {
+                if let Some(value) = overrides.get(row_index) {
+                    values[out_idx] = Some(value.clone());
+                }
+            }
+        }
+
+        Ok(Some(values))
+    }
+
     pub(crate) fn row_mut(
         &mut self,
         row_index: usize,
@@ -358,6 +698,99 @@ impl TableImpl {
 
     pub(crate) fn rows_mut(&mut self) -> Result<&mut [RecordValue], TableError> {
         Ok(self.ensure_loaded_mut()?.rows.as_mut_slice())
+    }
+
+    pub(crate) fn set_cached_scalar_cell(
+        &mut self,
+        row_index: usize,
+        column: &str,
+        value: ScalarValue,
+    ) -> Result<Option<ScalarValue>, TableError> {
+        if let Some(loaded_rows) = self.loaded_rows.get_mut() {
+            let Some(row) = loaded_rows.rows.get_mut(row_index) else {
+                return Ok(Some(value));
+            };
+            row.upsert(column.to_string(), Value::Scalar(value));
+            return Ok(None);
+        }
+
+        if row_index >= self.row_count() {
+            return Ok(Some(value));
+        }
+
+        if let Some(loaded) = self.loaded_scalar_columns.get_mut()
+            && let Some(column_values) = loaded.columns.get_mut(column)
+        {
+            if let Some(cell) = column_values.get_mut(row_index) {
+                *cell = Some(value);
+                return Ok(None);
+            }
+            return Ok(Some(value));
+        }
+
+        self.pending_scalar_cells
+            .by_column
+            .entry(column.to_string())
+            .or_default()
+            .insert(row_index, value);
+        Ok(None)
+    }
+
+    pub(crate) fn set_cached_array_cell(
+        &mut self,
+        row_index: usize,
+        column: &str,
+        value: ArrayValue,
+    ) -> Result<Option<ArrayValue>, TableError> {
+        if let Some(loaded_rows) = self.loaded_rows.get_mut() {
+            let Some(row) = loaded_rows.rows.get_mut(row_index) else {
+                return Ok(Some(value));
+            };
+            row.upsert(column.to_string(), Value::Array(value));
+            return Ok(None);
+        }
+
+        if row_index >= self.row_count() {
+            return Ok(Some(value));
+        }
+
+        if let Some(cached_column) = self.loaded_array_columns.get_mut(column) {
+            if cached_column.get().is_some() {
+                let column_values = cached_column
+                    .get_mut()
+                    .expect("array column initialized before mutable access");
+                if let Some(cell) = column_values.get_mut(row_index) {
+                    *cell = Some(value);
+                    return Ok(None);
+                }
+                return Ok(Some(value));
+            }
+        }
+        self.pending_array_cells
+            .by_column
+            .entry(column.to_string())
+            .or_default()
+            .insert(row_index, value);
+        Ok(None)
+    }
+
+    pub(crate) fn reserve_pending_array_cells(&mut self, column: &str, additional: usize) {
+        self.pending_array_cells
+            .by_column
+            .entry(column.to_string())
+            .or_default()
+            .reserve(additional);
+    }
+
+    pub(crate) fn pending_scalar_cell_values(
+        &self,
+        column: &str,
+    ) -> Option<Vec<(usize, ScalarValue)>> {
+        self.pending_scalar_cells.by_column.get(column).map(|rows| {
+            rows.iter()
+                .map(|(&row_index, value)| (row_index, value.clone()))
+                .collect()
+        })
     }
 
     pub(crate) fn undefined_for_row_mut(
@@ -443,7 +876,9 @@ impl TableImpl {
             loaded_rows
         };
         self.loaded_scalar_columns = OnceCell::new();
+        self.pending_scalar_cells = PendingScalarCells::default();
         self.loaded_array_columns = lazy_array_column_store(schema.as_ref());
+        self.pending_array_cells = PendingArrayCells::default();
         self.persisted_row_count = self.loaded_rows.get().map_or(0, |loaded| loaded.rows.len());
         self.lazy_rows = None;
         self.keywords = keywords;
@@ -454,5 +889,27 @@ impl TableImpl {
     #[cfg(test)]
     pub(crate) fn has_loaded_rows(&self) -> bool {
         self.loaded_rows.get().is_some()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn has_loaded_array_column(&self, column: &str) -> bool {
+        self.loaded_array_columns
+            .get(column)
+            .is_some_and(|cached| cached.get().is_some())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn has_pending_array_cells(&self, column: &str) -> bool {
+        self.pending_array_cells
+            .by_column
+            .get(column)
+            .is_some_and(|cells| !cells.rows.is_empty())
+    }
+
+    pub(crate) fn has_pending_scalar_cells(&self, column: &str) -> bool {
+        self.pending_scalar_cells
+            .by_column
+            .get(column)
+            .is_some_and(|cells| !cells.is_empty())
     }
 }

--- a/crates/casa-vla/src/importer.rs
+++ b/crates/casa-vla/src/importer.rs
@@ -3,7 +3,10 @@
 
 use std::collections::HashMap;
 use std::f64::consts::PI;
+use std::fs::{File, OpenOptions, create_dir_all};
+use std::io::Write;
 use std::path::PathBuf;
+use std::time::Instant;
 
 use casa_ms::builder::MeasurementSetBuilder;
 use casa_ms::ms::MeasurementSet;
@@ -32,6 +35,8 @@ const DEFAULT_FLAG_CATEGORIES: usize = 6;
 const DEFAULT_TELESCOPE_NAME: &str = "VLA";
 const SECONDS_PER_JULIAN_YEAR: f64 = 365.25 * 86_400.0;
 const SPEED_OF_LIGHT_M_PER_S: f64 = 299_792_458.0;
+const PERF_ENV: &str = "CASA_RS_IMPORTVLA_PERF";
+const PERF_DIR_ENV: &str = "CASA_RS_IMPORTVLA_PERF_DIR";
 const FLAG_CATEGORY_NAMES: [&str; DEFAULT_FLAG_CATEGORIES] = [
     "ONLINE_1", "ONLINE_2", "ONLINE_4", "ONLINE_8", "SHADOW", "FLAG_CMD",
 ];
@@ -49,6 +54,161 @@ pub struct ImportReport {
     pub logical_records_skipped: usize,
     /// Number of rows written to the main table.
     pub main_rows_written: usize,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum ImportPerfEventKind {
+    ImportCompleted,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct ImportPerfEvent {
+    kind: ImportPerfEventKind,
+    monotonic_ns: u64,
+    vis: String,
+    logical_records_seen: usize,
+    logical_records_imported: usize,
+    logical_records_skipped: usize,
+    main_rows_written: usize,
+    create_measurement_set_ns: u64,
+    normalize_record_ns: u64,
+    push_record_ns: u64,
+    reorder_baseline_ns: u64,
+    flag_row_ns: u64,
+    make_main_row_ns: u64,
+    append_main_row_ns: u64,
+    finish_metadata_ns: u64,
+    save_ns: u64,
+    total_ns: u64,
+    unattributed_ns: u64,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct ImportPerfSummary {
+    create_measurement_set_ns: u64,
+    normalize_record_ns: u64,
+    push_record_ns: u64,
+    reorder_baseline_ns: u64,
+    flag_row_ns: u64,
+    make_main_row_ns: u64,
+    append_main_row_ns: u64,
+    finish_metadata_ns: u64,
+    save_ns: u64,
+}
+
+struct ImportPerfTracer {
+    started_at: Option<Instant>,
+    json_file: Option<File>,
+    log_file: Option<File>,
+}
+
+impl ImportPerfTracer {
+    fn from_env() -> Self {
+        if std::env::var_os(PERF_ENV).is_none() {
+            return Self::disabled();
+        }
+        let output_dir = std::env::var_os(PERF_DIR_ENV)
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("/tmp"));
+        if create_dir_all(&output_dir).is_err() {
+            return Self::disabled();
+        }
+        let pid = std::process::id();
+        let json_path = output_dir.join(format!("casa-vla-import-perf-{pid}.jsonl"));
+        let log_path = output_dir.join(format!("casa-vla-import-perf-{pid}.log"));
+        let json_file = open_append_file(&json_path);
+        let log_file = open_append_file(&log_path);
+        if json_file.is_none() && log_file.is_none() {
+            return Self::disabled();
+        }
+        Self {
+            started_at: Some(Instant::now()),
+            json_file,
+            log_file,
+        }
+    }
+
+    const fn disabled() -> Self {
+        Self {
+            started_at: None,
+            json_file: None,
+            log_file: None,
+        }
+    }
+
+    fn monotonic_ns(&self) -> u64 {
+        self.started_at
+            .map(|started| started.elapsed().as_nanos() as u64)
+            .unwrap_or_default()
+    }
+
+    fn emit_import_completed(
+        &mut self,
+        vis: &std::path::Path,
+        report: &ImportReport,
+        summary: ImportPerfSummary,
+        total_ns: u64,
+    ) {
+        if self.started_at.is_none() {
+            return;
+        }
+        let attributed_ns = summary.create_measurement_set_ns
+            + summary.normalize_record_ns
+            + summary.push_record_ns
+            + summary.finish_metadata_ns
+            + summary.save_ns;
+        let event = ImportPerfEvent {
+            kind: ImportPerfEventKind::ImportCompleted,
+            monotonic_ns: self.monotonic_ns(),
+            vis: vis.display().to_string(),
+            logical_records_seen: report.logical_records_seen,
+            logical_records_imported: report.logical_records_imported,
+            logical_records_skipped: report.logical_records_skipped,
+            main_rows_written: report.main_rows_written,
+            create_measurement_set_ns: summary.create_measurement_set_ns,
+            normalize_record_ns: summary.normalize_record_ns,
+            push_record_ns: summary.push_record_ns,
+            reorder_baseline_ns: summary.reorder_baseline_ns,
+            flag_row_ns: summary.flag_row_ns,
+            make_main_row_ns: summary.make_main_row_ns,
+            append_main_row_ns: summary.append_main_row_ns,
+            finish_metadata_ns: summary.finish_metadata_ns,
+            save_ns: summary.save_ns,
+            total_ns,
+            unattributed_ns: total_ns.saturating_sub(attributed_ns),
+        };
+        if let Some(file) = self.json_file.as_mut() {
+            let _ = serde_json::to_writer(&mut *file, &event);
+            let _ = writeln!(file);
+            let _ = file.flush();
+        }
+        if let Some(file) = self.log_file.as_mut() {
+            let _ = writeln!(
+                file,
+                "[+{:>7} ms] kind={:?} rows={} total_ms={:.2} create_ms={:.2} normalize_ms={:.2} push_ms={:.2} reorder_ms={:.2} flag_row_ms={:.2} make_row_ms={:.2} append_row_ms={:.2} finish_metadata_ms={:.2} save_ms={:.2} unattributed_ms={:.2}",
+                event.monotonic_ns / 1_000_000,
+                event.kind,
+                event.main_rows_written,
+                event.total_ns as f64 / 1_000_000.0,
+                event.create_measurement_set_ns as f64 / 1_000_000.0,
+                event.normalize_record_ns as f64 / 1_000_000.0,
+                event.push_record_ns as f64 / 1_000_000.0,
+                event.reorder_baseline_ns as f64 / 1_000_000.0,
+                event.flag_row_ns as f64 / 1_000_000.0,
+                event.make_main_row_ns as f64 / 1_000_000.0,
+                event.append_main_row_ns as f64 / 1_000_000.0,
+                event.finish_metadata_ns as f64 / 1_000_000.0,
+                event.save_ns as f64 / 1_000_000.0,
+                event.unattributed_ns as f64 / 1_000_000.0
+            );
+            let _ = file.flush();
+        }
+    }
+}
+
+fn open_append_file(path: &std::path::Path) -> Option<File> {
+    OpenOptions::new().create(true).append(true).open(path).ok()
 }
 
 #[derive(Debug, Clone)]
@@ -147,6 +307,8 @@ struct SpectralWindowEntry {
 pub fn import_archive_files_to_measurement_set_from_options(
     options: &ImportVlaOptions,
 ) -> Result<ImportReport, VlaError> {
+    let total_started = Instant::now();
+    let mut perf_tracer = ImportPerfTracer::from_env();
     validate_import_options(options)?;
     let vis = options.effective_vis_for_import()?;
     if vis.exists() {
@@ -162,33 +324,49 @@ pub fn import_archive_files_to_measurement_set_from_options(
         .with_main_column(OptionalMainColumn::ModelData)
         .with_optional_subtable(SubtableId::Source)
         .with_optional_subtable(SubtableId::Doppler);
+    let create_started = Instant::now();
     let ms = MeasurementSet::create(&vis, builder).map_err(|error| {
         VlaError::import(format!("create MeasurementSet {}: {error}", vis.display()))
     })?;
 
     let mut writer = MsImportWriter::new(options.clone(), ms)?;
+    writer.perf_summary.create_measurement_set_ns = create_started.elapsed().as_nanos() as u64;
     set_flag_category_names(writer.ms.main_table_mut())?;
     for path in options.require_archivefiles()? {
         let mut reader = VlaDiskReader::open(path)?;
         while let Some(record) = reader.next_record()? {
             writer.logical_records_seen += 1;
+            let normalize_started = Instant::now();
             if let Some(normalized) = normalize_record(&record, options)? {
+                writer.perf_summary.normalize_record_ns +=
+                    normalize_started.elapsed().as_nanos() as u64;
                 writer.logical_records_imported += 1;
+                let push_started = Instant::now();
                 writer.push_record(normalized)?;
+                writer.perf_summary.push_record_ns += push_started.elapsed().as_nanos() as u64;
             } else {
+                writer.perf_summary.normalize_record_ns +=
+                    normalize_started.elapsed().as_nanos() as u64;
                 writer.logical_records_skipped += 1;
                 writer.note_skipped_record();
             }
         }
     }
     writer.finish()?;
-    Ok(ImportReport {
+    let report = ImportReport {
         vis,
         logical_records_seen: writer.logical_records_seen,
         logical_records_imported: writer.logical_records_imported,
         logical_records_skipped: writer.logical_records_skipped,
         main_rows_written: writer.main_rows_written,
-    })
+    };
+    perf_tracer.emit_import_completed(
+        &report.vis,
+        &report,
+        writer.perf_summary,
+        total_started.elapsed().as_nanos() as u64,
+    );
+    Ok(report)
 }
 
 fn validate_import_options(options: &ImportVlaOptions) -> Result<(), VlaError> {
@@ -1014,6 +1192,7 @@ struct MsImportWriter {
     logical_records_imported: usize,
     logical_records_skipped: usize,
     main_rows_written: usize,
+    perf_summary: ImportPerfSummary,
     antenna_rows: HashMap<String, i32>,
     field_rows: HashMap<FieldKey, i32>,
     source_rows: HashMap<FieldKey, i32>,
@@ -1043,6 +1222,7 @@ impl MsImportWriter {
             logical_records_imported: 0,
             logical_records_skipped: 0,
             main_rows_written: 0,
+            perf_summary: ImportPerfSummary::default(),
             antenna_rows: HashMap::new(),
             field_rows: HashMap::new(),
             source_rows: HashMap::new(),
@@ -1237,6 +1417,7 @@ impl MsImportWriter {
     }
 
     fn finish(&mut self) -> Result<(), VlaError> {
+        let finish_started = Instant::now();
         for (&row, &(start, end)) in &self.observation_ranges {
             let mut obs = self.ms.observation_mut().map_err(|error| {
                 VlaError::import(format!("open OBSERVATION for update: {error}"))
@@ -1262,9 +1443,14 @@ impl MsImportWriter {
                 VlaError::import(format!("update OBSERVATION.RELEASE_DATE: {error}"))
             })?;
         }
-        self.ms
+        self.perf_summary.finish_metadata_ns = finish_started.elapsed().as_nanos() as u64;
+        let save_started = Instant::now();
+        let result = self
+            .ms
             .save_assuming_valid()
-            .map_err(|error| VlaError::import(format!("save MeasurementSet: {error}")))
+            .map_err(|error| VlaError::import(format!("save MeasurementSet: {error}")));
+        self.perf_summary.save_ns = save_started.elapsed().as_nanos() as u64;
+        result
     }
 
     fn ensure_direction_epoch(
@@ -1899,82 +2085,99 @@ impl MsImportWriter {
             row_weight,
             row_sigma,
             _row_corr_types,
-        ) = reorder_baseline_for_ms(
-            antenna1_id,
-            antenna2_id,
-            data,
-            corrected_data,
-            model_data,
-            flag,
-            flag_category,
-            weight,
-            sigma,
-            &corr_types,
-        )?;
+        ) = {
+            let reorder_started = Instant::now();
+            let result = reorder_baseline_for_ms(
+                antenna1_id,
+                antenna2_id,
+                data,
+                corrected_data,
+                model_data,
+                flag,
+                flag_category,
+                weight,
+                sigma,
+                &corr_types,
+            )?;
+            self.perf_summary.reorder_baseline_ns += reorder_started.elapsed().as_nanos() as u64;
+            result
+        };
         let row_uvw = if row_ant1 == antenna1_id && row_ant2 == antenna2_id {
             uvw_m
         } else {
             [-uvw_m[0], -uvw_m[1], -uvw_m[2]]
         };
-        let row_flag_row = flag_row_value(&row_flag)?;
-        let row = make_main_row(
-            &self.ms,
-            &[
-                ("ANTENNA1", Value::Scalar(ScalarValue::Int32(row_ant1))),
-                ("ANTENNA2", Value::Scalar(ScalarValue::Int32(row_ant2))),
-                ("ARRAY_ID", Value::Scalar(ScalarValue::Int32(array_id))),
-                (
-                    "DATA_DESC_ID",
-                    Value::Scalar(ScalarValue::Int32(data_desc_id)),
-                ),
-                (
-                    "EXPOSURE",
-                    Value::Scalar(ScalarValue::Float64(integration_seconds)),
-                ),
-                ("FEED1", Value::Scalar(ScalarValue::Int32(0))),
-                ("FEED2", Value::Scalar(ScalarValue::Int32(0))),
-                ("FIELD_ID", Value::Scalar(ScalarValue::Int32(field_id))),
-                ("FLAG", Value::Array(row_flag)),
-                ("FLAG_CATEGORY", Value::Array(row_flag_category)),
-                ("FLAG_ROW", Value::Scalar(ScalarValue::Bool(row_flag_row))),
-                (
-                    "INTERVAL",
-                    Value::Scalar(ScalarValue::Float64(integration_seconds)),
-                ),
-                (
-                    "OBSERVATION_ID",
-                    Value::Scalar(ScalarValue::Int32(observation_id)),
-                ),
-                ("PROCESSOR_ID", Value::Scalar(ScalarValue::Int32(-1))),
-                (
-                    "SCAN_NUMBER",
-                    Value::Scalar(ScalarValue::Int32(scan_number)),
-                ),
-                ("SIGMA", Value::Array(row_sigma)),
-                ("STATE_ID", Value::Scalar(ScalarValue::Int32(-1))),
-                ("TIME", Value::Scalar(ScalarValue::Float64(time_seconds))),
-                (
-                    "TIME_CENTROID",
-                    Value::Scalar(ScalarValue::Float64(time_seconds)),
-                ),
-                (
-                    "UVW",
-                    Value::Array(ArrayValue::Float64(
-                        ArrayD::from_shape_vec(IxDyn(&[3]).f(), row_uvw.to_vec()).map_err(
-                            |error| VlaError::import(format!("shape UVW array: {error}")),
-                        )?,
-                    )),
-                ),
-                ("WEIGHT", Value::Array(row_weight)),
-                ("DATA", Value::Array(row_data)),
-                ("CORRECTED_DATA", Value::Array(row_corrected)),
-                ("MODEL_DATA", Value::Array(row_model)),
-            ],
-        )?;
+        let row_flag_row = {
+            let flag_started = Instant::now();
+            let value = flag_row_value(&row_flag)?;
+            self.perf_summary.flag_row_ns += flag_started.elapsed().as_nanos() as u64;
+            value
+        };
+        let row = {
+            let make_started = Instant::now();
+            let row = make_main_row(
+                &self.ms,
+                &[
+                    ("ANTENNA1", Value::Scalar(ScalarValue::Int32(row_ant1))),
+                    ("ANTENNA2", Value::Scalar(ScalarValue::Int32(row_ant2))),
+                    ("ARRAY_ID", Value::Scalar(ScalarValue::Int32(array_id))),
+                    (
+                        "DATA_DESC_ID",
+                        Value::Scalar(ScalarValue::Int32(data_desc_id)),
+                    ),
+                    (
+                        "EXPOSURE",
+                        Value::Scalar(ScalarValue::Float64(integration_seconds)),
+                    ),
+                    ("FEED1", Value::Scalar(ScalarValue::Int32(0))),
+                    ("FEED2", Value::Scalar(ScalarValue::Int32(0))),
+                    ("FIELD_ID", Value::Scalar(ScalarValue::Int32(field_id))),
+                    ("FLAG", Value::Array(row_flag)),
+                    ("FLAG_CATEGORY", Value::Array(row_flag_category)),
+                    ("FLAG_ROW", Value::Scalar(ScalarValue::Bool(row_flag_row))),
+                    (
+                        "INTERVAL",
+                        Value::Scalar(ScalarValue::Float64(integration_seconds)),
+                    ),
+                    (
+                        "OBSERVATION_ID",
+                        Value::Scalar(ScalarValue::Int32(observation_id)),
+                    ),
+                    ("PROCESSOR_ID", Value::Scalar(ScalarValue::Int32(-1))),
+                    (
+                        "SCAN_NUMBER",
+                        Value::Scalar(ScalarValue::Int32(scan_number)),
+                    ),
+                    ("SIGMA", Value::Array(row_sigma)),
+                    ("STATE_ID", Value::Scalar(ScalarValue::Int32(-1))),
+                    ("TIME", Value::Scalar(ScalarValue::Float64(time_seconds))),
+                    (
+                        "TIME_CENTROID",
+                        Value::Scalar(ScalarValue::Float64(time_seconds)),
+                    ),
+                    (
+                        "UVW",
+                        Value::Array(ArrayValue::Float64(
+                            ArrayD::from_shape_vec(IxDyn(&[3]).f(), row_uvw.to_vec()).map_err(
+                                |error| VlaError::import(format!("shape UVW array: {error}")),
+                            )?,
+                        )),
+                    ),
+                    ("WEIGHT", Value::Array(row_weight)),
+                    ("DATA", Value::Array(row_data)),
+                    ("CORRECTED_DATA", Value::Array(row_corrected)),
+                    ("MODEL_DATA", Value::Array(row_model)),
+                ],
+            )?;
+            self.perf_summary.make_main_row_ns += make_started.elapsed().as_nanos() as u64;
+            row
+        };
+        let append_started = Instant::now();
         self.ms
             .main_table_mut()
             .add_row_assuming_valid(row)
             .map_err(|error| VlaError::import(format!("add MAIN row: {error}")))?;
+        self.perf_summary.append_main_row_ns += append_started.elapsed().as_nanos() as u64;
         self.main_rows_written += 1;
         Ok(())
     }
@@ -2614,6 +2817,73 @@ mod tests {
     use std::path::PathBuf;
 
     use crate::VlaDiskReader;
+    use tempfile::tempdir;
+
+    #[test]
+    fn import_perf_tracer_from_env_writes_jsonl_and_summary_log() {
+        let tempdir = tempdir().expect("create perf tempdir");
+        // SAFETY: test configures process-local env before constructing the tracer and
+        // clears it before returning; tests in this crate do not read these keys concurrently.
+        unsafe {
+            std::env::set_var(PERF_ENV, "1");
+            std::env::set_var(PERF_DIR_ENV, tempdir.path());
+        }
+
+        let mut tracer = ImportPerfTracer::from_env();
+        let report = ImportReport {
+            vis: PathBuf::from("/tmp/example.ms"),
+            logical_records_seen: 10,
+            logical_records_imported: 9,
+            logical_records_skipped: 1,
+            main_rows_written: 42,
+        };
+        tracer.emit_import_completed(
+            &report.vis,
+            &report,
+            ImportPerfSummary {
+                create_measurement_set_ns: 1,
+                normalize_record_ns: 2,
+                push_record_ns: 3,
+                reorder_baseline_ns: 4,
+                flag_row_ns: 5,
+                make_main_row_ns: 6,
+                append_main_row_ns: 7,
+                finish_metadata_ns: 8,
+                save_ns: 9,
+            },
+            40,
+        );
+
+        // SAFETY: paired cleanup for the test-local env configuration above.
+        unsafe {
+            std::env::remove_var(PERF_ENV);
+            std::env::remove_var(PERF_DIR_ENV);
+        }
+
+        let mut json_paths = Vec::new();
+        let mut log_paths = Vec::new();
+        for entry in std::fs::read_dir(tempdir.path()).expect("read perf dir") {
+            let path = entry.expect("read dir entry").path();
+            if path
+                .extension()
+                .is_some_and(|extension| extension == "jsonl")
+            {
+                json_paths.push(path);
+            } else if path.extension().is_some_and(|extension| extension == "log") {
+                log_paths.push(path);
+            }
+        }
+        assert_eq!(json_paths.len(), 1, "expected one jsonl perf trace");
+        assert_eq!(log_paths.len(), 1, "expected one log perf trace");
+
+        let json = std::fs::read_to_string(&json_paths[0]).expect("read perf jsonl");
+        assert!(json.contains("\"kind\":\"import_completed\""));
+        assert!(json.contains("\"main_rows_written\":42"));
+
+        let log = std::fs::read_to_string(&log_paths[0]).expect("read perf log");
+        assert!(log.contains("rows=42"));
+        assert!(log.contains("save_ms="));
+    }
 
     #[test]
     fn reorders_cross_hand_correlations_when_antennas_swap() {

--- a/crates/casars-imager/src/lib.rs
+++ b/crates/casars-imager/src/lib.rs
@@ -33,11 +33,9 @@ use casa_imaging::{
     trace_w_project_plan,
 };
 use casa_ms::MeasurementSet;
-use casa_ms::columns::data_columns::DataColumn;
-use casa_ms::columns::flag_columns::{FlagColumn, FlagRowColumn};
+use casa_ms::columns::flag_columns::FlagRowColumn;
 use casa_ms::columns::main_ids;
 use casa_ms::columns::time_columns::TimeColumn;
-use casa_ms::columns::uvw_column::UvwColumn;
 use casa_ms::columns::weight_columns::WeightSpectrumColumn;
 use casa_ms::derived::engine::{MsCalEngine, resolve_field_phase_direction_j2000};
 use casa_ms::schema::main_table::VisibilityDataColumn;
@@ -2121,6 +2119,71 @@ impl RunProducts {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+struct SelectedMainArrayColumn {
+    column_name: &'static str,
+    values: Vec<Option<ArrayValue>>,
+}
+
+impl SelectedMainArrayColumn {
+    fn load(
+        ms: &MeasurementSet,
+        column_name: &'static str,
+        row_indices: &[usize],
+    ) -> Result<Self, String> {
+        let values = ms
+            .main_table()
+            .get_array_cells_owned(column_name, row_indices)
+            .map_err(|error| format!("load selected {column_name} rows: {error}"))?;
+        Ok(Self {
+            column_name,
+            values,
+        })
+    }
+
+    fn get(&self, row_slot: usize) -> Result<&ArrayValue, String> {
+        self.values
+            .get(row_slot)
+            .and_then(|value| value.as_ref())
+            .ok_or_else(|| {
+                format!(
+                    "{} data missing for selected row slot {}",
+                    self.column_name, row_slot
+                )
+            })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum SelectedMainDataSource {
+    Single(SelectedMainArrayColumn),
+}
+
+impl SelectedMainDataSource {
+    fn load(
+        ms: &MeasurementSet,
+        column: VisibilityDataColumn,
+        row_indices: &[usize],
+    ) -> Result<Self, String> {
+        let column_name = match column {
+            VisibilityDataColumn::Data => "DATA",
+            VisibilityDataColumn::CorrectedData => "CORRECTED_DATA",
+            VisibilityDataColumn::ModelData => "MODEL_DATA",
+        };
+        Ok(Self::Single(SelectedMainArrayColumn::load(
+            ms,
+            column_name,
+            row_indices,
+        )?))
+    }
+
+    fn get(&self, row_slot: usize) -> Result<&ArrayValue, String> {
+        match self {
+            Self::Single(column) => column.get(row_slot),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
 struct PhaseCenter {
     field_id: Option<usize>,
     angles_rad: [f64; 2],
@@ -2596,20 +2659,61 @@ fn extract_constant_direction_angles(
     }
 }
 
+fn extract_uvw_from_array(value: &ArrayValue, row_index: usize) -> Result<[f64; 3], String> {
+    match value {
+        ArrayValue::Float64(values) => {
+            let slice = values
+                .as_slice()
+                .ok_or_else(|| format!("UVW row {row_index} must be contiguous Float64[3] data"))?;
+            if slice.len() != 3 {
+                return Err(format!(
+                    "UVW row {row_index} must have shape [3], found length {}",
+                    slice.len()
+                ));
+            }
+            Ok([slice[0], slice[1], slice[2]])
+        }
+        other => Err(format!(
+            "UVW row {row_index} must be Float64 array, found {:?}",
+            other.primitive_type()
+        )),
+    }
+}
+
 fn build_prepared_geometry_rows(
     ms: &MeasurementSet,
     selected_rows: &[SelectedMainRow],
     phase_center: &PhaseCenter,
     derived_engine: Option<&MsCalEngine>,
 ) -> Result<Vec<PreparedGeometryRow>, String> {
-    let uvw = UvwColumn::new(ms.main_table());
+    let geometry_started_at = Instant::now();
     let antenna1 = main_ids::antenna1(ms.main_table());
     let antenna2 = main_ids::antenna2(ms.main_table());
+    let selected_row_indices = selected_rows
+        .iter()
+        .map(|selected_row| selected_row.row_index)
+        .collect::<Vec<_>>();
+    let selected_uvw = SelectedMainArrayColumn::load(ms, "UVW", &selected_row_indices)?;
+    maybe_log_frontend_progress(
+        "prepare_plane_input/build_prepared_geometry_rows/load_selected_uvw",
+        geometry_started_at.elapsed(),
+        geometry_started_at.elapsed(),
+    );
     let pointing_ids = load_optional_i32_main_column(ms, "POINTING_ID")?;
+    maybe_log_frontend_progress(
+        "prepare_plane_input/build_prepared_geometry_rows/load_pointing_ids",
+        geometry_started_at.elapsed(),
+        geometry_started_at.elapsed(),
+    );
     let pointing_resolver = PointingDirectionResolver::new(ms)?;
+    maybe_log_frontend_progress(
+        "prepare_plane_input/build_prepared_geometry_rows/build_pointing_resolver",
+        geometry_started_at.elapsed(),
+        geometry_started_at.elapsed(),
+    );
     let mut field_phase_centers = BTreeMap::<usize, [f64; 2]>::new();
     let mut rows = Vec::with_capacity(selected_rows.len());
-    for selected_row in selected_rows {
+    for (row_slot, selected_row) in selected_rows.iter().enumerate() {
         let row = selected_row.row_index;
         let antenna1_id = antenna1
             .get(row)
@@ -2618,9 +2722,7 @@ fn build_prepared_geometry_rows(
             .get(row)
             .map_err(|error| format!("read ANTENNA2 row {row}: {error}"))?;
         let is_cross = antenna1_id != antenna2_id;
-        let raw_uvw_m = uvw
-            .get(row)
-            .map_err(|error| format!("read UVW row {row}: {error}"))?;
+        let raw_uvw_m = extract_uvw_from_array(selected_uvw.get(row_slot)?, row)?;
         let transform = row_imaging_transform(
             row,
             selected_row.field_id,
@@ -2706,6 +2808,11 @@ fn build_prepared_geometry_rows(
             transform,
         });
     }
+    maybe_log_frontend_progress(
+        "prepare_plane_input/build_prepared_geometry_rows/row_loop",
+        geometry_started_at.elapsed(),
+        geometry_started_at.elapsed(),
+    );
     Ok(rows)
 }
 
@@ -2722,6 +2829,7 @@ fn prepare_plane_input_with_trace(
     config: &CliConfig,
     data_column_kind: VisibilityDataColumn,
 ) -> Result<(PreparedInput, PreparedVisibilityTraceBundle), String> {
+    let prepare_started_at = Instant::now();
     let data_description = ms
         .data_description()
         .map_err(|error| format!("open DATA_DESCRIPTION: {error}"))?;
@@ -2732,14 +2840,25 @@ fn prepare_plane_input_with_trace(
     let polarization = ms
         .polarization()
         .map_err(|error| format!("open POLARIZATION: {error}"))?;
-    let data_column = ms
-        .data_column(data_column_kind)
-        .map_err(|error| format!("open data column: {error}"))?;
-    let flag_column = ms.flag_column();
-    let flag_row = ms.flag_row_column();
-    let weight_column = ms.weight_column();
-    let weight_spectrum = WeightSpectrumColumn::new(ms.main_table()).ok();
     let selection = select_main_rows(ms, config, &ddid_info)?;
+    maybe_log_frontend_progress(
+        "prepare_plane_input/select_main_rows",
+        prepare_started_at.elapsed(),
+        prepare_started_at.elapsed(),
+    );
+    let selected_row_indices = selection
+        .selected_rows
+        .iter()
+        .map(|selected_row| selected_row.row_index)
+        .collect::<Vec<_>>();
+    let data_column = SelectedMainDataSource::load(ms, data_column_kind, &selected_row_indices)?;
+    let flag_column = SelectedMainArrayColumn::load(ms, "FLAG", &selected_row_indices)?;
+    let flag_row = ms.flag_row_column();
+    let weight_column = SelectedMainArrayColumn::load(ms, "WEIGHT", &selected_row_indices)?;
+    let weight_spectrum = WeightSpectrumColumn::new(ms.main_table())
+        .ok()
+        .map(|_| SelectedMainArrayColumn::load(ms, "WEIGHT_SPECTRUM", &selected_row_indices))
+        .transpose()?;
     let derived_engine = if selection.needs_geometry_engine {
         Some(MsCalEngine::new(ms).map_err(|error| format!("build derived engine: {error}"))?)
     } else {
@@ -2751,6 +2870,11 @@ fn prepare_plane_input_with_trace(
         &selection.phase_center,
         derived_engine.as_ref(),
     )?;
+    maybe_log_frontend_progress(
+        "prepare_plane_input/build_prepared_geometry_rows",
+        prepare_started_at.elapsed(),
+        prepare_started_at.elapsed(),
+    );
     let cube_context = if config.spectral_mode.is_cube_like() {
         Some(CubeSetupContext {
             phase_center_field_id: selection.phase_center.field_id.ok_or_else(|| {
@@ -2786,7 +2910,7 @@ fn prepare_plane_input_with_trace(
         .iter()
         .map(SelectedMainRow::trace)
         .collect::<Vec<_>>();
-    for row in &geometry_rows {
+    for (row_slot, row) in geometry_rows.iter().enumerate() {
         prepared.accumulate_row(
             row,
             &data_column,
@@ -2795,8 +2919,14 @@ fn prepare_plane_input_with_trace(
             &weight_column,
             weight_spectrum.as_ref(),
             derived_engine.as_ref(),
+            row_slot,
         )?;
     }
+    maybe_log_frontend_progress(
+        "prepare_plane_input/accumulate_rows",
+        prepare_started_at.elapsed(),
+        prepare_started_at.elapsed(),
+    );
     prepared.finish_with_trace(
         ms,
         config.ms.display().to_string(),
@@ -3578,12 +3708,13 @@ impl PreparedSelection {
     fn accumulate_row(
         &mut self,
         geometry_row: &PreparedGeometryRow,
-        data_column: &DataColumn<'_>,
-        flag_column: &FlagColumn<'_>,
+        data_column: &SelectedMainDataSource,
+        flag_column: &SelectedMainArrayColumn,
         flag_row: &FlagRowColumn<'_>,
-        weight_column: &casa_ms::columns::weight_columns::WeightColumn<'_>,
-        weight_spectrum: Option<&WeightSpectrumColumn<'_>>,
+        weight_column: &SelectedMainArrayColumn,
+        weight_spectrum: Option<&SelectedMainArrayColumn>,
         derived_engine: Option<&MsCalEngine>,
+        row_slot: usize,
     ) -> Result<(), String> {
         let selected_row = &geometry_row.selected_row;
         let row = selected_row.row_index;
@@ -3594,15 +3725,18 @@ impl PreparedSelection {
             return Ok(());
         }
         let data = data_column
-            .get(row)
+            .get(row_slot)
             .map_err(|error| format!("read data row {row}: {error}"))?;
         let flags = flag_column
-            .get(row)
+            .get(row_slot)
             .map_err(|error| format!("read FLAG row {row}: {error}"))?;
         let row_weights = weight_column
-            .get(row)
+            .get(row_slot)
             .map_err(|error| format!("read WEIGHT row {row}: {error}"))?;
-        let weight_spectrum_row = weight_spectrum.and_then(|column| column.get(row).ok());
+        let weight_spectrum_row = weight_spectrum
+            .map(|column| column.get(row_slot))
+            .transpose()
+            .map_err(|error| format!("read WEIGHT_SPECTRUM row {row}: {error}"))?;
         let antenna1_id = geometry_row.antenna1_id;
         let antenna2_id = geometry_row.antenna2_id;
         let is_cross = geometry_row.is_cross;
@@ -5298,7 +5432,19 @@ fn infer_mfs_gridder_mode(
         direction_separation_rad(sample.pointing_direction_rad, phase_center_direction_rad) > 1.0e-8
     });
     if !needs_mosaic {
+        if frontend_progress_enabled() {
+            eprintln!(
+                "frontend stage=infer_mfs_gridder_mode mode=standard samples={}",
+                samples.len()
+            );
+        }
         return Ok(GridderMode::Standard);
+    }
+    if frontend_progress_enabled() {
+        eprintln!(
+            "frontend stage=infer_mfs_gridder_mode mode=mosaic samples={}",
+            samples.len()
+        );
     }
     Ok(GridderMode::Mosaic(MosaicGridderConfig {
         phase_center_direction_rad,

--- a/scripts/bench-calibrate-vs-casa.sh
+++ b/scripts/bench-calibrate-vs-casa.sh
@@ -41,12 +41,20 @@ field="${CAL_BENCH_FIELD:-0}"
 spw="${CAL_BENCH_SPW:-0}"
 refant="${CAL_BENCH_REFANT:-VA15}"
 apply_mode="${CAL_BENCH_APPLY_MODE:-calflag}"
+json_out="${CAL_BENCH_JSON_OUT:-}"
+casa_profile_dir="${CAL_BENCH_CASA_PROFILE_DIR:-}"
 
 echo "ms_path=$ms_path"
 echo "CASA_RS_CASA_PYTHON=$CASA_RS_CASA_PYTHON"
 echo "repeats=$repeats"
 echo "field=$field spw=$spw refant=$refant apply_mode=$apply_mode"
 echo "timing_excludes=measurement-set copy and caltable generation"
+if [[ -n "$json_out" ]]; then
+  echo "json_out=$json_out"
+fi
+if [[ -n "$casa_profile_dir" ]]; then
+  echo "casa_profile_dir=$casa_profile_dir"
+fi
 echo
 
 cargo build --release -p casa-calibration --bin calibrate >/dev/null
@@ -89,6 +97,37 @@ with open(path_list, "r", encoding="utf-8") as handle:
         values.append(float(current) / 1_000_000_000.0)
 if not values:
     raise SystemExit(f"no values provided for {field}")
+print(f"{statistics.median(values):.6f}")
+PY
+}
+
+median_from_json_traces() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import statistics
+import sys
+
+path_list = sys.argv[1]
+field = sys.argv[2]
+values = []
+with open(path_list, "r", encoding="utf-8") as handle:
+    for line in handle:
+        trace_path = line.strip()
+        if not trace_path:
+            continue
+        with open(trace_path, "r", encoding="utf-8") as trace_handle:
+            for raw in trace_handle:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                event = json.loads(raw)
+                if event.get("kind") != "apply_completed":
+                    continue
+                value = event.get(field)
+                if isinstance(value, int):
+                    values.append(float(value) / 1_000_000_000.0)
+if not values:
+    raise SystemExit(f"no trace values provided for {field}")
 print(f"{statistics.median(values):.6f}")
 PY
 }
@@ -170,11 +209,15 @@ PY
 echo "Rust calibrate timings (seconds):"
 rust_times="$tmpdir/rust-times.txt"
 rust_reports="$tmpdir/rust-report-paths.txt"
+rust_trace_paths="$tmpdir/rust-trace-paths.txt"
 for run in $(seq 1 "$repeats"); do
   run_ms="$tmpdir/rust-run-$run.ms"
   copy_ms "$ms_path" "$run_ms"
   rust_report="$tmpdir/rust-run-$run.json"
+  run_perf_dir="$tmpdir/rust-run-$run-perf"
+  mkdir -p "$run_perf_dir"
   /usr/bin/time -lp \
+    env CASA_RS_CALIBRATION_PERF=1 CASA_RS_CALIBRATION_PERF_DIR="$run_perf_dir" \
     target/release/calibrate \
       --ms "$run_ms" \
       --gaintables "$phase_gcal" \
@@ -187,6 +230,7 @@ for run in $(seq 1 "$repeats"); do
   printf "  run=%s real=%s\n" "$run" "$real_seconds"
   printf "%s\n" "$real_seconds" >>"$rust_times"
   printf "%s\n" "$rust_report" >>"$rust_reports"
+  find "$run_perf_dir" -name '*.jsonl' -print | sort | head -n1 >>"$rust_trace_paths"
 done
 rust_median="$(median_from_file "$rust_times")"
 rust_total_median="$(median_from_json_reports "$rust_reports" "timings.total_ns")"
@@ -196,9 +240,13 @@ rust_planning_selected_rows_median="$(median_from_json_reports "$rust_reports" "
 rust_planning_ms_spws_median="$(median_from_json_reports "$rust_reports" "timings.planning_measurement_set_spectral_windows_ns")"
 rust_planning_table_plans_median="$(median_from_json_reports "$rust_reports" "timings.planning_calibration_table_plans_ns")"
 rust_open_median="$(median_from_json_reports "$rust_reports" "timings.open_measurement_set_ns")"
+rust_row_field_index_median="$(median_from_json_reports "$rust_reports" "timings.row_field_index_lookup_ns")"
 rust_ensure_median="$(median_from_json_reports "$rust_reports" "timings.ensure_corrected_data_ns")"
 rust_corr_lookup_median="$(median_from_json_reports "$rust_reports" "timings.correlation_lookup_ns")"
 rust_cal_load_median="$(median_from_json_reports "$rust_reports" "timings.calibration_load_ns")"
+rust_row_read_median="$(median_from_json_traces "$rust_trace_paths" "row_read_total_ns")"
+rust_row_fetch_median="$(median_from_json_traces "$rust_trace_paths" "row_fetch_ns")"
+rust_row_read_overhead_median="$(median_from_json_traces "$rust_trace_paths" "row_read_overhead_ns")"
 rust_compute_median="$(median_from_json_reports "$rust_reports" "timings.row_compute_ns")"
 rust_writeback_median="$(median_from_json_reports "$rust_reports" "timings.row_writeback_ns")"
 rust_save_median="$(median_from_json_reports "$rust_reports" "timings.save_ns")"
@@ -210,16 +258,23 @@ echo "  planning_selected_rows_median=$rust_planning_selected_rows_median"
 echo "  planning_ms_spws_median=$rust_planning_ms_spws_median"
 echo "  planning_table_plans_median=$rust_planning_table_plans_median"
 echo "  open_ms_median=$rust_open_median"
+echo "  row_field_index_lookup_median=$rust_row_field_index_median"
 echo "  ensure_corrected_data_median=$rust_ensure_median"
 echo "  correlation_lookup_median=$rust_corr_lookup_median"
 echo "  calibration_load_median=$rust_cal_load_median"
+echo "  row_read_median=$rust_row_read_median"
+echo "  row_fetch_median=$rust_row_fetch_median"
+echo "  row_read_overhead_median=$rust_row_read_overhead_median"
 echo "  row_compute_median=$rust_compute_median"
 echo "  row_writeback_median=$rust_writeback_median"
 echo "  save_median=$rust_save_median"
 echo
 
 cat >"$tmpdir/casa-apply-bench.py" <<'PY'
+import cProfile
 import os
+import pathlib
+import pstats
 import statistics
 import time
 from casatasks import applycal
@@ -230,21 +285,45 @@ spw = os.environ["CASA_RS_APPLY_SPW"]
 caltable = os.environ["CASA_RS_APPLY_CALTABLE"]
 applymode = os.environ["CASA_RS_APPLY_MODE"]
 repeats = int(os.environ["CASA_RS_APPLY_REPEATS"])
+profile_dir = os.environ.get("CASA_RS_APPLY_PROFILE_DIR", "").strip()
+if profile_dir:
+    pathlib.Path(profile_dir).mkdir(parents=True, exist_ok=True)
 times = []
 
 for run in range(repeats):
     run_vis = os.path.join(os.environ["CASA_RS_APPLY_RUN_ROOT"], f"casa-run-{run + 1}.ms")
     start = time.perf_counter()
-    applycal(
-        vis=run_vis,
-        field=field,
-        spw=spw,
-        gaintable=[caltable],
-        interp=["nearest"],
-        calwt=False,
-        applymode=applymode,
-        flagbackup=False,
-    )
+    if profile_dir:
+        profiler = cProfile.Profile()
+        profiler.runcall(
+            applycal,
+            vis=run_vis,
+            field=field,
+            spw=spw,
+            gaintable=[caltable],
+            interp=["nearest"],
+            calwt=False,
+            applymode=applymode,
+            flagbackup=False,
+        )
+        profile_path = pathlib.Path(profile_dir) / f"casa-applycal-run-{run + 1}.pstats"
+        profiler.dump_stats(profile_path)
+        summary_path = pathlib.Path(profile_dir) / f"casa-applycal-run-{run + 1}.txt"
+        with summary_path.open("w", encoding="utf-8") as handle:
+            stats = pstats.Stats(profiler, stream=handle)
+            stats.sort_stats("cumulative")
+            stats.print_stats(40)
+    else:
+        applycal(
+            vis=run_vis,
+            field=field,
+            spw=spw,
+            gaintable=[caltable],
+            interp=["nearest"],
+            calwt=False,
+            applymode=applymode,
+            flagbackup=False,
+        )
     elapsed = time.perf_counter() - start
     times.append(elapsed)
     print(f"run={run + 1} real={elapsed:.6f}")
@@ -264,6 +343,7 @@ CASA_RS_APPLY_CALTABLE="$phase_gcal" \
 CASA_RS_APPLY_FIELD="$field" \
 CASA_RS_APPLY_SPW="$spw" \
 CASA_RS_APPLY_MODE="$apply_mode" \
+CASA_RS_APPLY_PROFILE_DIR="$casa_profile_dir" \
   "$CASA_RS_CASA_PYTHON" "$tmpdir/casa-apply-bench.py" | tee "$tmpdir/casa-output.txt" | sed 's/^/  /'
 
 casa_median="$(awk -F= '/^median=/ {print $2}' "$tmpdir/casa-output.txt" | tail -n1)"
@@ -277,3 +357,146 @@ ratio = rust / casa if casa else float("inf")
 winner = "Rust" if rust < casa else "CASA"
 print(f"Summary: rust_median={rust:.6f}s casa_median={casa:.6f}s ratio={ratio:.3f} winner={winner}")
 PY
+
+if [[ -n "$json_out" ]]; then
+  mkdir -p "$(dirname "$json_out")"
+  python3 - "$json_out" "$ms_path" "$repeats" "$field" "$spw" "$refant" "$apply_mode" "$rust_times" "$rust_reports" "$rust_trace_paths" "$tmpdir/casa-output.txt" <<'PY'
+import json
+import statistics
+import sys
+from pathlib import Path
+
+json_out = Path(sys.argv[1])
+ms_path = sys.argv[2]
+repeats = int(sys.argv[3])
+field = sys.argv[4]
+spw = sys.argv[5]
+refant = sys.argv[6]
+apply_mode = sys.argv[7]
+rust_times_path = Path(sys.argv[8])
+rust_reports_path = Path(sys.argv[9])
+rust_traces_path = Path(sys.argv[10])
+casa_output_path = Path(sys.argv[11])
+
+
+def read_lines(path: Path) -> list[str]:
+    return [line.strip() for line in path.read_text().splitlines() if line.strip()]
+
+
+def read_float_lines(path: Path) -> list[float]:
+    return [float(value) for value in read_lines(path)]
+
+
+def median(values: list[float]) -> float:
+    return statistics.median(values) if values else 0.0
+
+
+def report_field(report_path: Path, dotted: str) -> float:
+    current = json.loads(report_path.read_text())
+    for part in dotted.split("."):
+        current = current[part]
+    return float(current) / 1_000_000_000.0
+
+
+def trace_completed_event(path: Path) -> dict | None:
+    events = [
+        json.loads(line)
+        for line in path.read_text().splitlines()
+        if line.strip()
+    ]
+    completed = [event for event in events if event.get("kind") == "apply_completed"]
+    return completed[-1] if completed else None
+
+
+rust_times = read_float_lines(rust_times_path)
+rust_report_paths = [Path(value) for value in read_lines(rust_reports_path)]
+rust_trace_paths = [Path(value) for value in read_lines(rust_traces_path)]
+trace_events = [event for path in rust_trace_paths if path.exists() for event in [trace_completed_event(path)] if event is not None]
+
+report_fields = [
+    "timings.total_ns",
+    "timings.planning_ns",
+    "timings.planning_selection_ns",
+    "timings.planning_selected_rows_ns",
+    "timings.planning_measurement_set_spectral_windows_ns",
+    "timings.planning_calibration_table_plans_ns",
+    "timings.open_measurement_set_ns",
+    "timings.row_field_index_lookup_ns",
+    "timings.ensure_corrected_data_ns",
+    "timings.correlation_lookup_ns",
+    "timings.calibration_load_ns",
+    "timings.row_compute_ns",
+    "timings.row_writeback_ns",
+    "timings.save_ns",
+]
+
+trace_fields = [
+    "execute_apply_plan_ns",
+    "execute_apply_plan_unattributed_ns",
+    "row_field_index_lookup_ns",
+    "row_loop_ns",
+    "row_read_total_ns",
+    "row_fetch_ns",
+    "row_compute_ns",
+    "row_read_overhead_ns",
+    "row_writeback_ns",
+    "save_ns",
+    "drop_ns",
+    "total_ns",
+]
+
+report_medians = {
+    field_name: median([report_field(path, field_name) for path in rust_report_paths])
+    for field_name in report_fields
+}
+trace_medians = {
+    field_name: median([float(event.get(field_name, 0.0)) / 1_000_000_000.0 for event in trace_events])
+    for field_name in trace_fields
+}
+
+casa_runs: list[float] = []
+casa_median = 0.0
+for line in read_lines(casa_output_path):
+    if line.startswith("run="):
+        parts = dict(part.split("=", 1) for part in line.split())
+        casa_runs.append(float(parts["real"]))
+    elif line.startswith("median="):
+        casa_median = float(line.split("=", 1)[1])
+
+winner = "Rust" if median(rust_times) < casa_median else "CASA"
+ratio = (median(rust_times) / casa_median) if casa_median else float("inf")
+
+payload = {
+    "benchmark": "calibrate_vs_casa",
+    "measurement_set": ms_path,
+    "repeats": repeats,
+    "scenario": {
+        "field": field,
+        "spw": spw,
+        "refant": refant,
+        "apply_mode": apply_mode,
+    },
+    "rust": {
+        "real_seconds": {
+            "samples": rust_times,
+            "median": median(rust_times),
+        },
+        "report_median_seconds": report_medians,
+        "trace_median_seconds": trace_medians,
+    },
+    "casa": {
+        "real_seconds": {
+            "samples": casa_runs,
+            "median": casa_median,
+        }
+    },
+    "comparison": {
+        "ratio_rust_over_casa": ratio,
+        "winner": winner,
+    },
+}
+
+json_out.write_text(json.dumps(payload, indent=2) + "\n")
+print(f"Wrote benchmark JSON: {json_out}")
+PY
+fi

--- a/tools/perf/README.md
+++ b/tools/perf/README.md
@@ -4,6 +4,9 @@ This directory holds reusable performance-analysis tooling for the repository.
 
 ## Layout
 
+- `calibrate/`
+  - `README.md`: apply-path tracing and analysis notes
+  - `report.py`: JSONL-to-summary report script
 - `imexplore/`
   - `README.md`: feature-specific tracing and analysis notes
   - `report.py`: JSONL-to-summary report script

--- a/tools/perf/calibrate/README.md
+++ b/tools/perf/calibrate/README.md
@@ -1,0 +1,79 @@
+# `calibrate` Apply Performance Tracing
+
+`calibrate` can emit structured apply-performance traces for post-run analysis.
+
+## Files
+
+When `CASA_RS_CALIBRATION_PERF=1` is set, `calibrate` writes:
+
+- JSONL: `/tmp/casa-calibration-perf-<pid>.jsonl`
+- text summary: `/tmp/casa-calibration-perf-<pid>.log`
+
+Override the directory with:
+
+```bash
+CASA_RS_CALIBRATION_PERF_DIR=/path/to/output
+```
+
+## Runtime Controls
+
+- `CASA_RS_CALIBRATION_PERF=1`
+  Enable structured apply tracing.
+- `CASA_RS_CALIBRATION_PERF_DIR=/path`
+  Override the output directory.
+- `CASA_RS_CALIBRATION_PROFILE=1`
+  Keep the human-readable stderr timing summaries enabled.
+
+Example:
+
+```bash
+CASA_RS_CALIBRATION_PERF=1 \
+CASA_RS_CALIBRATION_PERF_DIR=/tmp/calibrate-perf \
+target/release/calibrate \
+  --ms /path/to.ms \
+  --gaintables /path/to.phase.gcal \
+  --field 0 \
+  --spw 0 \
+  --apply-mode calflag \
+  --format json >/tmp/calibrate-report.json
+```
+
+## Event Model
+
+The JSONL trace currently records:
+
+- `apply_plan_summary`
+- `apply_completed`
+
+Each event includes:
+
+- selected row count and calibration table count
+- row-field index lookup timing before the per-row apply loop
+- planning/open/apply/save/drop timings
+- row-read totals plus the split between fetch, compute, and read-overhead
+- execute-plan unattributed time after the bucketed phases are subtracted
+
+## Analysis Pipeline
+
+1. Run `calibrate` with `CASA_RS_CALIBRATION_PERF=1`.
+2. If you want the CLI report too, keep `--format json` and save stdout.
+3. If you want CASA-side comparison artifacts too, set `CAL_BENCH_CASA_PROFILE_DIR=/path`
+   when running `scripts/bench-calibrate-vs-casa.sh`; each CASA run writes a
+   `.pstats` file plus a cumulative-time text summary.
+4. Run the report script:
+
+```bash
+python3 tools/perf/calibrate/report.py /tmp/casa-calibration-perf-<pid>.jsonl
+```
+
+The script prints:
+
+- event counts
+- median / p95 timings for the main phase fields
+- the most recent apply-completed summary line
+
+## Scope
+
+This trace is for batch MeasurementSet apply work. It does not instrument CASA
+internals directly; cross-language comparisons should still be made with the
+benchmark scripts that run Rust and CASA on the same staged dataset.

--- a/tools/perf/calibrate/report.py
+++ b/tools/perf/calibrate/report.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Summarize `calibrate` apply-performance JSONL traces."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+from collections import Counter
+from pathlib import Path
+
+
+def load_events(path: Path) -> list[dict]:
+    events: list[dict] = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        events.append(json.loads(line))
+    return events
+
+
+def median_ms(values_ns: list[int]) -> float:
+    if not values_ns:
+        return 0.0
+    return statistics.median(values_ns) / 1_000_000.0
+
+
+def p95_ms(values_ns: list[int]) -> float:
+    if not values_ns:
+        return 0.0
+    ordered = sorted(values_ns)
+    index = round((len(ordered) - 1) * 0.95)
+    return ordered[index] / 1_000_000.0
+
+
+def field_values(events: list[dict], field: str) -> list[int]:
+    values: list[int] = []
+    for event in events:
+        value = event.get(field)
+        if isinstance(value, int):
+            values.append(value)
+    return values
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("jsonl", type=Path, help="Path to a JSONL perf trace")
+    args = parser.parse_args()
+
+    events = load_events(args.jsonl)
+    if not events:
+        print("No events found.")
+        return 0
+
+    kind_counts = Counter(event["kind"] for event in events if "kind" in event)
+    completed = [event for event in events if event.get("kind") == "apply_completed"]
+
+    print(f"Trace: {args.jsonl}")
+    print(f"Events: {len(events)}")
+    print("\nEvent counts:")
+    for kind, count in sorted(kind_counts.items()):
+        print(f"  {kind:24} {count}")
+
+    if completed:
+        print("\nApply-completed medians:")
+        for field in (
+            "planning_ns",
+            "open_measurement_set_ns",
+            "row_field_index_lookup_ns",
+            "ensure_corrected_data_ns",
+            "correlation_lookup_ns",
+            "calibration_load_ns",
+            "execute_apply_plan_ns",
+            "execute_apply_plan_unattributed_ns",
+            "row_read_total_ns",
+            "row_fetch_ns",
+            "row_compute_ns",
+            "row_read_overhead_ns",
+            "row_writeback_ns",
+            "save_ns",
+            "drop_ns",
+            "total_ns",
+        ):
+            values = field_values(completed, field)
+            print(
+                f"  {field:36} median={median_ms(values):8.3f} ms"
+                f"  p95={p95_ms(values):8.3f} ms"
+                f"  n={len(values)}"
+            )
+
+        latest = completed[-1]
+        print("\nLatest apply-completed:")
+        print(
+            "  "
+            f"rows={latest.get('selected_row_count', 0)} "
+            f"tables={latest.get('calibration_table_count', 0)} "
+            f"apply_mode={latest.get('apply_mode', '<unknown>')} "
+            f"row_field_index_ms={latest.get('row_field_index_lookup_ns', 0) / 1_000_000.0:.3f} "
+            f"row_read_ms={latest.get('row_read_total_ns', 0) / 1_000_000.0:.3f} "
+            f"row_read_overhead_ms={latest.get('row_read_overhead_ns', 0) / 1_000_000.0:.3f} "
+            f"row_write_ms={latest.get('row_writeback_ns', 0) / 1_000_000.0:.3f} "
+            f"save_ms={latest.get('save_ns', 0) / 1_000_000.0:.3f} "
+            f"total_ms={latest.get('total_ns', 0) / 1_000_000.0:.3f}"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Wave issue: #93

## Summary
- make `calibrate` use selected-row columnwise reads, lazy mutation, sparse partial saves, and structured perf tracing across `casa-calibration`, `casa-ms`, and `casa-tables`
- move dense `msexplore` visibility access onto selected-row array prefetch and replace the old over-budget hard failure with deterministic decimation
- add `importvla` perf tracing, tighten the remaining save-path analysis, and apply a small tiled-bool packing optimization in `casa-tables`
- localize the remaining imaging-facing gap to implicit POINTING resolution on standard-MFS paths and split that control-surface work into follow-up `#95`

## Representative evidence
- full AG189 `calibrate`: Rust `~0.87s` vs CASA `~1.239713s`
- full AG189 `msexplore`: Rust CLI `~84.79s -> ~10.17s`, max RSS `~13.5 GB -> ~2.8 GB`
- AG189 `importvla` rev11 continuum: Rust `~12.29s` vs CASA `~10.94s`
- AG189 `importvla` mixed rev11: Rust `~5.27s` vs CASA `~3.53s`
- real AG189 `importvla` Rust-vs-CASA parity test passed with `cpp-interop-tests`

## Verification
- `just quick`
- `cargo test -p casa-vla import_perf_tracer_from_env_writes_jsonl_and_summary_log -- --nocapture`
- `cargo test -p casa-tables bool_byte_bit_packing_round_trip -- --nocapture`
- `cargo test -p casa-tables bool_tile_storage_is_bit_packed -- --nocapture`
- `cargo test -p casa-calibration --test apply_execute -- --nocapture`
- `cargo test -p casa-vla --features cpp-interop-tests --test real_importvla_parity parity_ag189_revision_era_export -- --ignored --nocapture`

## Deferred
- `#94` memory-bounded table-access architecture study
- `#95` explicit imager `usepointing` control for standard-MFS paths
