### PR TITLE
Implement prepared row-buffer fast path

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -35,7 +35,7 @@ Additional constraints:
 - `casa-values` and `casa-aipsio` stay internal implementation crates.
 - `casa-table-read` owns the minimal shared read-only loader used by runtime data loaders.
 - `casa-tables` keeps the broader storage/write path crate-internal even when user-facing table APIs are exposed from the crate.
-- Within `casa-tables`, row/column/cell accessor objects are the canonical public table-data surface; legacy table-level convenience methods remain compatibility wrappers.
+- Within `casa-tables`, row/column/cell accessor objects are the canonical public table-data surface; prepared-row accessors provide the reusable selected-column row fast path, and legacy table-level convenience methods remain compatibility wrappers.
 - Versioned provider bundles are boundary contracts; UI projections are derived views, not separate truth sources.
 
 ## Runtime model

--- a/crates/casa-calibration/src/execute.rs
+++ b/crates/casa-calibration/src/execute.rs
@@ -510,6 +510,20 @@ pub(crate) fn evaluate_apply_rows(
     };
 
     let mut evaluated_rows = HashMap::new();
+    let mut main_rows = ms
+        .main_table()
+        .row_accessor()
+        .prepare(&[VisibilityDataColumn::Data.name(), "FLAG"])
+        .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+            path: ms_path.clone(),
+            source: MsError::from(source),
+        })?;
+    let data_index = main_rows
+        .column_index(VisibilityDataColumn::Data.name())
+        .expect("prepared apply reader includes DATA");
+    let flag_index = main_rows
+        .column_index("FLAG")
+        .expect("prepared apply reader includes FLAG");
     for row in &plan.selected_rows {
         let correlation_types = correlation_types_by_ddid
             .get(&row.data_desc_id)
@@ -517,31 +531,24 @@ pub(crate) fn evaluate_apply_rows(
                 data_desc_id: row.data_desc_id,
                 correlation_types: Vec::new(),
             })?;
-        let main_row = ms
-            .main_table()
-            .row_accessor()
-            .row(row.row_index)
-            .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+        main_rows.load(row.row_index).map_err(|source| {
+            ApplyExecutionError::MutateMeasurementSet {
                 path: ms_path.clone(),
                 source: MsError::from(source),
-            })?;
-        let data = array_row_value(
-            main_row,
-            row.row_index,
-            VisibilityDataColumn::Data.name(),
-            None,
-        )
-        .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
-            path: ms_path.clone(),
-            source: MsError::from(source),
+            }
         })?;
-        let original_flags =
-            array_row_value(main_row, row.row_index, "FLAG", None).map_err(|source| {
-                ApplyExecutionError::MutateMeasurementSet {
-                    path: ms_path.clone(),
-                    source: MsError::from(source),
-                }
-            })?;
+        let data = main_rows.array_at(data_index).map_err(|source| {
+            ApplyExecutionError::MutateMeasurementSet {
+                path: ms_path.clone(),
+                source: MsError::from(source),
+            }
+        })?;
+        let original_flags = main_rows.array_at(flag_index).map_err(|source| {
+            ApplyExecutionError::MutateMeasurementSet {
+                path: ms_path.clone(),
+                source: MsError::from(source),
+            }
+        })?;
 
         let result = apply_row(
             row,
@@ -761,18 +768,6 @@ fn execute_apply_plan(
         .is_some_and(|schema| schema.contains_column("WEIGHT_SPECTRUM"));
     let use_partial_main_save = !created_corrected_data_column;
     let mut changed_columns: Vec<&'static str> = vec![VisibilityDataColumn::CorrectedData.name()];
-    let row_field_index_lookup_started_at = Instant::now();
-    let row_field_indices = plan
-        .selected_rows
-        .first()
-        .map(|row| cached_apply_row_field_indices(ms.main_table(), row.row_index))
-        .transpose()
-        .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
-            path: ms_path.clone(),
-            source: MsError::from(source),
-        })?
-        .unwrap_or_default();
-    let row_field_index_lookup_ns = row_field_index_lookup_started_at.elapsed().as_nanos() as u64;
     let row_loop_started_at = Instant::now();
     if use_partial_main_save {
         let anticipated_updates = plan.selected_rows.len();
@@ -866,34 +861,36 @@ fn execute_apply_plan(
         prefetched_inputs
     };
 
-    for (row, prefetched_inputs) in plan.selected_rows.iter().zip(&prefetched_inputs) {
-        let correlation_types = correlation_types_by_ddid
-            .get(&row.data_desc_id)
-            .ok_or_else(|| ApplyExecutionError::UnsupportedCorrelationLayout {
-                data_desc_id: row.data_desc_id,
-                correlation_types: Vec::new(),
-            })?;
-        let row_compute_started_at = Instant::now();
-        let ExecutionRowResult {
-            corrected_data,
-            updated_flags,
-            updated_weight,
-            updated_weight_spectrum,
-            newly_flagged_samples,
-            row_became_fully_flagged,
-        } = apply_row_prefetched(
-            row,
-            correlation_types,
-            prefetched_inputs,
-            any_calwt && has_weight_spectrum,
-            &plan,
-            &loaded_tables,
-            parang_state.as_ref(),
-        )?;
-        row_compute_ns += row_compute_started_at.elapsed().as_nanos() as u64;
+    let row_field_index_lookup_ns;
+    if use_partial_main_save {
+        row_field_index_lookup_ns = 0;
+        for (row, prefetched_inputs) in plan.selected_rows.iter().zip(&prefetched_inputs) {
+            let correlation_types = correlation_types_by_ddid
+                .get(&row.data_desc_id)
+                .ok_or_else(|| ApplyExecutionError::UnsupportedCorrelationLayout {
+                    data_desc_id: row.data_desc_id,
+                    correlation_types: Vec::new(),
+                })?;
+            let row_compute_started_at = Instant::now();
+            let ExecutionRowResult {
+                corrected_data,
+                updated_flags,
+                updated_weight,
+                updated_weight_spectrum,
+                newly_flagged_samples,
+                row_became_fully_flagged,
+            } = apply_row_prefetched(
+                row,
+                correlation_types,
+                prefetched_inputs,
+                any_calwt && has_weight_spectrum,
+                &plan,
+                &loaded_tables,
+                parang_state.as_ref(),
+            )?;
+            row_compute_ns += row_compute_started_at.elapsed().as_nanos() as u64;
 
-        let row_writeback_started_at = Instant::now();
-        if use_partial_main_save {
+            let row_writeback_started_at = Instant::now();
             ms.main_table_mut()
                 .set_array_cell_assuming_valid(
                     row.row_index,
@@ -959,58 +956,148 @@ fn execute_apply_plan(
                         source: MsError::from(source),
                     })?;
             }
-        } else {
-            let mut row_accessor = ms.main_table_mut().row_accessor_mut();
-            let row_record = row_accessor.row_mut(row.row_index).map_err(|source| {
+            updated_row_count += 1;
+            row_writeback_ns += row_writeback_started_at.elapsed().as_nanos() as u64;
+        }
+    } else {
+        let row_field_index_lookup_started_at = Instant::now();
+        let mut prepared_columns = vec![VisibilityDataColumn::CorrectedData.name()];
+        if ms
+            .main_table()
+            .schema()
+            .is_some_and(|schema| schema.contains_column("FLAG"))
+        {
+            prepared_columns.push("FLAG");
+        }
+        if ms
+            .main_table()
+            .schema()
+            .is_some_and(|schema| schema.contains_column("FLAG_ROW"))
+        {
+            prepared_columns.push("FLAG_ROW");
+        }
+        if ms
+            .main_table()
+            .schema()
+            .is_some_and(|schema| schema.contains_column("WEIGHT"))
+        {
+            prepared_columns.push("WEIGHT");
+        }
+        if has_weight_spectrum {
+            prepared_columns.push("WEIGHT_SPECTRUM");
+        }
+        let mut prepared_main_rows = ms
+            .main_table_mut()
+            .row_accessor_mut()
+            .prepare(&prepared_columns)
+            .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                path: ms_path.clone(),
+                source: MsError::from(source),
+            })?;
+        let row_field_indices = ApplyRowFieldIndices {
+            corrected_data: prepared_main_rows
+                .column_index(VisibilityDataColumn::CorrectedData.name()),
+            flag: prepared_main_rows.column_index("FLAG"),
+            flag_row: prepared_main_rows.column_index("FLAG_ROW"),
+            weight: prepared_main_rows.column_index("WEIGHT"),
+            weight_spectrum: prepared_main_rows.column_index("WEIGHT_SPECTRUM"),
+        };
+        row_field_index_lookup_ns = row_field_index_lookup_started_at.elapsed().as_nanos() as u64;
+
+        for (row, prefetched_inputs) in plan.selected_rows.iter().zip(&prefetched_inputs) {
+            let correlation_types = correlation_types_by_ddid
+                .get(&row.data_desc_id)
+                .ok_or_else(|| ApplyExecutionError::UnsupportedCorrelationLayout {
+                    data_desc_id: row.data_desc_id,
+                    correlation_types: Vec::new(),
+                })?;
+            let row_compute_started_at = Instant::now();
+            let ExecutionRowResult {
+                corrected_data,
+                updated_flags,
+                updated_weight,
+                updated_weight_spectrum,
+                newly_flagged_samples,
+                row_became_fully_flagged,
+            } = apply_row_prefetched(
+                row,
+                correlation_types,
+                prefetched_inputs,
+                any_calwt && has_weight_spectrum,
+                &plan,
+                &loaded_tables,
+                parang_state.as_ref(),
+            )?;
+            row_compute_ns += row_compute_started_at.elapsed().as_nanos() as u64;
+
+            let row_writeback_started_at = Instant::now();
+            prepared_main_rows.seek(row.row_index).map_err(|source| {
                 ApplyExecutionError::MutateMeasurementSet {
                     path: ms_path.clone(),
                     source: MsError::from(source),
                 }
             })?;
-            write_row_value(
-                row_record,
-                VisibilityDataColumn::CorrectedData.name(),
-                row_field_indices.corrected_data,
-                Value::Array(corrected_data),
-            );
+            if let Some(slot_index) = row_field_indices.corrected_data {
+                prepared_main_rows
+                    .set_value_at(slot_index, Value::Array(corrected_data))
+                    .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                        path: ms_path.clone(),
+                        source: MsError::from(source),
+                    })?;
+            }
 
             if let Some(updated_flags) = updated_flags {
-                write_row_value(
-                    row_record,
-                    "FLAG",
-                    row_field_indices.flag,
-                    Value::Array(updated_flags),
-                );
+                if let Some(slot_index) = row_field_indices.flag {
+                    prepared_main_rows
+                        .set_value_at(slot_index, Value::Array(updated_flags))
+                        .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                            path: ms_path.clone(),
+                            source: MsError::from(source),
+                        })?;
+                }
                 if row_became_fully_flagged {
-                    write_row_value(
-                        row_record,
-                        "FLAG_ROW",
-                        row_field_indices.flag_row,
-                        Value::Scalar(ScalarValue::Bool(true)),
-                    );
+                    if let Some(slot_index) = row_field_indices.flag_row {
+                        prepared_main_rows
+                            .set_value_at(slot_index, Value::Scalar(ScalarValue::Bool(true)))
+                            .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                                path: ms_path.clone(),
+                                source: MsError::from(source),
+                            })?;
+                    }
                     flagged_row_count += 1;
                 }
                 flagged_sample_count += newly_flagged_samples;
             }
             if let Some(updated_weight) = updated_weight {
-                write_row_value(
-                    row_record,
-                    "WEIGHT",
-                    row_field_indices.weight,
-                    Value::Array(updated_weight),
-                );
+                if let Some(slot_index) = row_field_indices.weight {
+                    prepared_main_rows
+                        .set_value_at(slot_index, Value::Array(updated_weight))
+                        .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                            path: ms_path.clone(),
+                            source: MsError::from(source),
+                        })?;
+                }
             }
             if let Some(updated_weight_spectrum) = updated_weight_spectrum {
-                write_row_value(
-                    row_record,
-                    "WEIGHT_SPECTRUM",
-                    row_field_indices.weight_spectrum,
-                    Value::Array(updated_weight_spectrum),
-                );
+                if let Some(slot_index) = row_field_indices.weight_spectrum {
+                    prepared_main_rows
+                        .set_value_at(slot_index, Value::Array(updated_weight_spectrum))
+                        .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                            path: ms_path.clone(),
+                            source: MsError::from(source),
+                        })?;
+                }
             }
