### PR TITLE
Wave 98: add accessor-oriented table data API

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -35,6 +35,7 @@ Additional constraints:
 - `casa-values` and `casa-aipsio` stay internal implementation crates.
 - `casa-table-read` owns the minimal shared read-only loader used by runtime data loaders.
 - `casa-tables` keeps the broader storage/write path crate-internal even when user-facing table APIs are exposed from the crate.
+- Within `casa-tables`, row/column/cell accessor objects are the canonical public table-data surface; legacy table-level convenience methods remain compatibility wrappers.
 - Versioned provider bundles are boundary contracts; UI projections are derived views, not separate truth sources.
 
 ## Runtime model

--- a/crates/casa-calibration/src/execute.rs
+++ b/crates/casa-calibration/src/execute.rs
@@ -517,12 +517,14 @@ pub(crate) fn evaluate_apply_rows(
                 data_desc_id: row.data_desc_id,
                 correlation_types: Vec::new(),
             })?;
-        let main_row = ms.main_table().row(row.row_index).map_err(|source| {
-            ApplyExecutionError::MutateMeasurementSet {
+        let main_row = ms
+            .main_table()
+            .row_accessor()
+            .row(row.row_index)
+            .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
                 path: ms_path.clone(),
                 source: MsError::from(source),
-            }
-        })?;
+            })?;
         let data = array_row_value(
             main_row,
             row.row_index,
@@ -958,13 +960,13 @@ fn execute_apply_plan(
                     })?;
             }
         } else {
-            let row_record = ms
-                .main_table_mut()
-                .row_mut(row.row_index)
-                .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+            let mut row_accessor = ms.main_table_mut().row_accessor_mut();
+            let row_record = row_accessor.row_mut(row.row_index).map_err(|source| {
+                ApplyExecutionError::MutateMeasurementSet {
                     path: ms_path.clone(),
                     source: MsError::from(source),
-                })?;
+                }
+            })?;
             write_row_value(
                 row_record,
                 VisibilityDataColumn::CorrectedData.name(),
@@ -2548,7 +2550,7 @@ fn cached_apply_row_field_indices(
         return Ok(indices);
     }
 
-    let row = table.row(row_index)?;
+    let row = table.row_accessor().row(row_index)?;
     let mut indices = ApplyRowFieldIndices::default();
     for (field_index, field) in row.fields().iter().enumerate() {
         match field.name.as_str() {

--- a/crates/casa-ms/src/msexplore.rs
+++ b/crates/casa-ms/src/msexplore.rs
@@ -5963,7 +5963,9 @@ struct SelectedArrayColumn {
 impl SelectedArrayColumn {
     fn load(table: &Table, column: &'static str, row_indices: &[usize]) -> Result<Self, String> {
         let values = table
-            .get_array_cells_owned(column, row_indices)
+            .column_accessor(column)
+            .map_err(|error| error.to_string())?
+            .array_cells_owned(row_indices)
             .map_err(|error| error.to_string())?;
         Ok(Self { column, values })
     }

--- a/crates/casa-tables/src/lib.rs
+++ b/crates/casa-tables/src/lib.rs
@@ -27,6 +27,9 @@
 //! | Type | Role |
 //! |------|------|
 //! | [`Table`] | Create, query, and persist a table |
+//! | [`TableRow`] / [`TableRowMut`] | Canonical row-oriented table-data access |
+//! | [`TableColumn`] / [`TableColumnMut`] | Canonical column-oriented table-data access |
+//! | [`TableCell`] / [`TableCellMut`] | Canonical cell-oriented table-data access |
 //! | [`ConcatTable`] | A read-only virtual concatenation of tables |
 //! | [`RefTable`] | A view over a parent table's rows and/or columns |
 //! | [`SortOrder`] | Ascending or descending sort direction |
@@ -219,10 +222,11 @@
 //! # Relationship to C++ casacore
 //!
 //! In C++ casacore the same functionality is split across `Table`,
-//! `ScalarColumn<T>`, `ArrayColumn<T>`, and `TableRecord`. The Rust [`Table`]
-//! type unifies all of these into a single, dynamically typed interface.
-//! Column type safety is enforced at runtime by the accessor methods rather
-//! than through compile-time generics.
+//! `TableRow`, `TableColumn`, `ScalarColumn<T>`, `ArrayColumn<T>`, and
+//! `TableRecord`. In this crate, [`Table`] remains the owning object, while
+//! [`TableRow`], [`TableColumn`], and [`TableCell`] provide the preferred
+//! public data-access surface. The older table-level `row`/`cell`/`get_*`/`set_*`
+//! methods remain available as compatibility wrappers.
 //!
 //! # Demo program
 //!
@@ -263,7 +267,8 @@ pub use sorting::{TableGroup, TableIterator};
 pub use storage::{DataManagerInfo, StorageError, TableInfo, TilePixel, TiledFileIO};
 pub use table::{
     ColumnBinding, ColumnCellIter, ColumnCellRef, ColumnChunkIter, DataManagerKind, EndianFormat,
-    QueryResult, RecordColumnCell, RecordColumnIter, RowRange, Slicer, SortOrder, Table,
-    TableError, TableKind, TableOptions,
+    QueryResult, RecordColumnCell, RecordColumnIter, RowRange, Slicer, SortOrder, Table, TableCell,
+    TableCellMut, TableColumn, TableColumnMut, TableError, TableKind, TableOptions, TableRow,
+    TableRowMut,
 };
 pub use tablebrowser::{LinkedTableRef, TableBrowser, TableBrowserError, TableBrowserView};

--- a/crates/casa-tables/src/table/columns.rs
+++ b/crates/casa-tables/src/table/columns.rs
@@ -65,6 +65,62 @@ impl Table {
         self.inner.row_count()
     }
 
+    /// Returns the canonical read-only row accessor for this table.
+    pub fn row_accessor(&self) -> TableRow<'_> {
+        TableRow { table: self }
+    }
+
+    /// Returns the canonical mutable row accessor for this table.
+    pub fn row_accessor_mut(&mut self) -> TableRowMut<'_> {
+        TableRowMut { table: self }
+    }
+
+    /// Returns the canonical read-only column accessor for `column`.
+    pub fn column_accessor(&self, column: &str) -> Result<TableColumn<'_>, TableError> {
+        self.require_column(column)?;
+        Ok(TableColumn {
+            table: self,
+            column: column.to_string(),
+        })
+    }
+
+    /// Returns the canonical mutable column accessor for `column`.
+    pub fn column_accessor_mut(&mut self, column: &str) -> Result<TableColumnMut<'_>, TableError> {
+        self.require_column(column)?;
+        Ok(TableColumnMut {
+            table: self,
+            column: column.to_string(),
+        })
+    }
+
+    /// Returns the canonical read-only cell accessor for `(row_index, column)`.
+    pub fn cell_accessor(
+        &self,
+        row_index: usize,
+        column: &str,
+    ) -> Result<TableCell<'_>, TableError> {
+        self.require_row(row_index)?;
+        Ok(TableCell {
+            table: self,
+            row_index,
+            column: column.to_string(),
+        })
+    }
+
+    /// Returns the canonical mutable cell accessor for `(row_index, column)`.
+    pub fn cell_accessor_mut(
+        &mut self,
+        row_index: usize,
+        column: &str,
+    ) -> Result<TableCellMut<'_>, TableError> {
+        self.require_row(row_index)?;
+        Ok(TableCellMut {
+            table: self,
+            row_index,
+            column: column.to_string(),
+        })
+    }
+
     /// Returns a slice over all rows in insertion order.
     pub fn rows(&self) -> Result<&[RecordValue], TableError> {
         self.inner.rows()
@@ -126,6 +182,9 @@ impl Table {
     }
 
     /// Returns a shared reference to the row at `row_index`.
+    ///
+    /// Compatibility note: new row-oriented code should prefer
+    /// [`row_accessor`](Table::row_accessor).
     pub fn row(&self, row_index: usize) -> Result<&RecordValue, TableError> {
         self.inner
             .row(row_index)?
@@ -140,6 +199,9 @@ impl Table {
     /// Direct mutation through this reference bypasses schema validation.
     /// Use [`set_cell`][Table::set_cell] or [`add_row`][Table::add_row] for
     /// validated writes.
+    ///
+    /// Compatibility note: new row-oriented write paths should prefer
+    /// [`row_accessor_mut`](Table::row_accessor_mut).
     pub fn row_mut(&mut self, row_index: usize) -> Result<&mut RecordValue, TableError> {
         let row_count = self.row_count();
         self.inner
@@ -156,6 +218,9 @@ impl Table {
     /// column is simply absent from the row. Use [`get_scalar_cell`][Table::get_scalar_cell]
     /// or [`get_array_cell`][Table::get_array_cell] for type-checked access with
     /// descriptive errors.
+    ///
+    /// Compatibility note: new cell-oriented code should prefer
+    /// [`cell_accessor`](Table::cell_accessor).
     pub fn cell(&self, row_index: usize, column: &str) -> Result<Option<&Value>, TableError> {
         Ok(self.row(row_index)?.get(column))
     }
@@ -165,7 +230,10 @@ impl Table {
     /// This is a shorthand for `get_column_range(column, RowRange::new(0, row_count()))`.
     /// Returns [`TableError::SchemaColumnUnknown`] if a schema is attached and
     /// `column` is not declared in it.
-    pub fn get_column<'a>(&'a self, column: &'a str) -> Result<ColumnCellIter<'a>, TableError> {
+    ///
+    /// Compatibility note: new column-oriented code should prefer
+    /// [`column_accessor`](Table::column_accessor).
+    pub fn get_column<'a>(&'a self, column: &str) -> Result<ColumnCellIter<'a>, TableError> {
         self.get_column_range(column, RowRange::new(0, self.row_count()))
     }
 
@@ -176,14 +244,14 @@ impl Table {
     /// column is unknown or the range is invalid.
     pub fn get_column_range<'a>(
         &'a self,
-        column: &'a str,
+        column: &str,
         row_range: RowRange,
     ) -> Result<ColumnCellIter<'a>, TableError> {
         self.require_column(column)?;
         row_range.validate(self.row_count())?;
         Ok(ColumnCellIter {
             row_data: self.rows()?,
-            column,
+            column: column.to_string(),
             rows: row_range.iter(),
         })
     }
@@ -241,6 +309,9 @@ impl Table {
     ///
     /// This is a convenience wrapper around [`set_cell`][Table::set_cell] that
     /// wraps `value` in [`Value::Record`].
+    ///
+    /// Compatibility note: new cell-oriented write paths should prefer
+    /// [`cell_accessor_mut`](Table::cell_accessor_mut).
     pub fn set_record_cell(
         &mut self,
         row_index: usize,
@@ -255,7 +326,7 @@ impl Table {
     /// Shorthand for `get_record_column_range(column, RowRange::new(0, row_count()))`.
     pub fn get_record_column<'a>(
         &'a self,
-        column: &'a str,
+        column: &str,
     ) -> Result<RecordColumnIter<'a>, TableError> {
         self.get_record_column_range(column, RowRange::new(0, self.row_count()))
     }
@@ -268,7 +339,7 @@ impl Table {
     /// record column, or a cell has the wrong type.
     pub fn get_record_column_range<'a>(
         &'a self,
-        column: &'a str,
+        column: &str,
         row_range: RowRange,
     ) -> Result<RecordColumnIter<'a>, TableError> {
         self.require_column(column)?;
@@ -316,7 +387,7 @@ impl Table {
 
         Ok(RecordColumnIter {
             row_data,
-            column,
+            column: column.to_string(),
             rows: row_range.iter(),
             default_missing,
         })
@@ -327,6 +398,9 @@ impl Table {
     /// Shorthand for `put_column_range(column, RowRange::new(0, row_count()), values)`.
     /// Returns the number of cells written, or [`TableError`] if the value
     /// count does not match the row count.
+    ///
+    /// Compatibility note: new column-oriented write paths should prefer
+    /// [`column_accessor_mut`](Table::column_accessor_mut).
     pub fn put_column<I>(&mut self, column: &str, values: I) -> Result<usize, TableError>
     where
         I: IntoIterator<Item = Value>,
@@ -438,6 +512,9 @@ impl Table {
     ///
     /// Returns [`TableError`] if the row is out of bounds, the column is
     /// unknown per the schema, or the value violates the column type/shape.
+    ///
+    /// Compatibility note: new cell-oriented write paths should prefer
+    /// [`cell_accessor_mut`](Table::cell_accessor_mut).
     pub fn set_cell(
         &mut self,
         row_index: usize,
@@ -498,6 +575,9 @@ impl Table {
     ///
     /// This materializes the entire column into memory. For large tables,
     /// prefer [`Table::get_column`] or [`Table::iter_column_chunks`] which stream lazily.
+    ///
+    /// Compatibility note: new column-oriented code should prefer
+    /// [`column_accessor`](Table::column_accessor).
     pub fn column_cells(&self, column: &str) -> Result<Vec<Option<&Value>>, TableError> {
         Ok(self
             .rows()?
@@ -511,9 +591,12 @@ impl Table {
     /// Each iteration yields a `Vec<ColumnCellRef>` of up to `chunk_size` rows.
     /// This avoids materializing the entire column at once while still allowing
     /// batch processing.
+    ///
+    /// Compatibility note: new column-oriented code should prefer
+    /// [`column_accessor`](Table::column_accessor).
     pub fn iter_column_chunks<'a>(
         &'a self,
-        column: &'a str,
+        column: &str,
         row_range: RowRange,
         chunk_size: usize,
     ) -> Result<ColumnChunkIter<'a>, TableError> {
@@ -527,6 +610,9 @@ impl Table {
     /// Returns a reference to the array value in a cell without cloning.
     ///
     /// Use ndarray's slicing on the returned `ArrayValue` for sub-array access.
+    ///
+    /// Compatibility note: new cell-oriented code should prefer
+    /// [`cell_accessor`](Table::cell_accessor).
     pub fn get_array_cell(
         &self,
         row_index: usize,
@@ -568,6 +654,9 @@ impl Table {
     ///
     /// The output preserves the order of `row_indices`. Missing cells are
     /// returned as `None`.
+    ///
+    /// Compatibility note: new column-oriented code should prefer
+    /// [`column_accessor`](Table::column_accessor).
     pub fn get_array_cells_owned(
         &self,
         column: &str,
@@ -603,6 +692,9 @@ impl Table {
     /// Returns owned scalar values for every row in `column`.
     ///
     /// Missing cells are returned as `None`.
+    ///
+    /// Compatibility note: new column-oriented code should prefer
+    /// [`column_accessor`](Table::column_accessor).
     pub fn get_scalar_cells_owned(
         &self,
         column: &str,
@@ -626,6 +718,9 @@ impl Table {
     }
 
     /// Returns a reference to the scalar value in a cell without cloning.
+    ///
+    /// Compatibility note: new cell-oriented code should prefer
+    /// [`cell_accessor`](Table::cell_accessor).
     pub fn get_scalar_cell(
         &self,
         row_index: usize,
@@ -670,6 +765,10 @@ impl Table {
     /// updates the cached scalar column rather than forcing full-row
     /// materialization. If rows are already loaded, it mutates the row in
     /// memory directly.
+    ///
+    /// Compatibility note: new write paths should prefer
+    /// [`cell_accessor_mut`](Table::cell_accessor_mut) or
+    /// [`column_accessor_mut`](Table::column_accessor_mut).
     pub fn set_scalar_cell_assuming_valid(
         &mut self,
         row_index: usize,
@@ -694,6 +793,10 @@ impl Table {
     /// updates the cached array column rather than forcing full-row
     /// materialization. If rows are already loaded, it mutates the row in
     /// memory directly.
+    ///
+    /// Compatibility note: new write paths should prefer
+    /// [`cell_accessor_mut`](Table::cell_accessor_mut) or
+    /// [`column_accessor_mut`](Table::column_accessor_mut).
     pub fn set_array_cell_assuming_valid(
         &mut self,
         row_index: usize,
@@ -785,6 +888,421 @@ impl Table {
 
     fn require_row(&self, row_index: usize) -> Result<(), TableError> {
         self.row(row_index).map(|_| ())
+    }
+}
+
+impl<'a> TableRow<'a> {
+    /// Returns the number of rows in the underlying table.
+    pub fn row_count(&self) -> usize {
+        self.table.row_count()
+    }
+
+    /// Returns the row at `row_index`.
+    pub fn row(&self, row_index: usize) -> Result<&'a RecordValue, TableError> {
+        self.table.row(row_index)
+    }
+
+    /// Returns a cell accessor for `(row_index, column)`.
+    pub fn cell(&self, row_index: usize, column: &str) -> Result<TableCell<'a>, TableError> {
+        self.table.cell_accessor(row_index, column)
+    }
+
+    /// Returns the scalar cell at `(row_index, column)`.
+    pub fn scalar_cell(
+        &self,
+        row_index: usize,
+        column: &str,
+    ) -> Result<&'a ScalarValue, TableError> {
+        self.table.get_scalar_cell(row_index, column)
+    }
+
+    /// Returns the array cell at `(row_index, column)`.
+    pub fn array_cell(&self, row_index: usize, column: &str) -> Result<&'a ArrayValue, TableError> {
+        self.table.get_array_cell(row_index, column)
+    }
+
+    /// Returns the record cell at `(row_index, column)`.
+    pub fn record_cell(&self, row_index: usize, column: &str) -> Result<RecordValue, TableError> {
+        self.table.record_cell(row_index, column)
+    }
+}
+
+impl<'a> TableRowMut<'a> {
+    /// Returns the number of rows in the underlying table.
+    pub fn row_count(&self) -> usize {
+        self.table.row_count()
+    }
+
+    /// Returns the row at `row_index`.
+    pub fn row(&self, row_index: usize) -> Result<&RecordValue, TableError> {
+        self.table.row(row_index)
+    }
+
+    /// Returns the row at `row_index` for direct mutation.
+    pub fn row_mut(&mut self, row_index: usize) -> Result<&mut RecordValue, TableError> {
+        self.table.row_mut(row_index)
+    }
+
+    /// Returns a read-only cell accessor for `(row_index, column)`.
+    pub fn cell(&self, row_index: usize, column: &str) -> Result<TableCell<'_>, TableError> {
+        self.table.cell_accessor(row_index, column)
+    }
+
+    /// Returns a mutable cell accessor for `(row_index, column)`.
+    pub fn cell_mut(
+        &mut self,
+        row_index: usize,
+        column: &str,
+    ) -> Result<TableCellMut<'_>, TableError> {
+        self.table.cell_accessor_mut(row_index, column)
+    }
+
+    /// Writes `value` to `(row_index, column)`.
+    pub fn set_cell(
+        &mut self,
+        row_index: usize,
+        column: &str,
+        value: Value,
+    ) -> Result<(), TableError> {
+        self.table.set_cell(row_index, column, value)
+    }
+
+    /// Writes a record value to `(row_index, column)`.
+    pub fn set_record_cell(
+        &mut self,
+        row_index: usize,
+        column: &str,
+        value: RecordValue,
+    ) -> Result<(), TableError> {
+        self.table.set_record_cell(row_index, column, value)
+    }
+
+    /// Lazily updates a scalar cell while assuming schema validity.
+    pub fn set_scalar_cell_assuming_valid(
+        &mut self,
+        row_index: usize,
+        column: &str,
+        value: ScalarValue,
+    ) -> Result<(), TableError> {
+        self.table
+            .set_scalar_cell_assuming_valid(row_index, column, value)
+    }
+
+    /// Lazily updates an array cell while assuming schema validity.
+    pub fn set_array_cell_assuming_valid(
+        &mut self,
+        row_index: usize,
+        column: &str,
+        value: ArrayValue,
+    ) -> Result<(), TableError> {
+        self.table
+            .set_array_cell_assuming_valid(row_index, column, value)
+    }
+}
+
+impl<'a> TableColumn<'a> {
+    /// Returns the column name bound to this accessor.
+    pub fn name(&self) -> &str {
+        &self.column
+    }
+
+    /// Returns the number of rows in the underlying table.
+    pub fn row_count(&self) -> usize {
+        self.table.row_count()
+    }
+
+    /// Returns a cell accessor for `row_index`.
+    pub fn cell(&self, row_index: usize) -> Result<TableCell<'a>, TableError> {
+        self.table.cell_accessor(row_index, &self.column)
+    }
+
+    /// Returns the cell value at `row_index`, or `None` if absent.
+    pub fn get(&self, row_index: usize) -> Result<Option<&'a Value>, TableError> {
+        self.table.cell(row_index, &self.column)
+    }
+
+    /// Returns an iterator over all rows in the column.
+    pub fn iter(&self) -> Result<ColumnCellIter<'a>, TableError> {
+        self.table.get_column(&self.column)
+    }
+
+    /// Returns an iterator over a row range in the column.
+    pub fn iter_range(&self, row_range: RowRange) -> Result<ColumnCellIter<'a>, TableError> {
+        self.table.get_column_range(&self.column, row_range)
+    }
+
+    /// Returns record cells over all rows in the column.
+    pub fn record_iter(&self) -> Result<RecordColumnIter<'a>, TableError> {
+        self.table.get_record_column(&self.column)
+    }
+
+    /// Returns record cells over `row_range`.
+    pub fn record_iter_range(
+        &self,
+        row_range: RowRange,
+    ) -> Result<RecordColumnIter<'a>, TableError> {
+        self.table.get_record_column_range(&self.column, row_range)
+    }
+
+    /// Returns a chunked iterator over the column.
+    pub fn chunks(
+        &self,
+        row_range: RowRange,
+        chunk_size: usize,
+    ) -> Result<ColumnChunkIter<'a>, TableError> {
+        self.table
+            .iter_column_chunks(&self.column, row_range, chunk_size)
+    }
+
+    /// Returns all cells for the column as an allocated vector.
+    pub fn cells(&self) -> Result<Vec<Option<&'a Value>>, TableError> {
+        self.table.column_cells(&self.column)
+    }
+
+    /// Returns the scalar cell at `row_index`.
+    pub fn scalar_cell(&self, row_index: usize) -> Result<&'a ScalarValue, TableError> {
+        self.table.get_scalar_cell(row_index, &self.column)
+    }
+
+    /// Returns the array cell at `row_index`.
+    pub fn array_cell(&self, row_index: usize) -> Result<&'a ArrayValue, TableError> {
+        self.table.get_array_cell(row_index, &self.column)
+    }
+
+    /// Returns the record cell at `row_index`.
+    pub fn record_cell(&self, row_index: usize) -> Result<RecordValue, TableError> {
+        self.table.record_cell(row_index, &self.column)
+    }
+
+    /// Returns owned scalar values for the column.
+    pub fn scalar_cells_owned(&self) -> Result<Vec<Option<ScalarValue>>, TableError> {
+        self.table.get_scalar_cells_owned(&self.column)
+    }
+
+    /// Returns owned array values for the selected rows.
+    pub fn array_cells_owned(
+        &self,
+        row_indices: &[usize],
+    ) -> Result<Vec<Option<ArrayValue>>, TableError> {
+        self.table.get_array_cells_owned(&self.column, row_indices)
+    }
+}
+
+impl<'a> TableColumnMut<'a> {
+    /// Returns the column name bound to this accessor.
+    pub fn name(&self) -> &str {
+        &self.column
+    }
+
+    /// Returns the number of rows in the underlying table.
+    pub fn row_count(&self) -> usize {
+        self.table.row_count()
+    }
+
+    /// Returns a read-only cell accessor for `row_index`.
+    pub fn cell(&self, row_index: usize) -> Result<TableCell<'_>, TableError> {
+        self.table.cell_accessor(row_index, &self.column)
+    }
+
+    /// Returns a mutable cell accessor for `row_index`.
+    pub fn cell_mut(&mut self, row_index: usize) -> Result<TableCellMut<'_>, TableError> {
+        self.table.cell_accessor_mut(row_index, &self.column)
+    }
+
+    /// Returns an iterator over all rows in the column.
+    pub fn iter(&self) -> Result<ColumnCellIter<'_>, TableError> {
+        self.table.get_column(&self.column)
+    }
+
+    /// Returns an iterator over a row range in the column.
+    pub fn iter_range(&self, row_range: RowRange) -> Result<ColumnCellIter<'_>, TableError> {
+        self.table.get_column_range(&self.column, row_range)
+    }
+
+    /// Returns a chunked iterator over the column.
+    pub fn chunks(
+        &self,
+        row_range: RowRange,
+        chunk_size: usize,
+    ) -> Result<ColumnChunkIter<'_>, TableError> {
+        self.table
+            .iter_column_chunks(&self.column, row_range, chunk_size)
+    }
+
+    /// Returns the scalar cell at `row_index`.
+    pub fn scalar_cell(&self, row_index: usize) -> Result<&ScalarValue, TableError> {
+        self.table.get_scalar_cell(row_index, &self.column)
+    }
+
+    /// Returns the array cell at `row_index`.
+    pub fn array_cell(&self, row_index: usize) -> Result<&ArrayValue, TableError> {
+        self.table.get_array_cell(row_index, &self.column)
+    }
+
+    /// Returns owned scalar values for the column.
+    pub fn scalar_cells_owned(&self) -> Result<Vec<Option<ScalarValue>>, TableError> {
+        self.table.get_scalar_cells_owned(&self.column)
+    }
+
+    /// Returns owned array values for the selected rows.
+    pub fn array_cells_owned(
+        &self,
+        row_indices: &[usize],
+    ) -> Result<Vec<Option<ArrayValue>>, TableError> {
+        self.table.get_array_cells_owned(&self.column, row_indices)
+    }
+
+    /// Writes `value` to `row_index`.
+    pub fn set(&mut self, row_index: usize, value: Value) -> Result<(), TableError> {
+        self.table.set_cell(row_index, &self.column, value)
+    }
+
+    /// Writes a record value to `row_index`.
+    pub fn set_record(&mut self, row_index: usize, value: RecordValue) -> Result<(), TableError> {
+        self.table.set_record_cell(row_index, &self.column, value)
+    }
+
+    /// Lazily updates a scalar cell while assuming schema validity.
+    pub fn set_scalar_assuming_valid(
+        &mut self,
+        row_index: usize,
+        value: ScalarValue,
+    ) -> Result<(), TableError> {
+        self.table
+            .set_scalar_cell_assuming_valid(row_index, &self.column, value)
+    }
+
+    /// Lazily updates an array cell while assuming schema validity.
+    pub fn set_array_assuming_valid(
+        &mut self,
+        row_index: usize,
+        value: ArrayValue,
+    ) -> Result<(), TableError> {
+        self.table
+            .set_array_cell_assuming_valid(row_index, &self.column, value)
+    }
+
+    /// Writes a full column's values.
+    pub fn put<I>(&mut self, values: I) -> Result<usize, TableError>
+    where
+        I: IntoIterator<Item = Value>,
+    {
+        self.table.put_column(&self.column, values)
+    }
+
+    /// Writes values for `row_range`.
+    pub fn put_range<I>(&mut self, row_range: RowRange, values: I) -> Result<usize, TableError>
+    where
+        I: IntoIterator<Item = Value>,
+    {
+        self.table.put_column_range(&self.column, row_range, values)
+    }
+}
+
+impl<'a> TableCell<'a> {
+    /// Returns the row index bound to this accessor.
+    pub fn row_index(&self) -> usize {
+        self.row_index
+    }
+
+    /// Returns the column name bound to this accessor.
+    pub fn column(&self) -> &str {
+        &self.column
+    }
+
+    /// Returns the cell value, or `None` if absent.
+    pub fn value(&self) -> Result<Option<&'a Value>, TableError> {
+        self.table.cell(self.row_index, &self.column)
+    }
+
+    /// Returns the cell as a scalar value.
+    pub fn scalar(&self) -> Result<&'a ScalarValue, TableError> {
+        self.table.get_scalar_cell(self.row_index, &self.column)
+    }
+
+    /// Returns the cell as an array value.
+    pub fn array(&self) -> Result<&'a ArrayValue, TableError> {
+        self.table.get_array_cell(self.row_index, &self.column)
+    }
+
+    /// Returns the cell as a record value.
+    pub fn record(&self) -> Result<RecordValue, TableError> {
+        self.table.record_cell(self.row_index, &self.column)
+    }
+
+    /// Returns whether the cell is defined.
+    pub fn is_defined(&self) -> Result<bool, TableError> {
+        self.table.is_cell_defined(self.row_index, &self.column)
+    }
+
+    /// Returns the array shape of the cell, if it is an array.
+    pub fn array_shape(&self) -> Result<Option<Vec<usize>>, TableError> {
+        self.table.array_shape(self.row_index, &self.column)
+    }
+}
+
+impl<'a> TableCellMut<'a> {
+    /// Returns the row index bound to this accessor.
+    pub fn row_index(&self) -> usize {
+        self.row_index
+    }
+
+    /// Returns the column name bound to this accessor.
+    pub fn column(&self) -> &str {
+        &self.column
+    }
+
+    /// Returns the cell value, or `None` if absent.
+    pub fn value(&self) -> Result<Option<&Value>, TableError> {
+        self.table.cell(self.row_index, &self.column)
+    }
+
+    /// Returns the cell as a scalar value.
+    pub fn scalar(&self) -> Result<&ScalarValue, TableError> {
+        self.table.get_scalar_cell(self.row_index, &self.column)
+    }
+
+    /// Returns the cell as an array value.
+    pub fn array(&self) -> Result<&ArrayValue, TableError> {
+        self.table.get_array_cell(self.row_index, &self.column)
+    }
+
+    /// Returns the cell as a record value.
+    pub fn record(&self) -> Result<RecordValue, TableError> {
+        self.table.record_cell(self.row_index, &self.column)
+    }
+
+    /// Returns whether the cell is defined.
+    pub fn is_defined(&self) -> Result<bool, TableError> {
+        self.table.is_cell_defined(self.row_index, &self.column)
+    }
+
+    /// Returns the array shape of the cell, if it is an array.
+    pub fn array_shape(&self) -> Result<Option<Vec<usize>>, TableError> {
+        self.table.array_shape(self.row_index, &self.column)
+    }
+
+    /// Writes a new value to the cell.
+    pub fn set(&mut self, value: Value) -> Result<(), TableError> {
+        self.table.set_cell(self.row_index, &self.column, value)
+    }
+
+    /// Writes a record value to the cell.
+    pub fn set_record(&mut self, value: RecordValue) -> Result<(), TableError> {
+        self.table
+            .set_record_cell(self.row_index, &self.column, value)
+    }
+
+    /// Lazily updates the cell as a scalar while assuming schema validity.
+    pub fn set_scalar_assuming_valid(&mut self, value: ScalarValue) -> Result<(), TableError> {
+        self.table
+            .set_scalar_cell_assuming_valid(self.row_index, &self.column, value)
+    }
+
+    /// Lazily updates the cell as an array while assuming schema validity.
+    pub fn set_array_assuming_valid(&mut self, value: ArrayValue) -> Result<(), TableError> {
+        self.table
+            .set_array_cell_assuming_valid(self.row_index, &self.column, value)
     }
 }
 

