### PR TITLE
Issue 100: add bounded sparse write paths and scalar-cell buffering

### DIFF
--- a/crates/casa-tables/benches/row_buffer_bench.rs
+++ b/crates/casa-tables/benches/row_buffer_bench.rs
@@ -5,8 +5,10 @@
 //! path added in wave 99 on the same persisted table shape.
 
 use std::hint::black_box;
+use std::path::PathBuf;
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use ndarray::ArrayD;
 use tempfile::TempDir;
 
 use casa_tables::{ColumnSchema, DataManagerKind, Table, TableOptions, TableSchema};
@@ -58,6 +60,72 @@ fn persisted_row_table(row_count: usize) -> (TempDir, std::path::PathBuf) {
 
     table
         .save(TableOptions::new(&path).with_data_manager(DataManagerKind::StandardStMan))
+        .expect("save benchmark table");
+    (tempdir, path)
+}
+
+fn persisted_incremental_scalar_table(row_count: usize) -> (TempDir, PathBuf) {
+    let schema = TableSchema::new(vec![
+        ColumnSchema::scalar("id", PrimitiveType::Int32),
+        ColumnSchema::scalar("scan", PrimitiveType::Int32),
+        ColumnSchema::scalar("state", PrimitiveType::Int32),
+    ])
+    .expect("valid schema");
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let path = tempdir.path().join("incremental-sparse-bench.table");
+
+    let mut table = Table::with_schema(schema);
+    for row_index in 0..row_count {
+        table
+            .add_row(RecordValue::new(vec![
+                RecordField::new("id", Value::Scalar(ScalarValue::Int32(row_index as i32))),
+                RecordField::new(
+                    "scan",
+                    Value::Scalar(ScalarValue::Int32(((row_index / 8) * 10) as i32)),
+                ),
+                RecordField::new(
+                    "state",
+                    Value::Scalar(ScalarValue::Int32((row_index % 3) as i32)),
+                ),
+            ]))
+            .expect("add row");
+    }
+
+    table
+        .save(TableOptions::new(&path).with_data_manager(DataManagerKind::IncrementalStMan))
+        .expect("save benchmark table");
+    (tempdir, path)
+}
+
+fn persisted_tiled_single_column_table(row_count: usize) -> (TempDir, PathBuf) {
+    let schema = TableSchema::new(vec![ColumnSchema::array_fixed(
+        "data",
+        PrimitiveType::Float32,
+        vec![16, 4],
+    )])
+    .expect("valid schema");
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let path = tempdir.path().join("tiled-sparse-bench.table");
+
+    let mut table = Table::with_schema(schema);
+    for row_index in 0..row_count {
+        let values = (0..64)
+            .map(|offset| row_index as f32 + offset as f32)
+            .collect::<Vec<_>>();
+        table
+            .add_row(RecordValue::new(vec![RecordField::new(
+                "data",
+                Value::Array(ArrayValue::Float32(
+                    ArrayD::from_shape_vec(vec![16, 4], values).expect("shape data"),
+                )),
+            )]))
+            .expect("add row");
+    }
+
+    table
+        .save(TableOptions::new(&path).with_data_manager(DataManagerKind::TiledShapeStMan))
         .expect("save benchmark table");
     (tempdir, path)
 }
