### PR TITLE
Fix prepared row slot bounds checks

### DIFF
--- a/crates/casa-tables/src/table/columns.rs
+++ b/crates/casa-tables/src/table/columns.rs
@@ -1222,6 +1222,12 @@ impl<'a> PreparedTableRow<'a> {
     /// Returns the scalar value for `slot_index` in the current row without cloning.
     pub fn scalar_at(&self, slot_index: usize) -> Result<&ScalarValue, TableError> {
         let row_index = current_prepared_row_index(self.row_index)?;
+        let slot = self
+            .slots
+            .get(slot_index)
+            .ok_or_else(|| TableError::SchemaColumnUnknown {
+                column: format!("#{slot_index}"),
+            })?;
         if let Some(rows) = self.cached_rows.as_ref() {
             let row = rows.get(row_index).ok_or(TableError::RowOutOfBounds {
                 row_index,
@@ -1231,22 +1237,16 @@ impl<'a> PreparedTableRow<'a> {
                 Some(Value::Scalar(value)) => Ok(value),
                 Some(value) => Err(TableError::ColumnTypeMismatch {
                     row_index,
-                    column: self.slots[slot_index].column.clone(),
+                    column: slot.column.clone(),
                     expected: "scalar",
                     found: value.kind(),
                 }),
                 None => Err(TableError::ColumnNotFound {
                     row_index,
-                    column: self.slots[slot_index].column.clone(),
+                    column: slot.column.clone(),
                 }),
             };
         }
-        let slot = self
-            .slots
-            .get(slot_index)
-            .ok_or_else(|| TableError::SchemaColumnUnknown {
-                column: format!("#{slot_index}"),
-            })?;
         match slot.kind {
             PreparedRowSlotKind::Scalar => self.table.get_scalar_cell(row_index, &slot.column),
             PreparedRowSlotKind::Array => Err(TableError::ColumnTypeMismatch {
@@ -1261,6 +1261,12 @@ impl<'a> PreparedTableRow<'a> {
     /// Returns the array value for `slot_index` in the current row without cloning.
     pub fn array_at(&self, slot_index: usize) -> Result<&ArrayValue, TableError> {
         let row_index = current_prepared_row_index(self.row_index)?;
+        let slot = self
+            .slots
+            .get(slot_index)
+            .ok_or_else(|| TableError::SchemaColumnUnknown {
+                column: format!("#{slot_index}"),
+            })?;
         if let Some(rows) = self.cached_rows.as_ref() {
             let row = rows.get(row_index).ok_or(TableError::RowOutOfBounds {
                 row_index,
@@ -1270,22 +1276,16 @@ impl<'a> PreparedTableRow<'a> {
                 Some(Value::Array(value)) => Ok(value),
                 Some(value) => Err(TableError::ColumnTypeMismatch {
                     row_index,
-                    column: self.slots[slot_index].column.clone(),
+                    column: slot.column.clone(),
                     expected: "array",
                     found: value.kind(),
                 }),
                 None => Err(TableError::ColumnNotFound {
                     row_index,
-                    column: self.slots[slot_index].column.clone(),
+                    column: slot.column.clone(),
                 }),
             };
         }
-        let slot = self
-            .slots
-            .get(slot_index)
-            .ok_or_else(|| TableError::SchemaColumnUnknown {
-                column: format!("#{slot_index}"),
-            })?;
         match slot.kind {
             PreparedRowSlotKind::Array => self.table.get_array_cell(row_index, &slot.column),
             PreparedRowSlotKind::Scalar => Err(TableError::ColumnTypeMismatch {

--- a/crates/casa-tables/src/table/tests.rs
+++ b/crates/casa-tables/src/table/tests.rs
@@ -1690,6 +1690,53 @@ fn prepared_row_reader_sees_pending_and_cached_lazy_updates() {
 }
 
 #[test]
+fn prepared_row_cached_fast_path_rejects_invalid_slot_index() {
+    let schema = TableSchema::new(vec![
+        ColumnSchema::scalar("id", PrimitiveType::Int32),
+        ColumnSchema::array_fixed("data", PrimitiveType::Int32, vec![2]),
+    ])
+    .expect("schema");
+
+    for dm in [
+        DataManagerKind::StManAipsIO,
+        DataManagerKind::StandardStMan,
+        DataManagerKind::IncrementalStMan,
+    ] {
+        let mut table = Table::with_schema(schema.clone());
+        table
+            .add_row(RecordValue::new(vec![
+                RecordField::new("id", Value::Scalar(ScalarValue::Int32(1))),
+                RecordField::new("data", Value::Array(ArrayValue::from_i32_vec(vec![7, 9]))),
+            ]))
+            .expect("push row");
+
+        let root = unique_test_dir(&format!("prepared_row_invalid_slot_{dm:?}"));
+        std::fs::create_dir_all(&root).expect("create test dir");
+        table
+            .save(TableOptions::new(&root).with_data_manager(dm))
+            .expect("save disk-backed table");
+
+        let reopened = Table::open(TableOptions::new(&root)).expect("open lazy table");
+        let mut prepared = reopened
+            .row_accessor()
+            .prepare(&["id", "data"])
+            .expect("prepare reader");
+        prepared.load(0).expect("load row");
+
+        assert!(matches!(
+            prepared.scalar_at(99),
+            Err(TableError::SchemaColumnUnknown { column }) if column == "#99"
+        ));
+        assert!(matches!(
+            prepared.array_at(99),
+            Err(TableError::SchemaColumnUnknown { column }) if column == "#99"
+        ));
+
+        std::fs::remove_dir_all(&root).expect("cleanup test dir");
+    }
+}
+
+#[test]
 fn prepared_row_access_rejects_record_columns() {
     let schema = TableSchema::new(vec![ColumnSchema::record("meta")]).expect("schema");
     let table = Table::with_schema(schema);


### PR DESCRIPTION
Follow-up to #106.

This fixes a post-merge review note: `PreparedTableRow::scalar_at()` and `PreparedTableRow::array_at()` could panic on an invalid `slot_index` in the cached-row fast path instead of returning `TableError::SchemaColumnUnknown`.

## What changed
- validate `slot_index` up front in the cached and non-cached paths
- return the same `SchemaColumnUnknown` error shape for invalid prepared-row slot access
- add regression coverage for the lazy cached fast path across the supported storage managers

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p casa-tables prepared_row -- --nocapture`
- `just quick`