--- a/crates/casa-tables/src/table/columns.rs
+++ b/crates/casa-tables/src/table/columns.rs
@@ -100,6 +100,7 @@ impl Table {
         column: &str,
     ) -> Result<TableCell<'_>, TableError> {
         self.require_row(row_index)?;
+        self.require_column(column)?;
         Ok(TableCell {
             table: self,
             row_index,
@@ -114,6 +115,7 @@ impl Table {
         column: &str,
     ) -> Result<TableCellMut<'_>, TableError> {
         self.require_row(row_index)?;
+        self.require_column(column)?;
         Ok(TableCellMut {
             table: self,
             row_index,

--- a/crates/casa-tables/src/table/mod.rs
+++ b/crates/casa-tables/src/table/mod.rs
@@ -525,7 +525,7 @@ pub struct RecordColumnCell {
 /// For batch processing, see [`ColumnChunkIter`] via [`Table::iter_column_chunks`].
 pub struct ColumnCellIter<'a> {
     row_data: &'a [RecordValue],
-    column: &'a str,
+    column: String,
     rows: RowRangeIter,
 }
 
@@ -535,7 +535,7 @@ impl<'a> Iterator for ColumnCellIter<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.rows.next().map(|row_index| ColumnCellRef {
             row_index,
-            value: self.row_data[row_index].get(self.column),
+            value: self.row_data[row_index].get(&self.column),
         })
     }
 }