@@ -221,5 +289,91 @@ fn bench_row_writes(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_row_reads, bench_row_writes);
+fn bench_sparse_partial_writes(c: &mut Criterion) {
+    let (_incremental_tempdir, incremental_path) = persisted_incremental_scalar_table(8192);
+    let (_tiled_tempdir, tiled_path) = persisted_tiled_single_column_table(2048);
+    let mut group = c.benchmark_group("sparse_partial_write");
+
+    group.bench_function("incremental_scalar_rows_8k", |b| {
+        b.iter_batched(
+            || Table::open(TableOptions::new(&incremental_path)).expect("open table"),
+            |mut table| {
+                table
+                    .set_scalar_cell_assuming_valid(2, "id", ScalarValue::Int32(2002))
+                    .expect("set row 2 id");
+                table
+                    .set_scalar_cell_assuming_valid(4097, "scan", ScalarValue::Int32(9041))
+                    .expect("set row 4097 scan");
+                table
+                    .save_selected_rows_in_place_assuming_valid(&["id", "scan"], &[2, 4097])
+                    .expect("sparse incremental partial save");
+                black_box(table.row_count())
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("tiled_single_column_rows_2k", |b| {
+        b.iter_batched(
+            || Table::open(TableOptions::new(&tiled_path)).expect("open table"),
+            |mut table| {
+                let values = (0..64)
+                    .map(|offset| 20_000.0 + offset as f32)
+                    .collect::<Vec<_>>();
+                table
+                    .set_array_cell_assuming_valid(
+                        1024,
+                        "data",
+                        ArrayValue::Float32(
+                            ArrayD::from_shape_vec(vec![16, 4], values)
+                                .expect("updated sparse tiled shape"),
+                        ),
+                    )
+                    .expect("set sparse tiled cell");
+                table
+                    .save_selected_rows_in_place_assuming_valid(&["data"], &[1024])
+                    .expect("sparse tiled partial save");
+                black_box(table.row_count())
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+fn bench_lazy_single_cell_reads(c: &mut Criterion) {
+    let (_incremental_tempdir, incremental_path) = persisted_incremental_scalar_table(8192);
+    let mut group = c.benchmark_group("lazy_single_cell_read");
+
+    group.bench_function("incremental_scalar_rows_8k", |b| {
+        b.iter_batched(
+            || Table::open(TableOptions::new(&incremental_path)).expect("open table"),
+            |table| {
+                let mut acc = 0i64;
+                for row_index in [2usize, 511, 4097, 7001] {
+                    let value = table
+                        .get_scalar_cell(row_index, "scan")
+                        .expect("get buffered scalar cell");
+                    let ScalarValue::Int32(value) = value else {
+                        panic!("expected int32 scalar");
+                    };
+                    acc += i64::from(*value);
+                }
+                black_box(acc)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_row_reads,
+    bench_row_writes,
+    bench_sparse_partial_writes,
+    bench_lazy_single_cell_reads
+);
 criterion_main!(benches);

--- a/crates/casa-tables/src/storage/incremental_stman.rs
+++ b/crates/casa-tables/src/storage/incremental_stman.rs
@@ -15,11 +15,13 @@
 //! C++ equivalent: `casacore/tables/DataMan/ISMBase`, `ISMBucket`, `ISMIndex`,
 //! `ISMColumn`.
 
+use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
 use casa_aipsio::{AipsIo, ByteOrder};
+use casa_types::ScalarValue;
 
 use super::StorageError;
 use super::canonical::{
@@ -31,11 +33,14 @@ use super::canonical::{
 };
 use super::data_type::CasacoreDataType;
 use super::stman_aipsio::ColumnRawData;
+use super::stman_aipsio::scalar_value_is_default;
 use super::stman_array_file::StManArrayFileReader;
 use super::table_control::ColumnDescContents;
 
 const ISM_HEADER_SIZE: u64 = 512;
 const AIPSIO_MAGIC: u32 = 0xbebebebe;
+
+type SparseScalarRowValues = Vec<(usize, Option<casa_types::ScalarValue>)>;
 
 // ---------------------------------------------------------------------------
 // In-memory AipsIO helpers
@@ -998,6 +1003,108 @@ pub(crate) fn read_ism_file(
     }
 
     Ok(result)
+}
+
+pub(crate) fn read_ism_scalar_column_rows(
+    file_path: &Path,
+    dm_blob: &[u8],
+    col_descs: &[&ColumnDescContents],
+    target_col_idx: usize,
+    selected_rows: &[usize],
+) -> Result<Option<Vec<Option<ScalarValue>>>, StorageError> {
+    if selected_rows.is_empty() {
+        return Ok(Some(Vec::new()));
+    }
+
+    let _dm_name = parse_ism_dm_blob(dm_blob)?;
+    let mut file = File::open(file_path)?;
+    let header = parse_ism_header(&mut file)?;
+    let index = parse_ism_index(&mut file, &header)?;
+    let big_endian = header.big_endian;
+
+    if target_col_idx >= col_descs.len() {
+        return Err(StorageError::FormatMismatch(format!(
+            "ISM scalar column index {target_col_idx} is out of range"
+        )));
+    }
+    let target_col_desc = col_descs[target_col_idx];
+    if target_col_desc.is_array || target_col_desc.is_record() {
+        return Ok(None);
+    }
+
+    let owned_col_descs: Vec<ColumnDescContents> =
+        col_descs.iter().map(|col| (*col).clone()).collect();
+    let col_info: Vec<(CasacoreDataType, usize)> = owned_col_descs
+        .iter()
+        .map(|col_desc| {
+            let scalar_dt =
+                CasacoreDataType::from_primitive_type(col_desc.require_primitive_type()?, false);
+            let nrelem = if col_desc.is_array && !col_desc.shape.is_empty() {
+                col_desc.shape.iter().map(|&s| s as usize).product()
+            } else {
+                1
+            };
+            Ok((scalar_dt, nrelem))
+        })
+        .collect::<Result<_, StorageError>>()?;
+
+    let mut requests: Vec<(usize, usize)> = selected_rows
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(out_idx, row_index)| (row_index, out_idx))
+        .collect();
+    requests.sort_unstable_by_key(|&(row_index, _)| row_index);
+
+    let mut values = vec![None; selected_rows.len()];
+    let mut cached_interval = None;
+    let mut cached_bucket_start = 0usize;
+    let mut cached_bucket_values: Vec<Option<ScalarValue>> = Vec::new();
+
+    for (row_index, out_idx) in requests {
+        let interval = index
+            .rows
+            .partition_point(|&start| start <= row_index as u64);
+        if interval == 0 || interval >= index.rows.len() {
+            return Err(StorageError::FormatMismatch(format!(
+                "ISM index has no bucket for row {row_index}"
+            )));
+        }
+        let interval_idx = interval - 1;
+        if interval_idx >= index.bucket_nrs.len() {
+            return Err(StorageError::FormatMismatch(format!(
+                "ISM bucket number missing for row interval {interval_idx}"
+            )));
+        }
+
+        if cached_interval != Some(interval_idx) {
+            cached_interval = Some(interval_idx);
+            cached_bucket_start = index.rows[interval_idx] as usize;
+            let bucket_end = index.rows[interval_idx + 1] as usize;
+            let raw_bucket = read_ism_bucket(&mut file, &header, index.bucket_nrs[interval_idx])?;
+            let bucket = parse_ism_bucket(&raw_bucket, owned_col_descs.len(), big_endian)?;
+            let bucket_rows = load_scalar_bucket_values(
+                &bucket,
+                &owned_col_descs,
+                &col_info,
+                bucket_end.saturating_sub(cached_bucket_start),
+                big_endian,
+            )?;
+            cached_bucket_values = bucket_rows.get(target_col_idx).cloned().ok_or_else(|| {
+                StorageError::FormatMismatch(format!(
+                    "ISM scalar column '{}' missing from parsed bucket",
+                    target_col_desc.col_name
+                ))
+            })?;
+        }
+
+        values[out_idx] = cached_bucket_values
+            .get(row_index.saturating_sub(cached_bucket_start))
+            .cloned()
+            .unwrap_or(None);
+    }
+
+    Ok(Some(values))
 }
 
 fn default_value(
@@ -2187,6 +2294,135 @@ pub(crate) fn save_ism_file_scalar_columns_rows_in_place(
     Ok(true)
 }
 
+pub(crate) fn save_ism_file_scalar_columns_sparse_rows_in_place(
+    file_path: &Path,
+    col_descs: &[ColumnDescContents],
+    sparse_columns: &[Option<SparseScalarRowValues>],
+    changed_rows: &[usize],
+    big_endian: bool,
+) -> Result<bool, StorageError> {
+    if sparse_columns.len() != col_descs.len() {
+        return Err(StorageError::FormatMismatch(format!(
+            "ISM sparse scalar column count mismatch: expected {}, got {}",
+            col_descs.len(),
+            sparse_columns.len()
+        )));
+    }
+    if changed_rows.is_empty() || col_descs.is_empty() {
+        return Ok(false);
+    }
+    if sparse_columns.iter().all(Option::is_none) {
+        return Ok(false);
+    }
+    if col_descs
+        .iter()
+        .any(|col_desc| col_desc.is_array || col_desc.is_record())
+    {
+        return Ok(false);
+    }
+
+    let col_info: Vec<(CasacoreDataType, usize)> = col_descs
+        .iter()
+        .map(|c| {
+            let dt = CasacoreDataType::from_primitive_type(c.require_primitive_type()?, false);
+            Ok((dt, 1usize))
+        })
+        .collect::<Result<_, StorageError>>()?;
+
+    let mut file = OpenOptions::new().read(true).write(true).open(file_path)?;
+    let header = parse_ism_header(&mut file)?;
+    if header.big_endian != big_endian {
+        return Err(StorageError::FormatMismatch(format!(
+            "ISM endian mismatch for sparse save: file={}, requested={}",
+            header.big_endian, big_endian
+        )));
+    }
+    let index = parse_ism_index(&mut file, &header)?;
+    if index.rows.len() < 2 || index.bucket_nrs.is_empty() {
+        return Ok(false);
+    }
+
+    let mut changed_intervals = Vec::new();
+    let mut last_interval = None;
+    for &row_idx in changed_rows {
+        let interval = index.rows.partition_point(|&start| start <= row_idx as u64);
+        if interval == 0 {
+            continue;
+        }
+        let interval_idx = interval - 1;
+        if interval_idx >= index.bucket_nrs.len() {
+            continue;
+        }
+        if last_interval != Some(interval_idx) {
+            changed_intervals.push(interval_idx);
+            last_interval = Some(interval_idx);
+        }
+    }
+    if changed_intervals.is_empty() {
+        return Ok(false);
+    }
+
+    let sparse_lookup: Vec<Option<HashMap<usize, Option<casa_types::ScalarValue>>>> =
+        sparse_columns
+            .iter()
+            .map(|column| {
+                column
+                    .as_ref()
+                    .map(|column| column.iter().cloned().collect::<HashMap<_, _>>())
+            })
+            .collect();
+
+    let mut patched_buckets = Vec::with_capacity(changed_intervals.len());
+    for interval_idx in changed_intervals {
+        let bucket_start = index.rows[interval_idx] as usize;
+        let bucket_end = index.rows[interval_idx + 1] as usize;
+        let bucket_nr = index.bucket_nrs[interval_idx];
+        let raw_bucket = read_ism_bucket(&mut file, &header, bucket_nr)?;
+        let bucket = parse_ism_bucket(&raw_bucket, col_descs.len(), big_endian)?;
+        let bucket_rows = load_scalar_bucket_values(
+            &bucket,
+            col_descs,
+            &col_info,
+            bucket_end.saturating_sub(bucket_start),
+            big_endian,
+        )?;
+
+        let mut owned_columns = bucket_rows;
+        for (col_idx, overrides) in sparse_lookup.iter().enumerate() {
+            let Some(overrides) = overrides else {
+                continue;
+            };
+            for (&row_idx, value) in overrides {
+                if row_idx < bucket_start || row_idx >= bucket_end {
+                    continue;
+                }
+                owned_columns[col_idx][row_idx - bucket_start] = value.clone();
+            }
+        }
+
+        let column_refs: Vec<_> = owned_columns.iter().map(Vec::as_slice).collect();
+        let Some(raw) = build_ism_scalar_bucket_for_row_range(
+            &col_info,
+            &column_refs,
+            0,
+            bucket_end.saturating_sub(bucket_start),
+            header.bucket_size,
+            big_endian,
+        )?
+        else {
+            return Ok(false);
+        };
+        patched_buckets.push((bucket_nr, raw));
+    }
+
+    for (bucket_nr, raw) in patched_buckets {
+        let offset = ISM_HEADER_SIZE + (bucket_nr as u64) * (header.bucket_size as u64);
+        file.seek(SeekFrom::Start(offset))?;
+        file.write_all(&raw)?;
+    }
+    Ok(true)
+}
+
 fn build_ism_scalar_bucket_for_row_range(
     col_info: &[(CasacoreDataType, usize)],
     scalar_columns: &[&[Option<casa_types::ScalarValue>]],
@@ -2230,6 +2466,72 @@ fn build_ism_scalar_bucket_for_row_range(
     }
 
     serialize_ism_bucket(bucket_size, &data, &col_indices, big_endian)
+}
+
+fn load_scalar_bucket_values(
+    bucket: &IsmBucket,
+    col_descs: &[ColumnDescContents],
+    col_info: &[(CasacoreDataType, usize)],
+    rows_in_bucket: usize,
+    big_endian: bool,
+) -> Result<Vec<Vec<Option<casa_types::ScalarValue>>>, StorageError> {
+    let mut values = Vec::with_capacity(col_descs.len());
+    for (col_idx, col_desc) in col_descs.iter().enumerate() {
+        let (dt, _) = col_info[col_idx];
+        let mut column = Vec::with_capacity(rows_in_bucket);
+        if col_idx >= bucket.col_indices.len() {
+            let value = default_value(dt, false, col_desc);
+            let scalar = match value {
+                casa_types::Value::Scalar(scalar) => scalar,
+                other => {
+                    return Err(StorageError::FormatMismatch(format!(
+                        "ISM default value for column '{}' is not scalar: {other:?}",
+                        col_desc.col_name
+                    )));
+                }
+            };
+            let value = if (col_desc.option & 2) != 0
+                && scalar_value_is_default(
+                    &casa_types::Value::Scalar(scalar.clone()),
+                    col_desc.require_primitive_type()?,
+                ) {
+                None
+            } else {
+                Some(scalar)
+            };
+            column.resize(rows_in_bucket, value);
+            values.push(column);
+            continue;
+        }
+
+        let col_index = &bucket.col_indices[col_idx];
+        for rel_row in 0..rows_in_bucket {
+            let interval = get_interval(col_index, rel_row as u32);
+            let data_offset = col_index.offsets[interval] as usize;
+            let value = read_scalar_at(&bucket.data, data_offset, dt, big_endian)?;
+            let scalar = match value {
+                casa_types::Value::Scalar(scalar) => scalar,
+                other => {
+                    return Err(StorageError::FormatMismatch(format!(
+                        "ISM sparse bucket value for column '{}' is not scalar: {other:?}",
+                        col_desc.col_name
+                    )));
+                }
+            };
+            if (col_desc.option & 2) != 0
+                && scalar_value_is_default(
+                    &casa_types::Value::Scalar(scalar.clone()),
+                    col_desc.require_primitive_type()?,
+                )
+            {
+                column.push(None);
+            } else {
+                column.push(Some(scalar));
+            }
+        }
+        values.push(column);
+    }
+    Ok(values)
 }
 
 fn serialize_ism_bucket(

--- a/crates/casa-tables/src/storage/mod.rs
+++ b/crates/casa-tables/src/storage/mod.rs
@@ -31,13 +31,16 @@ use crate::schema::{SchemaError, TableSchema};
 
 use self::data_type::CasacoreDataType;
 use self::incremental_stman::{
-    IsmColumnResult, read_ism_file, write_ism_file, write_ism_file_indexed,
+    IsmColumnResult, read_ism_file, read_ism_scalar_column_rows, write_ism_file,
+    write_ism_file_indexed,
 };
-use self::standard_stman::{read_ssm_file, write_ssm_file, write_ssm_file_indexed};
+use self::standard_stman::{
+    read_ssm_file, read_ssm_scalar_column_rows, write_ssm_file, write_ssm_file_indexed,
+};
 use self::stman_aipsio::scalar_value_is_default;
 use self::stman_aipsio::{
     StManColumnData, StManColumnInfo, extract_row_value, read_stman_array_column_rows,
-    read_stman_file, read_stman_scalar_column, write_stman_file,
+    read_stman_file, read_stman_scalar_column, read_stman_scalar_column_rows, write_stman_file,
 };
 pub(crate) use self::table_control::RefTableDatContents;
 use self::virtual_engine::{VirtualContext, is_virtual_engine, lookup_engine};
@@ -1036,6 +1039,41 @@ impl CompositeStorage {
         }
     }
 
+    pub(crate) fn load_scalar_column_rows_with_row_hint(
+        &self,
+        table_path: &Path,
+        column: &str,
+        selected_rows: &[usize],
+        row_hint: Option<u64>,
+    ) -> Result<Vec<Option<ScalarValue>>, StorageError> {
+        if selected_rows.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let control_path = table_path.join(TABLE_CONTROL_FILE);
+        if !table_path.exists() {
+            return Err(StorageError::MissingPath(table_path.to_path_buf()));
+        }
+        if !control_path.exists() {
+            return Err(StorageError::MissingControlFile(control_path));
+        }
+
+        match read_table_dat_dispatch(&control_path)? {
+            TableDatResult::Plain(table_dat) => self.load_plain_scalar_column_rows(
+                table_path,
+                &table_dat,
+                column,
+                selected_rows,
+                row_hint,
+            ),
+            TableDatResult::Ref(_) | TableDatResult::Concat(_) => {
+                let snapshot = self.load_with_row_hint(table_path, row_hint)?;
+                let values = scalar_column_from_snapshot(&snapshot, column)?;
+                Ok(select_scalar_rows(&values, selected_rows))
+            }
+        }
+    }
+
     pub(crate) fn load_array_column_with_row_hint(
         &self,
         table_path: &Path,
@@ -1579,6 +1617,133 @@ impl CompositeStorage {
             row_count: nrrow,
             columns,
         })
+    }
+
+    fn load_plain_scalar_column_rows(
+        &self,
+        table_path: &Path,
+        table_dat: &TableDatContents,
+        column: &str,
+        selected_rows: &[usize],
+        row_hint: Option<u64>,
+    ) -> Result<Vec<Option<ScalarValue>>, StorageError> {
+        let desc_idx = table_dat
+            .table_desc
+            .columns
+            .iter()
+            .position(|desc| desc.col_name == column)
+            .ok_or_else(|| {
+                StorageError::FormatMismatch(format!("scalar column '{column}' not found"))
+            })?;
+        let col_desc = &table_dat.table_desc.columns[desc_idx];
+        if col_desc.is_array || col_desc.is_record() {
+            return Err(StorageError::FormatMismatch(format!(
+                "column '{column}' is not a scalar column"
+            )));
+        }
+
+        if table_dat
+            .column_set
+            .data_managers
+            .iter()
+            .any(|dm| is_virtual_engine(&dm.type_name))
+        {
+            let snapshot = self.load_plain_table_filtered(table_path, table_dat, row_hint, None)?;
+            let values = scalar_column_from_snapshot(&snapshot, column)?;
+            return Ok(select_scalar_rows(&values, selected_rows));
+        }
+
+        let dm_seq_nr = table_dat
+            .column_set
+            .columns
+            .iter()
+            .find(|entry| entry.original_name == column)
+            .ok_or_else(|| {
+                StorageError::FormatMismatch(format!(
+                    "scalar column '{column}' missing ColumnSet binding"
+                ))
+            })?
+            .dm_seq_nr;
+        let dm = table_dat
+            .column_set
+            .data_managers
+            .iter()
+            .find(|dm| dm.seq_nr == dm_seq_nr)
+            .ok_or_else(|| {
+                StorageError::FormatMismatch(format!(
+                    "scalar column '{column}' missing data manager {dm_seq_nr}"
+                ))
+            })?;
+        let data_path = table_path.join(format!("{}{}", TABLE_DATA_FILE_PREFIX, dm.seq_nr));
+        let bound_cols: Vec<(usize, &_)> = table_dat
+            .column_set
+            .columns
+            .iter()
+            .enumerate()
+            .filter(|(_, pc)| pc.dm_seq_nr == dm.seq_nr)
+            .collect();
+        let target_col_idx = bound_cols
+            .iter()
+            .position(|(candidate_desc_idx, _)| *candidate_desc_idx == desc_idx)
+            .ok_or_else(|| {
+                StorageError::FormatMismatch(format!(
+                    "scalar column '{column}' missing data-manager binding index"
+                ))
+            })?;
+
+        match dm.type_name.as_str() {
+            "StManAipsIO" => {
+                let group_col_descs: Vec<_> = bound_cols
+                    .iter()
+                    .map(|(bound_desc_idx, _)| {
+                        table_dat.table_desc.columns[*bound_desc_idx].clone()
+                    })
+                    .collect();
+                if let Some(values) = read_stman_scalar_column_rows(
+                    &data_path,
+                    &group_col_descs,
+                    target_col_idx,
+                    selected_rows,
+                    ByteOrder::BigEndian,
+                )? {
+                    return Ok(values);
+                }
+            }
+            "StandardStMan" => {
+                let group_col_descs: Vec<_> = bound_cols
+                    .iter()
+                    .map(|(bound_desc_idx, _)| &table_dat.table_desc.columns[*bound_desc_idx])
+                    .collect();
+                if let Some(values) = read_ssm_scalar_column_rows(
+                    &data_path,
+                    &dm.data,
+                    &group_col_descs,
+                    target_col_idx,
+                    selected_rows,
+                )? {
+                    return Ok(values);
+                }
+            }
+            "IncrementalStMan" => {
+                let group_col_descs: Vec<_> = bound_cols
+                    .iter()
+                    .map(|(bound_desc_idx, _)| &table_dat.table_desc.columns[*bound_desc_idx])
+                    .collect();
+                if let Some(values) = read_ism_scalar_column_rows(
+                    &data_path,
+                    &dm.data,
+                    &group_col_descs,
+                    target_col_idx,
+                    selected_rows,
+                )? {
+                    return Ok(values);
+                }
+            }
+            _ => {}
+        }
+
+        let values = self.load_plain_scalar_column(table_path, table_dat, column, row_hint)?;
+        Ok(select_scalar_rows(&values, selected_rows))
     }
 
     fn load_plain_array_column(
@@ -2607,6 +2772,16 @@ fn select_array_rows(
     values: &[Option<ArrayValue>],
     selected_rows: &[usize],
 ) -> Vec<Option<ArrayValue>> {
+    selected_rows
+        .iter()
+        .map(|&row_idx| values.get(row_idx).cloned().unwrap_or(None))
+        .collect()
+}
+
+fn select_scalar_rows(
+    values: &[Option<ScalarValue>],
+    selected_rows: &[usize],
+) -> Vec<Option<ScalarValue>> {
     selected_rows
         .iter()
         .map(|&row_idx| values.get(row_idx).cloned().unwrap_or(None))

--- a/crates/casa-tables/src/storage/standard_stman.rs
+++ b/crates/casa-tables/src/storage/standard_stman.rs
@@ -20,7 +20,7 @@ use std::path::Path;
 use casa_aipsio::{AipsIo, ByteOrder};
 use ndarray::ShapeBuilder;
 
-use casa_types::{ArrayValue, Value};
+use casa_types::{ArrayValue, ScalarValue, Value};
 use ndarray::{ArrayD, IxDyn};
 
 use super::StorageError;
@@ -509,6 +509,111 @@ fn read_i32_canonical(src: &[u8], big_endian: bool) -> i32 {
     }
 }
 
+fn extract_scalar_from_ssm_bytes(
+    bytes: &[u8],
+    data_type: CasacoreDataType,
+    big_endian: bool,
+) -> Result<Value, StorageError> {
+    let value = match data_type {
+        CasacoreDataType::TpUChar => Value::Scalar(ScalarValue::UInt8(bytes[0])),
+        CasacoreDataType::TpShort => Value::Scalar(ScalarValue::Int16(if big_endian {
+            i16::from_be_bytes(bytes.try_into().map_err(|_| {
+                StorageError::FormatMismatch("invalid SSM i16 scalar width".to_string())
+            })?)
+        } else {
+            i16::from_le_bytes(bytes.try_into().map_err(|_| {
+                StorageError::FormatMismatch("invalid SSM i16 scalar width".to_string())
+            })?)
+        })),
+        CasacoreDataType::TpUShort => Value::Scalar(ScalarValue::UInt16(if big_endian {
+            u16::from_be_bytes(bytes.try_into().map_err(|_| {
+                StorageError::FormatMismatch("invalid SSM u16 scalar width".to_string())
+            })?)
+        } else {
+            u16::from_le_bytes(bytes.try_into().map_err(|_| {
+                StorageError::FormatMismatch("invalid SSM u16 scalar width".to_string())
+            })?)
+        })),
+        CasacoreDataType::TpInt => Value::Scalar(ScalarValue::Int32(if big_endian {
+            read_i32_be(bytes)
+        } else {
+            i32::from_le_bytes(bytes.try_into().map_err(|_| {
+                StorageError::FormatMismatch("invalid SSM i32 scalar width".to_string())
+            })?)
+        })),
+        CasacoreDataType::TpUInt => Value::Scalar(ScalarValue::UInt32(if big_endian {
+            u32::from_be_bytes(bytes.try_into().map_err(|_| {
+                StorageError::FormatMismatch("invalid SSM u32 scalar width".to_string())
+            })?)
+        } else {
+            u32::from_le_bytes(bytes.try_into().map_err(|_| {
+                StorageError::FormatMismatch("invalid SSM u32 scalar width".to_string())
+            })?)
+        })),
+        CasacoreDataType::TpFloat => Value::Scalar(ScalarValue::Float32(if big_endian {
+            read_f32_be(bytes)
+        } else {
+            read_f32_le(bytes)
+        })),
+        CasacoreDataType::TpDouble => Value::Scalar(ScalarValue::Float64(if big_endian {
+            read_f64_be(bytes)
+        } else {
+            read_f64_le(bytes)
+        })),
+        CasacoreDataType::TpInt64 => Value::Scalar(ScalarValue::Int64(if big_endian {
+            i64::from_be_bytes(bytes.try_into().map_err(|_| {
+                StorageError::FormatMismatch("invalid SSM i64 scalar width".to_string())
+            })?)
+        } else {
+            i64::from_le_bytes(bytes.try_into().map_err(|_| {
+                StorageError::FormatMismatch("invalid SSM i64 scalar width".to_string())
+            })?)
+        })),
+        CasacoreDataType::TpComplex => {
+            if bytes.len() != 8 {
+                return Err(StorageError::FormatMismatch(
+                    "invalid SSM complex32 scalar width".to_string(),
+                ));
+            }
+            let re = if big_endian {
+                read_f32_be(&bytes[..4])
+            } else {
+                read_f32_le(&bytes[..4])
+            };
+            let im = if big_endian {
+                read_f32_be(&bytes[4..8])
+            } else {
+                read_f32_le(&bytes[4..8])
+            };
+            Value::Scalar(ScalarValue::Complex32(casa_types::Complex32::new(re, im)))
+        }
+        CasacoreDataType::TpDComplex => {
+            if bytes.len() != 16 {
+                return Err(StorageError::FormatMismatch(
+                    "invalid SSM complex64 scalar width".to_string(),
+                ));
+            }
+            let re = if big_endian {
+                read_f64_be(&bytes[..8])
+            } else {
+                read_f64_le(&bytes[..8])
+            };
+            let im = if big_endian {
+                read_f64_be(&bytes[8..16])
+            } else {
+                read_f64_le(&bytes[8..16])
+            };
+            Value::Scalar(ScalarValue::Complex64(casa_types::Complex64::new(re, im)))
+        }
+        other => {
+            return Err(StorageError::FormatMismatch(format!(
+                "unsupported SSM scalar type {other:?}"
+            )));
+        }
+    };
+    Ok(value)
+}
+
 // ---------------------------------------------------------------------------
 // String bucket reader
 // ---------------------------------------------------------------------------
@@ -907,6 +1012,123 @@ pub(crate) fn read_ssm_file(
     }
 
     Ok(result)
+}
+
+pub(crate) fn read_ssm_scalar_column_rows(
+    file_path: &Path,
+    dm_blob: &[u8],
+    col_descs: &[&ColumnDescContents],
+    target_col_idx: usize,
+    selected_rows: &[usize],
+) -> Result<Option<Vec<Option<ScalarValue>>>, StorageError> {
+    if selected_rows.is_empty() {
+        return Ok(Some(Vec::new()));
+    }
+
+    let mut file = File::open(file_path)?;
+    let header = parse_ssm_header(&mut file)?;
+    let dm_info = parse_ssm_dm_blob(dm_blob)?;
+    let indices = parse_ssm_indices(&mut file, &header)?;
+
+    if target_col_idx >= col_descs.len() {
+        return Err(StorageError::FormatMismatch(format!(
+            "SSM scalar column index {target_col_idx} is out of range"
+        )));
+    }
+    if target_col_idx >= dm_info.column_offsets.len()
+        || target_col_idx >= dm_info.col_index_map.len()
+    {
+        return Err(StorageError::FormatMismatch(format!(
+            "SSM scalar column index {target_col_idx} missing dm blob metadata"
+        )));
+    }
+
+    let col_desc = col_descs[target_col_idx];
+    if col_desc.is_array || col_desc.is_record() {
+        return Ok(None);
+    }
+
+    let column_offset = dm_info.column_offsets[target_col_idx] as usize;
+    let index_nr = dm_info.col_index_map[target_col_idx] as usize;
+    if index_nr >= indices.len() {
+        return Err(StorageError::FormatMismatch(format!(
+            "SSM column '{}' references index {index_nr} but only {} indices exist",
+            col_desc.col_name,
+            indices.len()
+        )));
+    }
+    let index = &indices[index_nr];
+    let be = header.big_endian;
+
+    let mut requests: Vec<(usize, usize)> = selected_rows
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(out_idx, row_index)| (row_index, out_idx))
+        .collect();
+    requests.sort_unstable_by_key(|&(row_index, _)| row_index);
+
+    let mut cached_bucket_nr = None;
+    let mut cached_bucket = Vec::new();
+    let mut values = vec![None; selected_rows.len()];
+    let (elem_bytes, _) = canonical_element_size(col_desc.data_type);
+
+    for (row_index, out_idx) in requests {
+        let (bucket_nr, start_row, _end_row) =
+            index.find_bucket(row_index as u64).ok_or_else(|| {
+                StorageError::FormatMismatch(format!("SSM index has no bucket for row {row_index}"))
+            })?;
+        if cached_bucket_nr != Some(bucket_nr) {
+            cached_bucket = read_bucket(&mut file, &header, bucket_nr)?;
+            cached_bucket_nr = Some(bucket_nr);
+        }
+        let row_in_bucket = (row_index as u64 - start_row) as usize;
+        let value = match col_desc.data_type {
+            CasacoreDataType::TpBool => {
+                let byte_offset = column_offset + row_in_bucket / 8;
+                let bit_offset = row_in_bucket % 8;
+                Value::Scalar(ScalarValue::Bool(
+                    ((cached_bucket[byte_offset] >> bit_offset) & 1) != 0,
+                ))
+            }
+            CasacoreDataType::TpString => {
+                let ref_offset = column_offset + row_in_bucket * 12;
+                let str_bucket = read_i32_canonical(&cached_bucket[ref_offset..], be);
+                let str_offset = read_i32_canonical(&cached_bucket[ref_offset + 4..], be);
+                let str_length = read_i32_canonical(&cached_bucket[ref_offset + 8..], be);
+                let string = if str_length <= 8 {
+                    String::from_utf8(
+                        cached_bucket[ref_offset..ref_offset + str_length as usize].to_vec(),
+                    )
+                    .map_err(|err| StorageError::FormatMismatch(format!("invalid UTF-8: {err}")))?
+                } else {
+                    read_ssm_string(&mut file, &header, str_bucket, str_offset, str_length)?
+                };
+                Value::Scalar(ScalarValue::String(string))
+            }
+            _ => {
+                let data_start = column_offset + row_in_bucket * elem_bytes;
+                let data_end = data_start + elem_bytes;
+                extract_scalar_from_ssm_bytes(
+                    &cached_bucket[data_start..data_end],
+                    col_desc.data_type,
+                    be,
+                )?
+            }
+        };
+        values[out_idx] = Some(match value {
+            Value::Scalar(scalar) => scalar,
+            other => {
+                return Err(StorageError::FormatMismatch(format!(
+                    "SSM column '{}' expected scalar value, found {:?}",
+                    col_desc.col_name,
+                    other.kind()
+                )));
+            }
+        });
+    }
+
+    Ok(Some(values))
 }
 
 fn read_column_from_buckets(

--- a/crates/casa-tables/src/storage/stman_aipsio.rs
+++ b/crates/casa-tables/src/storage/stman_aipsio.rs
@@ -743,6 +743,87 @@ pub(crate) fn read_stman_array_column_rows(
     Ok(Some(values))
 }
 
+pub(crate) fn read_stman_scalar_column_rows(
+    path: &Path,
+    columns: &[ColumnDescContents],
+    target_col_idx: usize,
+    selected_rows: &[usize],
+    byte_order: ByteOrder,
+) -> Result<Option<Vec<Option<ScalarValue>>>, StorageError> {
+    if selected_rows.is_empty() {
+        return Ok(Some(Vec::new()));
+    }
+    let layouts = parse_sparse_column_layouts(path, columns, byte_order)?;
+    let Some(layout) = layouts
+        .get(target_col_idx)
+        .and_then(|layout| layout.as_ref())
+    else {
+        return Ok(None);
+    };
+    let column = columns.get(target_col_idx).ok_or_else(|| {
+        StorageError::FormatMismatch(format!(
+            "target StManAipsIO scalar column index {target_col_idx} is out of range"
+        ))
+    })?;
+
+    let mut main_file = std::fs::File::open(path)?;
+    let mut requests: Vec<(usize, usize)> = selected_rows
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(out_idx, row_index)| (row_index, out_idx))
+        .collect();
+    requests.sort_unstable_by_key(|&(row_index, _)| row_index);
+
+    let mut values = vec![None; selected_rows.len()];
+    match layout {
+        SparseColumnLayout::ScalarBoolPacked { extents } => {
+            for (row_index, out_idx) in requests {
+                let (slot, bit_offset) = locate_bit_extent_slot(extents, row_index)?;
+                main_file.seek(SeekFrom::Start(slot))?;
+                let mut byte = [0u8; 1];
+                main_file.read_exact(&mut byte)?;
+                let scalar = ScalarValue::Bool(((byte[0] >> bit_offset) & 1) != 0);
+                values[out_idx] = if (column.option & 2) != 0
+                    && scalar_value_is_default(
+                        &Value::Scalar(scalar.clone()),
+                        column.require_primitive_type()?,
+                    ) {
+                    None
+                } else {
+                    Some(scalar)
+                };
+            }
+        }
+        SparseColumnLayout::ScalarFixed { data_type, extents } => {
+            let row_width = scalar_fixed_width_bytes(*data_type).ok_or_else(|| {
+                StorageError::FormatMismatch(format!(
+                    "unsupported direct StManAipsIO scalar type {data_type:?}"
+                ))
+            })?;
+            let mut raw = vec![0u8; row_width];
+            for (row_index, out_idx) in requests {
+                let slot = locate_extent_slot(extents, row_index)?;
+                main_file.seek(SeekFrom::Start(slot))?;
+                main_file.read_exact(&mut raw)?;
+                let scalar = decode_fixed_scalar_value(*data_type, &raw)?;
+                values[out_idx] = if (column.option & 2) != 0
+                    && scalar_value_is_default(
+                        &Value::Scalar(scalar.clone()),
+                        column.require_primitive_type()?,
+                    ) {
+                    None
+                } else {
+                    Some(scalar)
+                };
+            }
+        }
+        _ => return Ok(None),
+    }
+
+    Ok(Some(values))
+}
+
 pub(crate) fn read_stman_scalar_column(
     path: &Path,
     columns: &[ColumnDescContents],

--- a/crates/casa-tables/src/storage/tiled_stman.rs
+++ b/crates/casa-tables/src/storage/tiled_stman.rs
@@ -212,7 +212,7 @@ fn read_tiled_header(path: &Path) -> Result<(TiledVariant, TiledStManHeader), St
 
     // The outermost AipsIO object is the derived-class envelope.
     let outer_type = io.get_next_type()?;
-    let _outer_version = io.getstart(&outer_type)?;
+    let outer_version = io.getstart(&outer_type)?;
 
     match outer_type.as_str() {
         "TiledColumnStMan" => {
@@ -257,7 +257,11 @@ fn read_tiled_header(path: &Path) -> Result<(TiledVariant, TiledStManHeader), St
             // default_tile_shape, nrrowLast, rowMap, cubeMap, posMap.
             let header = read_tiled_stman_base(&mut io)?;
             let default_tile_shape = read_iposition(&mut io)?;
-            let nrrow_last = io.get_u64().unwrap_or(io.get_u32().unwrap_or(0) as u64);
+            let nrrow_last = if outer_version >= 2 {
+                io.get_u64()?
+            } else {
+                io.get_u32()? as u64
+            };
             let row_map = read_block_u64(&mut io)?;
             let cube_map = read_block_u32(&mut io)?;
             let pos_map = read_block_u32(&mut io)?;
@@ -1899,19 +1903,17 @@ fn load_tiled_column_rows_cell_variant(
             dt,
             elem_size,
         )?;
-        let mut decoded = extract_selected_rows_from_cube_raw(
-            &raw,
-            &cube.cube_shape,
-            std::iter::once(SelectedCubeRow {
-                out_idx: 0,
-                pos_in_cube: 0,
-            }),
-            col_desc,
-            dt,
-            header.big_endian,
-            1,
-        )?;
-        outputs[out_idx] = decoded.pop().flatten();
+        outputs[out_idx] = match decode_array_value(&raw, &cube.cube_shape, dt, header.big_endian)?
+        {
+            Value::Array(array) => Some(array),
+            other => {
+                return Err(StorageError::FormatMismatch(format!(
+                    "tiled cell row '{}' expected array value, found {:?}",
+                    col_desc.col_name,
+                    other.kind()
+                )));
+            }
+        };
     }
     Ok(outputs)
 }
@@ -2146,6 +2148,304 @@ pub(crate) fn save_tiled_single_column_values(
             )
         }
     }
+}
+
+type SparseArrayRowValues = Vec<(usize, Option<ArrayValue>)>;
+
+#[derive(Clone, Copy, Debug)]
+struct SparseTiledCubeRowPatch {
+    global_row_idx: usize,
+    pos_in_cube: usize,
+}
+
+pub(crate) fn save_tiled_columns_sparse_rows_in_place(
+    table_path: &Path,
+    dm_seq_nr: u32,
+    dm_type_name: &str,
+    col_descs: &[ColumnDescContents],
+    sparse_columns: &[Option<SparseArrayRowValues>],
+    changed_rows: &[usize],
+) -> Result<bool, StorageError> {
+    if changed_rows.is_empty() {
+        return Ok(true);
+    }
+    if col_descs.len() != sparse_columns.len() {
+        return Ok(false);
+    }
+    match dm_type_name {
+        "TiledColumnStMan" => save_tiled_column_group_rows_sparse_in_place(
+            table_path,
+            dm_seq_nr,
+            col_descs,
+            sparse_columns,
+            changed_rows,
+        ),
+        "TiledCellStMan" => save_tiled_cell_group_rows_sparse_in_place(
+            table_path,
+            dm_seq_nr,
+            col_descs,
+            sparse_columns,
+            changed_rows,
+        ),
+        "TiledDataStMan" => save_tiled_data_group_rows_sparse_in_place(
+            table_path,
+            dm_seq_nr,
+            col_descs,
+            sparse_columns,
+            changed_rows,
+        ),
+        "TiledShapeStMan" => save_tiled_shape_group_rows_sparse_in_place(
+            table_path,
+            dm_seq_nr,
+            col_descs,
+            sparse_columns,
+            changed_rows,
+        ),
+        _ => Ok(false),
+    }
+}
+
+fn cube_with_single_row_axis(cube: &TsmCubeInfo) -> TsmCubeInfo {
+    let mut cube_with_row_axis = cube.clone();
+    cube_with_row_axis.cube_shape.push(1);
+    cube_with_row_axis.tile_shape.push(1);
+    cube_with_row_axis
+}
+
+fn save_tiled_column_group_rows_sparse_in_place(
+    table_path: &Path,
+    dm_seq_nr: u32,
+    col_descs: &[ColumnDescContents],
+    sparse_columns: &[Option<SparseArrayRowValues>],
+    changed_rows: &[usize],
+) -> Result<bool, StorageError> {
+    let header_path = table_path.join(format!("table.f{dm_seq_nr}"));
+    let (variant, header) = read_tiled_header(&header_path)?;
+    if !matches!(variant, TiledVariant::Column { .. })
+        || header.col_data_types.len() != col_descs.len()
+    {
+        return Ok(false);
+    }
+    let Some(cube) = header.cubes.first() else {
+        return Ok(false);
+    };
+    if cube.file_seq_nr < 0 || cube.cube_shape.is_empty() {
+        return Ok(false);
+    }
+    let row_axis = cube.cube_shape.len() - 1;
+    let row_count = cube.cube_shape[row_axis];
+    let row_patches: Vec<_> = changed_rows
+        .iter()
+        .copied()
+        .filter(|&row_idx| row_idx < row_count)
+        .map(|row_idx| SparseTiledCubeRowPatch {
+            global_row_idx: row_idx,
+            pos_in_cube: row_idx,
+        })
+        .collect();
+    if row_patches.is_empty() {
+        return Ok(true);
+    }
+    patch_tiled_cube_sparse_rows(
+        table_path,
+        dm_seq_nr,
+        col_descs,
+        sparse_columns,
+        header.big_endian,
+        &header.col_data_types,
+        cube,
+        &row_patches,
+    )?;
+    Ok(true)
+}
+
+fn save_tiled_cell_group_rows_sparse_in_place(
+    table_path: &Path,
+    dm_seq_nr: u32,
+    col_descs: &[ColumnDescContents],
+    sparse_columns: &[Option<SparseArrayRowValues>],
+    changed_rows: &[usize],
+) -> Result<bool, StorageError> {
+    let header_path = table_path.join(format!("table.f{dm_seq_nr}"));
+    let (variant, header) = read_tiled_header(&header_path)?;
+    if !matches!(variant, TiledVariant::Cell { .. })
+        || header.col_data_types.len() != col_descs.len()
+    {
+        return Ok(false);
+    }
+
+    for &row_idx in changed_rows {
+        let Some(cube) = header.cubes.get(row_idx) else {
+            continue;
+        };
+        if cube.file_seq_nr < 0 || cube.cube_shape.is_empty() {
+            continue;
+        }
+        let cube_with_row_axis = cube_with_single_row_axis(cube);
+        patch_tiled_cube_sparse_rows(
+            table_path,
+            dm_seq_nr,
+            col_descs,
+            sparse_columns,
+            header.big_endian,
+            &header.col_data_types,
+            &cube_with_row_axis,
+            &[SparseTiledCubeRowPatch {
+                global_row_idx: row_idx,
+                pos_in_cube: 0,
+            }],
+        )?;
+    }
+
+    Ok(true)
+}
+
+fn save_tiled_data_group_rows_sparse_in_place(
+    table_path: &Path,
+    dm_seq_nr: u32,
+    col_descs: &[ColumnDescContents],
+    sparse_columns: &[Option<SparseArrayRowValues>],
+    changed_rows: &[usize],
+) -> Result<bool, StorageError> {
+    let header_path = table_path.join(format!("table.f{dm_seq_nr}"));
+    let (variant, header) = read_tiled_header(&header_path)?;
+    let TiledVariant::Data {
+        row_map,
+        cube_map,
+        pos_map,
+        ..
+    } = variant
+    else {
+        return Ok(false);
+    };
+    if header.col_data_types.len() != col_descs.len() || row_map.is_empty() {
+        return Ok(false);
+    }
+
+    let mut patches_by_cube: std::collections::BTreeMap<usize, Vec<SparseTiledCubeRowPatch>> =
+        std::collections::BTreeMap::new();
+    for &row_idx in changed_rows {
+        let chunk = match row_map.binary_search(&(row_idx as u64)) {
+            Ok(i) => i,
+            Err(i) => {
+                if i == 0 {
+                    continue;
+                }
+                i - 1
+            }
+        };
+        let cube_idx = cube_map[chunk] as usize;
+        if cube_idx >= header.cubes.len() {
+            continue;
+        }
+        let chunk_start = row_map[chunk] as usize;
+        let pos_in_cube = pos_map[chunk] as usize + (row_idx - chunk_start);
+        patches_by_cube
+            .entry(cube_idx)
+            .or_default()
+            .push(SparseTiledCubeRowPatch {
+                global_row_idx: row_idx,
+                pos_in_cube,
+            });
+    }
+    if patches_by_cube.is_empty() {
+        return Ok(true);
+    }
+
+    for (cube_idx, row_patches) in patches_by_cube {
+        let cube = &header.cubes[cube_idx];
+        if cube.file_seq_nr < 0 || cube.cube_shape.is_empty() {
+            continue;
+        }
+        patch_tiled_cube_sparse_rows(
+            table_path,
+            dm_seq_nr,
+            col_descs,
+            sparse_columns,
+            header.big_endian,
+            &header.col_data_types,
+            cube,
+            &row_patches,
+        )?;
+    }
+
+    Ok(true)
+}
+
+fn save_tiled_shape_group_rows_sparse_in_place(
+    table_path: &Path,
+    dm_seq_nr: u32,
+    col_descs: &[ColumnDescContents],
+    sparse_columns: &[Option<SparseArrayRowValues>],
+    changed_rows: &[usize],
+) -> Result<bool, StorageError> {
+    let header_path = table_path.join(format!("table.f{dm_seq_nr}"));
+    let (variant, header) = read_tiled_header(&header_path)?;
+    let TiledVariant::Shape {
+        nr_used_row_map,
+        row_map,
+        cube_map,
+        pos_map,
+        ..
+    } = variant
+    else {
+        return Ok(false);
+    };
+    if header.col_data_types.len() != col_descs.len() {
+        return Ok(false);
+    }
+    let n_intervals = nr_used_row_map as usize;
+    if n_intervals == 0 {
+        return Ok(false);
+    }
+
+    let mut patches_by_cube: std::collections::BTreeMap<usize, Vec<SparseTiledCubeRowPatch>> =
+        std::collections::BTreeMap::new();
+    for &row_idx in changed_rows {
+        let interval = row_map[..n_intervals].partition_point(|&rm| rm < row_idx as u32);
+        if interval >= n_intervals {
+            continue;
+        }
+        let cube_idx = cube_map[interval] as usize;
+        if cube_idx == 0 || cube_idx >= header.cubes.len() {
+            continue;
+        }
+        let diff = row_map[interval] as usize - row_idx;
+        let Some(pos_in_cube) = (pos_map[interval] as usize).checked_sub(diff) else {
+            return Err(StorageError::FormatMismatch(format!(
+                "invalid TiledShapeStMan row map for row {row_idx}: interval {interval} has pos {} < diff {diff}",
+                pos_map[interval]
+            )));
+        };
+        patches_by_cube
+            .entry(cube_idx)
+            .or_default()
+            .push(SparseTiledCubeRowPatch {
+                global_row_idx: row_idx,
+                pos_in_cube,
+            });
+    }
+    if patches_by_cube.is_empty() {
+        return Ok(true);
+    }
+
+    for (cube_idx, row_patches) in patches_by_cube {
+        let cube = &header.cubes[cube_idx];
+        if cube.file_seq_nr < 0 || cube.cube_shape.is_empty() {
+            continue;
+        }
+        patch_tiled_cube_sparse_rows(
+            table_path,
+            dm_seq_nr,
+            col_descs,
+            sparse_columns,
+            header.big_endian,
+            &header.col_data_types,
+            cube,
+            &row_patches,
+        )?;
+    }
+    Ok(true)
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -2434,6 +2734,194 @@ fn patch_single_column_tiled_cube_rows(
             write_tile_storage(&mut packed_tile, col_data_type, &unpacked_tile, nrpixels);
             file.seek(SeekFrom::Start(tile_start as u64))?;
             file.write_all(&packed_tile)?;
+        }
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn patch_tiled_cube_sparse_rows(
+    table_path: &Path,
+    dm_seq_nr: u32,
+    col_descs: &[ColumnDescContents],
+    sparse_columns: &[Option<SparseArrayRowValues>],
+    big_endian: bool,
+    col_data_types: &[CasacoreDataType],
+    cube: &TsmCubeInfo,
+    row_patches: &[SparseTiledCubeRowPatch],
+) -> Result<(), StorageError> {
+    let ndim = cube.cube_shape.len();
+    if ndim == 0 {
+        return Ok(());
+    }
+    let row_axis = ndim - 1;
+    if row_axis == 0 {
+        return Err(StorageError::FormatMismatch(
+            "tiled sparse save requires array-valued cells".to_string(),
+        ));
+    }
+
+    struct SparseColumnPatch {
+        col_data_type: CasacoreDataType,
+        elem_size: usize,
+        expected_row_bytes: usize,
+        row_block_bytes: usize,
+        tile_storage_len: usize,
+        col_offset: usize,
+        encoded_rows: std::collections::HashMap<usize, Vec<u8>>,
+    }
+
+    let cell_shape = &cube.cube_shape[..row_axis];
+    let tile_cell_shape = &cube.tile_shape[..row_axis];
+    let row_tile_len = cube.tile_shape[row_axis].max(1);
+    let row_block_pixels: usize = tile_cell_shape.iter().product();
+    let nrpixels: usize = cube.tile_shape.iter().product();
+    let (bucket_size, col_offsets) = compute_tile_layout(col_data_types, &cube.tile_shape);
+    let tiles_per_dim: Vec<usize> = cube
+        .cube_shape
+        .iter()
+        .zip(cube.tile_shape.iter())
+        .map(|(&cube_len, &tile_len)| cube_len.div_ceil(tile_len))
+        .collect();
+    let cell_tiles_per_dim = &tiles_per_dim[..row_axis];
+    let cell_tile_total = cell_tiles_per_dim.iter().product::<usize>().max(1);
+
+    let mut column_patches = Vec::new();
+    for (col_idx, sparse_values) in sparse_columns.iter().enumerate() {
+        let Some(sparse_values) = sparse_values else {
+            continue;
+        };
+        if col_idx >= col_descs.len() || col_idx >= col_data_types.len() {
+            return Ok(());
+        }
+        let col_data_type = col_data_types[col_idx];
+        let elem_size = tile_element_size(col_data_type);
+        if elem_size == 0 {
+            return Err(StorageError::FormatMismatch(format!(
+                "tiled sparse save does not support non-primitive array column {}",
+                col_descs[col_idx].col_name
+            )));
+        }
+        let expected_row_bytes = cell_shape.iter().product::<usize>() * elem_size;
+        let mut encoded_rows = std::collections::HashMap::with_capacity(sparse_values.len());
+        for (row_idx, value) in sparse_values {
+            let encoded = match value {
+                Some(value) => {
+                    let wrapped = Value::Array(value.clone());
+                    let (encoded, dt) = encode_array_value(&wrapped, big_endian)?;
+                    if dt != col_data_type {
+                        return Err(StorageError::FormatMismatch(format!(
+                            "tiled sparse save column {} expected {:?} but encoded {:?}",
+                            col_descs[col_idx].col_name, col_data_type, dt
+                        )));
+                    }
+                    if encoded.len() != expected_row_bytes {
+                        return Err(StorageError::FormatMismatch(format!(
+                            "tiled sparse save column {} expected {expected_row_bytes} row bytes but encoded {}",
+                            col_descs[col_idx].col_name,
+                            encoded.len()
+                        )));
+                    }
+                    encoded
+                }
+                None => vec![0u8; expected_row_bytes],
+            };
+            encoded_rows.insert(*row_idx, encoded);
+        }
+        if encoded_rows.is_empty() {
+            continue;
+        }
+        column_patches.push(SparseColumnPatch {
+            col_data_type,
+            elem_size,
+            expected_row_bytes,
+            row_block_bytes: row_block_pixels * elem_size,
+            tile_storage_len: tile_storage_bytes(col_data_type, nrpixels),
+            col_offset: col_offsets[col_idx],
+            encoded_rows,
+        });
+    }
+    if column_patches.is_empty() {
+        return Ok(());
+    }
+
+    let mut patches_by_row_tile: std::collections::BTreeMap<usize, Vec<SparseTiledCubeRowPatch>> =
+        std::collections::BTreeMap::new();
+    for &patch in row_patches {
+        patches_by_row_tile
+            .entry(patch.pos_in_cube / row_tile_len)
+            .or_default()
+            .push(patch);
+    }
+
+    let tsm_path = tsm_data_path(table_path, dm_seq_nr, cube.file_seq_nr as u32);
+    let mut file = OpenOptions::new().read(true).write(true).open(&tsm_path)?;
+    for (row_tile_idx, row_tile_patches) in patches_by_row_tile {
+        if row_tile_idx >= tiles_per_dim[row_axis] {
+            continue;
+        }
+        for cell_tile_linear in 0..cell_tile_total {
+            let cell_tile_pos = if cell_tiles_per_dim.is_empty() {
+                Vec::new()
+            } else {
+                linear_to_nd(cell_tile_linear, cell_tiles_per_dim)
+            };
+            let mut tile_pos = cell_tile_pos.clone();
+            tile_pos.push(row_tile_idx);
+            let tile_idx = nd_to_linear(&tile_pos, &tiles_per_dim);
+            let tile_start = cube.file_offset as usize + tile_idx * bucket_size;
+            let mut packed_bucket = vec![0u8; bucket_size];
+            file.seek(SeekFrom::Start(tile_start as u64))?;
+            file.read_exact(&mut packed_bucket)?;
+
+            let cell_cube_start: Vec<usize> = (0..row_axis)
+                .map(|dim| cell_tile_pos.get(dim).copied().unwrap_or(0) * cube.tile_shape[dim])
+                .collect();
+            let actual_cell_extent: Vec<usize> = (0..row_axis)
+                .map(|dim| {
+                    std::cmp::min(cube.tile_shape[dim], cell_shape[dim] - cell_cube_start[dim])
+                })
+                .collect();
+
+            for column_patch in &column_patches {
+                let src_start = column_patch.col_offset;
+                let src_end = src_start + column_patch.tile_storage_len;
+                let mut unpacked_tile = read_tile_storage(
+                    &packed_bucket[src_start..src_end],
+                    column_patch.col_data_type,
+                    nrpixels,
+                );
+                for patch in &row_tile_patches {
+                    let Some(encoded_row) = column_patch.encoded_rows.get(&patch.global_row_idx)
+                    else {
+                        continue;
+                    };
+                    debug_assert_eq!(encoded_row.len(), column_patch.expected_row_bytes);
+                    let local_row = patch.pos_in_cube % row_tile_len;
+                    let row_slice_start = local_row * column_patch.row_block_bytes;
+                    let row_slice_end = row_slice_start + column_patch.row_block_bytes;
+                    let row_tile = &mut unpacked_tile[row_slice_start..row_slice_end];
+                    copy_cube_to_tile(
+                        encoded_row,
+                        cell_shape,
+                        row_tile,
+                        tile_cell_shape,
+                        &cell_cube_start,
+                        &actual_cell_extent,
+                        column_patch.elem_size,
+                    );
+                }
+                write_tile_storage(
+                    &mut packed_bucket[src_start..src_end],
+                    column_patch.col_data_type,
+                    &unpacked_tile,
+                    nrpixels,
+                );
+            }
+
+            file.seek(SeekFrom::Start(tile_start as u64))?;
+            file.write_all(&packed_bucket)?;
         }
     }
 
@@ -5355,7 +5843,13 @@ fn dot_product(a: &[usize], b: &[usize]) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use casa_types::{ArrayValue, PrimitiveType, RecordField, RecordValue, Value};
+    use ndarray::ArrayD;
     use tempfile::tempdir;
+
+    use crate::storage::TABLE_CONTROL_FILE;
+    use crate::storage::table_control::{read_table_dat, write_table_dat};
+    use crate::{ColumnSchema, DataManagerKind, Table, TableOptions, TableSchema};
 
     fn make_bool_tile_pattern(base: usize) -> Vec<bool> {
         (0..4).map(|i| (base + i) % 3 == 0).collect()
@@ -5550,5 +6044,116 @@ mod tests {
                 assert_eq!(reconstructed[idx], cube_data[idx], "mismatch at ({i},{j})");
             }
         }
+    }
+
+    #[test]
+    fn sparse_partial_save_patches_tiled_data_rows_from_legacy_header() {
+        let schema = TableSchema::new(vec![ColumnSchema::array_fixed(
+            "data",
+            PrimitiveType::Float32,
+            vec![2, 2],
+        )])
+        .expect("schema");
+
+        let mut table = Table::with_schema(schema);
+        for row_idx in 0..4 {
+            table
+                .add_row(RecordValue::new(vec![RecordField::new(
+                    "data",
+                    Value::Array(ArrayValue::Float32(
+                        ArrayD::from_shape_vec(
+                            vec![2, 2],
+                            vec![
+                                row_idx as f32,
+                                row_idx as f32 + 10.0,
+                                row_idx as f32 + 20.0,
+                                row_idx as f32 + 30.0,
+                            ],
+                        )
+                        .expect("shape data"),
+                    )),
+                )]))
+                .expect("push row");
+        }
+
+        let dir = tempdir().expect("tempdir");
+        let table_path = dir.path().join("tiled-data-compat.table");
+        std::fs::create_dir_all(&table_path).expect("create table dir");
+        table
+            .save(
+                TableOptions::new(&table_path).with_data_manager(DataManagerKind::TiledColumnStMan),
+            )
+            .expect("save tiled-column table");
+
+        let control_path = table_path.join(TABLE_CONTROL_FILE);
+        let mut table_dat = read_table_dat(&control_path).expect("read table.dat");
+        for dm in &mut table_dat.column_set.data_managers {
+            if dm.type_name == "TiledColumnStMan" {
+                dm.type_name = "TiledDataStMan".to_string();
+            }
+        }
+        for desc in &mut table_dat.table_desc.columns {
+            if desc.data_manager_type == "TiledColumnStMan" {
+                desc.data_manager_type = "TiledDataStMan".to_string();
+            }
+        }
+        write_table_dat(&control_path, &table_dat).expect("rewrite table.dat");
+
+        let header_path = table_path.join("table.f0");
+        let (variant, header) = read_tiled_header(&header_path).expect("read tiled header");
+        let TiledVariant::Column { default_tile_shape } = variant else {
+            panic!("expected TiledColumnStMan header");
+        };
+        write_tiled_header(
+            &header_path,
+            &TiledVariant::Data {
+                default_tile_shape,
+                nrrow_last: header.nrrow,
+                row_map: vec![0],
+                cube_map: vec![0],
+                pos_map: vec![0],
+            },
+            &header,
+        )
+        .expect("rewrite TiledDataStMan header");
+
+        let mut reopened =
+            Table::open(TableOptions::new(&table_path)).expect("open tiled-data table");
+        assert_eq!(reopened.data_manager_info()[0].dm_type, "TiledDataStMan");
+
+        reopened
+            .set_array_cell_assuming_valid(
+                2,
+                "data",
+                ArrayValue::Float32(
+                    ArrayD::from_shape_vec(vec![2, 2], vec![402.0, 412.0, 422.0, 432.0])
+                        .expect("shape updated data"),
+                ),
+            )
+            .expect("set tiled-data array cell lazily");
+
+        reopened
+            .save_selected_rows_in_place_assuming_valid(&["data"], &[2])
+            .expect("sparse tiled-data partial save");
+
+        let verify = Table::open(TableOptions::new(&table_path)).expect("reopen tiled-data table");
+        assert_eq!(
+            verify.get_array_cell(0, "data").expect("data row 0"),
+            &ArrayValue::Float32(
+                ArrayD::from_shape_vec(vec![2, 2], vec![0.0, 10.0, 20.0, 30.0]).unwrap()
+            )
+        );
+        assert_eq!(
+            verify.get_array_cell(2, "data").expect("data row 2"),
+            &ArrayValue::Float32(
+                ArrayD::from_shape_vec(vec![2, 2], vec![402.0, 412.0, 422.0, 432.0]).unwrap()
+            )
+        );
+        assert_eq!(
+            verify.get_array_cell(3, "data").expect("data row 3"),
+            &ArrayValue::Float32(
+                ArrayD::from_shape_vec(vec![2, 2], vec![3.0, 13.0, 23.0, 33.0]).unwrap()
+            )
+        );
     }
 }

--- a/crates/casa-tables/src/table/io.rs
+++ b/crates/casa-tables/src/table/io.rs
@@ -3,7 +3,12 @@ use super::*;
 #[cfg(unix)]
 use crate::lock::read_sync_data_from_table_dir;
 use crate::storage::StorageProfiler;
-use casa_types::ScalarValue;
+use casa_types::{ArrayValue, ScalarValue};
+
+type SparseArrayRowValues = Vec<(usize, Option<ArrayValue>)>;
+type SparseArrayColumns = Vec<Option<SparseArrayRowValues>>;
+type SparseScalarRowValues = Vec<(usize, Option<ScalarValue>)>;
+type SparseScalarColumns = Vec<Option<SparseScalarRowValues>>;
 
 impl Table {
     /// Opens an existing table from disk.
@@ -451,17 +456,43 @@ impl Table {
                     }
                 }
                 "IncrementalStMan" => {
-                    let sparse_saved = if let (Some(rows), Some(scalar_group_columns)) = (
-                        changed_rows.as_ref(),
-                        borrow_scalar_group_columns_from_current_cells(self, &group_col_descs)?,
-                    ) {
-                        crate::storage::incremental_stman::save_ism_file_scalar_columns_rows_in_place(
-                            &data_path,
-                            &group_col_descs,
-                            &scalar_group_columns,
-                            rows,
-                            table_dat.big_endian,
-                        )?
+                    let group_changed_columns: std::collections::HashSet<&str> = group_col_descs
+                        .iter()
+                        .filter_map(|desc| {
+                            changed_set
+                                .contains(desc.col_name.as_str())
+                                .then_some(desc.col_name.as_str())
+                        })
+                        .collect();
+                    let sparse_saved = if let Some(rows) = changed_rows.as_ref() {
+                        if let Some(sparse_group_columns) =
+                            collect_sparse_scalar_group_values_from_current_cells(
+                                self,
+                                rows,
+                                &group_col_descs,
+                                &group_changed_columns,
+                            )?
+                        {
+                            crate::storage::incremental_stman::save_ism_file_scalar_columns_sparse_rows_in_place(
+                                &data_path,
+                                &group_col_descs,
+                                &sparse_group_columns,
+                                rows,
+                                table_dat.big_endian,
+                            )?
+                        } else if let Some(scalar_group_columns) =
+                            borrow_scalar_group_columns_from_current_cells(self, &group_col_descs)?
+                        {
+                            crate::storage::incremental_stman::save_ism_file_scalar_columns_rows_in_place(
+                                &data_path,
+                                &group_col_descs,
+                                &scalar_group_columns,
+                                rows,
+                                table_dat.big_endian,
+                            )?
+                        } else {
+                            false
+                        }
                     } else {
                         false
                     };
@@ -503,26 +534,44 @@ impl Table {
                     }
                 }
                 "TiledColumnStMan" | "TiledShapeStMan" | "TiledCellStMan" | "TiledDataStMan" => {
-                    if group_col_descs.len() != 1 {
-                        return Err(TableError::Storage(format!(
-                            "partial in-place save only supports single-column tiled groups; seq {} has {} columns",
-                            group.seq_nr,
-                            group_col_descs.len()
-                        )));
-                    }
-                    let values = collect_column_values_from_current_cells(
-                        self,
-                        self.row_count(),
-                        &group_col_descs[0],
-                    )?;
-                    let value_refs: Vec<_> = values.iter().map(|value| value.as_ref()).collect();
+                    let group_changed_columns: std::collections::HashSet<&str> = group_col_descs
+                        .iter()
+                        .filter_map(|desc| {
+                            changed_set
+                                .contains(desc.col_name.as_str())
+                                .then_some(desc.col_name.as_str())
+                        })
+                        .collect();
                     let dm_name = if group_col_descs[0].data_manager_group.is_empty() {
                         group_col_descs[0].col_name.as_str()
                     } else {
                         group_col_descs[0].data_manager_group.as_str()
                     };
-                    let sparse_saved = match changed_rows.as_ref() {
-                        Some(rows) => {
+                    let sparse_saved = if let Some(rows) = changed_rows.as_ref() {
+                        if let Some(sparse_group_columns) =
+                            collect_sparse_array_group_values_from_current_cells(
+                                self,
+                                rows,
+                                &group_col_descs,
+                                &group_changed_columns,
+                            )?
+                        {
+                            crate::storage::tiled_stman::save_tiled_columns_sparse_rows_in_place(
+                                source_path,
+                                group.seq_nr,
+                                &group.dm_type,
+                                &group_col_descs,
+                                &sparse_group_columns,
+                                rows,
+                            )?
+                        } else if group_col_descs.len() == 1 {
+                            let values = collect_column_values_from_current_cells(
+                                self,
+                                self.row_count(),
+                                &group_col_descs[0],
+                            )?;
+                            let value_refs: Vec<_> =
+                                values.iter().map(|value| value.as_ref()).collect();
                             crate::storage::tiled_stman::save_tiled_single_column_rows_in_place(
                                 source_path,
                                 group.seq_nr,
@@ -536,22 +585,50 @@ impl Table {
                                     dm_name,
                                 },
                             )?
+                        } else {
+                            false
                         }
-                        None => false,
+                    } else {
+                        false
                     };
                     if !sparse_saved {
-                        crate::storage::tiled_stman::save_tiled_single_column_values(
-                            source_path,
-                            group.seq_nr,
-                            &group_col_descs[0],
-                            &value_refs,
-                            crate::storage::tiled_stman::SingleColumnTiledSaveOptions {
-                                dm_type_name: &group.dm_type,
-                                big_endian: table_dat.big_endian,
-                                default_tile_shape: None,
+                        if group_col_descs.len() == 1 {
+                            let values = collect_column_values_from_current_cells(
+                                self,
+                                self.row_count(),
+                                &group_col_descs[0],
+                            )?;
+                            let value_refs: Vec<_> =
+                                values.iter().map(|value| value.as_ref()).collect();
+                            crate::storage::tiled_stman::save_tiled_single_column_values(
+                                source_path,
+                                group.seq_nr,
+                                &group_col_descs[0],
+                                &value_refs,
+                                crate::storage::tiled_stman::SingleColumnTiledSaveOptions {
+                                    dm_type_name: &group.dm_type,
+                                    big_endian: table_dat.big_endian,
+                                    default_tile_shape: None,
+                                    dm_name,
+                                },
+                            )?;
+                        } else {
+                            let rows = build_group_rows_from_current_cells(
+                                self,
+                                self.row_count(),
+                                &group_col_descs,
+                            )?;
+                            crate::storage::tiled_stman::save_tiled_columns(
+                                source_path,
+                                group.seq_nr,
+                                &group.dm_type,
+                                &group_col_descs,
+                                &rows,
+                                table_dat.big_endian,
+                                None,
                                 dm_name,
-                            },
-                        )?;
+                            )?;
+                        }
                     }
                 }
                 other => {
@@ -934,6 +1011,67 @@ fn borrow_scalar_group_columns_from_current_cells<'a>(
         values.push(column_values);
     }
     Ok(Some(values))
+}
+
+fn collect_sparse_scalar_group_values_from_current_cells(
+    table: &Table,
+    row_indices: &[usize],
+    col_descs: &[crate::storage::table_control::ColumnDescContents],
+    changed_columns: &std::collections::HashSet<&str>,
+) -> Result<Option<SparseScalarColumns>, TableError> {
+    let mut columns = Vec::with_capacity(col_descs.len());
+    for col_desc in col_descs {
+        if col_desc.is_array || col_desc.is_record() {
+            return Ok(None);
+        }
+        if !changed_columns.contains(col_desc.col_name.as_str()) {
+            columns.push(None);
+            continue;
+        }
+        let Some(pending_values) = table.inner.pending_scalar_cells(&col_desc.col_name) else {
+            return Ok(None);
+        };
+        let mut values = Vec::with_capacity(row_indices.len());
+        for &row_index in row_indices {
+            if let Some(value) = pending_values.get(&row_index) {
+                values.push((row_index, Some(value.clone())));
+            }
+        }
+        columns.push(Some(values));
+    }
+    Ok(Some(columns))
+}
+
+fn collect_sparse_array_group_values_from_current_cells(
+    table: &Table,
+    row_indices: &[usize],
+    col_descs: &[crate::storage::table_control::ColumnDescContents],
+    changed_columns: &std::collections::HashSet<&str>,
+) -> Result<Option<SparseArrayColumns>, TableError> {
+    let mut columns = Vec::with_capacity(col_descs.len());
+    for col_desc in col_descs {
+        if !col_desc.is_array || col_desc.is_record() {
+            return Ok(None);
+        }
+        if !changed_columns.contains(col_desc.col_name.as_str()) {
+            columns.push(None);
+            continue;
+        }
+        let Some(pending_values) = table.inner.pending_array_cells(&col_desc.col_name) else {
+            return Ok(None);
+        };
+        let mut values = Vec::with_capacity(row_indices.len());
+        for &row_index in row_indices {
+            if let Some((_, value)) = pending_values
+                .iter()
+                .find(|(pending_row, _)| *pending_row == row_index)
+            {
+                values.push((row_index, Some(value.clone())));
+            }
+        }
+        columns.push(Some(values));
+    }
+    Ok(Some(columns))
 }
 
 fn current_value_for_column(

--- a/crates/casa-tables/src/table/tests.rs
+++ b/crates/casa-tables/src/table/tests.rs
@@ -1986,6 +1986,65 @@ fn lazy_disk_open_reads_selected_array_cells_without_loading_full_tiled_column()
 }
 
 #[test]
+fn lazy_disk_open_reads_scalar_cells_without_loading_full_scalar_columns() {
+    let schema = TableSchema::new(vec![
+        ColumnSchema::scalar("id", PrimitiveType::Int32),
+        ColumnSchema::scalar("scan", PrimitiveType::Int32),
+    ])
+    .expect("schema");
+
+    for dm in [
+        DataManagerKind::StManAipsIO,
+        DataManagerKind::StandardStMan,
+        DataManagerKind::IncrementalStMan,
+    ] {
+        let mut table = Table::with_schema(schema.clone());
+        for (id, scan) in [(1, 10), (2, 20), (3, 30), (4, 40)] {
+            table
+                .add_row(RecordValue::new(vec![
+                    RecordField::new("id", Value::Scalar(ScalarValue::Int32(id))),
+                    RecordField::new("scan", Value::Scalar(ScalarValue::Int32(scan))),
+                ]))
+                .expect("push row");
+        }
+
+        let root = unique_test_dir(&format!("lazy_scalar_cell_buffered_{dm:?}"));
+        std::fs::create_dir_all(&root).expect("create test dir");
+        table
+            .save(TableOptions::new(&root).with_data_manager(dm))
+            .expect("save disk-backed table");
+
+        let reopened = Table::open(TableOptions::new(&root)).expect("open lazy table");
+        assert!(!reopened.inner.has_loaded_rows());
+        assert!(!reopened.inner.has_loaded_scalar_column("id"));
+        assert!(!reopened.inner.has_loaded_scalar_column("scan"));
+
+        assert_eq!(
+            reopened.get_scalar_cell(3, "id").expect("id row 3"),
+            &ScalarValue::Int32(4)
+        );
+        assert_eq!(
+            reopened.get_scalar_cell(1, "scan").expect("scan row 1"),
+            &ScalarValue::Int32(20)
+        );
+        assert!(
+            !reopened.inner.has_loaded_rows(),
+            "scalar cell reads should not force row materialization for {dm:?}"
+        );
+        assert!(
+            !reopened.inner.has_loaded_scalar_column("id"),
+            "scalar cell reads should not populate the full scalar-column cache for {dm:?}"
+        );
+        assert!(
+            !reopened.inner.has_loaded_scalar_column("scan"),
+            "scalar cell reads should not populate the full scalar-column cache for {dm:?}"
+        );
+
+        std::fs::remove_dir_all(&root).expect("cleanup test dir");
+    }
+}
+
+#[test]
 fn partial_save_with_changed_rows_patches_stman_aipsio_indirect_arrays() {
     let schema = TableSchema::new(vec![
         ColumnSchema::scalar("flag_row", PrimitiveType::Bool),
@@ -2214,6 +2273,248 @@ fn partial_save_with_changed_rows_patches_only_touched_tiled_rows() {
 }
 
 #[test]
+fn partial_save_with_changed_rows_patches_only_touched_multi_column_tiled_rows() {
+    let schema = TableSchema::new(vec![
+        ColumnSchema::array_fixed("DATA", PrimitiveType::Float32, vec![2, 2]),
+        ColumnSchema::array_fixed("WEIGHT", PrimitiveType::Float32, vec![2, 2]),
+    ])
+    .expect("schema");
+
+    let mut table = Table::with_schema(schema);
+    for row_idx in 0..4 {
+        table
+            .add_row(RecordValue::new(vec![
+                RecordField::new(
+                    "DATA",
+                    Value::Array(ArrayValue::Float32(
+                        ArrayD::from_shape_vec(
+                            vec![2, 2],
+                            vec![
+                                row_idx as f32,
+                                row_idx as f32 + 10.0,
+                                row_idx as f32 + 20.0,
+                                row_idx as f32 + 30.0,
+                            ],
+                        )
+                        .expect("shape DATA"),
+                    )),
+                ),
+                RecordField::new(
+                    "WEIGHT",
+                    Value::Array(ArrayValue::Float32(
+                        ArrayD::from_shape_vec(
+                            vec![2, 2],
+                            vec![
+                                row_idx as f32 + 100.0,
+                                row_idx as f32 + 110.0,
+                                row_idx as f32 + 120.0,
+                                row_idx as f32 + 130.0,
+                            ],
+                        )
+                        .expect("shape WEIGHT"),
+                    )),
+                ),
+            ]))
+            .expect("push row");
+    }
+
+    let root = unique_test_dir("partial_save_changed_rows_tiled_shape_multi_column");
+    std::fs::create_dir_all(&root).expect("create test dir");
+    table
+        .save(TableOptions::new(&root).with_data_manager(DataManagerKind::TiledShapeStMan))
+        .expect("save tiled-shape table");
+
+    let mut reopened = Table::open(TableOptions::new(&root)).expect("open tiled-shape table");
+    let tiled_groups: Vec<_> = reopened
+        .data_manager_info()
+        .iter()
+        .filter(|dm| dm.dm_type == "TiledShapeStMan")
+        .collect();
+    assert_eq!(tiled_groups.len(), 1);
+    assert_eq!(tiled_groups[0].columns.len(), 2);
+    assert!(
+        tiled_groups[0]
+            .columns
+            .iter()
+            .any(|column| column == "DATA")
+    );
+    assert!(
+        tiled_groups[0]
+            .columns
+            .iter()
+            .any(|column| column == "WEIGHT")
+    );
+
+    reopened
+        .set_array_cell_assuming_valid(
+            1,
+            "DATA",
+            ArrayValue::Float32(
+                ArrayD::from_shape_vec(vec![2, 2], vec![201.0, 211.0, 221.0, 231.0])
+                    .expect("shape updated DATA"),
+            ),
+        )
+        .expect("set DATA lazily");
+    reopened
+        .set_array_cell_assuming_valid(
+            2,
+            "WEIGHT",
+            ArrayValue::Float32(
+                ArrayD::from_shape_vec(vec![2, 2], vec![302.0, 312.0, 322.0, 332.0])
+                    .expect("shape updated WEIGHT"),
+            ),
+        )
+        .expect("set WEIGHT lazily");
+    assert!(!reopened.inner.has_loaded_rows());
+    assert!(reopened.inner.has_pending_array_cells("DATA"));
+    assert!(reopened.inner.has_pending_array_cells("WEIGHT"));
+    assert!(!reopened.inner.has_loaded_array_column("DATA"));
+    assert!(!reopened.inner.has_loaded_array_column("WEIGHT"));
+
+    reopened
+        .save_selected_rows_in_place_assuming_valid(&["DATA", "WEIGHT"], &[1, 2])
+        .expect("partial save with tiled group row hints");
+    assert!(
+        !reopened.inner.has_loaded_rows(),
+        "multi-column tiled sparse save should not force row materialization"
+    );
+    assert!(
+        !reopened.inner.has_loaded_array_column("DATA"),
+        "multi-column tiled sparse save should not materialize the DATA column"
+    );
+    assert!(
+        !reopened.inner.has_loaded_array_column("WEIGHT"),
+        "multi-column tiled sparse save should not materialize the WEIGHT column"
+    );
+
+    let verify = Table::open(TableOptions::new(&root)).expect("reopen after sparse partial save");
+    assert_eq!(
+        verify.get_array_cell(0, "DATA").expect("DATA row 0"),
+        &ArrayValue::Float32(
+            ArrayD::from_shape_vec(vec![2, 2], vec![0.0, 10.0, 20.0, 30.0]).unwrap()
+        )
+    );
+    assert_eq!(
+        verify.get_array_cell(1, "DATA").expect("DATA row 1"),
+        &ArrayValue::Float32(
+            ArrayD::from_shape_vec(vec![2, 2], vec![201.0, 211.0, 221.0, 231.0]).unwrap()
+        )
+    );
+    assert_eq!(
+        verify.get_array_cell(2, "DATA").expect("DATA row 2"),
+        &ArrayValue::Float32(
+            ArrayD::from_shape_vec(vec![2, 2], vec![2.0, 12.0, 22.0, 32.0]).unwrap()
+        )
+    );
+    assert_eq!(
+        verify.get_array_cell(1, "WEIGHT").expect("WEIGHT row 1"),
+        &ArrayValue::Float32(
+            ArrayD::from_shape_vec(vec![2, 2], vec![101.0, 111.0, 121.0, 131.0]).unwrap()
+        )
+    );
+    assert_eq!(
+        verify.get_array_cell(2, "WEIGHT").expect("WEIGHT row 2"),
+        &ArrayValue::Float32(
+            ArrayD::from_shape_vec(vec![2, 2], vec![302.0, 312.0, 322.0, 332.0]).unwrap()
+        )
+    );
+    assert_eq!(
+        verify.get_array_cell(3, "WEIGHT").expect("WEIGHT row 3"),
+        &ArrayValue::Float32(
+            ArrayD::from_shape_vec(vec![2, 2], vec![103.0, 113.0, 123.0, 133.0]).unwrap()
+        )
+    );
+
+    std::fs::remove_dir_all(&root).expect("cleanup test dir");
+}
+
+#[test]
+fn partial_save_with_changed_rows_patches_only_touched_tiled_cell_rows() {
+    let schema = TableSchema::new(vec![ColumnSchema::array_fixed(
+        "data",
+        PrimitiveType::Float32,
+        vec![2, 2],
+    )])
+    .expect("schema");
+
+    let mut table = Table::with_schema(schema);
+    for row_idx in 0..4 {
+        table
+            .add_row(RecordValue::new(vec![RecordField::new(
+                "data",
+                Value::Array(ArrayValue::Float32(
+                    ArrayD::from_shape_vec(
+                        vec![2, 2],
+                        vec![
+                            row_idx as f32,
+                            row_idx as f32 + 10.0,
+                            row_idx as f32 + 20.0,
+                            row_idx as f32 + 30.0,
+                        ],
+                    )
+                    .expect("shape data"),
+                )),
+            )]))
+            .expect("push row");
+    }
+
+    let root = unique_test_dir("partial_save_changed_rows_tiled_cell");
+    std::fs::create_dir_all(&root).expect("create test dir");
+    table
+        .save(TableOptions::new(&root).with_data_manager(DataManagerKind::TiledCellStMan))
+        .expect("save tiled-cell table");
+
+    let mut reopened = Table::open(TableOptions::new(&root)).expect("open tiled-cell table");
+    reopened
+        .set_array_cell_assuming_valid(
+            2,
+            "data",
+            ArrayValue::Float32(
+                ArrayD::from_shape_vec(vec![2, 2], vec![202.0, 212.0, 222.0, 232.0])
+                    .expect("shape updated data"),
+            ),
+        )
+        .expect("set array cell lazily");
+    assert!(!reopened.inner.has_loaded_rows());
+    assert!(reopened.inner.has_pending_array_cells("data"));
+    assert!(!reopened.inner.has_loaded_array_column("data"));
+
+    reopened
+        .save_selected_rows_in_place_assuming_valid(&["data"], &[2])
+        .expect("partial save with tiled-cell row hint");
+    assert!(
+        !reopened.inner.has_loaded_rows(),
+        "tiled-cell sparse save should not force row materialization"
+    );
+    assert!(
+        !reopened.inner.has_loaded_array_column("data"),
+        "tiled-cell sparse save should not materialize the array column"
+    );
+
+    let verify = Table::open(TableOptions::new(&root)).expect("reopen after sparse partial save");
+    assert_eq!(
+        verify.get_array_cell(0, "data").expect("data row 0"),
+        &ArrayValue::Float32(
+            ArrayD::from_shape_vec(vec![2, 2], vec![0.0, 10.0, 20.0, 30.0]).unwrap()
+        )
+    );
+    assert_eq!(
+        verify.get_array_cell(2, "data").expect("data row 2"),
+        &ArrayValue::Float32(
+            ArrayD::from_shape_vec(vec![2, 2], vec![202.0, 212.0, 222.0, 232.0]).unwrap()
+        )
+    );
+    assert_eq!(
+        verify.get_array_cell(3, "data").expect("data row 3"),
+        &ArrayValue::Float32(
+            ArrayD::from_shape_vec(vec![2, 2], vec![3.0, 13.0, 23.0, 33.0]).unwrap()
+        )
+    );
+
+    std::fs::remove_dir_all(&root).expect("cleanup test dir");
+}
+
+#[test]
 fn partial_save_with_changed_rows_patches_only_touched_incremental_rows() {
     let schema = TableSchema::new(vec![
         ColumnSchema::scalar("id", PrimitiveType::Int32),
@@ -2256,6 +2557,14 @@ fn partial_save_with_changed_rows_patches_only_touched_incremental_rows() {
     assert!(
         !reopened.inner.has_loaded_rows(),
         "sparse incremental save should not force row materialization"
+    );
+    assert!(
+        !reopened.inner.has_loaded_scalar_column("id"),
+        "sparse incremental save should not materialize the id column"
+    );
+    assert!(
+        !reopened.inner.has_loaded_scalar_column("scan"),
+        "sparse incremental save should not materialize the scan column"
     );
 
     let verify =

--- a/crates/casa-tables/src/table_impl.rs
+++ b/crates/casa-tables/src/table_impl.rs
@@ -88,6 +88,8 @@ struct PendingArrayCells {
     by_column: HashMap<String, PendingArrayColumn>,
 }
 
+type BufferedScalarColumn = Vec<OnceCell<Option<ScalarValue>>>;
+
 pub(crate) enum LazyScalarLookup<'a> {
     Hit(&'a ScalarValue),
     Missing,
@@ -120,6 +122,21 @@ fn lazy_scalar_column_store(
         .filter(|column| matches!(column.column_type(), ColumnType::Scalar))
         .map(|column| (column.name().to_string(), OnceCell::new()))
         .collect()
+}
+
+fn lazy_buffered_scalar_cell_store(
+    schema: Option<&TableSchema>,
+) -> HashMap<String, OnceCell<BufferedScalarColumn>> {
+    schema
+        .into_iter()
+        .flat_map(|schema| schema.columns())
+        .filter(|column| matches!(column.column_type(), ColumnType::Scalar))
+        .map(|column| (column.name().to_string(), OnceCell::new()))
+        .collect()
+}
+
+fn new_buffered_scalar_column(row_count: usize) -> BufferedScalarColumn {
+    (0..row_count).map(|_| OnceCell::new()).collect()
 }
 
 fn eager_loaded_rows(
@@ -191,6 +208,7 @@ fn apply_prepared_array_overrides(
 pub(crate) struct TableImpl {
     loaded_rows: OnceCell<LoadedRows>,
     loaded_scalar_columns: HashMap<String, OnceCell<Vec<Option<ScalarValue>>>>,
+    buffered_scalar_cells: HashMap<String, OnceCell<BufferedScalarColumn>>,
     pending_scalar_cells: PendingScalarCells,
     loaded_array_columns: HashMap<String, OnceCell<Vec<Option<ArrayValue>>>>,
     pending_array_cells: PendingArrayCells,
@@ -213,6 +231,7 @@ impl TableImpl {
         Self {
             loaded_rows,
             loaded_scalar_columns: HashMap::new(),
+            buffered_scalar_cells: HashMap::new(),
             pending_scalar_cells: PendingScalarCells::default(),
             loaded_array_columns: HashMap::new(),
             pending_array_cells: PendingArrayCells::default(),
@@ -233,6 +252,7 @@ impl TableImpl {
         Self {
             loaded_rows,
             loaded_scalar_columns: HashMap::new(),
+            buffered_scalar_cells: HashMap::new(),
             pending_scalar_cells: PendingScalarCells::default(),
             loaded_array_columns: HashMap::new(),
             pending_array_cells: PendingArrayCells::default(),
@@ -259,6 +279,7 @@ impl TableImpl {
         Self {
             loaded_rows,
             loaded_scalar_columns: lazy_scalar_column_store(schema.as_ref()),
+            buffered_scalar_cells: lazy_buffered_scalar_cell_store(schema.as_ref()),
             pending_scalar_cells: PendingScalarCells::default(),
             loaded_array_columns: lazy_array_column_store(schema.as_ref()),
             pending_array_cells: PendingArrayCells::default(),
@@ -280,6 +301,7 @@ impl TableImpl {
         Self {
             loaded_rows: OnceCell::new(),
             loaded_scalar_columns: lazy_scalar_column_store(schema.as_ref()),
+            buffered_scalar_cells: lazy_buffered_scalar_cell_store(schema.as_ref()),
             pending_scalar_cells: PendingScalarCells::default(),
             loaded_array_columns: lazy_array_column_store(schema.as_ref()),
             pending_array_cells: PendingArrayCells::default(),
@@ -358,6 +380,43 @@ impl TableImpl {
                 Some(format!(
                     "row_count_hint={} values={}",
                     source.row_count_hint,
+                    values.len()
+                )),
+            );
+        }
+        Ok(values)
+    }
+
+    fn load_scalar_column_rows_now(
+        source: &LazyRowsSource,
+        column: &str,
+        row_indices: &[usize],
+    ) -> Result<Vec<Option<ScalarValue>>, TableError> {
+        let mut profiler = StorageProfiler::start(format!(
+            "table_impl::load_scalar_column_rows_now path={} column={column}",
+            source.path.display()
+        ));
+        let storage = CompositeStorage;
+        let values = storage
+            .load_scalar_column_rows_with_row_hint(
+                &source.path,
+                column,
+                row_indices,
+                Some(source.row_count_hint as u64),
+            )
+            .map_err(|err| {
+                TableError::Storage(format!(
+                    "failed to load selected rows for scalar column '{column}' from table {}: {err}",
+                    source.path.display()
+                ))
+            })?;
+        if let Some(profiler) = profiler.as_mut() {
+            profiler.mark_with_detail(
+                "storage_load_complete",
+                Some(format!(
+                    "row_count_hint={} requested_rows={} values={}",
+                    source.row_count_hint,
+                    row_indices.len(),
                     values.len()
                 )),
             );
@@ -608,16 +667,36 @@ impl TableImpl {
         let Some(cached_column) = self.loaded_scalar_columns.get(column) else {
             return Ok(LazyScalarLookup::Unknown);
         };
-        if cached_column.get().is_none() {
-            let loaded = Self::load_scalar_column_now(source, column)?;
-            let _ = cached_column.set(loaded);
+        if let Some(values) = cached_column.get() {
+            return match values.get(row_index) {
+                Some(Some(value)) => Ok(LazyScalarLookup::Hit(value)),
+                Some(None) | None => Ok(LazyScalarLookup::Missing),
+            };
         }
-        let values = cached_column
+
+        let Some(buffered_column) = self.buffered_scalar_cells.get(column) else {
+            return Ok(LazyScalarLookup::Unknown);
+        };
+        if buffered_column.get().is_none() {
+            let _ = buffered_column.set(new_buffered_scalar_column(self.row_count()));
+        }
+        let buffered = buffered_column
             .get()
-            .expect("scalar column initialized before access");
-        match values.get(row_index) {
-            Some(Some(value)) => Ok(LazyScalarLookup::Hit(value)),
-            Some(None) | None => Ok(LazyScalarLookup::Missing),
+            .expect("buffered scalar column initialized before access");
+        let Some(buffered_cell) = buffered.get(row_index) else {
+            return Ok(LazyScalarLookup::Missing);
+        };
+        if buffered_cell.get().is_none() {
+            let loaded = Self::load_scalar_column_rows_now(source, column, &[row_index])?;
+            let value = loaded.into_iter().next().unwrap_or(None);
+            let _ = buffered_cell.set(value);
+        }
+        match buffered_cell
+            .get()
+            .expect("buffered scalar cell initialized before access")
+        {
+            Some(value) => Ok(LazyScalarLookup::Hit(value)),
+            None => Ok(LazyScalarLookup::Missing),
         }
     }
 
@@ -875,6 +954,20 @@ impl TableImpl {
             .reserve(additional);
     }
 
+    pub(crate) fn pending_scalar_cells(
+        &self,
+        column: &str,
+    ) -> Option<&HashMap<usize, ScalarValue>> {
+        self.pending_scalar_cells.by_column.get(column)
+    }
+
+    pub(crate) fn pending_array_cells(&self, column: &str) -> Option<&[(usize, ArrayValue)]> {
+        self.pending_array_cells
+            .by_column
+            .get(column)
+            .map(|cells| cells.rows.as_slice())
+    }
+
     pub(crate) fn undefined_for_row_mut(
         &mut self,
         row_index: usize,
@@ -958,6 +1051,7 @@ impl TableImpl {
             loaded_rows
         };
         self.loaded_scalar_columns = lazy_scalar_column_store(schema.as_ref());
+        self.buffered_scalar_cells = lazy_buffered_scalar_cell_store(schema.as_ref());
         self.pending_scalar_cells = PendingScalarCells::default();
         self.loaded_array_columns = lazy_array_column_store(schema.as_ref());
         self.pending_array_cells = PendingArrayCells::default();


### PR DESCRIPTION
Wave issue: #100

## Summary
- add sparse selected-row in-place write paths for `IncrementalStMan` and tiled storage-manager groups, including shared tiled groups and `TiledCellStMan` / legacy `TiledDataStMan` coverage
- add bounded lazy scalar single-cell reads via selected-row storage loads and sparse per-row buffering instead of whole-column cache population
- add regression coverage and Criterion harnesses for sparse writes and lazy scalar-cell reads

## Changed From Plan
- I initially extended lazy single-cell array reads the same way, but a tiled-array microbenchmark showed that per-cell reloading regresses that path unless the buffer unit is tile-aware
- this PR keeps the scalar single-cell buffering slice and defers generalized array single-cell buffering to the next tiled-aware read pass

## Deferred Work
- bounded lazy array single-cell reads that buffer at the tiled storage unit rather than per-cell
- representative caller migrations in `casa-ms` / `casa-calibration`
- the remaining full issue `#100` read-side rollout beyond scalar single-cell access

## Verification
- `cargo test -p casa-tables`
- `cargo bench -p casa-tables --bench row_buffer_bench -- lazy_single_cell_read`
  - current branch: `114.89-116.23 µs`
  - same benchmark on `origin/main`: `720.13-733.28 µs`
- `cargo bench -p casa-tables --bench row_buffer_bench -- sparse_partial_write`
  - earlier current-branch evidence: incremental `309.14-333.79 µs`, tiled `335.30-398.50 µs`
  - same benchmark on `origin/main`: incremental `5.9913-6.0116 ms`, tiled `1.0591-1.0827 ms`
- `just quick` is still running locally as of PR creation; it has already passed formatting, clippy, and the repo workspace through the long `casa-ms` suites without failures so far

## Risks
- the new lazy read buffering in this PR is intentionally limited to scalar single-cell access; array single-cell reads still use the prior behavior until a tile-aware buffered design lands
- the local long-gate result should still be confirmed to completion before merge