+            updated_row_count += 1;
+            row_writeback_ns += row_writeback_started_at.elapsed().as_nanos() as u64;
         }
-        updated_row_count += 1;
-        row_writeback_ns += row_writeback_started_at.elapsed().as_nanos() as u64;
+
+        prepared_main_rows
+            .flush()
+            .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                path: ms_path.clone(),
+                source: MsError::from(source),
+            })?;
     }
     let row_loop_ns = row_loop_started_at.elapsed().as_nanos() as u64;
 
@@ -2518,113 +2605,11 @@ fn ensure_corrected_data_column(ms: &mut MeasurementSet) -> Result<bool, TableEr
 
 #[derive(Clone, Copy, Default)]
 struct ApplyRowFieldIndices {
-    data: Option<usize>,
     corrected_data: Option<usize>,
     flag: Option<usize>,
     flag_row: Option<usize>,
     weight: Option<usize>,
     weight_spectrum: Option<usize>,
-}
-
-fn cached_apply_row_field_indices(
-    table: &Table,
-    row_index: usize,
-) -> Result<ApplyRowFieldIndices, TableError> {
-    if let Some(schema) = table.schema() {
-        let mut indices = ApplyRowFieldIndices::default();
-        for (field_index, column) in schema.columns().iter().enumerate() {
-            match column.name() {
-                name if name == VisibilityDataColumn::Data.name() => {
-                    indices.data = Some(field_index);
-                }
-                name if name == VisibilityDataColumn::CorrectedData.name() => {
-                    indices.corrected_data = Some(field_index);
-                }
-                "FLAG" => indices.flag = Some(field_index),
-                "FLAG_ROW" => indices.flag_row = Some(field_index),
-                "WEIGHT" => indices.weight = Some(field_index),
-                "WEIGHT_SPECTRUM" => indices.weight_spectrum = Some(field_index),
-                _ => {}
-            }
-        }
-        return Ok(indices);
-    }
-
-    let row = table.row_accessor().row(row_index)?;
-    let mut indices = ApplyRowFieldIndices::default();
-    for (field_index, field) in row.fields().iter().enumerate() {
-        match field.name.as_str() {
-            name if name == VisibilityDataColumn::Data.name() => {
-                indices.data = Some(field_index);
-            }
-            name if name == VisibilityDataColumn::CorrectedData.name() => {
-                indices.corrected_data = Some(field_index);
-            }
-            "FLAG" => indices.flag = Some(field_index),
-            "FLAG_ROW" => indices.flag_row = Some(field_index),
-            "WEIGHT" => indices.weight = Some(field_index),
-            "WEIGHT_SPECTRUM" => indices.weight_spectrum = Some(field_index),
-            _ => {}
-        }
-    }
-    Ok(indices)
-}
-
-fn cached_row_value<'a>(
-    row: &'a casa_types::RecordValue,
-    column: &str,
-    field_index: Option<usize>,
-) -> Option<&'a Value> {
-    if let Some(field_index) = field_index {
-        if let Some(field) = row.fields().get(field_index) {
-            if field.name == column {
-                return Some(&field.value);
-            }
-        }
-    }
-    row.get(column)
-}
-
-fn array_row_value<'a>(
-    row: &'a casa_types::RecordValue,
-    row_index: usize,
-    column: &str,
-    field_index: Option<usize>,
-) -> Result<&'a ArrayValue, TableError> {
-    match cached_row_value(row, column, field_index) {
-        Some(Value::Array(array)) => Ok(array),
-        Some(value) => Err(TableError::ColumnTypeMismatch {
-            row_index,
-            column: column.to_string(),
-            expected: "array",
-            found: value.kind(),
-        }),
-        None => Err(TableError::ColumnNotFound {
-            row_index,
-            column: column.to_string(),
-        }),
-    }
-}
-
-fn write_row_value(
-    row: &mut casa_types::RecordValue,
-    column: &str,
-    field_index: Option<usize>,
-    value: Value,
-) {
-    if let Some(field_index) = field_index {
-        if let Some(field) = row.fields_mut().get_mut(field_index) {
-            if field.name == column {
-                field.value = value;
-                return;
-            }
-        }
-    }
-    if let Some(existing) = row.get_mut(column) {
-        *existing = value;
-    } else {
-        row.upsert(column, value);
-    }
 }
 
 fn display_ms_path(ms: &MeasurementSet) -> String {
@@ -2909,27 +2894,6 @@ mod tests {
         let log = fs::read_to_string(log_paths[0].clone()).expect("summary log");
         assert!(log.contains("kind=ApplyCompleted"));
         assert!(log.contains("row_read_overhead_ms=0.00"));
-    }
-
-    #[test]
-    fn cached_apply_row_field_indices_uses_schema_without_rows() {
-        let main_schema = MeasurementSetBuilder::new()
-            .with_main_column(OptionalMainColumn::Data)
-            .with_main_column(OptionalMainColumn::CorrectedData)
-            .with_main_column(OptionalMainColumn::WeightSpectrum)
-            .build_schemas()
-            .expect("schemas")
-            .main;
-        let table = Table::with_schema(main_schema);
-
-        let indices = cached_apply_row_field_indices(&table, 0).expect("schema lookup");
-
-        assert!(indices.data.is_some());
-        assert!(indices.corrected_data.is_some());
-        assert!(indices.flag.is_some());
-        assert!(indices.flag_row.is_some());
-        assert!(indices.weight.is_some());
-        assert!(indices.weight_spectrum.is_some());
     }
 
     fn default_main_value(column: &ColumnSchema) -> Value {

--- a/crates/casa-calibration/tests/apply_execute.rs
+++ b/crates/casa-calibration/tests/apply_execute.rs
@@ -385,6 +385,55 @@ fn execute_apply_calflag_marks_samples_when_solution_is_missing() {
 }
 
 #[test]
+fn execute_apply_calflag_marks_samples_when_solution_is_missing_without_seeded_corrected_data() {
+    let dir = TempDir::new().expect("tempdir");
+    let ms_path = common::create_apply_fixture_ms(dir.path(), false);
+    let caltable_path = common::create_apply_gain_caltable(
+        &dir.path().join("phase.gcal"),
+        &["TARGET0"],
+        &[common::SyntheticGainSolutionRow {
+            time_seconds: 100.0,
+            field_id: 0,
+            spectral_window_id: 0,
+            antenna_id: 0,
+            gains: vec![
+                casa_types::Complex32::new(2.0, 0.0),
+                casa_types::Complex32::new(4.0, 0.0),
+            ],
+            flags: vec![false, false],
+        }],
+    );
+
+    let report = execute_apply_from_path(
+        &ms_path,
+        &ApplyPlanRequest {
+            selection: MsSelection::new().spw(&[0]),
+            apply_mode: ApplyMode::CalFlag,
+            parang: false,
+            calibration_tables: vec![ApplyCalibrationTableSpec::new(&caltable_path)],
+        },
+    )
+    .expect("apply calibration with calflag via prepared-row writeback");
+
+    assert!(report.created_corrected_data_column);
+    assert_eq!(report.flagged_sample_count, 4);
+    assert_eq!(report.flagged_row_count, 1);
+
+    let ms = MeasurementSet::open(&ms_path).expect("reopen measurement set");
+    let _corrected_column = ms
+        .data_column(VisibilityDataColumn::CorrectedData)
+        .expect("corrected data accessor");
+
+    let flag_column = ms.flag_column();
+    let flags = flag_column.get(0).expect("read flags");
+    let ArrayValue::Bool(flags) = flags else {
+        panic!("expected bool flags");
+    };
+    assert!(flags.iter().all(|flag| *flag));
+    assert!(ms.flag_row_column().get(0).expect("flag row"));
+}
+
+#[test]
 fn execute_apply_calwt_updates_weight_column_for_gain_tables() {
     let dir = TempDir::new().expect("tempdir");
     let ms_path = common::create_apply_fixture_ms(dir.path(), true);
@@ -441,6 +490,91 @@ fn execute_apply_calwt_updates_weight_column_for_gain_tables() {
 
     assert_eq!(weight[[0]], 100.0);
     assert_eq!(weight[[1]], 1600.0);
+}
+
+#[test]
+fn execute_apply_calwt_updates_weight_paths_without_seeded_corrected_data() {
+    let dir = TempDir::new().expect("tempdir");
+    let ms_path = common::create_apply_fixture_ms_with_options(dir.path(), false, true);
+    let caltable_path = common::create_apply_gain_caltable(
+        &dir.path().join("phase.gcal"),
+        &["TARGET0"],
+        &[
+            common::SyntheticGainSolutionRow {
+                time_seconds: 100.0,
+                field_id: 0,
+                spectral_window_id: 0,
+                antenna_id: 0,
+                gains: vec![
+                    casa_types::Complex32::new(2.0, 0.0),
+                    casa_types::Complex32::new(4.0, 0.0),
+                ],
+                flags: vec![false, false],
+            },
+            common::SyntheticGainSolutionRow {
+                time_seconds: 100.0,
+                field_id: 0,
+                spectral_window_id: 0,
+                antenna_id: 1,
+                gains: vec![
+                    casa_types::Complex32::new(5.0, 0.0),
+                    casa_types::Complex32::new(10.0, 0.0),
+                ],
+                flags: vec![false, false],
+            },
+        ],
+    );
+
+    let mut spec = ApplyCalibrationTableSpec::new(&caltable_path);
+    spec.calwt = true;
+    let report = execute_apply_from_path(
+        &ms_path,
+        &ApplyPlanRequest {
+            selection: MsSelection::new().spw(&[0]),
+            apply_mode: ApplyMode::CalOnly,
+            parang: false,
+            calibration_tables: vec![spec],
+        },
+    )
+    .expect("apply calibration with channelized calwt via prepared-row writeback");
+
+    assert!(report.created_corrected_data_column);
+    assert_eq!(report.updated_row_count, 1);
+
+    let ms = MeasurementSet::open(&ms_path).expect("reopen measurement set");
+    let corrected_column = ms
+        .data_column(VisibilityDataColumn::CorrectedData)
+        .expect("corrected data accessor");
+    let corrected = corrected_column.get(0).expect("read corrected row");
+    let ArrayValue::Complex32(corrected) = corrected else {
+        panic!("expected Complex32 corrected data");
+    };
+    assert_eq!(corrected[[0, 0]], casa_types::Complex32::new(0.1, 0.0));
+    assert_eq!(corrected[[1, 0]], casa_types::Complex32::new(0.0, 0.025));
+    assert_eq!(corrected[[0, 1]], casa_types::Complex32::new(0.2, 0.0));
+    assert_eq!(corrected[[1, 1]], casa_types::Complex32::new(0.0, 0.05));
+
+    let weight_spectrum = ms
+        .main_table()
+        .get_array_cell(0, "WEIGHT_SPECTRUM")
+        .expect("read weight spectrum row");
+    let ArrayValue::Float32(weight_spectrum) = weight_spectrum else {
+        panic!("expected float32 WEIGHT_SPECTRUM");
+    };
+    assert_eq!(weight_spectrum[[0, 0]], 700.0);
+    assert_eq!(weight_spectrum[[0, 1]], 700.0);
+    assert_eq!(weight_spectrum[[1, 0]], 17_600.0);
+    assert_eq!(weight_spectrum[[1, 1]], 17_600.0);
+
+    let weight = ms
+        .main_table()
+        .get_array_cell(0, "WEIGHT")
+        .expect("read weight row");
+    let ArrayValue::Float32(weight) = weight else {
+        panic!("expected float32 WEIGHT");
+    };
+    assert_eq!(weight[[0]], 700.0);
+    assert_eq!(weight[[1]], 17_600.0);
 }
 
 #[test]

--- a/crates/casa-calibration/tests/bandpass_solve.rs
+++ b/crates/casa-calibration/tests/bandpass_solve.rs
@@ -161,6 +161,138 @@ fn solve_bandpass_with_prior_gain_corrects_synthetic_ms_downstream() {
 }
 
 #[test]
+fn solve_bandpass_with_prior_gain_corrects_dense_synthetic_ms_downstream() {
+    let dir = TempDir::new().expect("tempdir");
+    let prior_gains = [
+        [Complex32::new(1.0, 0.0), Complex32::new(1.0, 0.0)],
+        [
+            Complex32::new(0.9553365, 0.29552022),
+            Complex32::new(0.921061, -0.38941833),
+        ],
+        [
+            Complex32::new(0.9800666, -0.19866933),
+            Complex32::new(0.87758255, 0.47942555),
+        ],
+    ];
+    let bandpass_gains = [
+        [
+            [Complex32::new(1.0, 0.0), Complex32::new(1.0, 0.0)],
+            [Complex32::new(1.0, 0.0), Complex32::new(1.0, 0.0)],
+        ],
+        [
+            [Complex32::new(1.1, 0.15), Complex32::new(0.8, -0.2)],
+            [Complex32::new(0.95, -0.1), Complex32::new(1.2, 0.25)],
+        ],
+        [
+            [Complex32::new(0.9, -0.05), Complex32::new(1.15, 0.18)],
+            [Complex32::new(1.05, 0.12), Complex32::new(0.88, -0.14)],
+        ],
+    ];
+    let clusters = (0..128)
+        .map(|index| common::SyntheticBandpassTimeCluster {
+            field_id: 0,
+            time_seconds: 100.0 + index as f64,
+            scan_number: 1,
+            prior_gains,
+            bandpass_gains,
+        })
+        .collect::<Vec<_>>();
+    let ms_path = common::create_bandpass_solve_fixture_ms(dir.path(), &clusters);
+
+    let prior_table = common::create_apply_gain_caltable(
+        &dir.path().join("prior_dense.gcal"),
+        &["TARGET0"],
+        &[
+            common::SyntheticGainSolutionRow {
+                time_seconds: 100.0,
+                field_id: 0,
+                spectral_window_id: 0,
+                antenna_id: 0,
+                gains: vec![prior_gains[0][0], prior_gains[0][1]],
+                flags: vec![false, false],
+            },
+            common::SyntheticGainSolutionRow {
+                time_seconds: 100.0,
+                field_id: 0,
+                spectral_window_id: 0,
+                antenna_id: 1,
+                gains: vec![prior_gains[1][0], prior_gains[1][1]],
+                flags: vec![false, false],
+            },
+            common::SyntheticGainSolutionRow {
+                time_seconds: 100.0,
+                field_id: 0,
+                spectral_window_id: 0,
+                antenna_id: 2,
+                gains: vec![prior_gains[2][0], prior_gains[2][1]],
+                flags: vec![false, false],
+            },
+        ],
+    );
+
+    let bandpass_table = dir.path().join("bandpass_dense.bcal");
+    let report = solve_bandpass_from_path(
+        &ms_path,
+        &BandpassSolveRequest {
+            selection: MsSelection::new().field(&[0]).spw(&[0]),
+            output_table: bandpass_table.clone(),
+            refant: RefAntSelector::AntennaId(0),
+            prior_calibration_tables: vec![ApplyCalibrationTableSpec::new(&prior_table)],
+            parang: false,
+            combine: BandpassSolveCombine::default(),
+            band_type: BandpassType::B,
+            normalize_average_amplitude: false,
+            amplitude_degree: 3,
+            phase_degree: 3,
+            smodel: [1.0, 0.0, 0.0, 0.0],
+        },
+    )
+    .expect("solve dense bandpass");
+
+    assert_eq!(report.solution_row_count, 3);
+    assert_eq!(report.channel_count, 2);
+
+    execute_apply_from_path(
+        &ms_path,
+        &ApplyPlanRequest {
+            selection: MsSelection::new().field(&[0]).spw(&[0]),
+            apply_mode: ApplyMode::CalFlag,
+            parang: false,
+            calibration_tables: vec![
+                ApplyCalibrationTableSpec::new(&prior_table),
+                ApplyCalibrationTableSpec::new(&bandpass_table),
+            ],
+        },
+    )
+    .expect("apply dense prior + bandpass");
+
+    let ms = MeasurementSet::open(&ms_path).expect("reopen solved dense ms");
+    let row_count = ms.main_table().row_count();
+    assert_eq!(row_count, clusters.len() * 3);
+    for row in [0, row_count / 2, row_count - 1] {
+        let corrected = ms
+            .main_table()
+            .get_array_cell(row, VisibilityDataColumn::CorrectedData.name())
+            .expect("corrected data");
+        let ArrayValue::Complex32(values) = corrected else {
+            panic!("corrected data row {row} was not Complex32");
+        };
+        let values = values
+            .view()
+            .into_dimensionality::<Ix2>()
+            .expect("2-D corrected data");
+        for sample in values {
+            assert!(
+                (*sample - Complex32::new(1.0, 0.0)).norm() <= 1.0e-3,
+                "expected unity corrected sample on row {row}, found ({:.6},{:.6})",
+                sample.re,
+                sample.im
+            );
+        }
+    }
+}
+
+#[test]
 fn solve_bandpass_with_combine_scan_writes_one_solution_group_across_scans() {
     let dir = TempDir::new().expect("tempdir");
     let prior_gains = [

--- a/crates/casa-tables/Cargo.toml
+++ b/crates/casa-tables/Cargo.toml
@@ -43,5 +43,9 @@ name = "t_scalar_record_column"
 name = "taql_bench"
 harness = false
 
+[[bench]]
+name = "row_buffer_bench"
+harness = false
+
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/casa-tables/benches/row_buffer_bench.rs
+++ b/crates/casa-tables/benches/row_buffer_bench.rs
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//! Criterion benchmarks for row-oriented table access.
+//!
+//! Compares the legacy materialized row path against the reusable prepared-row
+//! path added in wave 99 on the same persisted table shape.
+
+use std::hint::black_box;
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use tempfile::TempDir;
+
+use casa_tables::{ColumnSchema, DataManagerKind, Table, TableOptions, TableSchema};
+use casa_types::{ArrayValue, PrimitiveType, RecordField, RecordValue, ScalarValue, Value};
+
+fn persisted_row_table(row_count: usize) -> (TempDir, std::path::PathBuf) {
+    let schema = TableSchema::new(vec![
+        ColumnSchema::scalar("id", PrimitiveType::Int32),
+        ColumnSchema::scalar("weight", PrimitiveType::Float64),
+        ColumnSchema::array_fixed("data", PrimitiveType::Int32, vec![4]),
+        ColumnSchema::array_fixed("other", PrimitiveType::Int32, vec![512]),
+        ColumnSchema::scalar("flag", PrimitiveType::Bool),
+    ])
+    .expect("valid schema");
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let path = tempdir.path().join("row-bench.table");
+
+    let mut table = Table::with_schema(schema);
+    for row_index in 0..row_count {
+        table
+            .add_row(RecordValue::new(vec![
+                RecordField::new("id", Value::Scalar(ScalarValue::Int32(row_index as i32))),
+                RecordField::new(
+                    "weight",
+                    Value::Scalar(ScalarValue::Float64(row_index as f64 * 0.25)),
+                ),
+                RecordField::new(
+                    "data",
+                    Value::Array(ArrayValue::from_i32_vec(vec![
+                        row_index as i32,
+                        row_index as i32 + 1,
+                        row_index as i32 + 2,
+                        row_index as i32 + 3,
+                    ])),
+                ),
+                RecordField::new(
+                    "other",
+                    Value::Array(ArrayValue::from_i32_vec(
+                        (0..512)
+                            .map(|offset| row_index as i32 + offset)
+                            .collect::<Vec<_>>(),
+                    )),
+                ),
+                RecordField::new("flag", Value::Scalar(ScalarValue::Bool(row_index % 2 == 0))),
+            ]))
+            .expect("add row");
+    }
+
+    table
+        .save(TableOptions::new(&path).with_data_manager(DataManagerKind::StandardStMan))
+        .expect("save benchmark table");
+    (tempdir, path)
+}
+
+fn int32_from_value(value: &Value) -> i32 {
+    match value {
+        Value::Scalar(ScalarValue::Int32(v)) => *v,
+        other => panic!("expected int32 scalar, got {other:?}"),
+    }
+}
+
+fn float64_from_value(value: &Value) -> f64 {
+    match value {
+        Value::Scalar(ScalarValue::Float64(v)) => *v,
+        other => panic!("expected float64 scalar, got {other:?}"),
+    }
+}
+
+fn first_i32_from_value(value: &Value) -> i32 {
+    match value {
+        Value::Array(ArrayValue::Int32(values)) => values[[0]],
+        other => panic!("expected int32 array, got {other:?}"),
+    }
+}
+
+fn bench_row_reads(c: &mut Criterion) {
+    let (_tempdir, path) = persisted_row_table(4096);
+    let mut group = c.benchmark_group("row_buffer_read");
+
+    group.bench_function("materialized_rows_4k", |b| {
+        b.iter_batched(
+            || Table::open(TableOptions::new(&path)).expect("open table"),
+            |table| {
+                let rows = table.row_accessor();
+                let mut acc = 0.0f64;
+                for row_index in 0..rows.row_count() {
+                    let row = rows.row(row_index).expect("row");
+                    let id = int32_from_value(row.get("id").expect("id"));
+                    let weight = float64_from_value(row.get("weight").expect("weight"));
+                    let first = first_i32_from_value(row.get("data").expect("data"));
+                    acc += f64::from(id + first) + weight;
+                }
+                black_box(acc)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("prepared_rows_4k", |b| {
+        b.iter_batched(
+            || Table::open(TableOptions::new(&path)).expect("open table"),
+            |table| {
+                let mut prepared = table
+                    .row_accessor()
+                    .prepare(&["id", "weight", "data"])
+                    .expect("prepare rows");
+                let id_index = prepared.column_index("id").expect("id index");
+                let weight_index = prepared.column_index("weight").expect("weight index");
+                let data_index = prepared.column_index("data").expect("data index");
+                let mut acc = 0.0f64;
+                for row_index in 0..prepared.row_count() {
+                    prepared.load(row_index).expect("load row");
+                    let id = match prepared.scalar_at(id_index).expect("id slot") {
+                        ScalarValue::Int32(value) => *value,
+                        other => panic!("expected int32 scalar, got {other:?}"),
+                    };
+                    let weight = match prepared.scalar_at(weight_index).expect("weight slot") {
+                        ScalarValue::Float64(value) => *value,
+                        other => panic!("expected float64 scalar, got {other:?}"),
+                    };
+                    let first = match prepared.array_at(data_index).expect("data slot") {
+                        ArrayValue::Int32(values) => values[[0]],
+                        other => panic!("expected int32 array, got {other:?}"),
+                    };
+                    acc += f64::from(id + first) + weight;
+                }
+                black_box(acc)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+fn bench_row_writes(c: &mut Criterion) {
+    let (_tempdir, path) = persisted_row_table(4096);
+    let mut group = c.benchmark_group("row_buffer_write");
+
+    group.bench_function("materialized_rows_4k", |b| {
+        b.iter_batched(
+            || Table::open(TableOptions::new(&path)).expect("open table"),
+            |mut table| {
+                let mut rows = table.row_accessor_mut();
+                for row_index in 0..rows.row_count() {
+                    let row = rows.row_mut(row_index).expect("row_mut");
+                    if let Value::Scalar(ScalarValue::Float64(v)) =
+                        row.get_mut("weight").expect("weight")
+                    {
+                        *v += 1.0;
+                    }
+                    if let Value::Scalar(ScalarValue::Bool(v)) = row.get_mut("flag").expect("flag")
+                    {
+                        *v = !*v;
+                    }
+                    if let Value::Array(ArrayValue::Int32(values)) =
+                        row.get_mut("data").expect("data")
+                    {
+                        values[[0]] += 1;
+                    }
+                }
+                black_box(rows.row_count())
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("prepared_rows_4k", |b| {
+        b.iter_batched(
+            || Table::open(TableOptions::new(&path)).expect("open table"),
+            |mut table| {
+                let mut prepared = table
+                    .row_accessor_mut()
+                    .prepare(&["weight", "flag", "data"])
+                    .expect("prepare mutable rows");
+                let weight_index = prepared.column_index("weight").expect("weight index");
+                let flag_index = prepared.column_index("flag").expect("flag index");
+                let data_index = prepared.column_index("data").expect("data index");
+                for row_index in 0..prepared.row_count() {
+                    prepared.seek(row_index).expect("seek row");
+                    prepared
+                        .set_value_at(
+                            weight_index,
+                            Value::Scalar(ScalarValue::Float64(row_index as f64 * 0.25 + 1.0)),
+                        )
+                        .expect("set weight");
+                    prepared
+                        .set_value_at(
+                            flag_index,
+                            Value::Scalar(ScalarValue::Bool(row_index % 2 != 0)),
+                        )
+                        .expect("set flag");
+                    prepared
+                        .set_value_at(
+                            data_index,
+                            Value::Array(ArrayValue::from_i32_vec(vec![
+                                row_index as i32 + 1,
+                                row_index as i32 + 1,
+                                row_index as i32 + 2,
+                                row_index as i32 + 3,
+                            ])),
+                        )
+                        .expect("set data");
+                }
+                black_box(prepared.row_count())
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_row_reads, bench_row_writes);
+criterion_main!(benches);

--- a/crates/casa-tables/src/storage/mod.rs
+++ b/crates/casa-tables/src/storage/mod.rs
@@ -51,6 +51,19 @@ pub(crate) const TABLE_CONTROL_FILE: &str = "table.dat";
 pub(crate) const TABLE_DATA_FILE_PREFIX: &str = "table.f";
 pub(crate) const TABLE_INFO_FILE: &str = "table.info";
 
+fn reorder_row_to_requested_columns(row: &RecordValue, columns: &[&str]) -> RecordValue {
+    RecordValue::new(
+        columns
+            .iter()
+            .filter_map(|column| {
+                row.get(column)
+                    .cloned()
+                    .map(|value| RecordField::new(*column, value))
+            })
+            .collect(),
+    )
+}
+
 fn storage_profile_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| match std::env::var("CASA_RS_STORAGE_PROFILE") {
@@ -859,11 +872,57 @@ impl CompositeStorage {
 
         match read_table_dat_dispatch(&control_path)? {
             TableDatResult::Plain(table_dat) => {
-                self.load_plain_table(table_path, &table_dat, row_hint)
+                self.load_plain_table_filtered(table_path, &table_dat, row_hint, None)
             }
             TableDatResult::Ref(ref_dat) => self.load_ref_table(table_path, &ref_dat),
             TableDatResult::Concat(concat_dat) => self.load_concat_table(table_path, &concat_dat),
         }
+    }
+
+    pub(crate) fn load_selected_columns_with_row_hint(
+        &self,
+        table_path: &Path,
+        columns: &[&str],
+        row_hint: Option<u64>,
+    ) -> Result<StorageSnapshot, StorageError> {
+        if !table_path.exists() {
+            return Err(StorageError::MissingPath(table_path.to_path_buf()));
+        }
+
+        let control_path = table_path.join(TABLE_CONTROL_FILE);
+        if !control_path.is_file() {
+            return Err(StorageError::MissingControlFile(control_path));
+        }
+
+        let requested_columns: HashSet<&str> = columns.iter().copied().collect();
+        let mut snapshot = match read_table_dat_dispatch(&control_path)? {
+            TableDatResult::Plain(table_dat) => self.load_plain_table_filtered(
+                table_path,
+                &table_dat,
+                row_hint,
+                Some(&requested_columns),
+            ),
+            TableDatResult::Ref(_) | TableDatResult::Concat(_) => {
+                let mut snapshot = self.load_with_row_hint(table_path, row_hint)?;
+                for row in &mut snapshot.rows {
+                    *row = RecordValue::new(
+                        row.fields()
+                            .iter()
+                            .filter(|field| requested_columns.contains(field.name.as_str()))
+                            .cloned()
+                            .collect(),
+                    );
+                }
+                for undefined in &mut snapshot.undefined_cells {
+                    undefined.retain(|column| requested_columns.contains(column.as_str()));
+                }
+                Ok(snapshot)
+            }
+        }?;
+        for row in &mut snapshot.rows {
+            *row = reorder_row_to_requested_columns(row, columns);
+        }
+        Ok(snapshot)
     }
 
     pub(crate) fn save_metadata_only(
@@ -1043,18 +1102,46 @@ impl CompositeStorage {
     /// - Pass 1: Load stored columns from storage managers (StManAipsIO, StandardStMan).
     /// - Pass 2: Materialize virtual columns from virtual engines.
     /// - Pass 3: Reject any remaining unknown DM types.
-    fn load_plain_table(
+    fn load_plain_table_filtered(
         &self,
         table_path: &Path,
         table_dat: &TableDatContents,
         row_hint: Option<u64>,
+        requested_columns: Option<&HashSet<&str>>,
     ) -> Result<StorageSnapshot, StorageError> {
+        if let Some(requested_columns) = requested_columns
+            && table_dat
+                .column_set
+                .data_managers
+                .iter()
+                .any(|dm| is_virtual_engine(&dm.type_name))
+        {
+            let mut snapshot =
+                self.load_plain_table_filtered(table_path, table_dat, row_hint, None)?;
+            for row in &mut snapshot.rows {
+                *row = RecordValue::new(
+                    row.fields()
+                        .iter()
+                        .filter(|field| requested_columns.contains(field.name.as_str()))
+                        .cloned()
+                        .collect(),
+                );
+            }
+            for undefined in &mut snapshot.undefined_cells {
+                undefined.retain(|column| requested_columns.contains(column.as_str()));
+            }
+            return Ok(snapshot);
+        }
+
         let schema = table_dat.to_table_schema()?;
         let keywords = table_dat.table_desc.table_keywords.clone();
         let column_keywords: HashMap<String, RecordValue> = table_dat
             .table_desc
             .columns
             .iter()
+            .filter(|c| {
+                requested_columns.is_none_or(|requested| requested.contains(c.col_name.as_str()))
+            })
             .filter(|c| !c.keywords.fields().is_empty())
             .map(|c| (c.col_name.clone(), c.keywords.clone()))
             .collect();
@@ -1081,13 +1168,25 @@ impl CompositeStorage {
 
             let data_path = table_path.join(format!("{}{}", TABLE_DATA_FILE_PREFIX, dm.seq_nr));
 
-            let bound_cols: Vec<(usize, &_)> = table_dat
+            let all_bound_cols: Vec<(usize, &_)> = table_dat
                 .column_set
                 .columns
                 .iter()
                 .enumerate()
                 .filter(|(_, pc)| pc.dm_seq_nr == dm.seq_nr)
                 .collect();
+            let bound_cols: Vec<(usize, &_)> = all_bound_cols
+                .iter()
+                .copied()
+                .filter(|(_, pc)| {
+                    requested_columns
+                        .is_none_or(|requested| requested.contains(pc.original_name.as_str()))
+                })
+                .collect();
+
+            if bound_cols.is_empty() {
+                continue;
+            }
 
             match dm.type_name.as_str() {
                 "StManAipsIO" => {
@@ -1097,7 +1196,7 @@ impl CompositeStorage {
                     load_stman_aipsio_columns(
                         &data_path,
                         &table_dat.table_desc.columns,
-                        &bound_cols,
+                        &all_bound_cols,
                         &mut rows,
                         &mut undefined_cells,
                         nrrow,
@@ -1207,7 +1306,15 @@ impl CompositeStorage {
                     .iter()
                     .enumerate()
                     .filter(|(_, pc)| pc.dm_seq_nr == dm.seq_nr)
+                    .filter(|(_, pc)| {
+                        requested_columns
+                            .is_none_or(|requested| requested.contains(pc.original_name.as_str()))
+                    })
                     .collect();
+
+                if bound_cols.is_empty() {
+                    continue;
+                }
 
                 for &(desc_idx, _) in &bound_cols {
                     virtual_columns.insert(table_dat.table_desc.columns[desc_idx].col_name.clone());
@@ -1228,6 +1335,21 @@ impl CompositeStorage {
 
         // Build DM info from table.dat entries.
         let dm_info = extract_dm_info(table_dat);
+
+        if let Some(requested_columns) = requested_columns {
+            for row in &mut rows {
+                *row = RecordValue::new(
+                    row.fields()
+                        .iter()
+                        .filter(|field| requested_columns.contains(field.name.as_str()))
+                        .cloned()
+                        .collect(),
+                );
+            }
+            for undefined in &mut undefined_cells {
+                undefined.retain(|column| requested_columns.contains(column.as_str()));
+            }
+        }
 
         Ok(StorageSnapshot {
             row_count: rows.len(),
@@ -1265,7 +1387,7 @@ impl CompositeStorage {
             .iter()
             .any(|dm| is_virtual_engine(&dm.type_name))
         {
-            let snapshot = self.load_plain_table(table_path, table_dat, row_hint)?;
+            let snapshot = self.load_plain_table_filtered(table_path, table_dat, row_hint, None)?;
             return scalar_column_from_snapshot(&snapshot, column);
         }
 
@@ -1366,7 +1488,7 @@ impl CompositeStorage {
             .iter()
             .any(|dm| is_virtual_engine(&dm.type_name))
         {
-            let snapshot = self.load_plain_table(table_path, table_dat, row_hint)?;
+            let snapshot = self.load_plain_table_filtered(table_path, table_dat, row_hint, None)?;
             return Ok(scalar_columns_from_snapshot(&snapshot));
         }
 
@@ -1442,7 +1564,8 @@ impl CompositeStorage {
                         .iter()
                         .any(|(desc_idx, _)| !table_dat.table_desc.columns[*desc_idx].is_array)
                     {
-                        let snapshot = self.load_plain_table(table_path, table_dat, row_hint)?;
+                        let snapshot =
+                            self.load_plain_table_filtered(table_path, table_dat, row_hint, None)?;
                         return Ok(scalar_columns_from_snapshot(&snapshot));
                     }
                 }
@@ -1486,7 +1609,7 @@ impl CompositeStorage {
             .iter()
             .any(|dm| is_virtual_engine(&dm.type_name))
         {
-            let snapshot = self.load_plain_table(table_path, table_dat, row_hint)?;
+            let snapshot = self.load_plain_table_filtered(table_path, table_dat, row_hint, None)?;
             return array_column_from_snapshot(&snapshot, column);
         }
 
@@ -1630,7 +1753,7 @@ impl CompositeStorage {
             .iter()
             .any(|dm| is_virtual_engine(&dm.type_name))
         {
-            let snapshot = self.load_plain_table(table_path, table_dat, row_hint)?;
+            let snapshot = self.load_plain_table_filtered(table_path, table_dat, row_hint, None)?;
             let values = array_column_from_snapshot(&snapshot, column)?;
             return Ok(select_array_rows(&values, selected_rows));
         }

--- a/crates/casa-tables/src/table/columns.rs
+++ b/crates/casa-tables/src/table/columns.rs
@@ -3,6 +3,139 @@ use std::collections::HashSet;
 
 use super::*;
 
+fn compile_prepared_row_slots(
+    table: &Table,
+    columns: &[&str],
+) -> Result<
+    (
+        Vec<PreparedRowSlot>,
+        std::collections::HashMap<String, usize>,
+    ),
+    TableError,
+> {
+    let schema = table
+        .schema()
+        .ok_or(TableError::PreparedRowRequiresSchema)?;
+    let mut slots = Vec::with_capacity(columns.len());
+    let mut column_indices = std::collections::HashMap::with_capacity(columns.len());
+
+    for &column in columns {
+        table.require_column(column)?;
+        let schema_column = schema
+            .columns()
+            .iter()
+            .find(|candidate| candidate.name() == column)
+            .ok_or_else(|| TableError::SchemaColumnUnknown {
+                column: column.to_string(),
+            })?;
+        let kind = match schema_column.column_type() {
+            ColumnType::Scalar => PreparedRowSlotKind::Scalar,
+            ColumnType::Array(_) => PreparedRowSlotKind::Array,
+            ColumnType::Record => {
+                return Err(TableError::PreparedRowRecordColumnUnsupported {
+                    column: column.to_string(),
+                });
+            }
+        };
+        let slot_index = slots.len();
+        slots.push(PreparedRowSlot {
+            column: column.to_string(),
+            kind,
+        });
+        column_indices
+            .entry(column.to_string())
+            .or_insert(slot_index);
+    }
+
+    Ok((slots, column_indices))
+}
+
+fn placeholder_value(kind: PreparedRowSlotKind) -> Value {
+    match kind {
+        PreparedRowSlotKind::Scalar => Value::Scalar(ScalarValue::Bool(false)),
+        PreparedRowSlotKind::Array => Value::Array(ArrayValue::from_bool_vec(Vec::new())),
+    }
+}
+
+fn prepared_row_record(slots: &[PreparedRowSlot]) -> RecordValue {
+    RecordValue::new(
+        slots
+            .iter()
+            .map(|slot| RecordField::new(slot.column.clone(), placeholder_value(slot.kind)))
+            .collect(),
+    )
+}
+
+fn load_prepared_row_value(
+    table: &Table,
+    row_index: usize,
+    slot: &PreparedRowSlot,
+) -> Result<Value, TableError> {
+    match slot.kind {
+        PreparedRowSlotKind::Scalar => table
+            .get_scalar_cell(row_index, &slot.column)
+            .map(|value| Value::Scalar(value.clone())),
+        PreparedRowSlotKind::Array => table
+            .get_array_cell(row_index, &slot.column)
+            .map(|value| Value::Array(value.clone())),
+    }
+}
+
+fn fill_prepared_row_buffer(
+    table: &Table,
+    slots: &[PreparedRowSlot],
+    row: &mut RecordValue,
+    row_index: usize,
+) -> Result<(), TableError> {
+    let fields = row.fields_mut();
+    for (slot, field) in slots.iter().zip(fields.iter_mut()) {
+        field.value = load_prepared_row_value(table, row_index, slot)?;
+    }
+    Ok(())
+}
+
+fn current_prepared_row_index(row_index: Option<usize>) -> Result<usize, TableError> {
+    row_index.ok_or(TableError::RowOutOfBounds {
+        row_index: 0,
+        row_count: 0,
+    })
+}
+
+fn flush_prepared_row_buffer(
+    table: &mut Table,
+    slots: &[PreparedRowSlot],
+    row: &RecordValue,
+    row_index: usize,
+) -> Result<(), TableError> {
+    for (slot, field) in slots.iter().zip(row.fields().iter()) {
+        match (slot.kind, &field.value) {
+            (PreparedRowSlotKind::Scalar, Value::Scalar(value)) => {
+                table.set_scalar_cell_assuming_valid(row_index, &slot.column, value.clone())?;
+            }
+            (PreparedRowSlotKind::Array, Value::Array(value)) => {
+                table.set_array_cell_assuming_valid(row_index, &slot.column, value.clone())?;
+            }
+            (PreparedRowSlotKind::Scalar, value) => {
+                return Err(TableError::ColumnTypeMismatch {
+                    row_index,
+                    column: slot.column.clone(),
+                    expected: "scalar",
+                    found: value.kind(),
+                });
+            }
+            (PreparedRowSlotKind::Array, value) => {
+                return Err(TableError::ColumnTypeMismatch {
+                    row_index,
+                    column: slot.column.clone(),
+                    expected: "array",
+                    found: value.kind(),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
 impl Table {
     /// Returns the attached schema, if any.
     ///
@@ -899,6 +1032,23 @@ impl<'a> TableRow<'a> {
         self.table.row_count()
     }
 
+    /// Prepares a reusable row buffer for `columns`.
+    ///
+    /// The returned accessor compiles a stable slot order once and reuses a
+    /// single `RecordValue` buffer across repeated row loads.
+    pub fn prepare(self, columns: &[&str]) -> Result<PreparedTableRow<'a>, TableError> {
+        let (slots, column_indices) = compile_prepared_row_slots(self.table, columns)?;
+        Ok(PreparedTableRow {
+            table: self.table,
+            row: prepared_row_record(&slots),
+            slots,
+            column_indices,
+            cached_rows: self.table.inner.prepared_rows(columns)?,
+            row_index: None,
+            row_materialized: false,
+        })
+    }
+
     /// Returns the row at `row_index`.
     pub fn row(&self, row_index: usize) -> Result<&'a RecordValue, TableError> {
         self.table.row(row_index)
@@ -933,6 +1083,23 @@ impl<'a> TableRowMut<'a> {
     /// Returns the number of rows in the underlying table.
     pub fn row_count(&self) -> usize {
         self.table.row_count()
+    }
+
+    /// Prepares a reusable mutable row buffer for `columns`.
+    ///
+    /// Call [`PreparedTableRowMut::flush`] after the final mutation so the
+    /// last loaded row is written back through the table accessor layer.
+    pub fn prepare(self, columns: &[&str]) -> Result<PreparedTableRowMut<'a>, TableError> {
+        let (slots, column_indices) = compile_prepared_row_slots(self.table, columns)?;
+        Ok(PreparedTableRowMut {
+            table: self.table,
+            row: prepared_row_record(&slots),
+            slots,
+            column_indices,
+            row_index: None,
+            row_materialized: false,
+            dirty: false,
+        })
     }
 
     /// Returns the row at `row_index`.
@@ -999,6 +1166,258 @@ impl<'a> TableRowMut<'a> {
     ) -> Result<(), TableError> {
         self.table
             .set_array_cell_assuming_valid(row_index, column, value)
+    }
+}
+
+impl<'a> PreparedTableRow<'a> {
+    /// Returns the number of rows in the underlying table.
+    pub fn row_count(&self) -> usize {
+        self.table.row_count()
+    }
+
+    /// Returns the stable slot index for `column`.
+    pub fn column_index(&self, column: &str) -> Option<usize> {
+        self.column_indices.get(column).copied()
+    }
+
+    /// Returns the currently loaded row index, if any.
+    pub fn current_row_index(&self) -> Option<usize> {
+        self.row_index
+    }
+
+    /// Returns the current reusable row buffer, if one has been loaded.
+    pub fn row(&mut self) -> Option<&RecordValue> {
+        let row_index = self.row_index?;
+        if let Some(rows) = self.cached_rows.as_ref() {
+            if !self.row_materialized {
+                let cached_row = rows.get(row_index)?;
+                for (target, source) in self
+                    .row
+                    .fields_mut()
+                    .iter_mut()
+                    .zip(cached_row.fields().iter())
+                {
+                    target.value = source.value.clone();
+                }
+                self.row_materialized = true;
+            }
+            return Some(&self.row);
+        }
+        if !self.row_materialized {
+            fill_prepared_row_buffer(self.table, &self.slots, &mut self.row, row_index).ok()?;
+            self.row_materialized = true;
+        }
+        Some(&self.row)
+    }
+
+    /// Selects `row_index` as the current row for indexed access.
+    pub fn load(&mut self, row_index: usize) -> Result<(), TableError> {
+        self.table
+            .require_row_index_without_loading_rows(row_index)?;
+        self.row_index = Some(row_index);
+        self.row_materialized = false;
+        Ok(())
+    }
+
+    /// Returns the scalar value for `slot_index` in the current row without cloning.
+    pub fn scalar_at(&self, slot_index: usize) -> Result<&ScalarValue, TableError> {
+        let row_index = current_prepared_row_index(self.row_index)?;
+        if let Some(rows) = self.cached_rows.as_ref() {
+            let row = rows.get(row_index).ok_or(TableError::RowOutOfBounds {
+                row_index,
+                row_count: rows.len(),
+            })?;
+            return match row.fields().get(slot_index).map(|field| &field.value) {
+                Some(Value::Scalar(value)) => Ok(value),
+                Some(value) => Err(TableError::ColumnTypeMismatch {
+                    row_index,
+                    column: self.slots[slot_index].column.clone(),
+                    expected: "scalar",
+                    found: value.kind(),
+                }),
+                None => Err(TableError::ColumnNotFound {
+                    row_index,
+                    column: self.slots[slot_index].column.clone(),
+                }),
+            };
+        }
+        let slot = self
+            .slots
+            .get(slot_index)
+            .ok_or_else(|| TableError::SchemaColumnUnknown {
+                column: format!("#{slot_index}"),
+            })?;
+        match slot.kind {
+            PreparedRowSlotKind::Scalar => self.table.get_scalar_cell(row_index, &slot.column),
+            PreparedRowSlotKind::Array => Err(TableError::ColumnTypeMismatch {
+                row_index,
+                column: slot.column.clone(),
+                expected: "scalar",
+                found: ValueKind::Array,
+            }),
+        }
+    }
+
+    /// Returns the array value for `slot_index` in the current row without cloning.
+    pub fn array_at(&self, slot_index: usize) -> Result<&ArrayValue, TableError> {
+        let row_index = current_prepared_row_index(self.row_index)?;
+        if let Some(rows) = self.cached_rows.as_ref() {
+            let row = rows.get(row_index).ok_or(TableError::RowOutOfBounds {
+                row_index,
+                row_count: rows.len(),
+            })?;
+            return match row.fields().get(slot_index).map(|field| &field.value) {
+                Some(Value::Array(value)) => Ok(value),
+                Some(value) => Err(TableError::ColumnTypeMismatch {
+                    row_index,
+                    column: self.slots[slot_index].column.clone(),
+                    expected: "array",
+                    found: value.kind(),
+                }),
+                None => Err(TableError::ColumnNotFound {
+                    row_index,
+                    column: self.slots[slot_index].column.clone(),
+                }),
+            };
+        }
+        let slot = self
+            .slots
+            .get(slot_index)
+            .ok_or_else(|| TableError::SchemaColumnUnknown {
+                column: format!("#{slot_index}"),
+            })?;
+        match slot.kind {
+            PreparedRowSlotKind::Array => self.table.get_array_cell(row_index, &slot.column),
+            PreparedRowSlotKind::Scalar => Err(TableError::ColumnTypeMismatch {
+                row_index,
+                column: slot.column.clone(),
+                expected: "array",
+                found: ValueKind::Scalar,
+            }),
+        }
+    }
+}
+
+impl<'a> PreparedTableRowMut<'a> {
+    /// Returns the number of rows in the underlying table.
+    pub fn row_count(&self) -> usize {
+        self.table.row_count()
+    }
+
+    /// Returns the stable slot index for `column`.
+    pub fn column_index(&self, column: &str) -> Option<usize> {
+        self.column_indices.get(column).copied()
+    }
+
+    /// Returns the currently loaded row index, if any.
+    pub fn current_row_index(&self) -> Option<usize> {
+        self.row_index
+    }
+
+    /// Returns the current reusable row buffer, if one has been loaded.
+    pub fn row(&self) -> Option<&RecordValue> {
+        self.row_materialized.then_some(&self.row)
+    }
+
+    /// Returns the current reusable row buffer for mutation, if one has been loaded.
+    pub fn row_mut(&mut self) -> Option<&mut RecordValue> {
+        if self.row_materialized {
+            self.dirty = true;
+            Some(&mut self.row)
+        } else {
+            None
+        }
+    }
+
+    /// Loads `row_index` into the reusable row buffer.
+    ///
+    /// If the current row buffer is dirty and `row_index` differs from the
+    /// loaded row, the current row is flushed first.
+    pub fn load(&mut self, row_index: usize) -> Result<&RecordValue, TableError> {
+        self.table
+            .require_row_index_without_loading_rows(row_index)?;
+        if self.row_index != Some(row_index) || !self.row_materialized {
+            self.flush()?;
+            fill_prepared_row_buffer(self.table, &self.slots, &mut self.row, row_index)?;
+            self.row_index = Some(row_index);
+            self.row_materialized = true;
+        }
+        Ok(&self.row)
+    }
+
+    /// Selects `row_index` as the current row for direct indexed writes.
+    ///
+    /// This avoids loading the reusable row buffer unless [`row_mut`](Self::row_mut)
+    /// is used afterwards.
+    pub fn seek(&mut self, row_index: usize) -> Result<(), TableError> {
+        self.table
+            .require_row_index_without_loading_rows(row_index)?;
+        if self.row_index != Some(row_index) && self.dirty {
+            self.flush()?;
+        }
+        if self.row_index != Some(row_index) {
+            self.row_materialized = false;
+        }
+        self.row_index = Some(row_index);
+        Ok(())
+    }
+
+    /// Flushes the current row buffer through the table accessor layer.
+    pub fn flush(&mut self) -> Result<(), TableError> {
+        let Some(row_index) = self.row_index else {
+            self.dirty = false;
+            return Ok(());
+        };
+        if self.dirty {
+            flush_prepared_row_buffer(self.table, &self.slots, &self.row, row_index)?;
+            self.dirty = false;
+        }
+        Ok(())
+    }
+
+    /// Writes `value` to `slot_index` in the currently selected row.
+    ///
+    /// This is the fast path for callers that already computed replacement
+    /// values and do not need a materialized row buffer.
+    pub fn set_value_at(&mut self, slot_index: usize, value: Value) -> Result<(), TableError> {
+        let row_index = current_prepared_row_index(self.row_index)?;
+        if self.dirty && self.row_materialized {
+            if let Some(field) = self.row.fields_mut().get_mut(slot_index) {
+                field.value = value;
+                return Ok(());
+            }
+        }
+        let slot = self
+            .slots
+            .get(slot_index)
+            .ok_or_else(|| TableError::SchemaColumnUnknown {
+                column: format!("#{slot_index}"),
+            })?;
+        if self.row_materialized
+            && let Some(field) = self.row.fields_mut().get_mut(slot_index)
+        {
+            field.value = value.clone();
+        }
+        match (slot.kind, value) {
+            (PreparedRowSlotKind::Scalar, Value::Scalar(value)) => self
+                .table
+                .set_scalar_cell_assuming_valid(row_index, &slot.column, value),
+            (PreparedRowSlotKind::Array, Value::Array(value)) => self
+                .table
+                .set_array_cell_assuming_valid(row_index, &slot.column, value),
+            (PreparedRowSlotKind::Scalar, value) => Err(TableError::ColumnTypeMismatch {
+                row_index,
+                column: slot.column.clone(),
+                expected: "scalar",
+                found: value.kind(),
+            }),
+            (PreparedRowSlotKind::Array, value) => Err(TableError::ColumnTypeMismatch {
+                row_index,
+                column: slot.column.clone(),
+                expected: "array",
+                found: value.kind(),
+            }),
+        }
     }
 }
 

--- a/crates/casa-tables/src/table/io.rs
+++ b/crates/casa-tables/src/table/io.rs
@@ -904,16 +904,6 @@ fn collect_sparse_column_values_from_current_cells<'a>(
         let Some(col_desc) = col_descs.iter().find(|desc| desc.col_name == column) else {
             continue;
         };
-        if !col_desc.is_array
-            && let Some(pending_values) = table.inner.pending_scalar_cell_values(column)
-        {
-            let values = pending_values
-                .into_iter()
-                .map(|(row_index, value)| (row_index, Some(Value::Scalar(value))))
-                .collect();
-            patches.insert(column, values);
-            continue;
-        }
         let mut values = Vec::with_capacity(row_indices.len());
         for &row_index in row_indices {
             values.push((

--- a/crates/casa-tables/src/table/mod.rs
+++ b/crates/casa-tables/src/table/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use casa_types::{ArrayValue, Complex64, RecordField, RecordValue, ScalarValue, Value, ValueKind};
@@ -616,6 +616,51 @@ pub struct TableRowMut<'a> {
     pub(crate) table: &'a mut Table,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PreparedRowSlotKind {
+    Scalar,
+    Array,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PreparedRowSlot {
+    pub(crate) column: String,
+    pub(crate) kind: PreparedRowSlotKind,
+}
+
+/// Read-only reusable row buffer for selected scalar/array columns.
+///
+/// Prepared row access compiles a stable slot order once, then reloads this
+/// same record-shaped buffer for each row. Callers can cache slot indices with
+/// [`PreparedTableRow::column_index`] and read the same offset repeatedly
+/// without per-row record allocation.
+#[derive(Debug, Clone)]
+pub struct PreparedTableRow<'a> {
+    pub(crate) table: &'a Table,
+    pub(crate) slots: Vec<PreparedRowSlot>,
+    pub(crate) column_indices: HashMap<String, usize>,
+    pub(crate) cached_rows: Option<Vec<RecordValue>>,
+    pub(crate) row_index: Option<usize>,
+    pub(crate) row: RecordValue,
+    pub(crate) row_materialized: bool,
+}
+
+/// Mutable reusable row buffer for selected scalar/array columns.
+///
+/// The buffer is reused across rows and flushes back through the table
+/// accessor layer, preserving lazy sparse writes rather than exposing
+/// storage-manager internals directly.
+#[derive(Debug)]
+pub struct PreparedTableRowMut<'a> {
+    pub(crate) table: &'a mut Table,
+    pub(crate) slots: Vec<PreparedRowSlot>,
+    pub(crate) column_indices: HashMap<String, usize>,
+    pub(crate) row_index: Option<usize>,
+    pub(crate) row: RecordValue,
+    pub(crate) row_materialized: bool,
+    pub(crate) dirty: bool,
+}
+
 /// Read-only column accessor for a [`Table`].
 ///
 /// This follows the same public-accessor direction as casacore's
@@ -758,6 +803,12 @@ pub enum TableError {
     /// A record-specific operation was attempted on a non-record schema column.
     #[error("column \"{column}\" is not a record column in schema")]
     SchemaColumnNotRecord { column: String },
+    /// Prepared row access currently requires an attached schema.
+    #[error("prepared row access requires an attached schema")]
+    PreparedRowRequiresSchema,
+    /// Prepared row access currently supports only scalar and array schema columns.
+    #[error("prepared row access does not yet support record column \"{column}\"")]
+    PreparedRowRecordColumnUnsupported { column: String },
     /// A required column (non-optional per schema) was absent from a row.
     #[error("schema column \"{column}\" is missing in row {row_index}")]
     SchemaColumnMissing { row_index: usize, column: String },

--- a/crates/casa-tables/src/table/tests.rs
+++ b/crates/casa-tables/src/table/tests.rs
@@ -13,6 +13,20 @@ use super::{
     TableOptions,
 };
 
+fn row_with_fixed_arrays(id: i32, data: &[i32], other: &[i32]) -> RecordValue {
+    RecordValue::new(vec![
+        RecordField::new("id", Value::Scalar(ScalarValue::Int32(id))),
+        RecordField::new(
+            "data",
+            Value::Array(ArrayValue::from_i32_vec(data.to_vec())),
+        ),
+        RecordField::new(
+            "other",
+            Value::Array(ArrayValue::from_i32_vec(other.to_vec())),
+        ),
+    ])
+}
+
 #[test]
 fn table_keeps_rows_in_order() {
     let first = RecordValue::new(vec![RecordField::new(
@@ -1300,6 +1314,395 @@ fn lazy_disk_open_reads_cells_without_materializing_rows() {
 
         std::fs::remove_dir_all(&root).expect("cleanup test dir");
     }
+}
+
+#[test]
+fn prepared_row_reader_reuses_buffer_without_materializing_rows() {
+    let schema = TableSchema::new(vec![
+        ColumnSchema::scalar("id", PrimitiveType::Int32),
+        ColumnSchema::array_fixed("data", PrimitiveType::Int32, vec![2]),
+        ColumnSchema::array_fixed("other", PrimitiveType::Int32, vec![2]),
+    ])
+    .expect("schema");
+
+    for dm in [
+        DataManagerKind::StManAipsIO,
+        DataManagerKind::StandardStMan,
+        DataManagerKind::IncrementalStMan,
+    ] {
+        let mut table = Table::with_schema(schema.clone());
+        table
+            .add_row(row_with_fixed_arrays(1, &[7, 9], &[100, 200]))
+            .expect("push row 0");
+        table
+            .add_row(row_with_fixed_arrays(2, &[11, 13], &[300, 400]))
+            .expect("push row 1");
+
+        let root = unique_test_dir(&format!("prepared_row_reader_{dm:?}"));
+        std::fs::create_dir_all(&root).expect("create test dir");
+        table
+            .save(TableOptions::new(&root).with_data_manager(dm))
+            .expect("save disk-backed table");
+
+        let reopened = Table::open(TableOptions::new(&root)).expect("open lazy table");
+        let mut prepared = reopened
+            .row_accessor()
+            .prepare(&["id", "data"])
+            .expect("prepare row reader");
+        let id_index = prepared.column_index("id").expect("id index");
+        let data_index = prepared.column_index("data").expect("data index");
+
+        prepared.load(0).expect("load first row");
+        assert_eq!(
+            prepared.scalar_at(id_index).expect("id slot"),
+            &ScalarValue::Int32(1)
+        );
+        assert_eq!(
+            prepared.array_at(data_index).expect("data slot"),
+            &ArrayValue::from_i32_vec(vec![7, 9])
+        );
+        let first_buffer_ptr = prepared
+            .row()
+            .expect("materialized first row")
+            .fields()
+            .as_ptr();
+        assert!(!reopened.inner.has_loaded_rows());
+        assert!(!reopened.inner.has_loaded_scalar_column("id"));
+        assert!(!reopened.inner.has_loaded_array_column("data"));
+        assert!(!reopened.inner.has_loaded_array_column("other"));
+
+        prepared.load(1).expect("load second row");
+        assert_eq!(
+            prepared.scalar_at(id_index).expect("id slot"),
+            &ScalarValue::Int32(2)
+        );
+        assert_eq!(
+            prepared.array_at(data_index).expect("data slot"),
+            &ArrayValue::from_i32_vec(vec![11, 13])
+        );
+        assert_eq!(
+            prepared
+                .row()
+                .expect("materialized second row")
+                .fields()
+                .as_ptr(),
+            first_buffer_ptr
+        );
+        assert!(!reopened.inner.has_loaded_rows());
+        assert!(!reopened.inner.has_loaded_scalar_column("id"));
+        assert!(!reopened.inner.has_loaded_array_column("data"));
+        assert!(!reopened.inner.has_loaded_array_column("other"));
+
+        std::fs::remove_dir_all(&root).expect("cleanup test dir");
+    }
+}
+
+#[test]
+fn prepared_row_writer_reuses_buffer_and_keeps_sparse_updates() {
+    let schema = TableSchema::new(vec![
+        ColumnSchema::scalar("id", PrimitiveType::Int32),
+        ColumnSchema::array_fixed("data", PrimitiveType::Int32, vec![2]),
+        ColumnSchema::array_fixed("other", PrimitiveType::Int32, vec![2]),
+    ])
+    .expect("schema");
+
+    for dm in [
+        DataManagerKind::StManAipsIO,
+        DataManagerKind::StandardStMan,
+        DataManagerKind::IncrementalStMan,
+    ] {
+        let mut table = Table::with_schema(schema.clone());
+        table
+            .add_row(row_with_fixed_arrays(1, &[7, 9], &[100, 200]))
+            .expect("push row 0");
+        table
+            .add_row(row_with_fixed_arrays(2, &[11, 13], &[300, 400]))
+            .expect("push row 1");
+
+        let root = unique_test_dir(&format!("prepared_row_writer_{dm:?}"));
+        std::fs::create_dir_all(&root).expect("create test dir");
+        table
+            .save(TableOptions::new(&root).with_data_manager(dm))
+            .expect("save disk-backed table");
+
+        let mut reopened = Table::open(TableOptions::new(&root)).expect("open lazy table");
+        let mut prepared = reopened
+            .row_accessor_mut()
+            .prepare(&["id", "data"])
+            .expect("prepare row writer");
+        let id_index = prepared.column_index("id").expect("id index");
+        let data_index = prepared.column_index("data").expect("data index");
+
+        prepared.load(0).expect("load first row");
+        let first_buffer_ptr = prepared.row().expect("row loaded").fields().as_ptr();
+        {
+            let row = prepared.row_mut().expect("mutable row");
+            row.fields_mut()[id_index].value = Value::Scalar(ScalarValue::Int32(10));
+            row.fields_mut()[data_index].value =
+                Value::Array(ArrayValue::from_i32_vec(vec![70, 90]));
+        }
+
+        prepared.load(1).expect("load second row");
+        assert_eq!(
+            prepared.row().expect("row loaded").fields().as_ptr(),
+            first_buffer_ptr
+        );
+        {
+            let row = prepared.row_mut().expect("mutable row");
+            row.fields_mut()[id_index].value = Value::Scalar(ScalarValue::Int32(20));
+            row.fields_mut()[data_index].value =
+                Value::Array(ArrayValue::from_i32_vec(vec![110, 130]));
+        }
+        prepared.flush().expect("flush prepared rows");
+
+        assert!(
+            !reopened.inner.has_loaded_rows(),
+            "prepared row writes should keep lazy row state for {dm:?}"
+        );
+        assert!(
+            reopened.inner.has_loaded_array_column("data")
+                || reopened.inner.has_pending_array_cells("data"),
+            "prepared row writes should keep updates isolated to the prepared data column for {dm:?}"
+        );
+        assert!(
+            !reopened.inner.has_loaded_array_column("other"),
+            "prepared row writes should not touch unrelated array columns for {dm:?}"
+        );
+        assert_eq!(
+            reopened
+                .get_scalar_cell(0, "id")
+                .expect("buffered scalar row 0"),
+            &ScalarValue::Int32(10)
+        );
+        assert_eq!(
+            reopened
+                .get_scalar_cell(1, "id")
+                .expect("buffered scalar row 1"),
+            &ScalarValue::Int32(20)
+        );
+
+        reopened
+            .save_selected_rows_in_place_assuming_valid(&["id", "data"], &[0, 1])
+            .expect("save prepared row updates");
+
+        let verify = Table::open(TableOptions::new(&root)).expect("reopen after prepared writes");
+        assert_eq!(
+            verify.get_scalar_cell(0, "id").expect("id row 0"),
+            &ScalarValue::Int32(10)
+        );
+        assert_eq!(
+            verify.get_scalar_cell(1, "id").expect("id row 1"),
+            &ScalarValue::Int32(20)
+        );
+        assert_eq!(
+            verify.get_array_cell(0, "data").expect("data row 0"),
+            &ArrayValue::from_i32_vec(vec![70, 90])
+        );
+        assert_eq!(
+            verify.get_array_cell(1, "data").expect("data row 1"),
+            &ArrayValue::from_i32_vec(vec![110, 130])
+        );
+        assert_eq!(
+            verify.get_array_cell(0, "other").expect("other row 0"),
+            &ArrayValue::from_i32_vec(vec![100, 200])
+        );
+        assert_eq!(
+            verify.get_array_cell(1, "other").expect("other row 1"),
+            &ArrayValue::from_i32_vec(vec![300, 400])
+        );
+
+        std::fs::remove_dir_all(&root).expect("cleanup test dir");
+    }
+}
+
+#[test]
+fn prepared_row_writer_seek_keeps_buffer_unmaterialized_and_direct_writes_coherent() {
+    let schema = TableSchema::new(vec![
+        ColumnSchema::scalar("id", PrimitiveType::Int32),
+        ColumnSchema::array_fixed("data", PrimitiveType::Int32, vec![2]),
+        ColumnSchema::array_fixed("other", PrimitiveType::Int32, vec![2]),
+    ])
+    .expect("schema");
+
+    for dm in [
+        DataManagerKind::StManAipsIO,
+        DataManagerKind::StandardStMan,
+        DataManagerKind::IncrementalStMan,
+    ] {
+        let mut table = Table::with_schema(schema.clone());
+        table
+            .add_row(row_with_fixed_arrays(1, &[1, 2], &[100, 200]))
+            .expect("push row 0");
+        table
+            .add_row(row_with_fixed_arrays(2, &[3, 4], &[300, 400]))
+            .expect("push row 1");
+
+        let root = unique_test_dir(&format!("prepared_row_writer_seek_{dm:?}"));
+        std::fs::create_dir_all(&root).expect("create test dir");
+        table
+            .save(TableOptions::new(&root).with_data_manager(dm))
+            .expect("save disk-backed table");
+
+        let mut reopened = Table::open(TableOptions::new(&root)).expect("open lazy table");
+        let mut prepared = reopened
+            .row_accessor_mut()
+            .prepare(&["id", "data"])
+            .expect("prepare row writer");
+        let id_index = prepared.column_index("id").expect("id index");
+        let data_index = prepared.column_index("data").expect("data index");
+
+        prepared.seek(0).expect("seek first row");
+        assert!(
+            prepared.row().is_none(),
+            "seek should not materialize the row buffer for {dm:?}"
+        );
+        assert!(
+            prepared.row_mut().is_none(),
+            "row_mut should stay unavailable until load materializes the buffer for {dm:?}"
+        );
+        prepared
+            .set_value_at(id_index, Value::Scalar(ScalarValue::Int32(10)))
+            .expect("direct scalar write");
+        prepared
+            .set_value_at(
+                data_index,
+                Value::Array(ArrayValue::from_i32_vec(vec![70, 90])),
+            )
+            .expect("direct array write");
+        assert!(
+            prepared.row().is_none(),
+            "direct writes through seek should not invent a row buffer for {dm:?}"
+        );
+
+        prepared.load(1).expect("load second row");
+        prepared
+            .set_value_at(id_index, Value::Scalar(ScalarValue::Int32(20)))
+            .expect("direct write-through keeps loaded buffer coherent");
+        assert_eq!(
+            prepared.row().expect("loaded row").fields()[id_index].value,
+            Value::Scalar(ScalarValue::Int32(20))
+        );
+
+        reopened
+            .save_selected_rows_in_place_assuming_valid(&["id", "data"], &[0, 1])
+            .expect("save prepared row updates");
+
+        let verify = Table::open(TableOptions::new(&root)).expect("reopen after prepared writes");
+        assert_eq!(
+            verify.get_scalar_cell(0, "id").expect("id row 0"),
+            &ScalarValue::Int32(10)
+        );
+        assert_eq!(
+            verify.get_scalar_cell(1, "id").expect("id row 1"),
+            &ScalarValue::Int32(20)
+        );
+        assert_eq!(
+            verify.get_array_cell(0, "data").expect("data row 0"),
+            &ArrayValue::from_i32_vec(vec![70, 90])
+        );
+        assert_eq!(
+            verify.get_array_cell(1, "data").expect("data row 1"),
+            &ArrayValue::from_i32_vec(vec![3, 4])
+        );
+
+        std::fs::remove_dir_all(&root).expect("cleanup test dir");
+    }
+}
+
+#[test]
+fn prepared_row_reader_sees_pending_and_cached_lazy_updates() {
+    let schema = TableSchema::new(vec![
+        ColumnSchema::scalar("id", PrimitiveType::Int32),
+        ColumnSchema::array_fixed("data", PrimitiveType::Int32, vec![2]),
+        ColumnSchema::array_fixed("other", PrimitiveType::Int32, vec![2]),
+    ])
+    .expect("schema");
+
+    for dm in [
+        DataManagerKind::StManAipsIO,
+        DataManagerKind::StandardStMan,
+        DataManagerKind::IncrementalStMan,
+    ] {
+        let mut table = Table::with_schema(schema.clone());
+        table
+            .add_row(row_with_fixed_arrays(1, &[7, 9], &[100, 200]))
+            .expect("push row 0");
+        table
+            .add_row(row_with_fixed_arrays(2, &[11, 13], &[300, 400]))
+            .expect("push row 1");
+
+        let root = unique_test_dir(&format!("prepared_row_reader_pending_{dm:?}"));
+        std::fs::create_dir_all(&root).expect("create test dir");
+        table
+            .save(TableOptions::new(&root).with_data_manager(dm))
+            .expect("save disk-backed table");
+
+        let mut reopened = Table::open(TableOptions::new(&root)).expect("open lazy table");
+        reopened
+            .set_scalar_cell_assuming_valid(0, "id", ScalarValue::Int32(10))
+            .expect("pending scalar update");
+        reopened
+            .set_array_cell_assuming_valid(0, "data", ArrayValue::from_i32_vec(vec![70, 90]))
+            .expect("pending array update");
+
+        reopened
+            .get_scalar_cell(1, "id")
+            .expect("prime scalar cache");
+        reopened
+            .get_array_cell(1, "data")
+            .expect("prime array cache");
+        reopened
+            .set_scalar_cell_assuming_valid(1, "id", ScalarValue::Int32(20))
+            .expect("cached scalar update");
+        reopened
+            .set_array_cell_assuming_valid(1, "data", ArrayValue::from_i32_vec(vec![110, 130]))
+            .expect("cached array update");
+
+        let mut prepared = reopened
+            .row_accessor()
+            .prepare(&["id", "data"])
+            .expect("prepare reader");
+        let id_index = prepared.column_index("id").expect("id index");
+        let data_index = prepared.column_index("data").expect("data index");
+
+        prepared.load(0).expect("load first row");
+        assert_eq!(
+            prepared.scalar_at(id_index).expect("row 0 id"),
+            &ScalarValue::Int32(10)
+        );
+        assert_eq!(
+            prepared.array_at(data_index).expect("row 0 data"),
+            &ArrayValue::from_i32_vec(vec![70, 90])
+        );
+
+        prepared.load(1).expect("load second row");
+        assert_eq!(
+            prepared.scalar_at(id_index).expect("row 1 id"),
+            &ScalarValue::Int32(20)
+        );
+        assert_eq!(
+            prepared.array_at(data_index).expect("row 1 data"),
+            &ArrayValue::from_i32_vec(vec![110, 130])
+        );
+
+        std::fs::remove_dir_all(&root).expect("cleanup test dir");
+    }
+}
+
+#[test]
+fn prepared_row_access_rejects_record_columns() {
+    let schema = TableSchema::new(vec![ColumnSchema::record("meta")]).expect("schema");
+    let table = Table::with_schema(schema);
+
+    let err = table
+        .row_accessor()
+        .prepare(&["meta"])
+        .expect_err("record column should be rejected");
+
+    assert!(matches!(
+        err,
+        TableError::PreparedRowRecordColumnUnsupported { column } if column == "meta"
+    ));
 }
 
 #[test]

--- a/crates/casa-tables/src/table_impl.rs
+++ b/crates/casa-tables/src/table_impl.rs
@@ -22,11 +22,6 @@ struct LoadedRows {
     undefined_cells: Vec<HashSet<String>>,
 }
 
-#[derive(Debug)]
-struct LoadedScalarColumns {
-    columns: HashMap<String, Vec<Option<ScalarValue>>>,
-}
-
 #[derive(Debug, Default)]
 struct PendingScalarCells {
     by_column: HashMap<String, HashMap<usize, ScalarValue>>,
@@ -116,6 +111,17 @@ fn lazy_array_column_store(
         .collect()
 }
 
+fn lazy_scalar_column_store(
+    schema: Option<&TableSchema>,
+) -> HashMap<String, OnceCell<Vec<Option<ScalarValue>>>> {
+    schema
+        .into_iter()
+        .flat_map(|schema| schema.columns())
+        .filter(|column| matches!(column.column_type(), ColumnType::Scalar))
+        .map(|column| (column.name().to_string(), OnceCell::new()))
+        .collect()
+}
+
 fn eager_loaded_rows(
     rows: Vec<RecordValue>,
     mut undefined_cells: Vec<HashSet<String>>,
@@ -129,10 +135,62 @@ fn eager_loaded_rows(
     }
 }
 
+fn apply_prepared_scalar_column(
+    rows: &mut [RecordValue],
+    column: &str,
+    values: &[Option<ScalarValue>],
+) {
+    for (row_index, value) in values.iter().enumerate() {
+        if let Some(value) = value
+            && let Some(row) = rows.get_mut(row_index)
+        {
+            row.upsert(column.to_string(), Value::Scalar(value.clone()));
+        }
+    }
+}
+
+fn apply_prepared_scalar_overrides(
+    rows: &mut [RecordValue],
+    column: &str,
+    values: &HashMap<usize, ScalarValue>,
+) {
+    for (&row_index, value) in values {
+        if let Some(row) = rows.get_mut(row_index) {
+            row.upsert(column.to_string(), Value::Scalar(value.clone()));
+        }
+    }
+}
+
+fn apply_prepared_array_column(
+    rows: &mut [RecordValue],
+    column: &str,
+    values: &[Option<ArrayValue>],
+) {
+    for (row_index, value) in values.iter().enumerate() {
+        if let Some(value) = value
+            && let Some(row) = rows.get_mut(row_index)
+        {
+            row.upsert(column.to_string(), Value::Array(value.clone()));
+        }
+    }
+}
+
+fn apply_prepared_array_overrides(
+    rows: &mut [RecordValue],
+    column: &str,
+    values: &PendingArrayColumn,
+) {
+    for (row_index, value) in &values.rows {
+        if let Some(row) = rows.get_mut(*row_index) {
+            row.upsert(column.to_string(), Value::Array(value.clone()));
+        }
+    }
+}
+
 #[derive(Debug, Default)]
 pub(crate) struct TableImpl {
     loaded_rows: OnceCell<LoadedRows>,
-    loaded_scalar_columns: OnceCell<LoadedScalarColumns>,
+    loaded_scalar_columns: HashMap<String, OnceCell<Vec<Option<ScalarValue>>>>,
     pending_scalar_cells: PendingScalarCells,
     loaded_array_columns: HashMap<String, OnceCell<Vec<Option<ArrayValue>>>>,
     pending_array_cells: PendingArrayCells,
@@ -154,7 +212,7 @@ impl TableImpl {
             .expect("initialize empty row store");
         Self {
             loaded_rows,
-            loaded_scalar_columns: OnceCell::new(),
+            loaded_scalar_columns: HashMap::new(),
             pending_scalar_cells: PendingScalarCells::default(),
             loaded_array_columns: HashMap::new(),
             pending_array_cells: PendingArrayCells::default(),
@@ -174,7 +232,7 @@ impl TableImpl {
             .expect("initialize eager row store");
         Self {
             loaded_rows,
-            loaded_scalar_columns: OnceCell::new(),
+            loaded_scalar_columns: HashMap::new(),
             pending_scalar_cells: PendingScalarCells::default(),
             loaded_array_columns: HashMap::new(),
             pending_array_cells: PendingArrayCells::default(),
@@ -200,7 +258,7 @@ impl TableImpl {
             .expect("initialize eager row store");
         Self {
             loaded_rows,
-            loaded_scalar_columns: OnceCell::new(),
+            loaded_scalar_columns: lazy_scalar_column_store(schema.as_ref()),
             pending_scalar_cells: PendingScalarCells::default(),
             loaded_array_columns: lazy_array_column_store(schema.as_ref()),
             pending_array_cells: PendingArrayCells::default(),
@@ -221,7 +279,7 @@ impl TableImpl {
     ) -> Self {
         Self {
             loaded_rows: OnceCell::new(),
-            loaded_scalar_columns: OnceCell::new(),
+            loaded_scalar_columns: lazy_scalar_column_store(schema.as_ref()),
             pending_scalar_cells: PendingScalarCells::default(),
             loaded_array_columns: lazy_array_column_store(schema.as_ref()),
             pending_array_cells: PendingArrayCells::default(),
@@ -273,17 +331,24 @@ impl TableImpl {
         Ok(loaded)
     }
 
-    fn load_scalar_columns_now(source: &LazyRowsSource) -> Result<LoadedScalarColumns, TableError> {
+    fn load_scalar_column_now(
+        source: &LazyRowsSource,
+        column: &str,
+    ) -> Result<Vec<Option<ScalarValue>>, TableError> {
         let mut profiler = StorageProfiler::start(format!(
-            "table_impl::load_scalar_columns_now path={}",
+            "table_impl::load_scalar_column_now path={} column={column}",
             source.path.display()
         ));
         let storage = CompositeStorage;
-        let snapshot = storage
-            .load_scalar_columns_with_row_hint(&source.path, Some(source.row_count_hint as u64))
+        let values = storage
+            .load_scalar_column_with_row_hint(
+                &source.path,
+                column,
+                Some(source.row_count_hint as u64),
+            )
             .map_err(|err| {
                 TableError::Storage(format!(
-                    "failed to load scalar columns for table {}: {err}",
+                    "failed to load scalar column '{column}' for table {}: {err}",
                     source.path.display()
                 ))
             })?;
@@ -291,15 +356,13 @@ impl TableImpl {
             profiler.mark_with_detail(
                 "storage_load_complete",
                 Some(format!(
-                    "row_count_hint={} columns={}",
+                    "row_count_hint={} values={}",
                     source.row_count_hint,
-                    snapshot.columns.len()
+                    values.len()
                 )),
             );
         }
-        Ok(LoadedScalarColumns {
-            columns: snapshot.columns,
-        })
+        Ok(values)
     }
 
     fn load_array_column_now(
@@ -449,6 +512,55 @@ impl TableImpl {
         Ok(self.ensure_loaded()?.rows.as_slice())
     }
 
+    pub(crate) fn prepared_rows(
+        &self,
+        columns: &[&str],
+    ) -> Result<Option<Vec<RecordValue>>, TableError> {
+        if self.loaded_rows.get().is_some() {
+            return Ok(None);
+        }
+
+        let Some(source) = &self.lazy_rows else {
+            return Ok(None);
+        };
+
+        let storage = CompositeStorage;
+        let mut rows = storage
+            .load_selected_columns_with_row_hint(
+                &source.path,
+                columns,
+                Some(source.row_count_hint as u64),
+            )
+            .map_err(|err| {
+                TableError::Storage(format!(
+                    "failed to load prepared rows for table {}: {err}",
+                    source.path.display()
+                ))
+            })?
+            .rows;
+
+        for &column in columns {
+            if let Some(cached_column) = self.loaded_scalar_columns.get(column)
+                && let Some(values) = cached_column.get()
+            {
+                apply_prepared_scalar_column(&mut rows, column, values);
+            }
+            if let Some(overrides) = self.pending_scalar_cells.by_column.get(column) {
+                apply_prepared_scalar_overrides(&mut rows, column, overrides);
+            }
+            if let Some(cached_column) = self.loaded_array_columns.get(column)
+                && let Some(values) = cached_column.get()
+            {
+                apply_prepared_array_column(&mut rows, column, values);
+            }
+            if let Some(overrides) = self.pending_array_cells.by_column.get(column) {
+                apply_prepared_array_overrides(&mut rows, column, overrides);
+            }
+        }
+
+        Ok(Some(rows))
+    }
+
     pub(crate) fn undefined_cells(&self) -> Result<&[HashSet<String>], TableError> {
         Ok(self.ensure_loaded()?.undefined_cells.as_slice())
     }
@@ -493,17 +605,16 @@ impl TableImpl {
             return Ok(LazyScalarLookup::Hit(value));
         }
 
-        if self.loaded_scalar_columns.get().is_none() {
-            let loaded = Self::load_scalar_columns_now(source)?;
-            let _ = self.loaded_scalar_columns.set(loaded);
-        }
-        let columns = self
-            .loaded_scalar_columns
-            .get()
-            .expect("scalar columns initialized before access");
-        let Some(values) = columns.columns.get(column) else {
+        let Some(cached_column) = self.loaded_scalar_columns.get(column) else {
             return Ok(LazyScalarLookup::Unknown);
         };
+        if cached_column.get().is_none() {
+            let loaded = Self::load_scalar_column_now(source, column)?;
+            let _ = cached_column.set(loaded);
+        }
+        let values = cached_column
+            .get()
+            .expect("scalar column initialized before access");
         match values.get(row_index) {
             Some(Some(value)) => Ok(LazyScalarLookup::Hit(value)),
             Some(None) | None => Ok(LazyScalarLookup::Missing),
@@ -522,15 +633,15 @@ impl TableImpl {
             return Ok(None);
         };
 
-        if self.loaded_scalar_columns.get().is_none() {
-            let loaded = Self::load_scalar_columns_now(source)?;
-            let _ = self.loaded_scalar_columns.set(loaded);
+        let Some(cached_column) = self.loaded_scalar_columns.get(column) else {
+            return Ok(None);
+        };
+        if cached_column.get().is_none() {
+            let loaded = Self::load_scalar_column_now(source, column)?;
+            let _ = cached_column.set(loaded);
         }
 
-        Ok(self
-            .loaded_scalar_columns
-            .get()
-            .and_then(|columns| columns.columns.get(column).map(|values| values.as_slice())))
+        Ok(cached_column.get().map(|values| values.as_slice()))
     }
 
     pub(crate) fn scalar_cells_owned(
@@ -549,8 +660,8 @@ impl TableImpl {
             return Ok(Some(values));
         }
 
-        if let Some(columns) = self.loaded_scalar_columns.get()
-            && let Some(values) = columns.columns.get(column)
+        if let Some(cached_column) = self.loaded_scalar_columns.get(column)
+            && let Some(values) = cached_column.get()
         {
             let mut values = values.clone();
             if let Some(overrides) = self.pending_scalar_cells.by_column.get(column) {
@@ -567,32 +678,11 @@ impl TableImpl {
             return Ok(None);
         };
 
-        let mut profiler = StorageProfiler::start(format!(
-            "table_impl::scalar_cells_owned path={} column={column}",
-            source.path.display()
-        ));
-        let storage = CompositeStorage;
-        let mut values = storage
-            .load_scalar_column_with_row_hint(
-                &source.path,
-                column,
-                Some(source.row_count_hint as u64),
-            )
-            .map_err(|err| {
-                TableError::Storage(format!(
-                    "failed to load scalar column '{column}' for table {}: {err}",
-                    source.path.display()
-                ))
-            })?;
-        if let Some(profiler) = profiler.as_mut() {
-            profiler.mark_with_detail(
-                "storage_load_complete",
-                Some(format!(
-                    "row_count_hint={} values={}",
-                    source.row_count_hint,
-                    values.len()
-                )),
-            );
+        let mut values = Self::load_scalar_column_now(source, column)?;
+        if let Some(cached_column) = self.loaded_scalar_columns.get(column)
+            && cached_column.get().is_none()
+        {
+            let _ = cached_column.set(values.clone());
         }
         if let Some(overrides) = self.pending_scalar_cells.by_column.get(column) {
             for (&row_index, value) in overrides {
@@ -718,9 +808,12 @@ impl TableImpl {
             return Ok(Some(value));
         }
 
-        if let Some(loaded) = self.loaded_scalar_columns.get_mut()
-            && let Some(column_values) = loaded.columns.get_mut(column)
+        if let Some(cached_column) = self.loaded_scalar_columns.get_mut(column)
+            && cached_column.get().is_some()
         {
+            let column_values = cached_column
+                .get_mut()
+                .expect("scalar column initialized before mutable access");
             if let Some(cell) = column_values.get_mut(row_index) {
                 *cell = Some(value);
                 return Ok(None);
@@ -780,17 +873,6 @@ impl TableImpl {
             .entry(column.to_string())
             .or_default()
             .reserve(additional);
-    }
-
-    pub(crate) fn pending_scalar_cell_values(
-        &self,
-        column: &str,
-    ) -> Option<Vec<(usize, ScalarValue)>> {
-        self.pending_scalar_cells.by_column.get(column).map(|rows| {
-            rows.iter()
-                .map(|(&row_index, value)| (row_index, value.clone()))
-                .collect()
-        })
     }
 
     pub(crate) fn undefined_for_row_mut(
@@ -875,7 +957,7 @@ impl TableImpl {
                 .expect("replace eager row store");
             loaded_rows
         };
-        self.loaded_scalar_columns = OnceCell::new();
+        self.loaded_scalar_columns = lazy_scalar_column_store(schema.as_ref());
         self.pending_scalar_cells = PendingScalarCells::default();
         self.loaded_array_columns = lazy_array_column_store(schema.as_ref());
         self.pending_array_cells = PendingArrayCells::default();
@@ -894,6 +976,13 @@ impl TableImpl {
     #[cfg(test)]
     pub(crate) fn has_loaded_array_column(&self, column: &str) -> bool {
         self.loaded_array_columns
+            .get(column)
+            .is_some_and(|cached| cached.get().is_some())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn has_loaded_scalar_column(&self, column: &str) -> bool {
+        self.loaded_scalar_columns
             .get(column)
             .is_some_and(|cached| cached.get().is_some())
     }

--- a/crates/casars/src/tests.rs
+++ b/crates/casars/src/tests.rs
@@ -407,9 +407,20 @@ fn calibrate_guided_flow_runs_gain_bandpass_and_apply_on_ngc5921() {
     let bandpass_table = app
         .field_text_for_test("out_table")
         .expect("solve-bandpass output table");
+    let bandpass_args = app
+        .execution_arguments_for_test()
+        .expect("build solve-bandpass execution arguments")
+        .into_iter()
+        .map(|value| value.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
 
     start_run_with_default_calibrate_launcher(&mut app);
-    assert!(app.wait_for_idle_for_test(Duration::from_secs(120)));
+    assert!(
+        app.wait_for_idle_for_test(Duration::from_secs(120)),
+        "status={} stderr={} args={bandpass_args:?}",
+        app.status_line_for_test(),
+        app.stderr_for_test()
+    );
     assert!(
         Path::new(&bandpass_table).exists(),
         "expected {bandpass_table} to exist"


### PR DESCRIPTION
Wave issue: #99

## Summary
- add prepared row accessors for reusable row-shaped reads and writes in `casa-tables`
- compile requested row layout once into stable slot metadata and slot indices
- migrate representative calibration hot paths to slot-based prepared access
- add targeted regression coverage and a benchmark for row-heavy read/write behavior

## Changed From Plan
- the lazy read fast path currently uses a selected-column snapshot backing instead of a storage-level fixed-offset streaming row buffer
- coherence repairs were needed so prepared reads see pending/cached lazy updates and the mutable `seek()` path cannot expose stale row-buffer state
- bounded/shared column buffering remains deferred to `#100`

## Verification
- `cargo test -p casa-tables prepared_row -- --nocapture`
- `cargo test -p casars calibrate_guided_flow_runs_gain_bandpass_and_apply_on_ngc5921 -- --nocapture`
- `cargo bench -p casa-tables --bench row_buffer_bench -- --sample-size 10`
- `just quick`
- `just verify`

## Perf Snapshot
- read: materialized `~7.80 ms`, prepared `~2.47 ms`
- write: materialized `~7.32 ms`, prepared `~1.52 ms`

## Deferred
- `#100` bounded/shared column buffering and backend-specific buffering policy