@@ -548,7 +548,7 @@ impl<'a> Iterator for ColumnCellIter<'a> {
 /// record cell is absent yield an empty [`RecordValue`] rather than an error.
 pub struct RecordColumnIter<'a> {
     row_data: &'a [RecordValue],
-    column: &'a str,
+    column: String,
     rows: RowRangeIter,
     default_missing: bool,
 }
@@ -558,7 +558,7 @@ impl<'a> Iterator for RecordColumnIter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.rows.next().map(|row_index| {
-            let value = match self.row_data[row_index].get(self.column) {
+            let value = match self.row_data[row_index].get(&self.column) {
                 Some(Value::Record(record)) => record.clone(),
                 Some(_) => unreachable!("record iterator was prevalidated"),
                 None => {
@@ -596,6 +596,64 @@ impl<'a> Iterator for ColumnChunkIter<'a> {
         let chunk: Vec<_> = self.inner.by_ref().take(self.chunk_size).collect();
         if chunk.is_empty() { None } else { Some(chunk) }
     }
+}
+
+/// Read-only row accessor for a [`Table`].
+///
+/// This is the canonical row-oriented read surface for normal clients.
+/// Table-level `row`/`cell` helpers remain available as compatibility methods.
+#[derive(Debug, Clone, Copy)]
+pub struct TableRow<'a> {
+    pub(crate) table: &'a Table,
+}
+
+/// Mutable row accessor for a [`Table`].
+///
+/// Use this for row-oriented updates instead of reaching directly into storage
+/// internals. Table-level setters remain available as compatibility methods.
+#[derive(Debug)]
+pub struct TableRowMut<'a> {
+    pub(crate) table: &'a mut Table,
+}
+
+/// Read-only column accessor for a [`Table`].
+///
+/// This follows the same public-accessor direction as casacore's
+/// `ROTableColumn`, `ScalarColumn<T>`, and `ArrayColumn<T>`.
+#[derive(Debug, Clone)]
+pub struct TableColumn<'a> {
+    pub(crate) table: &'a Table,
+    pub(crate) column: String,
+}
+
+/// Mutable column accessor for a [`Table`].
+///
+/// Use this for column-oriented updates while keeping storage-manager details
+/// internal to `casa-tables`.
+#[derive(Debug)]
+pub struct TableColumnMut<'a> {
+    pub(crate) table: &'a mut Table,
+    pub(crate) column: String,
+}
+
+/// Read-only cell accessor for a [`Table`].
+///
+/// Cell accessors tie a row index and column name together so callers can
+/// choose row-, column-, or direct-cell-oriented code without touching
+/// storage-manager internals.
+#[derive(Debug, Clone)]
+pub struct TableCell<'a> {
+    pub(crate) table: &'a Table,
+    pub(crate) row_index: usize,
+    pub(crate) column: String,
+}
+
+/// Mutable cell accessor for a [`Table`].
+#[derive(Debug)]
+pub struct TableCellMut<'a> {
+    pub(crate) table: &'a mut Table,
+    pub(crate) row_index: usize,
+    pub(crate) column: String,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/casa-tables/src/table/tests.rs
+++ b/crates/casa-tables/src/table/tests.rs
@@ -126,9 +126,22 @@ fn mutable_accessors_update_rows_columns_and_cells() {
             ),
         ]))
         .expect("add row");
+    table
+        .add_row(RecordValue::new(vec![
+            RecordField::new("id", Value::Scalar(ScalarValue::Int32(2))),
+            RecordField::new("data", Value::Array(ArrayValue::from_i32_vec(vec![5, 8]))),
+            RecordField::new(
+                "meta",
+                Value::Record(RecordValue::new(vec![RecordField::new(
+                    "label",
+                    Value::Scalar(ScalarValue::String("keep".to_string())),
+                )])),
+            ),
+        ]))
+        .expect("add second row");
 
     table
-        .cell_accessor_mut(0, "id")
+        .cell_accessor_mut(1, "id")
         .expect("scalar cell accessor")
         .set_scalar_assuming_valid(ScalarValue::Int32(11))
         .expect("set scalar");
@@ -136,13 +149,13 @@ fn mutable_accessors_update_rows_columns_and_cells() {
     table
         .column_accessor_mut("data")
         .expect("column accessor mut")
-        .set_array_assuming_valid(0, ArrayValue::from_i32_vec(vec![13, 21]))
+        .set_array_assuming_valid(1, ArrayValue::from_i32_vec(vec![13, 21]))
         .expect("set array");
 
     table
         .row_accessor_mut()
         .set_record_cell(
-            0,
+            1,
             "meta",
             RecordValue::new(vec![RecordField::new(
                 "label",
@@ -153,29 +166,67 @@ fn mutable_accessors_update_rows_columns_and_cells() {
 
     {
         let mut rows = table.row_accessor_mut();
-        let row = rows.row_mut(0).expect("mutable row accessor");
+        let row = rows.row_mut(1).expect("mutable row accessor");
         row.upsert("extra", Value::Scalar(ScalarValue::Bool(true)));
     }
 
     assert_eq!(
-        table.get_scalar_cell(0, "id").expect("id"),
+        table.get_scalar_cell(0, "id").expect("first id"),
+        &ScalarValue::Int32(1)
+    );
+    assert_eq!(
+        table.get_array_cell(0, "data").expect("first data"),
+        &ArrayValue::from_i32_vec(vec![2, 3])
+    );
+    assert_eq!(
+        table.record_cell(0, "meta").expect("first meta"),
+        RecordValue::new(vec![RecordField::new(
+            "label",
+            Value::Scalar(ScalarValue::String("old".to_string())),
+        )])
+    );
+    assert_eq!(table.cell(0, "extra"), Ok(None));
+    assert_eq!(
+        table.get_scalar_cell(1, "id").expect("id"),
         &ScalarValue::Int32(11)
     );
     assert_eq!(
-        table.get_array_cell(0, "data").expect("data"),
+        table.get_array_cell(1, "data").expect("data"),
         &ArrayValue::from_i32_vec(vec![13, 21])
     );
     assert_eq!(
-        table.record_cell(0, "meta").expect("meta"),
+        table.record_cell(1, "meta").expect("meta"),
         RecordValue::new(vec![RecordField::new(
             "label",
             Value::Scalar(ScalarValue::String("new".to_string())),
         )])
     );
     assert_eq!(
-        table.cell(0, "extra"),
+        table.cell(1, "extra"),
         Ok(Some(&Value::Scalar(ScalarValue::Bool(true))))
     );
+}
+
+#[test]
+fn cell_accessors_reject_unknown_columns() {
+    let schema =
+        TableSchema::new(vec![ColumnSchema::scalar("id", PrimitiveType::Int32)]).expect("schema");
+    let mut table = Table::with_schema(schema);
+    table
+        .add_row(RecordValue::new(vec![RecordField::new(
+            "id",
+            Value::Scalar(ScalarValue::Int32(1)),
+        )]))
+        .expect("add row");
+
+    assert!(matches!(
+        table.cell_accessor(0, "missing"),
+        Err(TableError::SchemaColumnUnknown { column }) if column == "missing"
+    ));
+    assert!(matches!(
+        table.cell_accessor_mut(0, "missing"),
+        Err(TableError::SchemaColumnUnknown { column }) if column == "missing"
+    ));
 }
 
 #[test]

--- a/crates/casa-tables/src/table/tests.rs
+++ b/crates/casa-tables/src/table/tests.rs
@@ -72,6 +72,113 @@ fn table_exposes_row_and_column_cell_access() {
 }
 
 #[test]
+fn canonical_accessors_read_rows_columns_and_cells() {
+    let meta = RecordValue::new(vec![RecordField::new(
+        "label",
+        Value::Scalar(ScalarValue::String("alpha".to_string())),
+    )]);
+    let data = ArrayValue::from_i32_vec(vec![3, 5, 8]);
+    let table = Table::from_rows(vec![RecordValue::new(vec![
+        RecordField::new("id", Value::Scalar(ScalarValue::Int32(7))),
+        RecordField::new("data", Value::Array(data.clone())),
+        RecordField::new("meta", Value::Record(meta.clone())),
+    ])]);
+
+    let rows = table.row_accessor();
+    let row = rows.row(0).expect("row 0");
+    assert_eq!(row.get("id"), Some(&Value::Scalar(ScalarValue::Int32(7))));
+
+    let column = table.column_accessor("data").expect("column accessor");
+    assert_eq!(column.array_cell(0).expect("array cell"), &data);
+    let iterated: Vec<_> = column
+        .iter()
+        .expect("column iter")
+        .map(|cell| (cell.row_index, cell.value.cloned()))
+        .collect();
+    assert_eq!(iterated, vec![(0, Some(Value::Array(data.clone())))]);
+
+    let cell = table.cell_accessor(0, "meta").expect("cell accessor");
+    assert_eq!(cell.row_index(), 0);
+    assert_eq!(cell.column(), "meta");
+    assert!(cell.is_defined().expect("defined"));
+    assert_eq!(cell.record().expect("record cell"), meta);
+}
+
+#[test]
+fn mutable_accessors_update_rows_columns_and_cells() {
+    let schema = TableSchema::new(vec![
+        ColumnSchema::scalar("id", PrimitiveType::Int32),
+        ColumnSchema::array_fixed("data", PrimitiveType::Int32, vec![2]),
+        ColumnSchema::record("meta"),
+    ])
+    .expect("schema");
+    let mut table = Table::with_schema(schema);
+    table
+        .add_row(RecordValue::new(vec![
+            RecordField::new("id", Value::Scalar(ScalarValue::Int32(1))),
+            RecordField::new("data", Value::Array(ArrayValue::from_i32_vec(vec![2, 3]))),
+            RecordField::new(
+                "meta",
+                Value::Record(RecordValue::new(vec![RecordField::new(
+                    "label",
+                    Value::Scalar(ScalarValue::String("old".to_string())),
+                )])),
+            ),
+        ]))
+        .expect("add row");
+
+    table
+        .cell_accessor_mut(0, "id")
+        .expect("scalar cell accessor")
+        .set_scalar_assuming_valid(ScalarValue::Int32(11))
+        .expect("set scalar");
+
+    table
+        .column_accessor_mut("data")
+        .expect("column accessor mut")
+        .set_array_assuming_valid(0, ArrayValue::from_i32_vec(vec![13, 21]))
+        .expect("set array");
+
+    table
+        .row_accessor_mut()
+        .set_record_cell(
+            0,
+            "meta",
+            RecordValue::new(vec![RecordField::new(
+                "label",
+                Value::Scalar(ScalarValue::String("new".to_string())),
+            )]),
+        )
+        .expect("set record");
+
+    {
+        let mut rows = table.row_accessor_mut();
+        let row = rows.row_mut(0).expect("mutable row accessor");
+        row.upsert("extra", Value::Scalar(ScalarValue::Bool(true)));
+    }
+
+    assert_eq!(
+        table.get_scalar_cell(0, "id").expect("id"),
+        &ScalarValue::Int32(11)
+    );
+    assert_eq!(
+        table.get_array_cell(0, "data").expect("data"),
+        &ArrayValue::from_i32_vec(vec![13, 21])
+    );
+    assert_eq!(
+        table.record_cell(0, "meta").expect("meta"),
+        RecordValue::new(vec![RecordField::new(
+            "label",
+            Value::Scalar(ScalarValue::String("new".to_string())),
+        )])
+    );
+    assert_eq!(
+        table.cell(0, "extra"),
+        Ok(Some(&Value::Scalar(ScalarValue::Bool(true))))
+    );
+}
+
+#[test]
 fn column_range_iteration_supports_stride() {
     let rows = (0..6)
         .map(|value| {


### PR DESCRIPTION
Wave issue: #98

## Summary

- add canonical row/column/cell accessor objects in `casa-tables` (`TableRow`, `TableRowMut`, `TableColumn`, `TableColumnMut`, `TableCell`, `TableCellMut`)
- document existing `Table::{row,cell,get_*,set_*}` methods as compatibility-oriented wrappers rather than the preferred long-term surface
- migrate representative accessor use into `casa-ms` and `casa-calibration`
- add accessor API coverage in `casa-tables` tests
- tighten closeout fixes for cell-accessor validation, multi-row mutation coverage, and architecture-sync docs

## Deferred work

- row-buffer reuse and compiled row layouts remain in `#99`
- bounded buffered column access remains in `#100`
- process-wide cache budget and multi-reader shared-read work remain in `#101`
- convenience-method deprecation/removal remains in `#102`
- clarify or internalize the `TiledFileIO` image/lattice implementation seam in `#104`

## Verification

- `cargo test -p casa-tables`
- `just quick`
- `just verify`
