### PR TITLE
Remove public table convenience methods

### DIFF
--- a/.github/workflows/wdad-project-sync.yml
+++ b/.github/workflows/wdad-project-sync.yml
@@ -268,21 +268,27 @@ jobs:
                 );
                 if (hasWdadStatus) continue;
 
-                if (content.state === "CLOSED") {
-                  await syncIssueBoard(
-                    content.number,
-                    {
-                      statusOptionId: statusOption.done,
-                      wdadOptionId: wdadOption.done,
-                      statusLabel: "Done",
-                      wdadLabel: "Done",
-                    },
-                    "missing WDAD reconciliation for closed issue"
-                  );
-                } else {
-                  await updateSingleSelect(node.id, fieldWdadId, wdadOption.backlog);
+                try {
+                  if (content.state === "CLOSED") {
+                    await syncIssueBoard(
+                      content.number,
+                      {
+                        statusOptionId: statusOption.done,
+                        wdadOptionId: wdadOption.done,
+                        statusLabel: "Done",
+                        wdadLabel: "Done",
+                      },
+                      "missing WDAD reconciliation for closed issue"
+                    );
+                  } else {
+                    await updateSingleSelect(node.id, fieldWdadId, wdadOption.backlog);
+                    console.log(
+                      `Synced issue #${content.number}: wdad=Backlog (missing WDAD reconciliation)`
+                    );
+                  }
+                } catch (error) {
                   console.log(
-                    `Synced issue #${content.number}: wdad=Backlog (missing WDAD reconciliation)`
+                    `Skipping issue #${content.number} during missing WDAD reconciliation: ${error.message}`
                   );
                 }
               }
@@ -394,7 +400,6 @@ jobs:
             }
 
             if (context.eventName === "pull_request_target") {
-              await syncProjectItemsMissingWdadStatus();
               const pr = context.payload.pull_request;
 
               if (context.payload.action === "closed" && !pr.merged_at) {

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -36,7 +36,7 @@ Additional constraints:
 - `casa-table-read` owns the minimal shared read-only loader used by runtime data loaders.
 - `casa-tables` keeps the broader storage/write path crate-internal even when user-facing table APIs are exposed from the crate.
 - Within `casa-tables`, lazy read paths are safe to share across threads under an in-process multi-reader, single-writer contract; shared tiled reads use a process-wide bounded cache, while dirty write state stays under exclusive mutable ownership.
-- Within `casa-tables`, row/column/cell accessor objects are the canonical public table-data surface; prepared-row accessors provide the reusable selected-column row fast path, and legacy table-level convenience methods remain compatibility wrappers.
+- Within `casa-tables`, row/column/cell accessor objects are the public table-data surface; prepared-row accessors provide the reusable selected-column row fast path, and the old table-level convenience wrappers have been removed from the public API.
 - Versioned provider bundles are boundary contracts; UI projections are derived views, not separate truth sources.
 
 ## Runtime model

--- a/crates/casa-calibration/src/bandpass.rs
+++ b/crates/casa-calibration/src/bandpass.rs
@@ -411,7 +411,8 @@ impl BandpassAccumulator {
             None => {
                 let data = ms
                     .main_table()
-                    .get_array_cell(row.row_index, "DATA")
+                    .cell_accessor(row.row_index, "DATA")
+                    .and_then(|cell| cell.array())
                     .map_err(|source| BandpassSolveError::OpenMeasurementSet {
                         path: ms
                             .path()
@@ -421,7 +422,8 @@ impl BandpassAccumulator {
                     })?;
                 let flags = ms
                     .main_table()
-                    .get_array_cell(row.row_index, "FLAG")
+                    .cell_accessor(row.row_index, "FLAG")
+                    .and_then(|cell| cell.array())
                     .map_err(|source| BandpassSolveError::OpenMeasurementSet {
                         path: ms
                             .path()
@@ -434,7 +436,8 @@ impl BandpassAccumulator {
         };
         let weights = ms
             .main_table()
-            .get_array_cell(row.row_index, "WEIGHT")
+            .cell_accessor(row.row_index, "WEIGHT")
+            .and_then(|cell| cell.array())
             .map_err(|source| BandpassSolveError::OpenMeasurementSet {
                 path: ms
                     .path()
@@ -588,7 +591,8 @@ fn build_bandpass_groups(
             Some(preapplied) => &preapplied.corrected_data,
             None => ms
                 .main_table()
-                .get_array_cell(row.row_index, "DATA")
+                .cell_accessor(row.row_index, "DATA")
+                .and_then(|cell| cell.array())
                 .map_err(|source| BandpassSolveError::OpenMeasurementSet {
                     path: ms
                         .path()

--- a/crates/casa-calibration/src/execute.rs
+++ b/crates/casa-calibration/src/execute.rs
@@ -790,14 +790,16 @@ fn execute_apply_plan(
         let row_fetch_started_at = Instant::now();
         let data_values = ms
             .main_table()
-            .get_array_cells_owned(VisibilityDataColumn::Data.name(), &selected_row_indices)
+            .column_accessor(VisibilityDataColumn::Data.name())
+            .and_then(|column| column.array_cells_owned(&selected_row_indices))
             .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
                 path: ms_path.clone(),
                 source: MsError::from(source),
             })?;
         let flag_values = ms
             .main_table()
-            .get_array_cells_owned("FLAG", &selected_row_indices)
+            .column_accessor("FLAG")
+            .and_then(|column| column.array_cells_owned(&selected_row_indices))
             .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
                 path: ms_path.clone(),
                 source: MsError::from(source),
@@ -805,7 +807,8 @@ fn execute_apply_plan(
         let weight_values = if any_calwt {
             Some(
                 ms.main_table()
-                    .get_array_cells_owned("WEIGHT", &selected_row_indices)
+                    .column_accessor("WEIGHT")
+                    .and_then(|column| column.array_cells_owned(&selected_row_indices))
                     .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
                         path: ms_path.clone(),
                         source: MsError::from(source),
@@ -892,11 +895,10 @@ fn execute_apply_plan(
 
             let row_writeback_started_at = Instant::now();
             ms.main_table_mut()
-                .set_array_cell_assuming_valid(
-                    row.row_index,
-                    VisibilityDataColumn::CorrectedData.name(),
-                    corrected_data,
-                )
+                .column_accessor_mut(VisibilityDataColumn::CorrectedData.name())
+                .and_then(|mut column| {
+                    column.set_array_assuming_valid(row.row_index, corrected_data)
+                })
                 .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
                     path: ms_path.clone(),
                     source: MsError::from(source),
@@ -907,7 +909,10 @@ fn execute_apply_plan(
                     changed_columns.push("FLAG");
                 }
                 ms.main_table_mut()
-                    .set_array_cell_assuming_valid(row.row_index, "FLAG", updated_flags)
+                    .column_accessor_mut("FLAG")
+                    .and_then(|mut column| {
+                        column.set_array_assuming_valid(row.row_index, updated_flags)
+                    })
                     .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
                         path: ms_path.clone(),
                         source: MsError::from(source),
@@ -917,11 +922,10 @@ fn execute_apply_plan(
                         changed_columns.push("FLAG_ROW");
                     }
                     ms.main_table_mut()
-                        .set_scalar_cell_assuming_valid(
-                            row.row_index,
-                            "FLAG_ROW",
-                            ScalarValue::Bool(true),
-                        )
+                        .column_accessor_mut("FLAG_ROW")
+                        .and_then(|mut column| {
+                            column.set_scalar_assuming_valid(row.row_index, ScalarValue::Bool(true))
+                        })
                         .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
                             path: ms_path.clone(),
                             source: MsError::from(source),
@@ -935,7 +939,10 @@ fn execute_apply_plan(
                     changed_columns.push("WEIGHT");
                 }
                 ms.main_table_mut()
-                    .set_array_cell_assuming_valid(row.row_index, "WEIGHT", updated_weight)
+                    .column_accessor_mut("WEIGHT")
+                    .and_then(|mut column| {
+                        column.set_array_assuming_valid(row.row_index, updated_weight)
+                    })
                     .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
                         path: ms_path.clone(),
                         source: MsError::from(source),
@@ -946,11 +953,10 @@ fn execute_apply_plan(
                     changed_columns.push("WEIGHT_SPECTRUM");
                 }
                 ms.main_table_mut()
-                    .set_array_cell_assuming_valid(
-                        row.row_index,
-                        "WEIGHT_SPECTRUM",
-                        updated_weight_spectrum,
-                    )
+                    .column_accessor_mut("WEIGHT_SPECTRUM")
+                    .and_then(|mut column| {
+                        column.set_array_assuming_valid(row.row_index, updated_weight_spectrum)
+                    })
                     .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
                         path: ms_path.clone(),
                         source: MsError::from(source),
@@ -2168,7 +2174,8 @@ fn load_calibration_table(
         let antenna_id = get_i32(&table, row_index, COL_ANTENNA1)?;
         let time_seconds = get_f64(&table, row_index, COL_TIME)?;
         let flags = table
-            .get_array_cell(row_index, COL_FLAG)
+            .cell_accessor(row_index, COL_FLAG)
+            .and_then(|cell| cell.array())
             .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
                 path: table_plan.spec.path.display().to_string(),
                 source: MsError::from(source),
@@ -2176,7 +2183,8 @@ fn load_calibration_table(
         let grid = match table_plan.summary.parameter_family {
             CalibrationParameterFamily::Complex => {
                 let gains = table
-                    .get_array_cell(row_index, COL_CPARAM)
+                    .cell_accessor(row_index, COL_CPARAM)
+                    .and_then(|cell| cell.array())
                     .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
                         path: table_plan.spec.path.display().to_string(),
                         source: MsError::from(source),
@@ -2191,7 +2199,8 @@ fn load_calibration_table(
                 if table_plan.summary.table_subtype.as_str() == "K Jones" =>
             {
                 let delays = table
-                    .get_array_cell(row_index, COL_FPARAM)
+                    .cell_accessor(row_index, COL_FPARAM)
+                    .and_then(|cell| cell.array())
                     .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
                         path: table_plan.spec.path.display().to_string(),
                         source: MsError::from(source),
@@ -2299,7 +2308,8 @@ fn load_bpoly_cal_desc_map(
     let mut entries = HashMap::new();
     for row_index in 0..cal_desc.row_count() {
         let spw_ids = cal_desc
-            .get_array_cell(row_index, COL_SPECTRAL_WINDOW_ID)
+            .cell_accessor(row_index, COL_SPECTRAL_WINDOW_ID)
+            .and_then(|cell| cell.array())
             .map_err(|source| ApplyExecutionError::UnsupportedCalibrationTable {
                 path: path.display().to_string(),
                 reason: format!(
@@ -2592,13 +2602,12 @@ fn ensure_corrected_data_column(ms: &mut MeasurementSet) -> Result<bool, TableEr
     for row_index in 0..row_count {
         let data = ms
             .main_table()
-            .get_array_cell(row_index, VisibilityDataColumn::Data.name())?
+            .cell_accessor(row_index, VisibilityDataColumn::Data.name())?
+            .array()?
             .clone();
-        ms.main_table_mut().set_cell(
-            row_index,
-            VisibilityDataColumn::CorrectedData.name(),
-            Value::Array(data),
-        )?;
+        ms.main_table_mut()
+            .cell_accessor_mut(row_index, VisibilityDataColumn::CorrectedData.name())?
+            .set(Value::Array(data))?;
     }
     Ok(true)
 }
@@ -2669,12 +2678,13 @@ fn correlation_receptors(code: i32) -> Option<(usize, usize)> {
 }
 
 fn get_i32(table: &Table, row_index: usize, column: &str) -> Result<i32, ApplyExecutionError> {
-    match table.get_scalar_cell(row_index, column).map_err(|source| {
-        ApplyExecutionError::MutateMeasurementSet {
+    match table
+        .cell_accessor(row_index, column)
+        .and_then(|cell| cell.scalar())
+        .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
             path: "<table>".to_string(),
             source: MsError::from(source),
-        }
-    })? {
+        })? {
         ScalarValue::Int32(value) => Ok(*value),
         other => Err(ApplyExecutionError::UnsupportedParameterShape {
             path: format!("{column}:{:?}", other.primitive_type()),
@@ -2684,12 +2694,13 @@ fn get_i32(table: &Table, row_index: usize, column: &str) -> Result<i32, ApplyEx
 }
 
 fn get_f64(table: &Table, row_index: usize, column: &str) -> Result<f64, ApplyExecutionError> {
-    match table.get_scalar_cell(row_index, column).map_err(|source| {
-        ApplyExecutionError::MutateMeasurementSet {
+    match table
+        .cell_accessor(row_index, column)
+        .and_then(|cell| cell.scalar())
+        .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
             path: "<table>".to_string(),
             source: MsError::from(source),
-        }
-    })? {
+        })? {
         ScalarValue::Float64(value) => Ok(*value),
         other => Err(ApplyExecutionError::UnsupportedParameterShape {
             path: format!("{column}:{:?}", other.primitive_type()),
@@ -2703,12 +2714,13 @@ fn get_complex32(
     row_index: usize,
     column: &str,
 ) -> Result<Complex32, ApplyExecutionError> {
-    match table.get_scalar_cell(row_index, column).map_err(|source| {
-        ApplyExecutionError::MutateMeasurementSet {
+    match table
+        .cell_accessor(row_index, column)
+        .and_then(|cell| cell.scalar())
+        .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
             path: "<table>".to_string(),
             source: MsError::from(source),
-        }
-    })? {
+        })? {
         ScalarValue::Complex32(value) => Ok(*value),
         ScalarValue::Complex64(value) => Ok(Complex32::new(value.re as f32, value.im as f32)),
         other => Err(ApplyExecutionError::UnsupportedParameterShape {
@@ -2723,12 +2735,13 @@ fn get_string(
     row_index: usize,
     column: &str,
 ) -> Result<String, ApplyExecutionError> {
-    match table.get_scalar_cell(row_index, column).map_err(|source| {
-        ApplyExecutionError::MutateMeasurementSet {
+    match table
+        .cell_accessor(row_index, column)
+        .and_then(|cell| cell.scalar())
+        .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
             path: "<table>".to_string(),
             source: MsError::from(source),
-        }
-    })? {
+        })? {
         ScalarValue::String(value) => Ok(value.clone()),
         other => Err(ApplyExecutionError::UnsupportedParameterShape {
             path: format!("{column}:{:?}", other.primitive_type()),
@@ -2743,12 +2756,13 @@ fn get_numeric_array(
     column: &str,
     path: &Path,
 ) -> Result<Vec<f64>, ApplyExecutionError> {
-    let values = table.get_array_cell(row_index, column).map_err(|source| {
-        ApplyExecutionError::UnsupportedCalibrationTable {
+    let values = table
+        .cell_accessor(row_index, column)
+        .and_then(|cell| cell.array())
+        .map_err(|source| ApplyExecutionError::UnsupportedCalibrationTable {
             path: path.display().to_string(),
             reason: format!("failed to read {column} row {row_index}: {source}"),
-        }
-    })?;
+        })?;
     match values {
         ArrayValue::Float32(values) => Ok(values.iter().map(|value| f64::from(*value)).collect()),
         ArrayValue::Float64(values) => Ok(values.iter().copied().collect()),
@@ -2769,12 +2783,13 @@ fn get_f64_array(
     column: &str,
     path: &Path,
 ) -> Result<Vec<f64>, ApplyExecutionError> {
-    let values = table.get_array_cell(row_index, column).map_err(|source| {
-        ApplyExecutionError::UnsupportedCalibrationTable {
+    let values = table
+        .cell_accessor(row_index, column)
+        .and_then(|cell| cell.array())
+        .map_err(|source| ApplyExecutionError::UnsupportedCalibrationTable {
             path: path.display().to_string(),
             reason: format!("failed to read {column} row {row_index}: {source}"),
-        }
-    })?;
+        })?;
     match values {
         ArrayValue::Float64(values) => Ok(values.iter().copied().collect()),
         ArrayValue::Float32(values) => Ok(values.iter().map(|value| f64::from(*value)).collect()),
@@ -3425,13 +3440,15 @@ mod tests {
         assert!(ensure_corrected_data_column(&mut ms).unwrap());
         let corrected = ms
             .main_table()
-            .get_array_cell(0, VisibilityDataColumn::CorrectedData.name())
+            .cell_accessor(0, VisibilityDataColumn::CorrectedData.name())
+            .and_then(|cell| cell.array())
             .unwrap()
             .clone();
         assert_eq!(
             corrected,
             *ms.main_table()
-                .get_array_cell(0, VisibilityDataColumn::Data.name())
+                .cell_accessor(0, VisibilityDataColumn::Data.name())
+                .and_then(|cell| cell.array())
                 .unwrap()
         );
         assert!(!ensure_corrected_data_column(&mut ms).unwrap());

--- a/crates/casa-calibration/src/fluxscale.rs
+++ b/crates/casa-calibration/src/fluxscale.rs
@@ -602,11 +602,8 @@ fn write_scaled_output(
         };
         let scaled = scale_gains(&row.gains, estimate.correction_factor, incremental);
         table
-            .set_cell(
-                row.row_index,
-                COL_CPARAM,
-                Value::Array(ArrayValue::Complex32(scaled)),
-            )
+            .cell_accessor_mut(row.row_index, COL_CPARAM)
+            .and_then(|mut cell| cell.set(Value::Array(ArrayValue::Complex32(scaled))))
             .map_err(|source| FluxScaleError::MutateOutput {
                 path: output_root.display().to_string(),
                 source: Box::new(source),
@@ -778,7 +775,8 @@ fn copy_table_tree(source: &Path, destination: &Path) -> Result<(), FluxScaleErr
 
 fn get_i32(table: &Table, row: usize, column: &str) -> Result<i32, FluxScaleError> {
     match table
-        .cell(row, column)
+        .cell_accessor(row, column)
+        .and_then(|cell| cell.value())
         .map_err(|source| FluxScaleError::MutateOutput {
             path: column.to_string(),
             source: Box::new(source),
@@ -797,7 +795,8 @@ fn get_i32(table: &Table, row: usize, column: &str) -> Result<i32, FluxScaleErro
 
 fn get_string(table: &Table, row: usize, column: &str) -> Result<String, FluxScaleError> {
     match table
-        .cell(row, column)
+        .cell_accessor(row, column)
+        .and_then(|cell| cell.value())
         .map_err(|source| FluxScaleError::MutateOutput {
             path: column.to_string(),
             source: Box::new(source),
@@ -815,23 +814,24 @@ fn get_string(table: &Table, row: usize, column: &str) -> Result<String, FluxSca
 }
 
 fn get_ref_frequency(table: &Table, row: usize) -> Result<f64, FluxScaleError> {
-    let chan_freq =
-        table
-            .get_array_cell(row, "CHAN_FREQ")
-            .map_err(|source| FluxScaleError::MutateOutput {
-                path: "CHAN_FREQ".to_string(),
-                source: Box::new(source),
-            })?;
+    let chan_freq = table
+        .cell_accessor(row, "CHAN_FREQ")
+        .and_then(|cell| cell.array())
+        .map_err(|source| FluxScaleError::MutateOutput {
+            path: "CHAN_FREQ".to_string(),
+            source: Box::new(source),
+        })?;
     match chan_freq {
         ArrayValue::Float64(values) if !values.is_empty() => {
             Ok(values.iter().copied().sum::<f64>() / values.len() as f64)
         }
-        _ => match table.cell(row, "REF_FREQUENCY").map_err(|source| {
-            FluxScaleError::MutateOutput {
+        _ => match table
+            .cell_accessor(row, "REF_FREQUENCY")
+            .and_then(|cell| cell.value())
+            .map_err(|source| FluxScaleError::MutateOutput {
                 path: "REF_FREQUENCY".to_string(),
                 source: Box::new(source),
-            }
-        })? {
+            })? {
             Some(Value::Scalar(ScalarValue::Float64(value))) => Ok(*value),
             Some(Value::Array(ArrayValue::Float64(values))) if values.len() == 1 => {
                 Ok(values.iter().copied().next().unwrap_or(0.0))
@@ -847,7 +847,8 @@ fn get_complex_array(
     column: &str,
 ) -> Result<ArrayD<Complex32>, FluxScaleError> {
     match table
-        .get_array_cell(row, column)
+        .cell_accessor(row, column)
+        .and_then(|cell| cell.array())
         .map_err(|source| FluxScaleError::MutateOutput {
             path: column.to_string(),
             source: Box::new(source),
@@ -865,7 +866,8 @@ fn get_complex_array(
 
 fn get_bool_array(table: &Table, row: usize, column: &str) -> Result<ArrayD<bool>, FluxScaleError> {
     match table
-        .get_array_cell(row, column)
+        .cell_accessor(row, column)
+        .and_then(|cell| cell.array())
         .map_err(|source| FluxScaleError::MutateOutput {
             path: column.to_string(),
             source: Box::new(source),

--- a/crates/casa-calibration/src/plan.rs
+++ b/crates/casa-calibration/src/plan.rs
@@ -551,7 +551,8 @@ fn build_selected_rows(
 
 fn load_i32_column(table: &Table, column: &str) -> Result<Vec<Option<i32>>, ApplyPlanError> {
     table
-        .get_scalar_cells_owned(column)
+        .column_accessor(column)
+        .and_then(|column| column.scalar_cells_owned())
         .map_err(|source| ApplyPlanError::Selection {
             source: MsError::from(source),
         })?
@@ -571,7 +572,8 @@ fn load_i32_column(table: &Table, column: &str) -> Result<Vec<Option<i32>>, Appl
 
 fn load_f64_column(table: &Table, column: &str) -> Result<Vec<Option<f64>>, ApplyPlanError> {
     table
-        .get_scalar_cells_owned(column)
+        .column_accessor(column)
+        .and_then(|column| column.scalar_cells_owned())
         .map_err(|source| ApplyPlanError::Selection {
             source: MsError::from(source),
         })?
@@ -902,7 +904,8 @@ fn load_caltable_field_directions(
             continue;
         }
         let phase_dir = table
-            .get_array_cell(row_index, "PHASE_DIR")
+            .cell_accessor(row_index, "PHASE_DIR")
+            .and_then(|cell| cell.array())
             .map_err(|source| ApplyPlanError::OpenSubtable {
                 path: summary.path.display().to_string(),
                 subtable: "FIELD",
@@ -988,7 +991,8 @@ fn load_bpoly_spectral_window_ids(path: &Path) -> Result<Vec<i32>, ApplyPlanErro
     let mut spw_ids = BTreeSet::new();
     for row in 0..table.row_count() {
         let values = table
-            .get_array_cell(row, "SPECTRAL_WINDOW_ID")
+            .cell_accessor(row, "SPECTRAL_WINDOW_ID")
+            .and_then(|cell| cell.array())
             .map_err(|source| ApplyPlanError::OpenSubtable {
                 path: path.display().to_string(),
                 subtable: "CAL_DESC",
@@ -1100,7 +1104,8 @@ fn unique_i32(values: impl IntoIterator<Item = i32>) -> Vec<i32> {
 
 fn get_string(table: &Table, row_index: usize, column: &str) -> Result<String, ApplyPlanError> {
     match table
-        .get_scalar_cell(row_index, column)
+        .cell_accessor(row_index, column)
+        .and_then(|cell| cell.scalar())
         .map_err(|source| ApplyPlanError::Selection {
             source: MsError::from(source),
         })? {
@@ -1116,11 +1121,12 @@ fn get_string(table: &Table, row_index: usize, column: &str) -> Result<String, A
 #[cfg(test)]
 fn get_i32(table: &Table, row_index: usize, column: &str) -> Result<i32, ApplyPlanError> {
     match table
-        .get_scalar_cell(row_index, column)
+        .cell_accessor(row_index, column)
+        .and_then(|cell| cell.scalar())
         .map_err(|source| ApplyPlanError::Selection {
             source: MsError::from(source),
         })? {
-        ScalarValue::Int32(value) => Ok(*value),
+        &ScalarValue::Int32(value) => Ok(value),
         other => Err(ApplyPlanError::ScalarTypeMismatch {
             context: format!("{column} row {row_index}"),
             expected: "Int32",
@@ -1132,11 +1138,12 @@ fn get_i32(table: &Table, row_index: usize, column: &str) -> Result<i32, ApplyPl
 #[cfg(test)]
 fn get_f64(table: &Table, row_index: usize, column: &str) -> Result<f64, ApplyPlanError> {
     match table
-        .get_scalar_cell(row_index, column)
+        .cell_accessor(row_index, column)
+        .and_then(|cell| cell.scalar())
         .map_err(|source| ApplyPlanError::Selection {
             source: MsError::from(source),
         })? {
-        ScalarValue::Float64(value) => Ok(*value),
+        &ScalarValue::Float64(value) => Ok(value),
         other => Err(ApplyPlanError::ScalarTypeMismatch {
             context: format!("{column} row {row_index}"),
             expected: "Float64",

--- a/crates/casa-calibration/src/plots.rs
+++ b/crates/casa-calibration/src/plots.rs
@@ -549,13 +549,14 @@ fn get_i32_scalar(
     column: &str,
     path: &str,
 ) -> Result<i32, CalibrationPlotError> {
-    match table.get_scalar_cell(row, column).map_err(|source| {
-        CalibrationPlotError::OpenCalibrationTable {
+    match table
+        .cell_accessor(row, column)
+        .and_then(|cell| cell.scalar())
+        .map_err(|source| CalibrationPlotError::OpenCalibrationTable {
             path: path.to_string(),
             source,
-        }
-    })? {
-        ScalarValue::Int32(value) => Ok(*value),
+        })? {
+        &ScalarValue::Int32(value) => Ok(value),
         other => Err(CalibrationPlotError::InvalidCalibrationTable {
             path: path.to_string(),
             reason: format!("expected Int32 in {column} row {row}, found {other:?}"),
@@ -569,13 +570,14 @@ fn get_f64_scalar(
     column: &str,
     path: &str,
 ) -> Result<f64, CalibrationPlotError> {
-    match table.get_scalar_cell(row, column).map_err(|source| {
-        CalibrationPlotError::OpenCalibrationTable {
+    match table
+        .cell_accessor(row, column)
+        .and_then(|cell| cell.scalar())
+        .map_err(|source| CalibrationPlotError::OpenCalibrationTable {
             path: path.to_string(),
             source,
-        }
-    })? {
-        ScalarValue::Float64(value) => Ok(*value),
+        })? {
+        &ScalarValue::Float64(value) => Ok(value),
         other => Err(CalibrationPlotError::InvalidCalibrationTable {
             path: path.to_string(),
             reason: format!("expected Float64 in {column} row {row}, found {other:?}"),
@@ -589,12 +591,13 @@ fn get_complex_array(
     column: &str,
     path: &str,
 ) -> Result<ndarray::ArrayD<Complex32>, CalibrationPlotError> {
-    match table.get_array_cell(row, column).map_err(|source| {
-        CalibrationPlotError::OpenCalibrationTable {
+    match table
+        .cell_accessor(row, column)
+        .and_then(|cell| cell.array())
+        .map_err(|source| CalibrationPlotError::OpenCalibrationTable {
             path: path.to_string(),
             source,
-        }
-    })? {
+        })? {
         ArrayValue::Complex32(values) => Ok(values.clone()),
         other => Err(CalibrationPlotError::InvalidCalibrationTable {
             path: path.to_string(),
@@ -604,7 +607,10 @@ fn get_complex_array(
 }
 
 fn get_flag_mask(table: &Table, row: usize, expected_len: usize) -> Vec<bool> {
-    match table.get_array_cell(row, COL_FLAG) {
+    match table
+        .cell_accessor(row, COL_FLAG)
+        .and_then(|cell| cell.array())
+    {
         Ok(ArrayValue::Bool(values)) => values.iter().copied().collect(),
         _ => vec![false; expected_len],
     }
@@ -653,7 +659,8 @@ fn spectral_window_frequencies(
         });
     }
     match spw_table
-        .get_array_cell(row, "CHAN_FREQ")
+        .cell_accessor(row, "CHAN_FREQ")
+        .and_then(|cell| cell.array())
         .map_err(|source| CalibrationPlotError::OpenCalibrationSubtable {
             path: path.to_string(),
             subtable: "SPECTRAL_WINDOW",

--- a/crates/casa-calibration/src/solve.rs
+++ b/crates/casa-calibration/src/solve.rs
@@ -309,7 +309,8 @@ pub fn solve_gain(
 
 pub(crate) fn get_i32(table: &Table, row: usize, column: &str) -> Result<i32, GainSolveError> {
     match table
-        .get_scalar_cell(row, column)
+        .cell_accessor(row, column)
+        .and_then(|cell| cell.scalar())
         .map_err(MsError::from)
         .map_err(|source| GainSolveError::OpenMeasurementSet {
             path: column.to_string(),
@@ -331,7 +332,8 @@ pub(crate) fn get_i32(table: &Table, row: usize, column: &str) -> Result<i32, Ga
 
 pub(crate) fn get_f64(table: &Table, row: usize, column: &str) -> Result<f64, GainSolveError> {
     match table
-        .get_scalar_cell(row, column)
+        .cell_accessor(row, column)
+        .and_then(|cell| cell.scalar())
         .map_err(MsError::from)
         .map_err(|source| GainSolveError::OpenMeasurementSet {
             path: column.to_string(),

--- a/crates/casa-calibration/src/solve/grouping.rs
+++ b/crates/casa-calibration/src/solve/grouping.rs
@@ -351,7 +351,8 @@ impl SolveAccumulator {
             None => {
                 let data = ms
                     .main_table()
-                    .get_array_cell(row.row_index, "DATA")
+                    .cell_accessor(row.row_index, "DATA")
+                    .and_then(|cell| cell.array())
                     .map_err(|source| GainSolveError::OpenMeasurementSet {
                         path: ms
                             .path()
@@ -361,7 +362,8 @@ impl SolveAccumulator {
                     })?;
                 let flags = ms
                     .main_table()
-                    .get_array_cell(row.row_index, "FLAG")
+                    .cell_accessor(row.row_index, "FLAG")
+                    .and_then(|cell| cell.array())
                     .map_err(|source| GainSolveError::OpenMeasurementSet {
                         path: ms
                             .path()
@@ -374,7 +376,8 @@ impl SolveAccumulator {
         };
         let weights = ms
             .main_table()
-            .get_array_cell(row.row_index, "WEIGHT")
+            .cell_accessor(row.row_index, "WEIGHT")
+            .and_then(|cell| cell.array())
             .map_err(|source| GainSolveError::OpenMeasurementSet {
                 path: ms
                     .path()

--- a/crates/casa-calibration/src/solve/writer.rs
+++ b/crates/casa-calibration/src/solve/writer.rs
@@ -308,51 +308,49 @@ fn write_gain_spectral_window_subtable(
 
         let center_index = chan_freq.len() / 2;
         table
-            .set_cell(row, "NUM_CHAN", Value::Scalar(ScalarValue::Int32(1)))
+            .cell_accessor_mut(row, "NUM_CHAN")
+            .and_then(|mut cell| cell.set(Value::Scalar(ScalarValue::Int32(1))))
             .map_err(|source| GainSolveError::CopySubtable {
                 subtable: "SPECTRAL_WINDOW".to_string(),
                 path: output_root.display().to_string(),
                 source: Box::new(source),
             })?;
         table
-            .set_cell(
-                row,
-                "CHAN_FREQ",
-                Value::Array(f64_array(&[chan_freq[center_index]])),
-            )
+            .cell_accessor_mut(row, "CHAN_FREQ")
+            .and_then(|mut cell| cell.set(Value::Array(f64_array(&[chan_freq[center_index]]))))
             .map_err(|source| GainSolveError::CopySubtable {
                 subtable: "SPECTRAL_WINDOW".to_string(),
                 path: output_root.display().to_string(),
                 source: Box::new(source),
             })?;
         table
-            .set_cell(
-                row,
-                "CHAN_WIDTH",
-                Value::Array(f64_array(&[chan_width.iter().copied().sum()])),
-            )
+            .cell_accessor_mut(row, "CHAN_WIDTH")
+            .and_then(|mut cell| {
+                cell.set(Value::Array(f64_array(&[chan_width.iter().copied().sum()])))
+            })
             .map_err(|source| GainSolveError::CopySubtable {
                 subtable: "SPECTRAL_WINDOW".to_string(),
                 path: output_root.display().to_string(),
                 source: Box::new(source),
             })?;
         table
-            .set_cell(
-                row,
-                "EFFECTIVE_BW",
-                Value::Array(f64_array(&[effective_bw.iter().copied().sum()])),
-            )
+            .cell_accessor_mut(row, "EFFECTIVE_BW")
+            .and_then(|mut cell| {
+                cell.set(Value::Array(f64_array(&[effective_bw
+                    .iter()
+                    .copied()
+                    .sum()])))
+            })
             .map_err(|source| GainSolveError::CopySubtable {
                 subtable: "SPECTRAL_WINDOW".to_string(),
                 path: output_root.display().to_string(),
                 source: Box::new(source),
             })?;
         table
-            .set_cell(
-                row,
-                "RESOLUTION",
-                Value::Array(f64_array(&[resolution.iter().copied().sum()])),
-            )
+            .cell_accessor_mut(row, "RESOLUTION")
+            .and_then(|mut cell| {
+                cell.set(Value::Array(f64_array(&[resolution.iter().copied().sum()])))
+            })
             .map_err(|source| GainSolveError::CopySubtable {
                 subtable: "SPECTRAL_WINDOW".to_string(),
                 path: output_root.display().to_string(),
@@ -373,7 +371,8 @@ fn write_gain_spectral_window_subtable(
 
 fn get_f64_array(table: &Table, row: usize, column: &str) -> Result<Vec<f64>, GainSolveError> {
     match table
-        .get_array_cell(row, column)
+        .cell_accessor(row, column)
+        .and_then(|cell| cell.array())
         .map_err(MsError::from)
         .map_err(|source| GainSolveError::OpenMeasurementSet {
             path: column.to_string(),

--- a/crates/casa-calibration/src/stats.rs
+++ b/crates/casa-calibration/src/stats.rs
@@ -318,7 +318,11 @@ fn resolve_datacolumn(
 }
 
 fn load_flag_mask(table: &Table, row: usize) -> Option<Vec<bool>> {
-    match table.get_array_cell(row, COL_FLAG).ok()? {
+    match table
+        .cell_accessor(row, COL_FLAG)
+        .and_then(|cell| cell.array())
+        .ok()?
+    {
         ArrayValue::Bool(values) => Some(values.iter().copied().collect()),
         _ => None,
     }
@@ -343,12 +347,13 @@ fn extract_row_values(
         | CalibrationStatsAxis::Real
         | CalibrationStatsAxis::Imaginary => {
             let column = datacolumn.expect("complex stats require datacolumn");
-            let array = table.get_array_cell(row, column).map_err(|source| {
-                CalibrationStatsError::Open {
+            let array = table
+                .cell_accessor(row, column)
+                .and_then(|cell| cell.array())
+                .map_err(|source| CalibrationStatsError::Open {
                     path: path.display().to_string(),
                     source,
-                }
-            })?;
+                })?;
             let ArrayValue::Complex32(values) = array else {
                 return Err(CalibrationStatsError::UnsupportedAxis {
                     path: path.display().to_string(),
@@ -378,15 +383,19 @@ fn extract_row_values(
                 .collect())
         }
         CalibrationStatsAxis::Column(column) => {
-            if let Ok(array) = table.get_array_cell(row, column) {
+            if let Ok(array) = table
+                .cell_accessor(row, column)
+                .and_then(|cell| cell.array())
+            {
                 flatten_real_array(array, flags, request, path, column)
             } else {
-                let scalar = table.get_scalar_cell(row, column).map_err(|source| {
-                    CalibrationStatsError::Open {
+                let scalar = table
+                    .cell_accessor(row, column)
+                    .and_then(|cell| cell.scalar())
+                    .map_err(|source| CalibrationStatsError::Open {
                         path: path.display().to_string(),
                         source,
-                    }
-                })?;
+                    })?;
                 scalar_to_sample(column, scalar, path).map(|sample| {
                     vec![SampleValue {
                         value: sample,
@@ -463,17 +472,17 @@ fn scalar_to_sample(
 }
 
 fn get_i32(table: &Table, row: usize, column: &str) -> Result<i32, CalibrationStatsError> {
-    let scalar =
-        table
-            .get_scalar_cell(row, column)
-            .map_err(|source| CalibrationStatsError::Open {
-                path: column.to_string(),
-                source,
-            })?;
-    match scalar {
-        ScalarValue::Int32(value) => Ok(*value),
+    let scalar = table
+        .cell_accessor(row, column)
+        .and_then(|cell| cell.scalar())
+        .map_err(|source| CalibrationStatsError::Open {
+            path: column.to_string(),
+            source,
+        })?;
+    match *scalar {
+        ScalarValue::Int32(value) => Ok(value),
         ScalarValue::Int64(value) => {
-            i32::try_from(*value).map_err(|_| CalibrationStatsError::UnsupportedAxis {
+            i32::try_from(value).map_err(|_| CalibrationStatsError::UnsupportedAxis {
                 path: column.to_string(),
                 axis: column.to_string(),
                 column: column.to_string(),

--- a/crates/casa-calibration/src/summary.rs
+++ b/crates/casa-calibration/src/summary.rs
@@ -225,7 +225,10 @@ fn summarize_parameter_column(
         .map(|data_type| format!("{data_type:?}"));
     let first_cell_shape = parameter_column.as_deref().and_then(|column| {
         for row in 0..table.row_count() {
-            if let Ok(array) = table.get_array_cell(row, column) {
+            if let Ok(array) = table
+                .cell_accessor(row, column)
+                .and_then(|cell| cell.array())
+            {
                 return Some(array.shape().to_vec());
             }
         }
@@ -477,10 +480,13 @@ fn scan_coverage(
             );
         }
         if has_time {
-            match table.get_scalar_cell(row, COL_TIME) {
-                Ok(ScalarValue::Float64(value)) => {
-                    min_time = Some(min_time.map_or(*value, |current| current.min(*value)));
-                    max_time = Some(max_time.map_or(*value, |current| current.max(*value)));
+            match table
+                .cell_accessor(row, COL_TIME)
+                .and_then(|cell| cell.scalar())
+            {
+                Ok(&ScalarValue::Float64(value)) => {
+                    min_time = Some(min_time.map_or(value, |current| current.min(value)));
+                    max_time = Some(max_time.map_or(value, |current| current.max(value)));
                 }
                 Ok(other) => issues.push(issue(
                     "time-column-type",
@@ -495,10 +501,13 @@ fn scan_coverage(
             }
         }
         if has_interval {
-            match table.get_scalar_cell(row, COL_INTERVAL) {
-                Ok(ScalarValue::Float64(value)) => {
-                    min_interval = Some(min_interval.map_or(*value, |current| current.min(*value)));
-                    max_interval = Some(max_interval.map_or(*value, |current| current.max(*value)));
+            match table
+                .cell_accessor(row, COL_INTERVAL)
+                .and_then(|cell| cell.scalar())
+            {
+                Ok(&ScalarValue::Float64(value)) => {
+                    min_interval = Some(min_interval.map_or(value, |current| current.min(value)));
+                    max_interval = Some(max_interval.map_or(value, |current| current.max(value)));
                 }
                 Ok(other) => issues.push(issue(
                     "interval-column-type",
@@ -544,7 +553,10 @@ fn scan_bpoly_spectral_window_ids(
     };
     let mut spw_ids = BTreeSet::new();
     for row in 0..table.row_count() {
-        match table.get_array_cell(row, COL_SPECTRAL_WINDOW_ID) {
+        match table
+            .cell_accessor(row, COL_SPECTRAL_WINDOW_ID)
+            .and_then(|cell| cell.array())
+        {
             Ok(casa_types::ArrayValue::Int32(values)) => {
                 for value in values.iter().copied() {
                     spw_ids.insert(value);
@@ -575,9 +587,12 @@ fn collect_i32_cell(
     values: &mut BTreeSet<i32>,
     issues: &mut Vec<CalibrationValidationIssue>,
 ) {
-    match table.get_scalar_cell(row, column) {
-        Ok(ScalarValue::Int32(value)) => {
-            values.insert(*value);
+    match table
+        .cell_accessor(row, column)
+        .and_then(|cell| cell.scalar())
+    {
+        Ok(&ScalarValue::Int32(value)) => {
+            values.insert(value);
         }
         Ok(other) => issues.push(issue(
             format!("unexpected-{column}-type"),

--- a/crates/casa-calibration/tests/apply_execute.rs
+++ b/crates/casa-calibration/tests/apply_execute.rs
@@ -482,7 +482,8 @@ fn execute_apply_calwt_updates_weight_column_for_gain_tables() {
     let ms = MeasurementSet::open(&ms_path).expect("reopen measurement set");
     let weight = ms
         .main_table()
-        .get_array_cell(0, "WEIGHT")
+        .cell_accessor(0, "WEIGHT")
+        .and_then(|cell| cell.array())
         .expect("read weight row");
     let ArrayValue::Float32(weight) = weight else {
         panic!("expected float32 WEIGHT");
@@ -556,7 +557,8 @@ fn execute_apply_calwt_updates_weight_paths_without_seeded_corrected_data() {
 
     let weight_spectrum = ms
         .main_table()
-        .get_array_cell(0, "WEIGHT_SPECTRUM")
+        .cell_accessor(0, "WEIGHT_SPECTRUM")
+        .and_then(|cell| cell.array())
         .expect("read weight spectrum row");
     let ArrayValue::Float32(weight_spectrum) = weight_spectrum else {
         panic!("expected float32 WEIGHT_SPECTRUM");
@@ -568,7 +570,8 @@ fn execute_apply_calwt_updates_weight_paths_without_seeded_corrected_data() {
 
     let weight = ms
         .main_table()
-        .get_array_cell(0, "WEIGHT")
+        .cell_accessor(0, "WEIGHT")
+        .and_then(|cell| cell.array())
         .expect("read weight row");
     let ArrayValue::Float32(weight) = weight else {
         panic!("expected float32 WEIGHT");
@@ -627,7 +630,8 @@ fn execute_apply_calwt_updates_weight_spectrum_and_reduces_weight() {
 
     let weight_spectrum = ms
         .main_table()
-        .get_array_cell(0, "WEIGHT_SPECTRUM")
+        .cell_accessor(0, "WEIGHT_SPECTRUM")
+        .and_then(|cell| cell.array())
         .expect("read weight spectrum row");
     let ArrayValue::Float32(weight_spectrum) = weight_spectrum else {
         panic!("expected float32 WEIGHT_SPECTRUM");
@@ -639,7 +643,8 @@ fn execute_apply_calwt_updates_weight_spectrum_and_reduces_weight() {
 
     let weight = ms
         .main_table()
-        .get_array_cell(0, "WEIGHT")
+        .cell_accessor(0, "WEIGHT")
+        .and_then(|cell| cell.array())
         .expect("read weight row");
     let ArrayValue::Float32(weight) = weight else {
         panic!("expected float32 WEIGHT");

--- a/crates/casa-calibration/tests/bandpass_solve.rs
+++ b/crates/casa-calibration/tests/bandpass_solve.rs
@@ -140,7 +140,8 @@ fn solve_bandpass_with_prior_gain_corrects_synthetic_ms_downstream() {
     for row in 0..ms.main_table().row_count() {
         let corrected = ms
             .main_table()
-            .get_array_cell(row, VisibilityDataColumn::CorrectedData.name())
+            .cell_accessor(row, VisibilityDataColumn::CorrectedData.name())
+            .and_then(|cell| cell.array())
             .expect("corrected data");
         let ArrayValue::Complex32(values) = corrected else {
             panic!("corrected data row {row} was not Complex32");
@@ -272,7 +273,8 @@ fn solve_bandpass_with_prior_gain_corrects_dense_synthetic_ms_downstream() {
     for row in [0, row_count / 2, row_count - 1] {
         let corrected = ms
             .main_table()
-            .get_array_cell(row, VisibilityDataColumn::CorrectedData.name())
+            .cell_accessor(row, VisibilityDataColumn::CorrectedData.name())
+            .and_then(|cell| cell.array())
             .expect("corrected data");
         let ArrayValue::Complex32(values) = corrected else {
             panic!("corrected data row {row} was not Complex32");
@@ -661,7 +663,11 @@ fn solve_bandpass_with_solnorm_normalizes_per_receptor_average_amplitude() {
 
     let table = Table::open(TableOptions::new(&bandpass_table)).expect("open bandpass table");
     for row in 0..table.row_count() {
-        let gains = match table.get_array_cell(row, "CPARAM").expect("CPARAM cell") {
+        let gains = match table
+            .cell_accessor(row, "CPARAM")
+            .and_then(|cell| cell.array())
+            .expect("CPARAM cell")
+        {
             ArrayValue::Complex32(values) => values
                 .view()
                 .into_dimensionality::<Ix2>()
@@ -799,7 +805,8 @@ fn solve_bpoly_bandpass_with_prior_gain_corrects_synthetic_ms_downstream() {
     for row in 0..ms.main_table().row_count() {
         let corrected = ms
             .main_table()
-            .get_array_cell(row, VisibilityDataColumn::CorrectedData.name())
+            .cell_accessor(row, VisibilityDataColumn::CorrectedData.name())
+            .and_then(|cell| cell.array())
             .expect("corrected data");
         let ArrayValue::Complex32(values) = corrected else {
             panic!("corrected data row {row} was not Complex32");

--- a/crates/casa-calibration/tests/casa_calibration_parity.rs
+++ b/crates/casa-calibration/tests/casa_calibration_parity.rs
@@ -2115,11 +2115,13 @@ fn assert_apply_state_close_with_complex_tolerances(
 
         let left_weight = left
             .main_table()
-            .get_array_cell(row, "WEIGHT")
+            .cell_accessor(row, "WEIGHT")
+            .and_then(|cell| cell.array())
             .expect("left WEIGHT");
         let right_weight = right
             .main_table()
-            .get_array_cell(row, "WEIGHT")
+            .cell_accessor(row, "WEIGHT")
+            .and_then(|cell| cell.array())
             .expect("right WEIGHT");
         assert_float_cells_close(row, "WEIGHT", left_weight, right_weight, 5.0e-4);
 
@@ -2138,11 +2140,13 @@ fn assert_apply_state_close_with_complex_tolerances(
         if left_has_weight_spectrum {
             let left_weight_spectrum = left
                 .main_table()
-                .get_array_cell(row, "WEIGHT_SPECTRUM")
+                .cell_accessor(row, "WEIGHT_SPECTRUM")
+                .and_then(|cell| cell.array())
                 .expect("left WEIGHT_SPECTRUM");
             let right_weight_spectrum = right
                 .main_table()
-                .get_array_cell(row, "WEIGHT_SPECTRUM")
+                .cell_accessor(row, "WEIGHT_SPECTRUM")
+                .and_then(|cell| cell.array())
                 .expect("right WEIGHT_SPECTRUM");
             assert_float_cells_close(
                 row,
@@ -2253,14 +2257,22 @@ fn read_cparam_rows_for_field(table_path: &std::path::Path, field_id: i32) -> Ve
     let table = Table::open(TableOptions::new(table_path)).expect("open caltable");
     let mut rows = Vec::new();
     for row in 0..table.row_count() {
-        let current_field_id = match table.cell(row, "FIELD_ID").expect("FIELD_ID cell") {
-            Some(casa_types::Value::Scalar(casa_types::ScalarValue::Int32(value))) => *value,
+        let current_field_id = match table
+            .cell_accessor(row, "FIELD_ID")
+            .and_then(|cell| cell.scalar())
+            .expect("FIELD_ID cell")
+        {
+            casa_types::ScalarValue::Int32(value) => *value,
             other => panic!("unexpected FIELD_ID value: {other:?}"),
         };
         if current_field_id != field_id {
             continue;
         }
-        let gains = match table.get_array_cell(row, "CPARAM").expect("CPARAM cell") {
+        let gains = match table
+            .cell_accessor(row, "CPARAM")
+            .and_then(|cell| cell.array())
+            .expect("CPARAM cell")
+        {
             ArrayValue::Complex32(values) => values.iter().copied().collect::<Vec<_>>(),
             other => panic!("unexpected CPARAM value: {other:?}"),
         };
@@ -2272,7 +2284,8 @@ fn read_cparam_rows_for_field(table_path: &std::path::Path, field_id: i32) -> Ve
 fn read_field_direction(table_path: &std::path::Path, field_id: usize) -> (f64, f64) {
     let table = Table::open(TableOptions::new(table_path.join("FIELD"))).expect("open FIELD table");
     let phase_dir = match table
-        .get_array_cell(field_id, "PHASE_DIR")
+        .cell_accessor(field_id, "PHASE_DIR")
+        .and_then(|cell| cell.array())
         .expect("PHASE_DIR cell")
     {
         ArrayValue::Float64(values) => values,

--- a/crates/casa-calibration/tests/common/mod.rs
+++ b/crates/casa-calibration/tests/common/mod.rs
@@ -1566,7 +1566,8 @@ fn set_field_directions_in_table(path: &Path, directions: &[(usize, f64, f64)]) 
             ArrayValue::Float64(ArrayD::from_shape_vec(vec![2, 1], vec![ra, dec]).unwrap());
         for column in ["DELAY_DIR", "PHASE_DIR", "REFERENCE_DIR"] {
             table
-                .set_cell(row, column, Value::Array(direction.clone()))
+                .cell_accessor_mut(row, column)
+                .and_then(|mut cell| cell.set(Value::Array(direction.clone())))
                 .expect("set FIELD direction");
         }
     }
@@ -1579,11 +1580,8 @@ fn set_antenna_mounts_in_table(path: &Path, mounts: &[(usize, &str)]) {
     let mut table = Table::open(TableOptions::new(path)).expect("open ANTENNA table");
     for &(row, mount) in mounts {
         table
-            .set_cell(
-                row,
-                "MOUNT",
-                Value::Scalar(ScalarValue::String(mount.to_string())),
-            )
+            .cell_accessor_mut(row, "MOUNT")
+            .and_then(|mut cell| cell.set(Value::Scalar(ScalarValue::String(mount.to_string()))))
             .expect("set ANTENNA mount");
     }
     table

--- a/crates/casa-calibration/tests/fluxscale.rs
+++ b/crates/casa-calibration/tests/fluxscale.rs
@@ -138,14 +138,22 @@ fn read_field_cparams(table_path: &std::path::Path, field_id: i32) -> Vec<Vec<Co
     let table = Table::open(TableOptions::new(table_path)).expect("open table");
     let mut rows = Vec::new();
     for row in 0..table.row_count() {
-        let row_field_id = match table.cell(row, "FIELD_ID").expect("FIELD_ID cell") {
+        let row_field_id = match table
+            .cell_accessor(row, "FIELD_ID")
+            .and_then(|cell| cell.value())
+            .expect("FIELD_ID cell")
+        {
             Some(Value::Scalar(ScalarValue::Int32(value))) => *value,
             other => panic!("unexpected FIELD_ID value: {other:?}"),
         };
         if row_field_id != field_id {
             continue;
         }
-        let gains = match table.get_array_cell(row, "CPARAM").expect("CPARAM cell") {
+        let gains = match table
+            .cell_accessor(row, "CPARAM")
+            .and_then(|cell| cell.array())
+            .expect("CPARAM cell")
+        {
             ArrayValue::Complex32(values) => values.iter().copied().collect::<Vec<_>>(),
             other => panic!("unexpected CPARAM value: {other:?}"),
         };

--- a/crates/casa-images/src/image.rs
+++ b/crates/casa-images/src/image.rs
@@ -725,9 +725,12 @@ impl<T: ImagePixel> PagedImage<T> {
             return Ok(data_type);
         }
 
-        let cell = table.cell(0, MAP_COLUMN)?.ok_or_else(|| {
-            ImageError::InvalidMetadata("missing 'map' column in row 0".to_string())
-        })?;
+        let cell = table
+            .cell_accessor(0, MAP_COLUMN)?
+            .value()?
+            .ok_or_else(|| {
+                ImageError::InvalidMetadata("missing 'map' column in row 0".to_string())
+            })?;
         match cell {
             Value::Array(array) => Ok(array.primitive_type()),
             _ => Err(ImageError::InvalidMetadata(
@@ -737,9 +740,12 @@ impl<T: ImagePixel> PagedImage<T> {
     }
 
     fn map_column_shape(table: &Table) -> Result<Vec<usize>, ImageError> {
-        let cell = table.cell(0, MAP_COLUMN)?.ok_or_else(|| {
-            ImageError::InvalidMetadata("missing 'map' column in row 0".to_string())
-        })?;
+        let cell = table
+            .cell_accessor(0, MAP_COLUMN)?
+            .value()?
+            .ok_or_else(|| {
+                ImageError::InvalidMetadata("missing 'map' column in row 0".to_string())
+            })?;
         match cell {
             Value::Array(array) => Ok(array.shape().to_vec()),
             _ => Err(ImageError::InvalidMetadata(
@@ -1834,7 +1840,8 @@ impl<T: ImagePixel> PagedImage<T> {
     fn read_array(&self) -> Result<ArrayD<T>, ImageError> {
         let cell = self
             .table
-            .cell(0, MAP_COLUMN)?
+            .cell_accessor(0, MAP_COLUMN)?
+            .value()?
             .ok_or_else(|| ImageError::InvalidMetadata("missing map cell".to_string()))?;
         match cell {
             Value::Array(array) => from_array_value(array.clone()),
@@ -1846,7 +1853,8 @@ impl<T: ImagePixel> PagedImage<T> {
 
     fn write_array(&mut self, array: &ArrayD<T>) -> Result<(), ImageError> {
         self.table
-            .set_cell(0, MAP_COLUMN, Value::Array(to_array_value(array)))?;
+            .cell_accessor_mut(0, MAP_COLUMN)?
+            .set(Value::Array(to_array_value(array)))?;
         Ok(())
     }
 
@@ -1972,8 +1980,9 @@ impl<T: ImagePixel> PagedImage<T> {
         let table = Table::open(TableOptions::new(path))?;
         let mut messages = Vec::new();
         for row in 0..table.row_count() {
-            if let Ok(Some(Value::Scalar(ScalarValue::String(message)))) =
-                table.cell(row, "MESSAGE")
+            if let Ok(Some(Value::Scalar(ScalarValue::String(message)))) = table
+                .cell_accessor(row, "MESSAGE")
+                .and_then(|cell| cell.value())
             {
                 messages.push(message.clone());
             }

--- a/crates/casa-lattices/src/paged_array.rs
+++ b/crates/casa-lattices/src/paged_array.rs
@@ -368,7 +368,9 @@ impl<T: LatticeElement> PagedArray<T> {
 
         // Read the shape from the cell.
         let cell = table
-            .cell(0, COLUMN_NAME)
+            .cell_accessor(0, COLUMN_NAME)
+            .map_err(table_err)?
+            .value()
             .map_err(table_err)?
             .ok_or_else(|| {
                 LatticeError::Table("PagedArray column not found or no rows".to_string())
@@ -560,7 +562,9 @@ impl<T: LatticeElement> PagedArray<T> {
         let table_ref = self.table.borrow();
         let table = table_ref.as_ref().unwrap();
         let cell = table
-            .cell(0, COLUMN_NAME)
+            .cell_accessor(0, COLUMN_NAME)
+            .map_err(table_err)?
+            .value()
             .map_err(table_err)?
             .ok_or_else(|| LatticeError::Table("PagedArray cell not found".to_string()))?;
         match cell {
@@ -577,7 +581,9 @@ impl<T: LatticeElement> PagedArray<T> {
             .get_mut()
             .as_mut()
             .unwrap()
-            .set_cell(0, COLUMN_NAME, Value::Array(array_value))
+            .cell_accessor_mut(0, COLUMN_NAME)
+            .map_err(table_err)?
+            .set(Value::Array(array_value))
             .map_err(table_err)
     }
 }

--- a/crates/casa-ms/examples/t_ms_iter.rs
+++ b/crates/casa-ms/examples/t_ms_iter.rs
@@ -119,10 +119,11 @@ fn main() {
         let first_row = g.row_indices[0];
         let scan = ms
             .main_table()
-            .get_scalar_cell(first_row, "SCAN_NUMBER")
+            .cell_accessor(first_row, "SCAN_NUMBER")
+            .and_then(|cell| cell.scalar())
             .ok()
             .and_then(|v| match v {
-                ScalarValue::Int32(s) => Some(*s),
+                &ScalarValue::Int32(s) => Some(s),
                 _ => None,
             })
             .unwrap_or(-1);

--- a/crates/casa-ms/src/derived/engine.rs
+++ b/crates/casa-ms/src/derived/engine.rs
@@ -695,10 +695,10 @@ fn resolve_reference_string(table: &Table, desc: &TableMeasDesc, row: usize) -> 
             tab_ref_types,
             tab_ref_codes,
         } => {
-            let code = match table.get_scalar_cell(row, ref_column)? {
-                ScalarValue::Int32(value) => *value,
-                ScalarValue::Int64(value) => *value as i32,
-                ScalarValue::UInt32(value) => *value as i32,
+            let code = match table.cell_accessor(row, ref_column)?.scalar()? {
+                &ScalarValue::Int32(value) => value,
+                &ScalarValue::Int64(value) => value as i32,
+                &ScalarValue::UInt32(value) => value as i32,
                 other => {
                     return Err(MsError::ColumnTypeMismatch {
                         column: ref_column.clone(),
@@ -727,7 +727,7 @@ fn resolve_reference_string(table: &Table, desc: &TableMeasDesc, row: usize) -> 
             })
         }
         MeasRefDesc::VariableString { ref_column } => {
-            match table.get_scalar_cell(row, ref_column)? {
+            match table.cell_accessor(row, ref_column)?.scalar()? {
                 ScalarValue::String(value) => Ok(value.clone()),
                 other => Err(MsError::ColumnTypeMismatch {
                     column: ref_column.clone(),

--- a/crates/casa-ms/src/listobs.rs
+++ b/crates/casa-ms/src/listobs.rs
@@ -3802,7 +3802,9 @@ mod tests {
 
     fn set_main_row_flag_matrix(ms: &mut MeasurementSet, row: usize, flags: ArrayD<bool>) {
         ms.main_table_mut()
-            .set_cell(row, "FLAG", Value::Array(ArrayValue::Bool(flags)))
+            .cell_accessor_mut(row, "FLAG")
+            .unwrap()
+            .set(Value::Array(ArrayValue::Bool(flags)))
             .unwrap();
     }
 }

--- a/crates/casa-ms/src/ms.rs
+++ b/crates/casa-ms/src/ms.rs
@@ -1262,10 +1262,12 @@ mod tests {
         assert_eq!(reopened.row_count(), 1);
         match reopened
             .main_table()
-            .get_scalar_cell(0, "FIELD_ID")
+            .cell_accessor(0, "FIELD_ID")
+            .unwrap()
+            .scalar()
             .expect("field id cell")
         {
-            ScalarValue::Int32(value) => assert_eq!(*value, 1),
+            &ScalarValue::Int32(value) => assert_eq!(value, 1),
             other => panic!(
                 "expected FIELD_ID to be Int32, found {:?}",
                 other.primitive_type()

--- a/crates/casa-ms/src/msexplore.rs
+++ b/crates/casa-ms/src/msexplore.rs
@@ -2827,14 +2827,14 @@ fn apply_msexplore_flag_edit_preview(
     }
     for (row, (matrix, flag_row)) in row_updates {
         ms.main_table_mut()
-            .set_cell(
-                row,
-                "FLAG",
-                Value::Array(ArrayValue::Bool(matrix.into_dyn())),
-            )
+            .cell_accessor_mut(row, "FLAG")
+            .map_err(|error| error.to_string())?
+            .set(Value::Array(ArrayValue::Bool(matrix.into_dyn())))
             .map_err(|error| error.to_string())?;
         ms.main_table_mut()
-            .set_cell(row, "FLAG_ROW", Value::Scalar(ScalarValue::Bool(flag_row)))
+            .cell_accessor_mut(row, "FLAG_ROW")
+            .map_err(|error| error.to_string())?
+            .set(Value::Scalar(ScalarValue::Bool(flag_row)))
             .map_err(|error| error.to_string())?;
     }
     Ok(preview)

--- a/crates/casa-ms/src/selection.rs
+++ b/crates/casa-ms/src/selection.rs
@@ -550,7 +550,8 @@ fn load_structured_selection_columns(
 
 fn load_i32_column(table: &Table, column: &str) -> MsResult<Vec<i32>> {
     table
-        .get_scalar_cells_owned(column)?
+        .column_accessor(column)?
+        .scalar_cells_owned()?
         .into_iter()
         .enumerate()
         .map(|(row, value)| match value {
@@ -571,7 +572,8 @@ fn load_i32_column(table: &Table, column: &str) -> MsResult<Vec<i32>> {
 
 fn load_f64_column(table: &Table, column: &str) -> MsResult<Vec<f64>> {
     table
-        .get_scalar_cells_owned(column)?
+        .column_accessor(column)?
+        .scalar_cells_owned()?
         .into_iter()
         .enumerate()
         .map(|(row, value)| match value {

--- a/crates/casa-ms/src/subtables/mod.rs
+++ b/crates/casa-ms/src/subtables/mod.rs
@@ -277,8 +277,8 @@ pub trait SubTable {
 
 /// Extract an `i32` from a scalar cell.
 pub(crate) fn get_i32(table: &Table, row: usize, col: &str) -> MsResult<i32> {
-    match table.get_scalar_cell(row, col)? {
-        ScalarValue::Int32(v) => Ok(*v),
+    match table.cell_accessor(row, col)?.scalar()? {
+        &ScalarValue::Int32(v) => Ok(v),
         other => Err(MsError::ColumnTypeMismatch {
             column: col.to_string(),
             table: "subtable".to_string(),
@@ -290,8 +290,8 @@ pub(crate) fn get_i32(table: &Table, row: usize, col: &str) -> MsResult<i32> {
 
 /// Extract an `f64` from a scalar cell.
 pub(crate) fn get_f64(table: &Table, row: usize, col: &str) -> MsResult<f64> {
-    match table.get_scalar_cell(row, col)? {
-        ScalarValue::Float64(v) => Ok(*v),
+    match table.cell_accessor(row, col)?.scalar()? {
+        &ScalarValue::Float64(v) => Ok(v),
         other => Err(MsError::ColumnTypeMismatch {
             column: col.to_string(),
             table: "subtable".to_string(),
@@ -303,8 +303,8 @@ pub(crate) fn get_f64(table: &Table, row: usize, col: &str) -> MsResult<f64> {
 
 /// Extract a `bool` from a scalar cell.
 pub(crate) fn get_bool(table: &Table, row: usize, col: &str) -> MsResult<bool> {
-    match table.get_scalar_cell(row, col)? {
-        ScalarValue::Bool(v) => Ok(*v),
+    match table.cell_accessor(row, col)?.scalar()? {
+        &ScalarValue::Bool(v) => Ok(v),
         other => Err(MsError::ColumnTypeMismatch {
             column: col.to_string(),
             table: "subtable".to_string(),
@@ -316,7 +316,7 @@ pub(crate) fn get_bool(table: &Table, row: usize, col: &str) -> MsResult<bool> {
 
 /// Extract a `&str` from a scalar cell.
 pub(crate) fn get_string(table: &Table, row: usize, col: &str) -> MsResult<String> {
-    match table.get_scalar_cell(row, col)? {
+    match table.cell_accessor(row, col)?.scalar()? {
         ScalarValue::String(v) => Ok(v.clone()),
         other => Err(MsError::ColumnTypeMismatch {
             column: col.to_string(),
@@ -329,7 +329,7 @@ pub(crate) fn get_string(table: &Table, row: usize, col: &str) -> MsResult<Strin
 
 /// Extract an array cell reference.
 pub(crate) fn get_array<'a>(table: &'a Table, row: usize, col: &str) -> MsResult<&'a ArrayValue> {
-    Ok(table.get_array_cell(row, col)?)
+    Ok(table.cell_accessor(row, col)?.array()?)
 }
 
 /// Extract an optional `i32` from a scalar cell.
@@ -388,7 +388,9 @@ pub(crate) fn set_scalar(
     col: &str,
     value: ScalarValue,
 ) -> MsResult<()> {
-    table.set_cell(row, col, Value::Scalar(value))?;
+    table
+        .cell_accessor_mut(row, col)?
+        .set(Value::Scalar(value))?;
     Ok(())
 }
 
@@ -399,6 +401,8 @@ pub(crate) fn set_array(
     col: &str,
     value: ArrayValue,
 ) -> MsResult<()> {
-    table.set_cell(row, col, Value::Array(value))?;
+    table
+        .cell_accessor_mut(row, col)?
+        .set(Value::Array(value))?;
     Ok(())
 }

--- a/crates/casa-ms/tests/pointing_subtable_regression.rs
+++ b/crates/casa-ms/tests/pointing_subtable_regression.rs
@@ -21,7 +21,8 @@ fn papersky_mosaic_pointing_direction_materializes_as_array() {
 
     let direction = pointing
         .table()
-        .get_array_cell(0, "DIRECTION")
+        .cell_accessor(0, "DIRECTION")
+        .and_then(|cell| cell.array())
         .expect("POINTING.DIRECTION row 0 should materialize as an array");
 
     let ArrayValue::Float64(direction) = direction else {

--- a/crates/casa-ms/tests/source_subtable_regression.rs
+++ b/crates/casa-ms/tests/source_subtable_regression.rs
@@ -20,7 +20,7 @@ fn ngc5921_with_flags_source_subtable_materializes_source_model_records() {
         "SOURCE subtable should contain rows"
     );
 
-    let first_row = source.table().row(0).expect("SOURCE row 0");
+    let first_row = source.table().row_accessor().row(0).expect("SOURCE row 0");
     assert!(
         matches!(first_row.get("SOURCE_MODEL"), Some(Value::Record(_))),
         "expected SOURCE_MODEL to materialize as a record, got {:?}",

--- a/crates/casa-tables/benches/row_buffer_bench.rs
+++ b/crates/casa-tables/benches/row_buffer_bench.rs
@@ -299,10 +299,14 @@ fn bench_sparse_partial_writes(c: &mut Criterion) {
             || Table::open(TableOptions::new(&incremental_path)).expect("open table"),
             |mut table| {
                 table
-                    .set_scalar_cell_assuming_valid(2, "id", ScalarValue::Int32(2002))
+                    .cell_accessor_mut(2, "id")
+                    .expect("row 2 id accessor")
+                    .set_scalar_assuming_valid(ScalarValue::Int32(2002))
                     .expect("set row 2 id");
                 table
-                    .set_scalar_cell_assuming_valid(4097, "scan", ScalarValue::Int32(9041))
+                    .cell_accessor_mut(4097, "scan")
+                    .expect("row 4097 scan accessor")
+                    .set_scalar_assuming_valid(ScalarValue::Int32(9041))
                     .expect("set row 4097 scan");
                 table
                     .save_selected_rows_in_place_assuming_valid(&["id", "scan"], &[2, 4097])
@@ -321,14 +325,12 @@ fn bench_sparse_partial_writes(c: &mut Criterion) {
                     .map(|offset| 20_000.0 + offset as f32)
                     .collect::<Vec<_>>();
                 table
-                    .set_array_cell_assuming_valid(
-                        1024,
-                        "data",
-                        ArrayValue::Float32(
-                            ArrayD::from_shape_vec(vec![16, 4], values)
-                                .expect("updated sparse tiled shape"),
-                        ),
-                    )
+                    .cell_accessor_mut(1024, "data")
+                    .expect("row 1024 data accessor")
+                    .set_array_assuming_valid(ArrayValue::Float32(
+                        ArrayD::from_shape_vec(vec![16, 4], values)
+                            .expect("updated sparse tiled shape"),
+                    ))
                     .expect("set sparse tiled cell");
                 table
                     .save_selected_rows_in_place_assuming_valid(&["data"], &[1024])
@@ -353,12 +355,14 @@ fn bench_lazy_single_cell_reads(c: &mut Criterion) {
                 let mut acc = 0i64;
                 for row_index in [2usize, 511, 4097, 7001] {
                     let value = table
-                        .get_scalar_cell(row_index, "scan")
+                        .cell_accessor(row_index, "scan")
+                        .expect("scan accessor")
+                        .scalar()
                         .expect("get buffered scalar cell");
-                    let ScalarValue::Int32(value) = value else {
+                    let &ScalarValue::Int32(value) = value else {
                         panic!("expected int32 scalar");
                     };
-                    acc += i64::from(*value);
+                    acc += i64::from(value);
                 }
                 black_box(acc)
             },

--- a/crates/casa-tables/examples/t_scalar_record_column.rs
+++ b/crates/casa-tables/examples/t_scalar_record_column.rs
@@ -64,7 +64,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     ];
 
     for (i, rec) in records.iter().enumerate() {
-        table.set_record_cell(i, "meta", rec.clone())?;
+        table
+            .cell_accessor_mut(i, "meta")?
+            .set_record(rec.clone())?;
     }
     println!("Wrote record values to 'meta' column\n");
 
@@ -96,7 +98,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // ── 6. Iterate over the record column ────────────────────────────
     println!("\n--- Iterating record column ---\n");
-    for cell in table.get_record_column("meta")? {
+    for cell in table.column_accessor("meta")?.record_iter()? {
         println!(
             "  row {}: {} field(s)",
             cell.row_index,

--- a/crates/casa-tables/examples/t_table_copy.rs
+++ b/crates/casa-tables/examples/t_table_copy.rs
@@ -60,9 +60,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\nVerifying {} rows in the copy...", copy.row_count());
 
     for (i, &(id, flux, name)) in rows.iter().enumerate() {
-        let cell_id = copy.cell(i, "id")?.expect("id cell exists");
-        let cell_flux = copy.cell(i, "flux")?.expect("flux cell exists");
-        let cell_name = copy.cell(i, "name")?.expect("name cell exists");
+        let cell_id = copy
+            .cell_accessor(i, "id")?
+            .value()?
+            .expect("id cell exists");
+        let cell_flux = copy
+            .cell_accessor(i, "flux")?
+            .value()?
+            .expect("flux cell exists");
+        let cell_name = copy
+            .cell_accessor(i, "name")?
+            .value()?
+            .expect("name cell exists");
 
         assert_eq!(
             cell_id,

--- a/crates/casa-tables/examples/t_table_iter.rs
+++ b/crates/casa-tables/examples/t_table_iter.rs
@@ -60,8 +60,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         // Print each row in this group.
         for &row_idx in &group.row_indices {
-            let cat = table.cell(row_idx, "category").unwrap();
-            let val = table.cell(row_idx, "value").unwrap();
+            let cat = table
+                .cell_accessor(row_idx, "category")
+                .and_then(|cell| cell.value())
+                .unwrap();
+            let val = table
+                .cell_accessor(row_idx, "value")
+                .and_then(|cell| cell.value())
+                .unwrap();
             println!("  row {row_idx}: category={cat:?}, value={val:?}");
         }
         println!();

--- a/crates/casa-tables/src/demo.rs
+++ b/crates/casa-tables/src/demo.rs
@@ -210,39 +210,39 @@ fn round_trip(
 
     for i in 0..nrow {
         // Scalar checks.
-        let ab = reopened.get_scalar_cell(i, "ab")?;
+        let ab = reopened.cell_accessor(i, "ab")?.scalar()?;
         if *ab != ScalarValue::Int32(i as i32) {
             appendln(out, &format!("MISMATCH ab row {i}: {ab:?}"));
         }
         cells_verified += 1;
 
-        let ad = reopened.get_scalar_cell(i, "ad")?;
+        let ad = reopened.cell_accessor(i, "ad")?.scalar()?;
         if *ad != ScalarValue::UInt32(i as u32 + 2) {
             appendln(out, &format!("MISMATCH ad row {i}: {ad:?}"));
         }
         cells_verified += 1;
 
-        let ag = reopened.get_scalar_cell(i, "ag")?;
+        let ag = reopened.cell_accessor(i, "ag")?.scalar()?;
         let expected_ag = ScalarValue::Complex64(Complex64::new(i as f64 + 3.0, -(i as f64 + 1.0)));
         if *ag != expected_ag {
             appendln(out, &format!("MISMATCH ag row {i}: {ag:?}"));
         }
         cells_verified += 1;
 
-        let ae = reopened.get_scalar_cell(i, "ae")?;
+        let ae = reopened.cell_accessor(i, "ae")?.scalar()?;
         if *ae != ScalarValue::Float32(i as f32 + 3.0) {
             appendln(out, &format!("MISMATCH ae row {i}: {ae:?}"));
         }
         cells_verified += 1;
 
-        let af = reopened.get_scalar_cell(i, "af")?;
+        let af = reopened.cell_accessor(i, "af")?.scalar()?;
         if *af != ScalarValue::String(format!("V{i}")) {
             appendln(out, &format!("MISMATCH af row {i}: {af:?}"));
         }
         cells_verified += 1;
 
         // Array check.
-        let arr = reopened.get_array_cell(i, "arr1")?;
+        let arr = reopened.cell_accessor(i, "arr1")?.array()?;
         let base = (i * nelem) as f32;
         let expected: Vec<f32> = (0..nelem).map(|k| base + k as f32).collect();
         let expected_arr = Array::from_shape_vec(IxDyn(&[2, 3, 4]), expected)
@@ -294,11 +294,14 @@ fn demo_column_iteration(out: &mut String) -> Result<(), TableError> {
     let table = build_demo_table()?;
 
     // get_column: iterate all cells of a scalar column.
-    let count = table.get_column("ab")?.count();
+    let count = table.column_accessor("ab")?.iter()?.count();
     appendln(out, &format!("get_column(\"ab\"): {count} cells"));
 
     // get_column_range: iterate a sub-range.
-    let count = table.get_column_range("ab", RowRange::new(2, 5))?.count();
+    let count = table
+        .column_accessor("ab")?
+        .iter_range(RowRange::new(2, 5))?
+        .count();
     appendln(
         out,
         &format!("get_column_range(\"ab\", 2..5): {count} cells"),
@@ -306,7 +309,8 @@ fn demo_column_iteration(out: &mut String) -> Result<(), TableError> {
 
     // iter_column_chunks: chunked iteration over an array column.
     let chunks: Vec<_> = table
-        .iter_column_chunks("arr1", RowRange::new(0, 10), 3)?
+        .column_accessor("arr1")?
+        .chunks(RowRange::new(0, 10), 3)?
         .collect();
     appendln(
         out,
@@ -317,7 +321,7 @@ fn demo_column_iteration(out: &mut String) -> Result<(), TableError> {
     );
 
     // column_cells: materialized vector.
-    let cells = table.column_cells("af")?;
+    let cells = table.column_accessor("af")?.cells()?;
     let defined = cells.iter().filter(|c| c.is_some()).count();
     appendln(out, &format!("column_cells(\"af\"): {defined} values"));
 
@@ -479,7 +483,7 @@ fn demo_ref_tables(out: &mut String) -> Result<(), TableError> {
             Value::Scalar(ScalarValue::String("modified".into())),
         )?;
     }
-    let af = table.cell(0, "af")?;
+    let af = table.cell_accessor(0, "af")?.value()?;
     appendln(out, &format!("write-through: row 0 af = {af:?}"));
 
     // Save and reopen round-trip.
@@ -964,7 +968,7 @@ fn demo_tiled_storage(out: &mut String) -> Result<(), TableError> {
 
         let mut ok = true;
         for i in 0..nrow {
-            let arr = reopened.get_array_cell(i, "data")?;
+            let arr = reopened.cell_accessor(i, "data")?.array()?;
             let base = (i * nelem) as f32;
             let expected: Vec<f32> = (0..nelem).map(|k| base + k as f32).collect();
             let expected_arr =
@@ -1018,7 +1022,7 @@ fn demo_tiled_storage(out: &mut String) -> Result<(), TableError> {
 
         let mut ok = true;
         for (i, shape) in shapes.iter().enumerate() {
-            let arr = reopened.get_array_cell(i, "data")?;
+            let arr = reopened.cell_accessor(i, "data")?.array()?;
             let nelem: usize = shape.iter().product();
             let base = (i * 10) as f32;
             let expected: Vec<f32> = (0..nelem).map(|k| base + k as f32).collect();
@@ -1072,7 +1076,7 @@ fn demo_tiled_storage(out: &mut String) -> Result<(), TableError> {
 
         let mut ok = true;
         for (i, shape) in shapes.iter().enumerate() {
-            let arr = reopened.get_array_cell(i, "data")?;
+            let arr = reopened.cell_accessor(i, "data")?.array()?;
             let nelem: usize = shape.iter().product();
             let base = (i * 10) as f32;
             let expected: Vec<f32> = (0..nelem).map(|k| base + k as f32).collect();
@@ -1177,15 +1181,15 @@ fn demo_virtual_columns(out: &mut String) -> Result<(), TableError> {
 
         let mut ok = true;
         for (i, (id, name, arr)) in base_data.iter().enumerate() {
-            let got_id = reopened.get_scalar_cell(i, "id")?;
+            let got_id = reopened.cell_accessor(i, "id")?.scalar()?;
             if *got_id != ScalarValue::Int32(*id) {
                 ok = false;
             }
-            let got_name = reopened.get_scalar_cell(i, "name")?;
+            let got_name = reopened.cell_accessor(i, "name")?.scalar()?;
             if *got_name != ScalarValue::String(name.to_string()) {
                 ok = false;
             }
-            let got_data = reopened.get_array_cell(i, "data")?;
+            let got_data = reopened.cell_accessor(i, "data")?.array()?;
             let expected = Array::from_shape_vec(IxDyn(&[3]), arr.to_vec()).unwrap();
             if let ArrayValue::Float32(v) = got_data {
                 if *v != expected {
@@ -1247,7 +1251,7 @@ fn demo_virtual_columns(out: &mut String) -> Result<(), TableError> {
 
         let mut ok = true;
         for (i, stored) in stored_rows.iter().enumerate() {
-            let arr = reopened.get_array_cell(i, "virtual_col")?;
+            let arr = reopened.cell_accessor(i, "virtual_col")?.array()?;
             if let ArrayValue::Float64(arr) = arr {
                 for (j, &s) in stored.iter().enumerate() {
                     let expected = s as f64 * scale + offset;
@@ -1325,7 +1329,7 @@ fn demo_virtual_columns(out: &mut String) -> Result<(), TableError> {
         let mut ok = true;
         for (i, data) in stored_rows.iter().enumerate() {
             // Fortran-order [2,3]: physical = [re0,im0,re1,im1,re2,im2]
-            let arr = reopened.get_array_cell(i, "virtual_col")?;
+            let arr = reopened.cell_accessor(i, "virtual_col")?.array()?;
             if let ArrayValue::Complex32(arr) = arr {
                 for j in 0..3 {
                     let re_stored = data[j * 2] as f64;

--- a/crates/casa-tables/src/indexing.rs
+++ b/crates/casa-tables/src/indexing.rs
@@ -122,7 +122,7 @@ impl<'a> ColumnsIndex<'a> {
         let mut sorted_keys = Vec::with_capacity(sorted_rows.len() * ncols);
         for &row in &sorted_rows {
             for col in &col_names {
-                match table.cell(row, col)? {
+                match table.cell_accessor(row, col)?.value()? {
                     Some(Value::Scalar(sv)) => sorted_keys.push(sv.clone()),
                     // Validated above — should not occur.
                     _ => unreachable!("index column must be scalar"),
@@ -606,7 +606,10 @@ mod tests {
         // Linear scan for comparison.
         let t2 = Instant::now();
         let linear: Vec<usize> = (0..n)
-            .filter(|&r| table.cell(r, "id") == Ok(Some(&Value::Scalar(ScalarValue::Int32(42)))))
+            .filter(|&r| {
+                table.cell_accessor(r, "id").and_then(|cell| cell.value())
+                    == Ok(Some(&Value::Scalar(ScalarValue::Int32(42))))
+            })
             .collect();
         let linear_ms = t2.elapsed().as_millis();
         assert_eq!(linear.len(), 100);

--- a/crates/casa-tables/src/lib.rs
+++ b/crates/casa-tables/src/lib.rs
@@ -224,9 +224,8 @@
 //! In C++ casacore the same functionality is split across `Table`,
 //! `TableRow`, `TableColumn`, `ScalarColumn<T>`, `ArrayColumn<T>`, and
 //! `TableRecord`. In this crate, [`Table`] remains the owning object, while
-//! [`TableRow`], [`TableColumn`], and [`TableCell`] provide the preferred
-//! public data-access surface. The older table-level `row`/`cell`/`get_*`/`set_*`
-//! methods remain available as compatibility wrappers.
+//! [`TableRow`], [`TableColumn`], and [`TableCell`] provide the public
+//! data-access surface.
 //!
 //! # Demo program
 //!

--- a/crates/casa-tables/src/ref_table.rs
+++ b/crates/casa-tables/src/ref_table.rs
@@ -71,7 +71,7 @@ impl RefLayout {
     {
         let mut row_map = Vec::new();
         for i in 0..parent.row_count() {
-            if predicate(parent.row(i)?) {
+            if predicate(parent.row_accessor().row(i)?) {
                 row_map.push(i);
             }
         }
@@ -250,13 +250,15 @@ impl<'a> RefTable<'a> {
     }
 
     pub fn row(&self, index: usize) -> Result<&RecordValue, TableError> {
-        self.parent.row(self.layout.translate_row(index)?)
+        self.parent
+            .row_accessor()
+            .row(self.layout.translate_row(index)?)
     }
 
     pub fn cell(&self, row: usize, column: &str) -> Result<Option<&Value>, TableError> {
         let parent_idx = self.layout.translate_row(row)?;
         let parent_col = self.layout.translate_column(column)?;
-        self.parent.cell(parent_idx, parent_col)
+        self.parent.cell_accessor(parent_idx, parent_col)?.value()
     }
 
     pub fn row_numbers(&self) -> &[usize] {
@@ -332,19 +334,23 @@ impl<'a> RefTableMut<'a> {
     }
 
     pub fn row(&self, index: usize) -> Result<&RecordValue, TableError> {
-        self.parent.row(self.layout.translate_row(index)?)
+        self.parent
+            .row_accessor()
+            .row(self.layout.translate_row(index)?)
     }
 
     pub fn cell(&self, row: usize, column: &str) -> Result<Option<&Value>, TableError> {
         let parent_idx = self.layout.translate_row(row)?;
         let parent_col = self.layout.translate_column(column)?;
-        self.parent.cell(parent_idx, parent_col)
+        self.parent.cell_accessor(parent_idx, parent_col)?.value()
     }
 
     pub fn set_cell(&mut self, row: usize, column: &str, value: Value) -> Result<(), TableError> {
         let parent_idx = self.layout.translate_row(row)?;
         let parent_col = self.layout.translate_column(column)?.to_string();
-        self.parent.set_cell(parent_idx, &parent_col, value)
+        self.parent
+            .cell_accessor_mut(parent_idx, &parent_col)?
+            .set(value)
     }
 
     pub fn row_numbers(&self) -> &[usize] {
@@ -471,7 +477,7 @@ mod tests {
             )
             .unwrap();
         }
-        let name = table.cell(2, "name").unwrap().unwrap();
+        let name = table.row_accessor().row(2).unwrap().get("name").unwrap();
         assert_eq!(
             name,
             &Value::Scalar(ScalarValue::String("modified".to_string()))
@@ -506,11 +512,11 @@ mod tests {
         let reopened = Table::open(crate::table::TableOptions::new(&ref_path)).unwrap();
         assert_eq!(reopened.row_count(), 3);
 
-        let id = reopened.cell(0, "id").unwrap().unwrap();
+        let id = reopened.row_accessor().row(0).unwrap().get("id").unwrap();
         assert_eq!(id, &Value::Scalar(ScalarValue::Int32(0)));
-        let id = reopened.cell(1, "id").unwrap().unwrap();
+        let id = reopened.row_accessor().row(1).unwrap().get("id").unwrap();
         assert_eq!(id, &Value::Scalar(ScalarValue::Int32(2)));
-        let id = reopened.cell(2, "id").unwrap().unwrap();
+        let id = reopened.row_accessor().row(2).unwrap().get("id").unwrap();
         assert_eq!(id, &Value::Scalar(ScalarValue::Int32(4)));
     }
 
@@ -558,7 +564,7 @@ mod tests {
         drop(view);
 
         assert_eq!(
-            reopened.cell(1, "name").unwrap(),
+            reopened.row_accessor().row(1).unwrap().get("name"),
             Some(&Value::Scalar(ScalarValue::String("projected".to_string())))
         );
 
@@ -572,7 +578,7 @@ mod tests {
         assert_eq!(saved.row_count(), 5);
         assert_eq!(saved.schema().unwrap().columns().len(), 1);
         assert_eq!(
-            saved.cell(1, "name").unwrap(),
+            saved.row_accessor().row(1).unwrap().get("name"),
             Some(&Value::Scalar(ScalarValue::String("projected".to_string())))
         );
     }

--- a/crates/casa-tables/src/sorting.rs
+++ b/crates/casa-tables/src/sorting.rs
@@ -104,7 +104,8 @@ impl<'a> TableIterator<'a> {
         for col_name in &self.key_columns {
             let value = self
                 .table
-                .cell(row_index, col_name)
+                .cell_accessor(row_index, col_name)
+                .and_then(|cell| cell.value())
                 .expect("table rows were validated when the iterator was created")
                 .cloned()
                 .unwrap_or(Value::Scalar(ScalarValue::Bool(false)));
@@ -166,7 +167,10 @@ pub(crate) fn argsort(table: &Table, keys: &[(&str, SortOrder)]) -> Result<Vec<u
         }
 
         for &(col_name, order) in keys {
-            let val_a = match table.cell(a, col_name) {
+            let val_a = match table
+                .cell_accessor(a, col_name)
+                .and_then(|cell| cell.value())
+            {
                 Ok(value) => value.and_then(|v| match v {
                     Value::Scalar(s) => Some(s),
                     _ => None,
@@ -176,7 +180,10 @@ pub(crate) fn argsort(table: &Table, keys: &[(&str, SortOrder)]) -> Result<Vec<u
                     return Ordering::Equal;
                 }
             };
-            let val_b = match table.cell(b, col_name) {
+            let val_b = match table
+                .cell_accessor(b, col_name)
+                .and_then(|cell| cell.value())
+            {
                 Ok(value) => value.and_then(|v| match v {
                     Value::Scalar(s) => Some(s),
                     _ => None,
@@ -244,7 +251,7 @@ pub(crate) fn validate_sort_column(table: &Table, col_name: &str) -> Result<(), 
 
     // Without schema, check the first row dynamically.
     if table.row_count() > 0 {
-        match table.cell(0, col_name)? {
+        match table.cell_accessor(0, col_name)?.value()? {
             Some(Value::Scalar(sv)) if sv.sort_cmp(sv).is_none() => {
                 return Err(TableError::SortKeyUnsortable {
                     column: col_name.to_string(),
@@ -609,12 +616,10 @@ mod tests {
         let reopened = Table::open(crate::table::TableOptions::new(&sorted_path)).unwrap();
         assert_eq!(reopened.row_count(), 5);
         // Should be 4,3,2,1,0.
+        let ids = reopened.column_accessor("id").unwrap();
         for i in 0..5 {
-            let val = reopened.cell(i, "id").unwrap();
-            assert_eq!(
-                val,
-                Some(&Value::Scalar(ScalarValue::Int32((4 - i) as i32)))
-            );
+            let val = ids.scalar_cell(i).unwrap();
+            assert_eq!(val, &ScalarValue::Int32((4 - i) as i32));
         }
     }
 }

--- a/crates/casa-tables/src/storage/tiled_stman.rs
+++ b/crates/casa-tables/src/storage/tiled_stman.rs
@@ -6604,9 +6604,10 @@ mod tests {
         assert_eq!(reopened.data_manager_info()[0].dm_type, "TiledDataStMan");
 
         reopened
-            .set_array_cell_assuming_valid(
+            .column_accessor_mut("data")
+            .expect("data column mut")
+            .set_array_assuming_valid(
                 2,
-                "data",
                 ArrayValue::Float32(
                     ArrayD::from_shape_vec(vec![2, 2], vec![402.0, 412.0, 422.0, 432.0])
                         .expect("shape updated data"),
@@ -6619,20 +6620,21 @@ mod tests {
             .expect("sparse tiled-data partial save");
 
         let verify = Table::open(TableOptions::new(&table_path)).expect("reopen tiled-data table");
+        let data = verify.column_accessor("data").expect("data column");
         assert_eq!(
-            verify.get_array_cell(0, "data").expect("data row 0"),
+            data.array_cell(0).expect("data row 0"),
             &ArrayValue::Float32(
                 ArrayD::from_shape_vec(vec![2, 2], vec![0.0, 10.0, 20.0, 30.0]).unwrap()
             )
         );
         assert_eq!(
-            verify.get_array_cell(2, "data").expect("data row 2"),
+            data.array_cell(2).expect("data row 2"),
             &ArrayValue::Float32(
                 ArrayD::from_shape_vec(vec![2, 2], vec![402.0, 412.0, 422.0, 432.0]).unwrap()
             )
         );
         assert_eq!(
-            verify.get_array_cell(3, "data").expect("data row 3"),
+            data.array_cell(3).expect("data row 3"),
             &ArrayValue::Float32(
                 ArrayD::from_shape_vec(vec![2, 2], vec![3.0, 13.0, 23.0, 33.0]).unwrap()
             )

--- a/crates/casa-tables/src/table/columns.rs
+++ b/crates/casa-tables/src/table/columns.rs
@@ -320,7 +320,7 @@ impl Table {
     ///
     /// Compatibility note: new row-oriented code should prefer
     /// [`row_accessor`](Table::row_accessor).
-    pub fn row(&self, row_index: usize) -> Result<&RecordValue, TableError> {
+    pub(crate) fn row(&self, row_index: usize) -> Result<&RecordValue, TableError> {
         self.inner
             .row(row_index)?
             .ok_or(TableError::RowOutOfBounds {
@@ -337,7 +337,7 @@ impl Table {
     ///
     /// Compatibility note: new row-oriented write paths should prefer
     /// [`row_accessor_mut`](Table::row_accessor_mut).
-    pub fn row_mut(&mut self, row_index: usize) -> Result<&mut RecordValue, TableError> {
+    pub(crate) fn row_mut(&mut self, row_index: usize) -> Result<&mut RecordValue, TableError> {
         let row_count = self.row_count();
         self.inner
             .row_mut(row_index)?
@@ -356,7 +356,11 @@ impl Table {
     ///
     /// Compatibility note: new cell-oriented code should prefer
     /// [`cell_accessor`](Table::cell_accessor).
-    pub fn cell(&self, row_index: usize, column: &str) -> Result<Option<&Value>, TableError> {
+    pub(crate) fn cell(
+        &self,
+        row_index: usize,
+        column: &str,
+    ) -> Result<Option<&Value>, TableError> {
         Ok(self.row(row_index)?.get(column))
     }
 
@@ -368,7 +372,7 @@ impl Table {
     ///
     /// Compatibility note: new column-oriented code should prefer
     /// [`column_accessor`](Table::column_accessor).
-    pub fn get_column<'a>(&'a self, column: &str) -> Result<ColumnCellIter<'a>, TableError> {
+    pub(crate) fn get_column<'a>(&'a self, column: &str) -> Result<ColumnCellIter<'a>, TableError> {
         self.get_column_range(column, RowRange::new(0, self.row_count()))
     }
 
@@ -377,7 +381,7 @@ impl Table {
     /// The iterator borrows the table's row data and yields one
     /// [`ColumnCellRef`] per selected row. Returns [`TableError`] if the
     /// column is unknown or the range is invalid.
-    pub fn get_column_range<'a>(
+    pub(crate) fn get_column_range<'a>(
         &'a self,
         column: &str,
         row_range: RowRange,
@@ -447,7 +451,7 @@ impl Table {
     ///
     /// Compatibility note: new cell-oriented write paths should prefer
     /// [`cell_accessor_mut`](Table::cell_accessor_mut).
-    pub fn set_record_cell(
+    pub(crate) fn set_record_cell(
         &mut self,
         row_index: usize,
         column: &str,
@@ -459,7 +463,7 @@ impl Table {
     /// Returns an iterator over every record cell in `column`, covering all rows.
     ///
     /// Shorthand for `get_record_column_range(column, RowRange::new(0, row_count()))`.
-    pub fn get_record_column<'a>(
+    pub(crate) fn get_record_column<'a>(
         &'a self,
         column: &str,
     ) -> Result<RecordColumnIter<'a>, TableError> {
@@ -472,7 +476,7 @@ impl Table {
     /// absent cells are defaulted to an empty [`RecordValue`] when the schema
     /// permits it. Returns [`TableError`] if the column is unknown, not a
     /// record column, or a cell has the wrong type.
-    pub fn get_record_column_range<'a>(
+    pub(crate) fn get_record_column_range<'a>(
         &'a self,
         column: &str,
         row_range: RowRange,
@@ -536,7 +540,7 @@ impl Table {
     ///
     /// Compatibility note: new column-oriented write paths should prefer
     /// [`column_accessor_mut`](Table::column_accessor_mut).
-    pub fn put_column<I>(&mut self, column: &str, values: I) -> Result<usize, TableError>
+    pub(crate) fn put_column<I>(&mut self, column: &str, values: I) -> Result<usize, TableError>
     where
         I: IntoIterator<Item = Value>,
     {
@@ -549,7 +553,7 @@ impl Table {
     /// `row_range`; otherwise [`TableError::ColumnWriteTooFewValues`] or
     /// [`TableError::ColumnWriteTooManyValues`] is returned. Returns the
     /// number of cells written on success.
-    pub fn put_column_range<I>(
+    pub(crate) fn put_column_range<I>(
         &mut self,
         column: &str,
         row_range: RowRange,
@@ -650,7 +654,7 @@ impl Table {
     ///
     /// Compatibility note: new cell-oriented write paths should prefer
     /// [`cell_accessor_mut`](Table::cell_accessor_mut).
-    pub fn set_cell(
+    pub(crate) fn set_cell(
         &mut self,
         row_index: usize,
         column: &str,
@@ -709,11 +713,12 @@ impl Table {
     /// Returns all cell values for `column` as an allocated `Vec`.
     ///
     /// This materializes the entire column into memory. For large tables,
-    /// prefer [`Table::get_column`] or [`Table::iter_column_chunks`] which stream lazily.
+    /// prefer [`Table::column_accessor`](Table::column_accessor) with
+    /// [`TableColumn::iter`] or [`TableColumn::chunks`] to stream lazily.
     ///
     /// Compatibility note: new column-oriented code should prefer
     /// [`column_accessor`](Table::column_accessor).
-    pub fn column_cells(&self, column: &str) -> Result<Vec<Option<&Value>>, TableError> {
+    pub(crate) fn column_cells(&self, column: &str) -> Result<Vec<Option<&Value>>, TableError> {
         Ok(self
             .rows()?
             .iter()
@@ -729,7 +734,7 @@ impl Table {
     ///
     /// Compatibility note: new column-oriented code should prefer
     /// [`column_accessor`](Table::column_accessor).
-    pub fn iter_column_chunks<'a>(
+    pub(crate) fn iter_column_chunks<'a>(
         &'a self,
         column: &str,
         row_range: RowRange,
@@ -748,7 +753,7 @@ impl Table {
     ///
     /// Compatibility note: new cell-oriented code should prefer
     /// [`cell_accessor`](Table::cell_accessor).
-    pub fn get_array_cell(
+    pub(crate) fn get_array_cell(
         &self,
         row_index: usize,
         column: &str,
@@ -792,7 +797,7 @@ impl Table {
     ///
     /// Compatibility note: new column-oriented code should prefer
     /// [`column_accessor`](Table::column_accessor).
-    pub fn get_array_cells_owned(
+    pub(crate) fn get_array_cells_owned(
         &self,
         column: &str,
         row_indices: &[usize],
@@ -830,7 +835,7 @@ impl Table {
     ///
     /// Compatibility note: new column-oriented code should prefer
     /// [`column_accessor`](Table::column_accessor).
-    pub fn get_scalar_cells_owned(
+    pub(crate) fn get_scalar_cells_owned(
         &self,
         column: &str,
     ) -> Result<Vec<Option<ScalarValue>>, TableError> {
@@ -856,7 +861,7 @@ impl Table {
     ///
     /// Compatibility note: new cell-oriented code should prefer
     /// [`cell_accessor`](Table::cell_accessor).
-    pub fn get_scalar_cell(
+    pub(crate) fn get_scalar_cell(
         &self,
         row_index: usize,
         column: &str,
@@ -904,7 +909,7 @@ impl Table {
     /// Compatibility note: new write paths should prefer
     /// [`cell_accessor_mut`](Table::cell_accessor_mut) or
     /// [`column_accessor_mut`](Table::column_accessor_mut).
-    pub fn set_scalar_cell_assuming_valid(
+    pub(crate) fn set_scalar_cell_assuming_valid(
         &mut self,
         row_index: usize,
         column: &str,
@@ -932,7 +937,7 @@ impl Table {
     /// Compatibility note: new write paths should prefer
     /// [`cell_accessor_mut`](Table::cell_accessor_mut) or
     /// [`column_accessor_mut`](Table::column_accessor_mut).
-    pub fn set_array_cell_assuming_valid(
+    pub(crate) fn set_array_cell_assuming_valid(
         &mut self,
         row_index: usize,
         column: &str,

--- a/crates/casa-tables/src/table/io.rs
+++ b/crates/casa-tables/src/table/io.rs
@@ -114,7 +114,8 @@ impl Table {
     /// This is intended for advanced callers that already know the in-memory
     /// table is schema-valid because all mutations went through validating APIs
     /// such as [`add_row`](crate::Table::add_row), [`add_column`](crate::Table::add_column),
-    /// and [`set_cell`](crate::Table::set_cell). It preserves the exact same
+    /// [`cell_accessor_mut`](crate::Table::cell_accessor_mut), and
+    /// [`column_accessor_mut`](crate::Table::column_accessor_mut). It preserves the exact same
     /// on-disk format as [`save`](Table::save), but skips the extra full-table
     /// validation pass before serialization.
     ///
@@ -1092,13 +1093,19 @@ fn current_value_for_column(
         )));
     }
     if col_desc.is_array {
-        match table.get_array_cell(row_index, &col_desc.col_name) {
+        match table
+            .column_accessor(&col_desc.col_name)
+            .and_then(|column| column.array_cell(row_index))
+        {
             Ok(value) => Ok(Some(Value::Array(value.clone()))),
             Err(TableError::ColumnNotFound { .. }) => Ok(None),
             Err(err) => Err(err),
         }
     } else {
-        match table.get_scalar_cell(row_index, &col_desc.col_name) {
+        match table
+            .column_accessor(&col_desc.col_name)
+            .and_then(|column| column.scalar_cell(row_index))
+        {
             Ok(value) => Ok(Some(Value::Scalar(value.clone()))),
             Err(TableError::ColumnNotFound { .. }) => Ok(None),
             Err(err) => Err(err),

--- a/crates/casa-tables/src/table/mod.rs
+++ b/crates/casa-tables/src/table/mod.rs
@@ -520,9 +520,10 @@ pub struct RecordColumnCell {
 
 /// An iterator over cells in a single column, yielding one [`ColumnCellRef`] per row.
 ///
-/// Obtain a `ColumnCellIter` via [`Table::get_column`] or [`Table::get_column_range`].
+/// Obtain a `ColumnCellIter` via [`Table::column_accessor`] and then
+/// [`TableColumn::iter`] or [`TableColumn::iter_range`].
 /// The iterator borrows the table's row data and does not allocate per cell.
-/// For batch processing, see [`ColumnChunkIter`] via [`Table::iter_column_chunks`].
+/// For batch processing, see [`ColumnChunkIter`] via [`TableColumn::chunks`].
 pub struct ColumnCellIter<'a> {
     row_data: &'a [RecordValue],
     column: String,
@@ -542,8 +543,8 @@ impl<'a> Iterator for ColumnCellIter<'a> {
 
 /// An iterator over cells in a record column, yielding one [`RecordColumnCell`] per row.
 ///
-/// Obtain a `RecordColumnIter` via [`Table::get_record_column`] or
-/// [`Table::get_record_column_range`]. When a [`TableSchema`] is attached and
+/// Obtain a `RecordColumnIter` via [`Table::column_accessor`] and then
+/// [`TableColumn::record_iter`] or [`TableColumn::record_iter_range`]. When a [`TableSchema`] is attached and
 /// the column is typed as [`crate::schema::ColumnType::Record`], rows whose
 /// record cell is absent yield an empty [`RecordValue`] rather than an error.
 pub struct RecordColumnIter<'a> {
@@ -581,9 +582,9 @@ impl<'a> Iterator for RecordColumnIter<'a> {
 /// count is not a multiple of `chunk_size`. An empty table (or an exhausted
 /// range) causes `next` to return `None` immediately.
 ///
-/// Obtain a `ColumnChunkIter` via [`Table::iter_column_chunks`]. This iterator
-/// is useful for processing columns in memory-bounded passes without
-/// materializing the entire column at once.
+/// Obtain a `ColumnChunkIter` via [`Table::column_accessor`] and then
+/// [`TableColumn::chunks`]. This iterator is useful for processing columns in
+/// memory-bounded passes without materializing the entire column at once.
 pub struct ColumnChunkIter<'a> {
     inner: ColumnCellIter<'a>,
     chunk_size: usize,

--- a/crates/casa-tables/src/table/mutation.rs
+++ b/crates/casa-tables/src/table/mutation.rs
@@ -81,7 +81,8 @@ impl Table {
     pub fn fill_column(&mut self, column: &str, value: Value) -> Result<(), TableError> {
         let n = self.row_count();
         for row_idx in 0..n {
-            self.set_cell(row_idx, column, value.clone())?;
+            self.cell_accessor_mut(row_idx, column)?
+                .set(value.clone())?;
         }
         Ok(())
     }
@@ -107,7 +108,8 @@ impl Table {
             if row_idx >= self.row_count() {
                 break;
             }
-            self.set_cell(row_idx, column, value.clone())?;
+            self.cell_accessor_mut(row_idx, column)?
+                .set(value.clone())?;
         }
         Ok(())
     }

--- a/crates/casa-tables/src/table/query.rs
+++ b/crates/casa-tables/src/table/query.rs
@@ -193,8 +193,15 @@ impl Table {
         row: usize,
         slicer: &Slicer,
     ) -> Result<Value, TableError> {
+        let row_count = self.row_count();
         let cell = self
-            .cell(row, column)?
+            .inner
+            .row(row)?
+            .ok_or(TableError::RowOutOfBounds {
+                row_index: row,
+                row_count,
+            })?
+            .get(column)
             .ok_or_else(|| TableError::ColumnNotFound {
                 row_index: row,
                 column: column.to_string(),
@@ -228,7 +235,11 @@ impl Table {
         slicer: &Slicer,
         data: &ArrayValue,
     ) -> Result<(), TableError> {
-        let _ = self.row(row)?;
+        let row_count = self.row_count();
+        let _ = self.inner.row(row)?.ok_or(TableError::RowOutOfBounds {
+            row_index: row,
+            row_count,
+        })?;
         let cell = self
             .inner
             .row_mut(row)?
@@ -618,14 +629,14 @@ where
             return std::cmp::Ordering::Equal;
         }
 
-        let va = match table.cell(a, column) {
+        let va = match table.cell_accessor(a, column).and_then(|cell| cell.value()) {
             Ok(value) => value,
             Err(err) => {
                 *error.borrow_mut() = Some(err);
                 return std::cmp::Ordering::Equal;
             }
         };
-        let vb = match table.cell(b, column) {
+        let vb = match table.cell_accessor(b, column).and_then(|cell| cell.value()) {
             Ok(value) => value,
             Err(err) => {
                 *error.borrow_mut() = Some(err);

--- a/crates/casa-tables/src/table/tests.rs
+++ b/crates/casa-tables/src/table/tests.rs
@@ -29,6 +29,146 @@ fn row_with_fixed_arrays(id: i32, data: &[i32], other: &[i32]) -> RecordValue {
     ])
 }
 
+fn table_row(table: &Table, row_index: usize) -> Result<&RecordValue, TableError> {
+    table.row_accessor().row(row_index)
+}
+
+fn table_cell<'a>(
+    table: &'a Table,
+    row_index: usize,
+    column: &str,
+) -> Result<Option<&'a Value>, TableError> {
+    Ok(table.row_accessor().row(row_index)?.get(column))
+}
+
+fn table_scalar<'a>(
+    table: &'a Table,
+    row_index: usize,
+    column: &str,
+) -> Result<&'a ScalarValue, TableError> {
+    table.column_accessor(column)?.scalar_cell(row_index)
+}
+
+fn table_array<'a>(
+    table: &'a Table,
+    row_index: usize,
+    column: &str,
+) -> Result<&'a ArrayValue, TableError> {
+    table.column_accessor(column)?.array_cell(row_index)
+}
+
+fn table_column_cells<'a>(
+    table: &'a Table,
+    column: &str,
+) -> Result<Vec<Option<&'a Value>>, TableError> {
+    table.column_accessor(column)?.cells()
+}
+
+fn table_column_range<'a>(
+    table: &'a Table,
+    column: &str,
+    row_range: RowRange,
+) -> Result<super::ColumnCellIter<'a>, TableError> {
+    table.column_accessor(column)?.iter_range(row_range)
+}
+
+fn table_record_column<'a>(
+    table: &'a Table,
+    column: &str,
+) -> Result<super::RecordColumnIter<'a>, TableError> {
+    table.column_accessor(column)?.record_iter()
+}
+
+fn table_record_column_range<'a>(
+    table: &'a Table,
+    column: &str,
+    row_range: RowRange,
+) -> Result<super::RecordColumnIter<'a>, TableError> {
+    table.column_accessor(column)?.record_iter_range(row_range)
+}
+
+fn table_iter_column_chunks<'a>(
+    table: &'a Table,
+    column: &str,
+    row_range: RowRange,
+    chunk_size: usize,
+) -> Result<super::ColumnChunkIter<'a>, TableError> {
+    table.column_accessor(column)?.chunks(row_range, chunk_size)
+}
+
+fn table_set_cell(
+    table: &mut Table,
+    row_index: usize,
+    column: &str,
+    value: Value,
+) -> Result<(), TableError> {
+    table.cell_accessor_mut(row_index, column)?.set(value)
+}
+
+fn table_set_record_cell(
+    table: &mut Table,
+    row_index: usize,
+    column: &str,
+    value: RecordValue,
+) -> Result<(), TableError> {
+    table
+        .cell_accessor_mut(row_index, column)?
+        .set_record(value)
+}
+
+fn table_put_column_range<I>(
+    table: &mut Table,
+    column: &str,
+    row_range: RowRange,
+    values: I,
+) -> Result<usize, TableError>
+where
+    I: IntoIterator<Item = Value>,
+{
+    table
+        .column_accessor_mut(column)?
+        .put_range(row_range, values)
+}
+
+fn table_set_scalar_assuming_valid(
+    table: &mut Table,
+    row_index: usize,
+    column: &str,
+    value: ScalarValue,
+) -> Result<(), TableError> {
+    table
+        .column_accessor_mut(column)?
+        .set_scalar_assuming_valid(row_index, value)
+}
+
+fn table_set_array_assuming_valid(
+    table: &mut Table,
+    row_index: usize,
+    column: &str,
+    value: ArrayValue,
+) -> Result<(), TableError> {
+    table
+        .column_accessor_mut(column)?
+        .set_array_assuming_valid(row_index, value)
+}
+
+fn table_scalar_cells_owned(
+    table: &Table,
+    column: &str,
+) -> Result<Vec<Option<ScalarValue>>, TableError> {
+    table.column_accessor(column)?.scalar_cells_owned()
+}
+
+fn table_array_cells_owned(
+    table: &Table,
+    column: &str,
+    row_indices: &[usize],
+) -> Result<Vec<Option<ArrayValue>>, TableError> {
+    table
+        .column_accessor(column)?
+        .array_cells_owned(row_indices)
+}
+
 #[test]
 fn table_keeps_rows_in_order() {
     let first = RecordValue::new(vec![RecordField::new(
@@ -57,27 +197,27 @@ fn table_exposes_row_and_column_cell_access() {
     ]);
     let mut table = Table::from_rows(vec![first.clone(), second.clone()]);
 
-    assert_eq!(table.row(0).unwrap(), &first);
+    assert_eq!(table_row(&table, 0).unwrap(), &first);
     assert_eq!(
-        table.cell(1, "id"),
+        table_cell(&table, 1, "id"),
         Ok(Some(&Value::Scalar(ScalarValue::Int32(2))))
     );
 
-    table
-        .set_cell(
-            1,
-            "name",
-            Value::Scalar(ScalarValue::String("beta".to_string())),
-        )
-        .expect("set cell");
+    table_set_cell(
+        &mut table,
+        1,
+        "name",
+        Value::Scalar(ScalarValue::String("beta".to_string())),
+    )
+    .expect("set cell");
     assert_eq!(
-        table.cell(1, "name"),
+        table_cell(&table, 1, "name"),
         Ok(Some(&Value::Scalar(ScalarValue::String(
             "beta".to_string()
         ))))
     );
 
-    let id_cells = table.column_cells("id").unwrap();
+    let id_cells = table_column_cells(&table, "id").unwrap();
     assert_eq!(
         id_cells,
         vec![
@@ -187,11 +327,11 @@ fn mutable_accessors_update_rows_columns_and_cells() {
     }
 
     assert_eq!(
-        table.get_scalar_cell(0, "id").expect("first id"),
+        table_scalar(&table, 0, "id").expect("first id"),
         &ScalarValue::Int32(1)
     );
     assert_eq!(
-        table.get_array_cell(0, "data").expect("first data"),
+        table_array(&table, 0, "data").expect("first data"),
         &ArrayValue::from_i32_vec(vec![2, 3])
     );
     assert_eq!(
@@ -201,13 +341,13 @@ fn mutable_accessors_update_rows_columns_and_cells() {
             Value::Scalar(ScalarValue::String("old".to_string())),
         )])
     );
-    assert_eq!(table.cell(0, "extra"), Ok(None));
+    assert_eq!(table_cell(&table, 0, "extra"), Ok(None));
     assert_eq!(
-        table.get_scalar_cell(1, "id").expect("id"),
+        table_scalar(&table, 1, "id").expect("id"),
         &ScalarValue::Int32(11)
     );
     assert_eq!(
-        table.get_array_cell(1, "data").expect("data"),
+        table_array(&table, 1, "data").expect("data"),
         &ArrayValue::from_i32_vec(vec![13, 21])
     );
     assert_eq!(
@@ -218,7 +358,7 @@ fn mutable_accessors_update_rows_columns_and_cells() {
         )])
     );
     assert_eq!(
-        table.cell(1, "extra"),
+        table_cell(&table, 1, "extra"),
         Ok(Some(&Value::Scalar(ScalarValue::Bool(true))))
     );
 }
@@ -257,11 +397,11 @@ fn column_range_iteration_supports_stride() {
         .collect();
     let table = Table::from_rows(rows);
 
-    let cells: Vec<(usize, Option<Value>)> = table
-        .get_column_range("id", RowRange::with_stride(1, 6, 2))
-        .expect("get strided range")
-        .map(|cell| (cell.row_index, cell.value.cloned()))
-        .collect();
+    let cells: Vec<(usize, Option<Value>)> =
+        table_column_range(&table, "id", RowRange::with_stride(1, 6, 2))
+            .expect("get strided range")
+            .map(|cell| (cell.row_index, cell.value.cloned()))
+            .collect();
     assert_eq!(
         cells,
         vec![
@@ -279,13 +419,13 @@ fn column_range_rejects_invalid_ranges() {
         Value::Scalar(ScalarValue::Int32(1)),
     )])]);
 
-    let bad_stride = table.get_column_range("id", RowRange::with_stride(0, 1, 0));
+    let bad_stride = table_column_range(&table, "id", RowRange::with_stride(0, 1, 0));
     assert!(matches!(
         bad_stride,
         Err(TableError::InvalidRowStride { stride: 0 })
     ));
 
-    let bad_end = table.get_column_range("id", RowRange::new(0, 2));
+    let bad_end = table_column_range(&table, "id", RowRange::new(0, 2));
     assert!(matches!(
         bad_end,
         Err(TableError::InvalidRowRange {
@@ -381,7 +521,7 @@ fn mutable_selection_sort_and_query_variants_write_through() {
             .unwrap();
     }
     assert_eq!(
-        table.cell(1, "name").unwrap(),
+        table_cell(&table, 1, "name").unwrap(),
         Some(&Value::Scalar(ScalarValue::String("projected".to_string())))
     );
 
@@ -404,7 +544,7 @@ fn mutable_selection_sort_and_query_variants_write_through() {
             .unwrap();
     }
     assert_eq!(
-        table.cell(1, "name").unwrap(),
+        table_cell(&table, 1, "name").unwrap(),
         Some(&Value::Scalar(ScalarValue::String("selected".to_string())))
     );
 
@@ -420,7 +560,7 @@ fn mutable_selection_sort_and_query_variants_write_through() {
             .unwrap();
     }
     assert_eq!(
-        table.cell(2, "name").unwrap(),
+        table_cell(&table, 2, "name").unwrap(),
         Some(&Value::Scalar(ScalarValue::String("sorted".to_string())))
     );
 
@@ -443,7 +583,7 @@ fn mutable_selection_sort_and_query_variants_write_through() {
             .unwrap();
     }
     assert_eq!(
-        table.cell(1, "name").unwrap(),
+        table_cell(&table, 1, "name").unwrap(),
         Some(&Value::Scalar(ScalarValue::String("custom".to_string())))
     );
 
@@ -458,7 +598,7 @@ fn mutable_selection_sort_and_query_variants_write_through() {
             .unwrap();
     }
     assert_eq!(
-        table.cell(0, "name").unwrap(),
+        table_cell(&table, 0, "name").unwrap(),
         Some(&Value::Scalar(ScalarValue::String("queried".to_string())))
     );
 
@@ -474,7 +614,7 @@ fn mutable_selection_sort_and_query_variants_write_through() {
             .unwrap();
     }
     assert_eq!(
-        table.cell(2, "name").unwrap(),
+        table_cell(&table, 2, "name").unwrap(),
         Some(&Value::Scalar(ScalarValue::String(
             "projected_query".to_string()
         )))
@@ -540,11 +680,11 @@ fn lazy_materialization_failures_return_storage_errors() {
     let reopened = Table::open(TableOptions::new(&path)).unwrap();
     assert_eq!(reopened.row_count(), 1);
     assert!(matches!(
-        reopened.row(0),
+        table_row(&reopened, 0),
         Err(TableError::Storage(msg)) if msg.contains("failed to materialize rows")
     ));
     assert!(matches!(
-        reopened.cell(0, "id"),
+        table_cell(&reopened, 0, "id"),
         Err(TableError::Storage(msg)) if msg.contains("failed to materialize rows")
     ));
 
@@ -581,12 +721,8 @@ fn sort_by_reports_missing_columns_and_orders_defined_before_undefined() {
             None,
         )
         .unwrap();
-    table
-        .set_cell(0, "opt", Value::Scalar(ScalarValue::Int32(10)))
-        .unwrap();
-    table
-        .set_cell(2, "opt", Value::Scalar(ScalarValue::Int32(5)))
-        .unwrap();
+    table_set_cell(&mut table, 0, "opt", Value::Scalar(ScalarValue::Int32(10))).unwrap();
+    table_set_cell(&mut table, 2, "opt", Value::Scalar(ScalarValue::Int32(5))).unwrap();
 
     let sorted = table
         .sort_by("opt", |a, b| match (a, b) {
@@ -699,11 +835,11 @@ fn record_column_range_defaults_missing_cells_for_record_schema() {
     ];
     let table = Table::from_rows_with_schema(rows, schema).expect("schema-valid rows");
 
-    let cells: Vec<(usize, RecordValue)> = table
-        .get_record_column_range("meta", RowRange::new(0, 3))
-        .expect("iterate record column")
-        .map(|cell| (cell.row_index, cell.value))
-        .collect();
+    let cells: Vec<(usize, RecordValue)> =
+        table_record_column_range(&table, "meta", RowRange::new(0, 3))
+            .expect("iterate record column")
+            .map(|cell| (cell.row_index, cell.value))
+            .collect();
 
     assert_eq!(
         cells,
@@ -720,7 +856,7 @@ fn record_column_range_without_schema_requires_all_rows_present() {
     let table = Table::from_rows(vec![record, RecordValue::new(vec![])]);
 
     assert_eq!(
-        table.get_record_column("meta").map(|iter| iter.count()),
+        table_record_column(&table, "meta").map(|iter| iter.count()),
         Err(TableError::ColumnNotFound {
             row_index: 1,
             column: "meta".to_string(),
@@ -742,7 +878,7 @@ fn record_column_range_rejects_non_record_cells() {
     ]);
 
     assert_eq!(
-        table.get_record_column("meta").map(|iter| iter.count()),
+        table_record_column(&table, "meta").map(|iter| iter.count()),
         Err(TableError::ColumnTypeMismatch {
             row_index: 1,
             column: "meta".to_string(),
@@ -765,9 +901,7 @@ fn set_record_cell_updates_row() {
         Value::Scalar(ScalarValue::Int32(42)),
     )]);
 
-    table
-        .set_record_cell(0, "meta", payload.clone())
-        .expect("set record cell");
+    table_set_record_cell(&mut table, 0, "meta", payload.clone()).expect("set record cell");
     assert_eq!(table.record_cell(0, "meta"), Ok(payload));
 }
 
@@ -829,30 +963,30 @@ fn put_column_range_streams_values_without_column_vecs() {
         )]),
     ]);
 
-    let written = table
-        .put_column_range(
-            "name",
-            RowRange::with_stride(0, 4, 2),
-            ["x", "y"]
-                .into_iter()
-                .map(|value| Value::Scalar(ScalarValue::String(value.to_string()))),
-        )
-        .expect("put strided range");
+    let written = table_put_column_range(
+        &mut table,
+        "name",
+        RowRange::with_stride(0, 4, 2),
+        ["x", "y"]
+            .into_iter()
+            .map(|value| Value::Scalar(ScalarValue::String(value.to_string()))),
+    )
+    .expect("put strided range");
     assert_eq!(written, 2);
     assert_eq!(
-        table.cell(0, "name"),
+        table_cell(&table, 0, "name"),
         Ok(Some(&Value::Scalar(ScalarValue::String("x".to_string()))))
     );
     assert_eq!(
-        table.cell(1, "name"),
+        table_cell(&table, 1, "name"),
         Ok(Some(&Value::Scalar(ScalarValue::String("b".to_string()))))
     );
     assert_eq!(
-        table.cell(2, "name"),
+        table_cell(&table, 2, "name"),
         Ok(Some(&Value::Scalar(ScalarValue::String("y".to_string()))))
     );
     assert_eq!(
-        table.cell(3, "name"),
+        table_cell(&table, 3, "name"),
         Ok(Some(&Value::Scalar(ScalarValue::String("d".to_string()))))
     );
 }
@@ -874,7 +1008,8 @@ fn put_column_range_checks_value_count() {
         )]),
     ]);
 
-    let too_few = table.put_column_range(
+    let too_few = table_put_column_range(
+        &mut table,
         "name",
         RowRange::new(0, 3),
         ["x", "y"]
@@ -903,7 +1038,8 @@ fn put_column_range_checks_value_count() {
             Value::Scalar(ScalarValue::String("c".to_string())),
         )]),
     ]);
-    let too_many = table.put_column_range(
+    let too_many = table_put_column_range(
+        &mut table,
         "name",
         RowRange::new(0, 3),
         ["x", "y", "z", "w"]
@@ -981,7 +1117,12 @@ fn variable_array_schema_allows_undefined_and_checks_ndim() {
     let two_d = Array2::from_shape_vec((1, 2), vec![4, 5])
         .expect("shape")
         .into_dyn();
-    let error = table.set_cell(0, "payload", Value::Array(ArrayValue::Int32(two_d)));
+    let error = table_set_cell(
+        &mut table,
+        0,
+        "payload",
+        Value::Array(ArrayValue::Int32(two_d)),
+    );
     assert_eq!(
         error,
         Err(TableError::ArrayNdimMismatch {
@@ -1023,7 +1164,7 @@ fn table_schema_round_trips_through_disk_storage() {
     assert_eq!(reopened.row_count(), 1);
     assert_eq!(reopened.schema(), Some(&schema));
     assert_eq!(
-        reopened.cell(0, "id"),
+        table_cell(&reopened, 0, "id"),
         Ok(Some(&Value::Scalar(ScalarValue::Int32(42))))
     );
     assert_eq!(
@@ -1061,7 +1202,7 @@ fn table_keywords_round_trip_through_disk_storage() {
 
     assert_eq!(reopened.row_count(), 1);
     assert_eq!(
-        reopened.cell(0, "id"),
+        table_cell(&reopened, 0, "id"),
         Ok(Some(&Value::Scalar(ScalarValue::Int32(42))))
     );
     assert_eq!(
@@ -1152,11 +1293,11 @@ fn metadata_only_save_updates_keywords_without_rewriting_row_storage() {
         Some(&Value::Scalar(ScalarValue::String("after".to_string())))
     );
     assert_eq!(
-        reopened.cell(0, "id"),
+        table_cell(&reopened, 0, "id"),
         Ok(Some(&Value::Scalar(ScalarValue::Int32(42))))
     );
     assert_eq!(
-        reopened.cell(0, "data"),
+        table_cell(&reopened, 0, "data"),
         Ok(Some(&Value::Array(ArrayValue::from_i32_vec(vec![7, 9]))))
     );
 
@@ -1175,22 +1316,22 @@ fn iter_column_chunks_batches_rows() {
         .collect();
     let table = Table::from_rows(rows);
 
-    let chunks: Vec<Vec<(usize, i32)>> = table
-        .iter_column_chunks("id", RowRange::new(0, 7), 3)
-        .expect("chunk iter")
-        .map(|chunk| {
-            chunk
-                .into_iter()
-                .map(|cell| {
-                    let v = match cell.value {
-                        Some(Value::Scalar(ScalarValue::Int32(n))) => n,
-                        _ => panic!("expected i32"),
-                    };
-                    (cell.row_index, *v)
-                })
-                .collect()
-        })
-        .collect();
+    let chunks: Vec<Vec<(usize, i32)>> =
+        table_iter_column_chunks(&table, "id", RowRange::new(0, 7), 3)
+            .expect("chunk iter")
+            .map(|chunk| {
+                chunk
+                    .into_iter()
+                    .map(|cell| {
+                        let v = match cell.value {
+                            Some(Value::Scalar(ScalarValue::Int32(n))) => n,
+                            _ => panic!("expected i32"),
+                        };
+                        (cell.row_index, *v)
+                    })
+                    .collect()
+            })
+            .collect();
 
     assert_eq!(
         chunks,
@@ -1214,11 +1355,11 @@ fn iter_column_chunks_with_stride() {
         .collect();
     let table = Table::from_rows(rows);
 
-    let chunks: Vec<Vec<usize>> = table
-        .iter_column_chunks("id", RowRange::with_stride(0, 6, 2), 2)
-        .expect("chunk iter")
-        .map(|chunk| chunk.into_iter().map(|cell| cell.row_index).collect())
-        .collect();
+    let chunks: Vec<Vec<usize>> =
+        table_iter_column_chunks(&table, "id", RowRange::with_stride(0, 6, 2), 2)
+            .expect("chunk iter")
+            .map(|chunk| chunk.into_iter().map(|cell| cell.row_index).collect())
+            .collect();
 
     assert_eq!(chunks, vec![vec![0, 2], vec![4]]);
 }
@@ -1231,7 +1372,7 @@ fn get_array_cell_returns_borrow() {
         Value::Array(array.clone()),
     )])]);
 
-    let borrowed = table.get_array_cell(0, "data").expect("get array cell");
+    let borrowed = table_array(&table, 0, "data").expect("get array cell");
     assert_eq!(borrowed, &array);
 }
 
@@ -1243,7 +1384,7 @@ fn get_array_cell_rejects_non_array() {
     )])]);
 
     assert!(matches!(
-        table.get_array_cell(0, "id"),
+        table_array(&table, 0, "id"),
         Err(TableError::ColumnTypeMismatch { .. })
     ));
 }
@@ -1253,7 +1394,7 @@ fn get_array_cell_rejects_missing() {
     let table = Table::from_rows(vec![RecordValue::new(vec![])]);
 
     assert!(matches!(
-        table.get_array_cell(0, "data"),
+        table_array(&table, 0, "data"),
         Err(TableError::ColumnNotFound { .. })
     ));
 }
@@ -1265,7 +1406,7 @@ fn get_scalar_cell_returns_borrow() {
         Value::Scalar(ScalarValue::Int32(42)),
     )])]);
 
-    let borrowed = table.get_scalar_cell(0, "id").expect("get scalar cell");
+    let borrowed = table_scalar(&table, 0, "id").expect("get scalar cell");
     assert_eq!(borrowed, &ScalarValue::Int32(42));
 }
 
@@ -1299,7 +1440,7 @@ fn lazy_disk_open_reads_cells_without_materializing_rows() {
         let reopened = Table::open(TableOptions::new(&root)).expect("open lazy table");
         assert!(!reopened.inner.has_loaded_rows());
         assert_eq!(
-            reopened.get_scalar_cell(0, "id").expect("scalar access"),
+            table_scalar(&reopened, 0, "id").expect("scalar access"),
             &ScalarValue::Int32(42)
         );
         assert!(
@@ -1307,7 +1448,7 @@ fn lazy_disk_open_reads_cells_without_materializing_rows() {
             "scalar access should not force row materialization for {dm:?}"
         );
 
-        let array = reopened.get_array_cell(0, "data").expect("array access");
+        let array = table_array(&reopened, 0, "data").expect("array access");
         assert_eq!(array, &ArrayValue::from_i32_vec(vec![7, 9]));
         assert!(
             !reopened.inner.has_loaded_rows(),
@@ -1471,15 +1612,11 @@ fn prepared_row_writer_reuses_buffer_and_keeps_sparse_updates() {
             "prepared row writes should not touch unrelated array columns for {dm:?}"
         );
         assert_eq!(
-            reopened
-                .get_scalar_cell(0, "id")
-                .expect("buffered scalar row 0"),
+            table_scalar(&reopened, 0, "id").expect("buffered scalar row 0"),
             &ScalarValue::Int32(10)
         );
         assert_eq!(
-            reopened
-                .get_scalar_cell(1, "id")
-                .expect("buffered scalar row 1"),
+            table_scalar(&reopened, 1, "id").expect("buffered scalar row 1"),
             &ScalarValue::Int32(20)
         );
 
@@ -1489,27 +1626,27 @@ fn prepared_row_writer_reuses_buffer_and_keeps_sparse_updates() {
 
         let verify = Table::open(TableOptions::new(&root)).expect("reopen after prepared writes");
         assert_eq!(
-            verify.get_scalar_cell(0, "id").expect("id row 0"),
+            table_scalar(&verify, 0, "id").expect("id row 0"),
             &ScalarValue::Int32(10)
         );
         assert_eq!(
-            verify.get_scalar_cell(1, "id").expect("id row 1"),
+            table_scalar(&verify, 1, "id").expect("id row 1"),
             &ScalarValue::Int32(20)
         );
         assert_eq!(
-            verify.get_array_cell(0, "data").expect("data row 0"),
+            table_array(&verify, 0, "data").expect("data row 0"),
             &ArrayValue::from_i32_vec(vec![70, 90])
         );
         assert_eq!(
-            verify.get_array_cell(1, "data").expect("data row 1"),
+            table_array(&verify, 1, "data").expect("data row 1"),
             &ArrayValue::from_i32_vec(vec![110, 130])
         );
         assert_eq!(
-            verify.get_array_cell(0, "other").expect("other row 0"),
+            table_array(&verify, 0, "other").expect("other row 0"),
             &ArrayValue::from_i32_vec(vec![100, 200])
         );
         assert_eq!(
-            verify.get_array_cell(1, "other").expect("other row 1"),
+            table_array(&verify, 1, "other").expect("other row 1"),
             &ArrayValue::from_i32_vec(vec![300, 400])
         );
 
@@ -1591,19 +1728,19 @@ fn prepared_row_writer_seek_keeps_buffer_unmaterialized_and_direct_writes_cohere
 
         let verify = Table::open(TableOptions::new(&root)).expect("reopen after prepared writes");
         assert_eq!(
-            verify.get_scalar_cell(0, "id").expect("id row 0"),
+            table_scalar(&verify, 0, "id").expect("id row 0"),
             &ScalarValue::Int32(10)
         );
         assert_eq!(
-            verify.get_scalar_cell(1, "id").expect("id row 1"),
+            table_scalar(&verify, 1, "id").expect("id row 1"),
             &ScalarValue::Int32(20)
         );
         assert_eq!(
-            verify.get_array_cell(0, "data").expect("data row 0"),
+            table_array(&verify, 0, "data").expect("data row 0"),
             &ArrayValue::from_i32_vec(vec![70, 90])
         );
         assert_eq!(
-            verify.get_array_cell(1, "data").expect("data row 1"),
+            table_array(&verify, 1, "data").expect("data row 1"),
             &ArrayValue::from_i32_vec(vec![3, 4])
         );
 
@@ -1640,25 +1777,27 @@ fn prepared_row_reader_sees_pending_and_cached_lazy_updates() {
             .expect("save disk-backed table");
 
         let mut reopened = Table::open(TableOptions::new(&root)).expect("open lazy table");
-        reopened
-            .set_scalar_cell_assuming_valid(0, "id", ScalarValue::Int32(10))
+        table_set_scalar_assuming_valid(&mut reopened, 0, "id", ScalarValue::Int32(10))
             .expect("pending scalar update");
-        reopened
-            .set_array_cell_assuming_valid(0, "data", ArrayValue::from_i32_vec(vec![70, 90]))
-            .expect("pending array update");
+        table_set_array_assuming_valid(
+            &mut reopened,
+            0,
+            "data",
+            ArrayValue::from_i32_vec(vec![70, 90]),
+        )
+        .expect("pending array update");
 
-        reopened
-            .get_scalar_cell(1, "id")
-            .expect("prime scalar cache");
-        reopened
-            .get_array_cell(1, "data")
-            .expect("prime array cache");
-        reopened
-            .set_scalar_cell_assuming_valid(1, "id", ScalarValue::Int32(20))
+        table_scalar(&reopened, 1, "id").expect("prime scalar cache");
+        table_array(&reopened, 1, "data").expect("prime array cache");
+        table_set_scalar_assuming_valid(&mut reopened, 1, "id", ScalarValue::Int32(20))
             .expect("cached scalar update");
-        reopened
-            .set_array_cell_assuming_valid(1, "data", ArrayValue::from_i32_vec(vec![110, 130]))
-            .expect("cached array update");
+        table_set_array_assuming_valid(
+            &mut reopened,
+            1,
+            "data",
+            ArrayValue::from_i32_vec(vec![110, 130]),
+        )
+        .expect("cached array update");
 
         let mut prepared = reopened
             .row_accessor()
@@ -1793,9 +1932,7 @@ fn lazy_disk_open_reads_scalar_column_owned_without_materializing_rows() {
         let reopened = Table::open(TableOptions::new(&root)).expect("open lazy table");
         assert!(!reopened.inner.has_loaded_rows());
 
-        let values = reopened
-            .get_scalar_cells_owned("scan")
-            .expect("read scalar column");
+        let values = table_scalar_cells_owned(&reopened, "scan").expect("read scalar column");
         assert_eq!(
             values,
             vec![Some(ScalarValue::Int32(10)), Some(ScalarValue::Int32(20))]
@@ -1848,24 +1985,23 @@ fn lazy_disk_open_mutates_and_partially_saves_without_materializing_rows() {
         let mut reopened = Table::open(TableOptions::new(&root)).expect("open lazy table");
         assert!(!reopened.inner.has_loaded_rows());
         assert_eq!(
-            reopened
-                .get_scalar_cell(0, "id")
-                .expect("prefetch id row 0"),
+            table_scalar(&reopened, 0, "id").expect("prefetch id row 0"),
             &ScalarValue::Int32(1)
         );
         assert_eq!(
-            reopened
-                .get_scalar_cell(1, "scan")
-                .expect("prefetch scan row 1"),
+            table_scalar(&reopened, 1, "scan").expect("prefetch scan row 1"),
             &ScalarValue::Int32(20)
         );
 
-        reopened
-            .set_scalar_cell_assuming_valid(1, "id", ScalarValue::Int32(22))
+        table_set_scalar_assuming_valid(&mut reopened, 1, "id", ScalarValue::Int32(22))
             .expect("set scalar cell lazily");
-        reopened
-            .set_array_cell_assuming_valid(0, "data", ArrayValue::from_i32_vec(vec![70, 90]))
-            .expect("set array cell lazily");
+        table_set_array_assuming_valid(
+            &mut reopened,
+            0,
+            "data",
+            ArrayValue::from_i32_vec(vec![70, 90]),
+        )
+        .expect("set array cell lazily");
         assert!(
             !reopened.inner.has_loaded_rows(),
             "lazy mutation should not force row materialization for {dm:?}"
@@ -1890,27 +2026,27 @@ fn lazy_disk_open_mutates_and_partially_saves_without_materializing_rows() {
         let verify = Table::open(TableOptions::new(&root)).expect("reopen after partial save");
         assert!(!verify.inner.has_loaded_rows());
         assert_eq!(
-            verify.get_scalar_cell(0, "id").expect("id row 0"),
+            table_scalar(&verify, 0, "id").expect("id row 0"),
             &ScalarValue::Int32(1)
         );
         assert_eq!(
-            verify.get_scalar_cell(1, "id").expect("id row 1"),
+            table_scalar(&verify, 1, "id").expect("id row 1"),
             &ScalarValue::Int32(22)
         );
         assert_eq!(
-            verify.get_scalar_cell(0, "scan").expect("scan row 0"),
+            table_scalar(&verify, 0, "scan").expect("scan row 0"),
             &ScalarValue::Int32(10)
         );
         assert_eq!(
-            verify.get_scalar_cell(1, "scan").expect("scan row 1"),
+            table_scalar(&verify, 1, "scan").expect("scan row 1"),
             &ScalarValue::Int32(20)
         );
         assert_eq!(
-            verify.get_array_cell(0, "data").expect("data row 0"),
+            table_array(&verify, 0, "data").expect("data row 0"),
             &ArrayValue::from_i32_vec(vec![70, 90])
         );
         assert_eq!(
-            verify.get_array_cell(1, "data").expect("data row 1"),
+            table_array(&verify, 1, "data").expect("data row 1"),
             &ArrayValue::from_i32_vec(vec![11, 13])
         );
 
@@ -1958,9 +2094,8 @@ fn lazy_disk_open_reads_selected_array_cells_without_loading_full_tiled_column()
     assert!(!reopened.inner.has_loaded_rows());
     assert!(!reopened.inner.has_loaded_array_column("data"));
 
-    let selected = reopened
-        .get_array_cells_owned("data", &[5, 2, 4])
-        .expect("read selected array cells");
+    let selected =
+        table_array_cells_owned(&reopened, "data", &[5, 2, 4]).expect("read selected array cells");
     assert_eq!(
         selected,
         vec![
@@ -2242,11 +2377,11 @@ fn lazy_disk_open_reads_scalar_cells_with_full_scalar_column_cache() {
         assert!(!reopened.inner.has_loaded_scalar_column("scan"));
 
         assert_eq!(
-            reopened.get_scalar_cell(3, "id").expect("id row 3"),
+            table_scalar(&reopened, 3, "id").expect("id row 3"),
             &ScalarValue::Int32(4)
         );
         assert_eq!(
-            reopened.get_scalar_cell(1, "scan").expect("scan row 1"),
+            table_scalar(&reopened, 1, "scan").expect("scan row 1"),
             &ScalarValue::Int32(20)
         );
         assert!(
@@ -2309,20 +2444,19 @@ fn partial_save_with_changed_rows_patches_stman_aipsio_indirect_arrays() {
         .expect("save disk-backed table");
 
     let mut reopened = Table::open(TableOptions::new(&root)).expect("open lazy table");
-    reopened
-        .set_scalar_cell_assuming_valid(1, "flag_row", ScalarValue::Bool(true))
+    table_set_scalar_assuming_valid(&mut reopened, 1, "flag_row", ScalarValue::Bool(true))
         .expect("set flag_row");
-    reopened
-        .set_array_cell_assuming_valid(
-            1,
-            "data",
-            ArrayValue::Float32(
-                ndarray::Array2::from_shape_vec((1, 3), vec![50.0, 60.0, 70.0])
-                    .expect("updated row 1 shape")
-                    .into_dyn(),
-            ),
-        )
-        .expect("set indirect data");
+    table_set_array_assuming_valid(
+        &mut reopened,
+        1,
+        "data",
+        ArrayValue::Float32(
+            ndarray::Array2::from_shape_vec((1, 3), vec![50.0, 60.0, 70.0])
+                .expect("updated row 1 shape")
+                .into_dyn(),
+        ),
+    )
+    .expect("set indirect data");
     assert!(!reopened.inner.has_loaded_rows());
     assert!(reopened.inner.has_pending_array_cells("data"));
 
@@ -2332,15 +2466,15 @@ fn partial_save_with_changed_rows_patches_stman_aipsio_indirect_arrays() {
 
     let verify = Table::open(TableOptions::new(&root)).expect("reopen after partial save");
     assert_eq!(
-        verify.get_scalar_cell(0, "flag_row").expect("row 0 flag"),
+        table_scalar(&verify, 0, "flag_row").expect("row 0 flag"),
         &ScalarValue::Bool(false)
     );
     assert_eq!(
-        verify.get_scalar_cell(1, "flag_row").expect("row 1 flag"),
+        table_scalar(&verify, 1, "flag_row").expect("row 1 flag"),
         &ScalarValue::Bool(true)
     );
     assert_eq!(
-        verify.get_array_cell(0, "data").expect("row 0 data"),
+        table_array(&verify, 0, "data").expect("row 0 data"),
         &ArrayValue::Float32(
             ndarray::Array2::from_shape_vec((2, 2), vec![1.0, 2.0, 3.0, 4.0])
                 .expect("verify row 0 shape")
@@ -2348,7 +2482,7 @@ fn partial_save_with_changed_rows_patches_stman_aipsio_indirect_arrays() {
         )
     );
     assert_eq!(
-        verify.get_array_cell(1, "data").expect("row 1 data"),
+        table_array(&verify, 1, "data").expect("row 1 data"),
         &ArrayValue::Float32(
             ndarray::Array2::from_shape_vec((1, 3), vec![50.0, 60.0, 70.0])
                 .expect("verify row 1 shape")
@@ -2389,9 +2523,8 @@ fn lazy_disk_open_reads_selected_indirect_array_cells_without_loading_full_stman
         .expect("save disk-backed table");
 
     let reopened = Table::open(TableOptions::new(&root)).expect("open lazy table");
-    let values = reopened
-        .get_array_cells_owned("data", &[2, 1])
-        .expect("selected indirect array rows");
+    let values =
+        table_array_cells_owned(&reopened, "data", &[2, 1]).expect("selected indirect array rows");
 
     assert_eq!(
         values,
@@ -2451,41 +2584,41 @@ fn partial_save_with_changed_rows_patches_only_touched_tiled_rows() {
         .expect("save tiled-shape table");
 
     let mut reopened = Table::open(TableOptions::new(&root)).expect("open tiled-shape table");
-    reopened
-        .set_array_cell_assuming_valid(
-            2,
-            "data",
-            ArrayValue::Float32(
-                ArrayD::from_shape_vec(vec![4, 1], vec![200.0, 210.0, 220.0, 230.0])
-                    .expect("shape updated data"),
-            ),
-        )
-        .expect("set array cell lazily");
+    table_set_array_assuming_valid(
+        &mut reopened,
+        2,
+        "data",
+        ArrayValue::Float32(
+            ArrayD::from_shape_vec(vec![4, 1], vec![200.0, 210.0, 220.0, 230.0])
+                .expect("shape updated data"),
+        ),
+    )
+    .expect("set array cell lazily");
     reopened
         .save_selected_rows_in_place_assuming_valid(&["data"], &[2])
         .expect("partial save with row hint");
 
     let verify = Table::open(TableOptions::new(&root)).expect("reopen after sparse partial save");
     assert_eq!(
-        verify.get_array_cell(0, "data").expect("data row 0"),
+        table_array(&verify, 0, "data").expect("data row 0"),
         &ArrayValue::Float32(
             ArrayD::from_shape_vec(vec![4, 1], vec![0.0, 10.0, 20.0, 30.0]).unwrap()
         )
     );
     assert_eq!(
-        verify.get_array_cell(1, "data").expect("data row 1"),
+        table_array(&verify, 1, "data").expect("data row 1"),
         &ArrayValue::Float32(
             ArrayD::from_shape_vec(vec![4, 1], vec![1.0, 11.0, 21.0, 31.0]).unwrap()
         )
     );
     assert_eq!(
-        verify.get_array_cell(2, "data").expect("data row 2"),
+        table_array(&verify, 2, "data").expect("data row 2"),
         &ArrayValue::Float32(
             ArrayD::from_shape_vec(vec![4, 1], vec![200.0, 210.0, 220.0, 230.0]).unwrap()
         )
     );
     assert_eq!(
-        verify.get_array_cell(3, "data").expect("data row 3"),
+        table_array(&verify, 3, "data").expect("data row 3"),
         &ArrayValue::Float32(
             ArrayD::from_shape_vec(vec![4, 1], vec![3.0, 13.0, 23.0, 33.0]).unwrap()
         )
@@ -2567,26 +2700,26 @@ fn partial_save_with_changed_rows_patches_only_touched_multi_column_tiled_rows()
             .any(|column| column == "WEIGHT")
     );
 
-    reopened
-        .set_array_cell_assuming_valid(
-            1,
-            "DATA",
-            ArrayValue::Float32(
-                ArrayD::from_shape_vec(vec![2, 2], vec![201.0, 211.0, 221.0, 231.0])
-                    .expect("shape updated DATA"),
-            ),
-        )
-        .expect("set DATA lazily");
-    reopened
-        .set_array_cell_assuming_valid(
-            2,
-            "WEIGHT",
-            ArrayValue::Float32(
-                ArrayD::from_shape_vec(vec![2, 2], vec![302.0, 312.0, 322.0, 332.0])
-                    .expect("shape updated WEIGHT"),
-            ),
-        )
-        .expect("set WEIGHT lazily");
+    table_set_array_assuming_valid(
+        &mut reopened,
+        1,
+        "DATA",
+        ArrayValue::Float32(
+            ArrayD::from_shape_vec(vec![2, 2], vec![201.0, 211.0, 221.0, 231.0])
+                .expect("shape updated DATA"),
+        ),
+    )
+    .expect("set DATA lazily");
+    table_set_array_assuming_valid(
+        &mut reopened,
+        2,
+        "WEIGHT",
+        ArrayValue::Float32(
+            ArrayD::from_shape_vec(vec![2, 2], vec![302.0, 312.0, 322.0, 332.0])
+                .expect("shape updated WEIGHT"),
+        ),
+    )
+    .expect("set WEIGHT lazily");
     assert!(!reopened.inner.has_loaded_rows());
     assert!(reopened.inner.has_pending_array_cells("DATA"));
     assert!(reopened.inner.has_pending_array_cells("WEIGHT"));
@@ -2611,37 +2744,37 @@ fn partial_save_with_changed_rows_patches_only_touched_multi_column_tiled_rows()
 
     let verify = Table::open(TableOptions::new(&root)).expect("reopen after sparse partial save");
     assert_eq!(
-        verify.get_array_cell(0, "DATA").expect("DATA row 0"),
+        table_array(&verify, 0, "DATA").expect("DATA row 0"),
         &ArrayValue::Float32(
             ArrayD::from_shape_vec(vec![2, 2], vec![0.0, 10.0, 20.0, 30.0]).unwrap()
         )
     );
     assert_eq!(
-        verify.get_array_cell(1, "DATA").expect("DATA row 1"),
+        table_array(&verify, 1, "DATA").expect("DATA row 1"),
         &ArrayValue::Float32(
             ArrayD::from_shape_vec(vec![2, 2], vec![201.0, 211.0, 221.0, 231.0]).unwrap()
         )
     );
     assert_eq!(
-        verify.get_array_cell(2, "DATA").expect("DATA row 2"),
+        table_array(&verify, 2, "DATA").expect("DATA row 2"),
         &ArrayValue::Float32(
             ArrayD::from_shape_vec(vec![2, 2], vec![2.0, 12.0, 22.0, 32.0]).unwrap()
         )
     );
     assert_eq!(
-        verify.get_array_cell(1, "WEIGHT").expect("WEIGHT row 1"),
+        table_array(&verify, 1, "WEIGHT").expect("WEIGHT row 1"),
         &ArrayValue::Float32(
             ArrayD::from_shape_vec(vec![2, 2], vec![101.0, 111.0, 121.0, 131.0]).unwrap()
         )
     );
     assert_eq!(
-        verify.get_array_cell(2, "WEIGHT").expect("WEIGHT row 2"),
+        table_array(&verify, 2, "WEIGHT").expect("WEIGHT row 2"),
         &ArrayValue::Float32(
             ArrayD::from_shape_vec(vec![2, 2], vec![302.0, 312.0, 322.0, 332.0]).unwrap()
         )
     );
     assert_eq!(
-        verify.get_array_cell(3, "WEIGHT").expect("WEIGHT row 3"),
+        table_array(&verify, 3, "WEIGHT").expect("WEIGHT row 3"),
         &ArrayValue::Float32(
             ArrayD::from_shape_vec(vec![2, 2], vec![103.0, 113.0, 123.0, 133.0]).unwrap()
         )
@@ -2687,16 +2820,16 @@ fn partial_save_with_changed_rows_patches_only_touched_tiled_cell_rows() {
         .expect("save tiled-cell table");
 
     let mut reopened = Table::open(TableOptions::new(&root)).expect("open tiled-cell table");
-    reopened
-        .set_array_cell_assuming_valid(
-            2,
-            "data",
-            ArrayValue::Float32(
-                ArrayD::from_shape_vec(vec![2, 2], vec![202.0, 212.0, 222.0, 232.0])
-                    .expect("shape updated data"),
-            ),
-        )
-        .expect("set array cell lazily");
+    table_set_array_assuming_valid(
+        &mut reopened,
+        2,
+        "data",
+        ArrayValue::Float32(
+            ArrayD::from_shape_vec(vec![2, 2], vec![202.0, 212.0, 222.0, 232.0])
+                .expect("shape updated data"),
+        ),
+    )
+    .expect("set array cell lazily");
     assert!(!reopened.inner.has_loaded_rows());
     assert!(reopened.inner.has_pending_array_cells("data"));
     assert!(!reopened.inner.has_loaded_array_column("data"));
@@ -2715,19 +2848,19 @@ fn partial_save_with_changed_rows_patches_only_touched_tiled_cell_rows() {
 
     let verify = Table::open(TableOptions::new(&root)).expect("reopen after sparse partial save");
     assert_eq!(
-        verify.get_array_cell(0, "data").expect("data row 0"),
+        table_array(&verify, 0, "data").expect("data row 0"),
         &ArrayValue::Float32(
             ArrayD::from_shape_vec(vec![2, 2], vec![0.0, 10.0, 20.0, 30.0]).unwrap()
         )
     );
     assert_eq!(
-        verify.get_array_cell(2, "data").expect("data row 2"),
+        table_array(&verify, 2, "data").expect("data row 2"),
         &ArrayValue::Float32(
             ArrayD::from_shape_vec(vec![2, 2], vec![202.0, 212.0, 222.0, 232.0]).unwrap()
         )
     );
     assert_eq!(
-        verify.get_array_cell(3, "data").expect("data row 3"),
+        table_array(&verify, 3, "data").expect("data row 3"),
         &ArrayValue::Float32(
             ArrayD::from_shape_vec(vec![2, 2], vec![3.0, 13.0, 23.0, 33.0]).unwrap()
         )
@@ -2767,11 +2900,9 @@ fn partial_save_with_changed_rows_patches_only_touched_incremental_rows() {
 
     let mut reopened = Table::open(TableOptions::new(&root)).expect("open incremental table");
     assert!(!reopened.inner.has_loaded_rows());
-    reopened
-        .set_scalar_cell_assuming_valid(2, "id", ScalarValue::Int32(2002))
+    table_set_scalar_assuming_valid(&mut reopened, 2, "id", ScalarValue::Int32(2002))
         .expect("set row 2 id");
-    reopened
-        .set_scalar_cell_assuming_valid(41, "scan", ScalarValue::Int32(9041))
+    table_set_scalar_assuming_valid(&mut reopened, 41, "scan", ScalarValue::Int32(9041))
         .expect("set row 41 scan");
     reopened
         .save_selected_rows_in_place_assuming_valid(&["id", "scan"], &[2, 41])
@@ -2792,27 +2923,27 @@ fn partial_save_with_changed_rows_patches_only_touched_incremental_rows() {
     let verify =
         Table::open(TableOptions::new(&root)).expect("reopen after sparse incremental save");
     assert_eq!(
-        verify.get_scalar_cell(1, "id").expect("id row 1"),
+        table_scalar(&verify, 1, "id").expect("id row 1"),
         &ScalarValue::Int32(1)
     );
     assert_eq!(
-        verify.get_scalar_cell(2, "id").expect("id row 2"),
+        table_scalar(&verify, 2, "id").expect("id row 2"),
         &ScalarValue::Int32(2002)
     );
     assert_eq!(
-        verify.get_scalar_cell(40, "scan").expect("scan row 40"),
+        table_scalar(&verify, 40, "scan").expect("scan row 40"),
         &ScalarValue::Int32(50)
     );
     assert_eq!(
-        verify.get_scalar_cell(41, "scan").expect("scan row 41"),
+        table_scalar(&verify, 41, "scan").expect("scan row 41"),
         &ScalarValue::Int32(9041)
     );
     assert_eq!(
-        verify.get_scalar_cell(42, "scan").expect("scan row 42"),
+        table_scalar(&verify, 42, "scan").expect("scan row 42"),
         &ScalarValue::Int32(50)
     );
     assert_eq!(
-        verify.get_scalar_cell(41, "state").expect("state row 41"),
+        table_scalar(&verify, 41, "state").expect("state row 41"),
         &ScalarValue::Int32(2)
     );
 
@@ -2827,7 +2958,7 @@ fn get_scalar_cell_rejects_non_scalar() {
     )])]);
 
     assert!(matches!(
-        table.get_scalar_cell(0, "data"),
+        table_scalar(&table, 0, "data"),
         Err(TableError::ColumnTypeMismatch { .. })
     ));
 }
@@ -2885,19 +3016,19 @@ fn build_endian_test_table() -> Table {
 fn verify_endian_test_table(t: &Table) {
     assert_eq!(t.row_count(), 2);
     assert_eq!(
-        t.cell(0, "i32_col"),
+        table_cell(t, 0, "i32_col"),
         Ok(Some(&Value::Scalar(ScalarValue::Int32(42))))
     );
     assert_eq!(
-        t.cell(0, "f64_col"),
+        table_cell(t, 0, "f64_col"),
         Ok(Some(&Value::Scalar(ScalarValue::Float64(2.78))))
     );
     assert_eq!(
-        t.cell(0, "str_col"),
+        table_cell(t, 0, "str_col"),
         Ok(Some(&Value::Scalar(ScalarValue::String("hello".into()))))
     );
     assert_eq!(
-        t.cell(1, "i32_col"),
+        table_cell(t, 1, "i32_col"),
         Ok(Some(&Value::Scalar(ScalarValue::Int32(-7))))
     );
 }
@@ -3090,8 +3221,8 @@ fn assert_save_with_bindings_preserves_scalar_values_when_row_field_order_varies
         .expect("save with bindings");
 
     let reopened = Table::open(TableOptions::new(&root)).expect("reopen table");
-    let row0 = reopened.row(0).expect("row 0");
-    let row1 = reopened.row(1).expect("row 1");
+    let row0 = table_row(&reopened, 0).expect("row 0");
+    let row1 = table_row(&reopened, 1).expect("row 1");
     assert_eq!(row0.get("A"), Some(&Value::Scalar(ScalarValue::Int32(10))));
     assert_eq!(row0.get("B"), Some(&Value::Scalar(ScalarValue::Int32(20))));
     assert_eq!(row1.get("A"), Some(&Value::Scalar(ScalarValue::Int32(30))));
@@ -3143,8 +3274,7 @@ fn fixed_shape_indirect_array_round_trips_through_disk() {
             .save(TableOptions::new(&root).with_data_manager(dm))
             .expect("save");
         let reopened = Table::open(TableOptions::new(&root)).expect("open");
-        match reopened
-            .cell(0, "data")
+        match table_cell(&reopened, 0, "data")
             .expect("row0 data")
             .expect("row0 data defined")
         {
@@ -3153,8 +3283,7 @@ fn fixed_shape_indirect_array_round_trips_through_disk() {
             }
             other => panic!("unexpected row0 value: {other:?}"),
         }
-        match reopened
-            .cell(1, "data")
+        match table_cell(&reopened, 1, "data")
             .expect("row1 data")
             .expect("row1 data defined")
         {
@@ -3236,13 +3365,13 @@ fn ism_slowly_changing() {
     let reopened = Table::open(TableOptions::new(&root)).expect("reopen");
     assert_eq!(reopened.row_count(), 10);
     for (i, (&expected_scan, &expected_flag)) in scans.iter().zip(flags.iter()).enumerate() {
-        let scan = reopened.get_scalar_cell(i, "SCAN_NUMBER").unwrap();
+        let scan = table_scalar(&reopened, i, "SCAN_NUMBER").unwrap();
         assert_eq!(
             *scan,
             ScalarValue::Int32(expected_scan),
             "row {i} SCAN_NUMBER"
         );
-        let flag = reopened.get_scalar_cell(i, "FLAG").unwrap();
+        let flag = table_scalar(&reopened, i, "FLAG").unwrap();
         assert_eq!(*flag, ScalarValue::Bool(expected_flag), "row {i} FLAG");
     }
     std::fs::remove_dir_all(&root).expect("cleanup");
@@ -3302,7 +3431,7 @@ fn add_column_populates_existing_rows() {
     assert_eq!(table.schema().unwrap().columns().len(), 3);
     for i in 0..3 {
         assert_eq!(
-            table.cell(i, "score"),
+            table_cell(&table, i, "score"),
             Ok(Some(&Value::Scalar(ScalarValue::Float64(0.0))))
         );
     }
@@ -3328,7 +3457,7 @@ fn add_column_round_trips_through_disk() {
         assert_eq!(reopened.schema().unwrap().columns().len(), 3);
         for i in 0..3 {
             assert_eq!(
-                reopened.cell(i, "score"),
+                table_cell(&reopened, i, "score"),
                 Ok(Some(&Value::Scalar(ScalarValue::Float64(99.5))))
             );
         }
@@ -3356,7 +3485,7 @@ fn add_column_none_default_with_undefined() {
     assert_eq!(table.schema().unwrap().columns().len(), 3);
     // Rows should not have the new field.
     for i in 0..3 {
-        assert_eq!(table.cell(i, "opt"), Ok(None));
+        assert_eq!(table_cell(&table, i, "opt"), Ok(None));
     }
 }
 
@@ -3386,7 +3515,7 @@ fn from_rows_with_schema_persists_missing_undefined_scalar_cells() {
     ];
 
     let table = Table::from_rows_with_schema(rows, schema).expect("table");
-    assert_eq!(table.cell(1, "opt"), Ok(None));
+    assert_eq!(table_cell(&table, 1, "opt"), Ok(None));
     assert!(
         table.undefined_cells().unwrap()[1].contains("opt"),
         "missing scalar field should be tracked as undefined"
@@ -3400,10 +3529,10 @@ fn from_rows_with_schema_persists_missing_undefined_scalar_cells() {
 
     let reopened = Table::open(TableOptions::new(&path)).expect("reopen table");
     assert_eq!(
-        reopened.cell(0, "opt"),
+        table_cell(&reopened, 0, "opt"),
         Ok(Some(&Value::Scalar(ScalarValue::Float64(2.5))))
     );
-    assert_eq!(reopened.cell(1, "opt"), Ok(None));
+    assert_eq!(table_cell(&reopened, 1, "opt"), Ok(None));
     assert!(reopened.undefined_cells().unwrap()[1].contains("opt"));
 }
 
@@ -3446,7 +3575,7 @@ fn remove_column_drops_from_all_rows() {
     assert_eq!(table.schema().unwrap().columns().len(), 1);
     assert!(!table.schema().unwrap().contains_column("name"));
     for i in 0..3 {
-        assert_eq!(table.cell(i, "name"), Ok(None));
+        assert_eq!(table_cell(&table, i, "name"), Ok(None));
     }
     assert!(table.column_keywords("name").is_none());
 }
@@ -3466,7 +3595,7 @@ fn remove_column_round_trips_through_disk() {
         assert_eq!(reopened.schema().unwrap().columns().len(), 1);
         assert!(!reopened.schema().unwrap().contains_column("name"));
         assert_eq!(
-            reopened.cell(0, "id"),
+            table_cell(&reopened, 0, "id"),
             Ok(Some(&Value::Scalar(ScalarValue::Int32(0))))
         );
         std::fs::remove_dir_all(&root).expect("cleanup");
@@ -3495,8 +3624,8 @@ fn rename_column_updates_rows_and_keywords() {
     assert!(table.schema().unwrap().contains_column("label"));
     assert!(!table.schema().unwrap().contains_column("name"));
     for i in 0..3 {
-        assert!(table.cell(i, "label").unwrap().is_some());
-        assert_eq!(table.cell(i, "name"), Ok(None));
+        assert!(table_cell(&table, i, "label").unwrap().is_some());
+        assert_eq!(table_cell(&table, i, "name"), Ok(None));
     }
     assert!(table.column_keywords("label").is_some());
     assert!(table.column_keywords("name").is_none());
@@ -3517,7 +3646,7 @@ fn rename_column_round_trips_through_disk() {
         assert!(reopened.schema().unwrap().contains_column("label"));
         assert!(!reopened.schema().unwrap().contains_column("name"));
         assert_eq!(
-            reopened.cell(0, "label"),
+            table_cell(&reopened, 0, "label"),
             Ok(Some(&Value::Scalar(ScalarValue::String("row0".into()))))
         );
         std::fs::remove_dir_all(&root).expect("cleanup");
@@ -3547,15 +3676,15 @@ fn remove_rows_compacts() {
     assert_eq!(table.row_count(), 3);
     // Remaining rows should be ids 0, 2, 4
     assert_eq!(
-        table.cell(0, "id"),
+        table_cell(&table, 0, "id"),
         Ok(Some(&Value::Scalar(ScalarValue::Int32(0))))
     );
     assert_eq!(
-        table.cell(1, "id"),
+        table_cell(&table, 1, "id"),
         Ok(Some(&Value::Scalar(ScalarValue::Int32(2))))
     );
     assert_eq!(
-        table.cell(2, "id"),
+        table_cell(&table, 2, "id"),
         Ok(Some(&Value::Scalar(ScalarValue::Int32(4))))
     );
 }
@@ -3574,11 +3703,11 @@ fn remove_rows_round_trips_through_disk() {
         let reopened = Table::open(TableOptions::new(&root)).expect("open");
         assert_eq!(reopened.row_count(), 2);
         assert_eq!(
-            reopened.cell(0, "id"),
+            table_cell(&reopened, 0, "id"),
             Ok(Some(&Value::Scalar(ScalarValue::Int32(0))))
         );
         assert_eq!(
-            reopened.cell(1, "id"),
+            table_cell(&reopened, 1, "id"),
             Ok(Some(&Value::Scalar(ScalarValue::Int32(2))))
         );
         std::fs::remove_dir_all(&root).expect("cleanup");
@@ -3618,19 +3747,19 @@ fn insert_row_at_position() {
 
     assert_eq!(table.row_count(), 4);
     assert_eq!(
-        table.cell(0, "id"),
+        table_cell(&table, 0, "id"),
         Ok(Some(&Value::Scalar(ScalarValue::Int32(0))))
     );
     assert_eq!(
-        table.cell(1, "id"),
+        table_cell(&table, 1, "id"),
         Ok(Some(&Value::Scalar(ScalarValue::Int32(99))))
     );
     assert_eq!(
-        table.cell(2, "id"),
+        table_cell(&table, 2, "id"),
         Ok(Some(&Value::Scalar(ScalarValue::Int32(1))))
     );
     assert_eq!(
-        table.cell(3, "id"),
+        table_cell(&table, 3, "id"),
         Ok(Some(&Value::Scalar(ScalarValue::Int32(2))))
     );
 }
@@ -3648,7 +3777,7 @@ fn insert_row_at_end() {
     table.insert_row(3, new_row).expect("insert at end");
     assert_eq!(table.row_count(), 4);
     assert_eq!(
-        table.cell(3, "id"),
+        table_cell(&table, 3, "id"),
         Ok(Some(&Value::Scalar(ScalarValue::Int32(99))))
     );
 }
@@ -3971,15 +4100,15 @@ fn memory_table_full_crud_cycle() {
     assert_eq!(table.row_count(), 2);
 
     // set_cell
-    table
-        .set_cell(
-            0,
-            "name",
-            Value::Scalar(ScalarValue::String("ALICE".into())),
-        )
-        .unwrap();
+    table_set_cell(
+        &mut table,
+        0,
+        "name",
+        Value::Scalar(ScalarValue::String("ALICE".into())),
+    )
+    .unwrap();
     assert_eq!(
-        table.cell(0, "name"),
+        table_cell(&table, 0, "name"),
         Ok(Some(&Value::Scalar(ScalarValue::String("ALICE".into()))))
     );
 
@@ -4019,7 +4148,7 @@ fn memory_table_save_materializes_to_disk() {
     assert!(!reopened.is_memory());
     assert_eq!(reopened.row_count(), 1);
     assert_eq!(
-        reopened.cell(0, "id"),
+        table_cell(&reopened, 0, "id"),
         Ok(Some(&Value::Scalar(ScalarValue::Int32(42))))
     );
     assert_eq!(
@@ -4059,7 +4188,7 @@ fn to_memory_copies_all_data() {
     assert!(mem.path().is_none());
     assert_eq!(mem.row_count(), 1);
     assert_eq!(
-        mem.cell(0, "id"),
+        table_cell(&mem, 0, "id"),
         Ok(Some(&Value::Scalar(ScalarValue::Int32(1))))
     );
     assert_eq!(
@@ -4210,7 +4339,7 @@ fn forward_column_round_trip() {
     assert_eq!(reopened.row_count(), 3);
     assert!(reopened.is_virtual_column("value"));
     for (i, expected) in [1.5, 2.5, 3.5].iter().enumerate() {
-        let val = reopened.cell(i, "value").unwrap();
+        let val = table_cell(&reopened, i, "value").unwrap();
         match val.unwrap() {
             Value::Scalar(ScalarValue::Float64(v)) => {
                 assert!(
@@ -4261,7 +4390,7 @@ fn scaled_array_round_trip() {
 
     for (i, stored) in [1i32, 2, 3].iter().enumerate() {
         let expected = (*stored as f64) * scale + offset;
-        let val = reopened.cell(i, "virtual_col").unwrap();
+        let val = table_cell(&reopened, i, "virtual_col").unwrap();
         match val.unwrap() {
             Value::Scalar(ScalarValue::Float64(v)) => {
                 assert!(
@@ -4333,13 +4462,13 @@ fn multi_dm_round_trip() {
     assert!(reopened.is_virtual_column("scaled_col"));
 
     // stored_int should be 5
-    match reopened.cell(0, "stored_int").unwrap().unwrap() {
+    match table_cell(&reopened, 0, "stored_int").unwrap().unwrap() {
         Value::Scalar(ScalarValue::Int32(v)) => assert_eq!(*v, 5),
         other => panic!("expected Int32(5), got {other:?}"),
     }
 
     // fwd_col should be 42.0 (from base table)
-    match reopened.cell(0, "fwd_col").unwrap().unwrap() {
+    match table_cell(&reopened, 0, "fwd_col").unwrap().unwrap() {
         Value::Scalar(ScalarValue::Float64(v)) => {
             assert!((v - 42.0).abs() < 1e-10, "fwd_col: expected 42.0, got {v}");
         }
@@ -4347,7 +4476,7 @@ fn multi_dm_round_trip() {
     }
 
     // scaled_col should be 5 * 3.0 + 1.0 = 16.0
-    match reopened.cell(0, "scaled_col").unwrap().unwrap() {
+    match table_cell(&reopened, 0, "scaled_col").unwrap().unwrap() {
         Value::Scalar(ScalarValue::Float64(v)) => {
             assert!(
                 (v - 16.0).abs() < 1e-10,
@@ -4815,7 +4944,7 @@ fn put_cell_slice_2d() {
         .put_cell_slice("data", 0, &slicer, &ArrayValue::Float64(patch))
         .unwrap();
 
-    match table.cell(0, "data").unwrap().unwrap() {
+    match table_cell(&table, 0, "data").unwrap().unwrap() {
         Value::Array(ArrayValue::Float64(a)) => {
             assert_eq!(a[[0, 0]], 0.0); // untouched
             assert_eq!(a[[1, 0]], 99.0); // patched
@@ -5045,21 +5174,21 @@ fn put_column_slice_multiple_rows() {
         .unwrap();
 
     // Row 0: [0, 11, 11, 0]
-    match table.cell(0, "data").unwrap().unwrap() {
+    match table_cell(&table, 0, "data").unwrap().unwrap() {
         Value::Array(ArrayValue::Float64(a)) => {
             assert_eq!(a.as_slice().unwrap(), &[0.0, 11.0, 11.0, 0.0]);
         }
         other => panic!("unexpected {other:?}"),
     }
     // Row 1: untouched
-    match table.cell(1, "data").unwrap().unwrap() {
+    match table_cell(&table, 1, "data").unwrap().unwrap() {
         Value::Array(ArrayValue::Float64(a)) => {
             assert_eq!(a.as_slice().unwrap(), &[0.0, 0.0, 0.0, 0.0]);
         }
         other => panic!("unexpected {other:?}"),
     }
     // Row 2: [0, 22, 22, 0]
-    match table.cell(2, "data").unwrap().unwrap() {
+    match table_cell(&table, 2, "data").unwrap().unwrap() {
         Value::Array(ArrayValue::Float64(a)) => {
             assert_eq!(a.as_slice().unwrap(), &[0.0, 22.0, 22.0, 0.0]);
         }
@@ -5190,7 +5319,7 @@ fn slice_helpers_cover_remaining_array_variants() {
             ),
         )
         .unwrap();
-    match table.cell(0, "c32").unwrap().unwrap() {
+    match table_cell(&table, 0, "c32").unwrap().unwrap() {
         Value::Array(ArrayValue::Complex32(values)) => {
             assert_eq!(values[[0]], Complex32::new(9.0, 1.0));
         }
@@ -5211,7 +5340,7 @@ fn slice_helpers_cover_remaining_array_variants() {
             ),
         )
         .unwrap();
-    match table.cell(0, "c64").unwrap().unwrap() {
+    match table_cell(&table, 0, "c64").unwrap().unwrap() {
         Value::Array(ArrayValue::Complex64(values)) => {
             assert_eq!(values[[1]], Complex64::new(8.0, 7.0));
         }
@@ -5229,7 +5358,7 @@ fn slice_helpers_cover_remaining_array_variants() {
             ),
         )
         .unwrap();
-    match table.cell(0, "text").unwrap().unwrap() {
+    match table_cell(&table, 0, "text").unwrap().unwrap() {
         Value::Array(ArrayValue::String(values)) => {
             assert_eq!(values[[0]], "delta");
         }
@@ -5244,7 +5373,7 @@ fn slice_helpers_cover_remaining_array_variants() {
             &ArrayValue::Float64(ArrayD::from_shape_vec(IxDyn(&[2]), vec![9.0, 9.0]).unwrap()),
         )
         .unwrap();
-    match table.cell(0, "ints").unwrap().unwrap() {
+    match table_cell(&table, 0, "ints").unwrap().unwrap() {
         Value::Array(ArrayValue::Int32(values)) => assert_eq!(values.as_slice().unwrap(), &[1, 2]),
         other => panic!("unexpected mismatch target value: {other:?}"),
     }
@@ -5280,7 +5409,7 @@ fn copy_rows_appends_all() {
     dst.copy_rows(&src).unwrap();
     assert_eq!(dst.row_count(), 3);
     assert_eq!(
-        dst.cell(2, "x"),
+        table_cell(&dst, 2, "x"),
         Ok(Some(&Value::Scalar(ScalarValue::Int32(2))))
     );
 }
@@ -5320,11 +5449,11 @@ fn copy_rows_with_mapping_selects_rows() {
     dst.copy_rows_with_mapping(&src, &[2, 0]).unwrap();
     assert_eq!(dst.row_count(), 2);
     assert_eq!(
-        dst.cell(0, "x"),
+        table_cell(&dst, 0, "x"),
         Ok(Some(&Value::Scalar(ScalarValue::Int32(30))))
     );
     assert_eq!(
-        dst.cell(1, "x"),
+        table_cell(&dst, 1, "x"),
         Ok(Some(&Value::Scalar(ScalarValue::Int32(10))))
     );
 }
@@ -5370,7 +5499,7 @@ fn fill_column_sets_all_cells() {
         .unwrap();
     for i in 0..3 {
         assert_eq!(
-            table.cell(i, "x"),
+            table_cell(&table, i, "x"),
             Ok(Some(&Value::Scalar(ScalarValue::Int32(99))))
         );
     }
@@ -5412,19 +5541,19 @@ fn fill_column_range_sets_subset() {
         .unwrap();
 
     assert_eq!(
-        table.cell(0, "x"),
+        table_cell(&table, 0, "x"),
         Ok(Some(&Value::Scalar(ScalarValue::Int32(0))))
     );
     assert_eq!(
-        table.cell(1, "x"),
+        table_cell(&table, 1, "x"),
         Ok(Some(&Value::Scalar(ScalarValue::Int32(77))))
     );
     assert_eq!(
-        table.cell(2, "x"),
+        table_cell(&table, 2, "x"),
         Ok(Some(&Value::Scalar(ScalarValue::Int32(0))))
     );
     assert_eq!(
-        table.cell(3, "x"),
+        table_cell(&table, 3, "x"),
         Ok(Some(&Value::Scalar(ScalarValue::Int32(77))))
     );
 }

--- a/crates/casa-tables/src/table_measures.rs
+++ b/crates/casa-tables/src/table_measures.rs
@@ -538,7 +538,7 @@ fn resolve_ref_string(
             tab_ref_types,
             tab_ref_codes,
         } => {
-            let code = match table.get_scalar_cell(row, ref_column)? {
+            let code = match table.cell_accessor(row, ref_column)?.scalar()? {
                 ScalarValue::Int32(v) => *v,
                 ScalarValue::Int64(v) => *v as i32,
                 ScalarValue::UInt32(v) => *v as i32,
@@ -566,7 +566,7 @@ fn resolve_ref_string(
             )))
         }
         MeasRefDesc::VariableString { ref_column } => {
-            match table.get_scalar_cell(row, ref_column)? {
+            match table.cell_accessor(row, ref_column)?.scalar()? {
                 ScalarValue::String(s) => Ok(s.clone()),
                 _ => Err(TableError::Storage(format!(
                     "ref column '{ref_column}' at row {row}: expected String"
@@ -832,11 +832,9 @@ impl<'a> ScalarMeasColumnMut<'a> {
     /// Writes a measure at `row`.
     pub fn put(&mut self, row: usize, mv: &MeasureValue) -> Result<(), TableError> {
         let vals = measure_values(mv);
-        self.table.set_cell(
-            row,
-            &self.column_name,
-            Value::Array(ArrayValue::from_f64_vec(vals)),
-        )?;
+        self.table
+            .cell_accessor_mut(row, &self.column_name)?
+            .set(Value::Array(ArrayValue::from_f64_vec(vals)))?;
         self.write_ref(row, mv)?;
         Ok(())
     }
@@ -859,13 +857,15 @@ impl<'a> ScalarMeasColumnMut<'a> {
                 let code = ref_string_to_code(self.desc.measure_type, &refer)?;
                 let ref_column = ref_column.clone();
                 self.table
-                    .set_cell(row, &ref_column, Value::Scalar(ScalarValue::Int32(code)))?;
+                    .cell_accessor_mut(row, &ref_column)?
+                    .set(Value::Scalar(ScalarValue::Int32(code)))?;
                 Ok(())
             }
             MeasRefDesc::VariableString { ref_column } => {
                 let ref_column = ref_column.clone();
                 self.table
-                    .set_cell(row, &ref_column, Value::Scalar(ScalarValue::String(refer)))?;
+                    .cell_accessor_mut(row, &ref_column)?
+                    .set(Value::Scalar(ScalarValue::String(refer)))?;
                 Ok(())
             }
         }
@@ -920,11 +920,9 @@ impl<'a> ArrayMeasColumnMut<'a> {
         for mv in measures {
             all_values.extend_from_slice(&measure_values(mv));
         }
-        self.table.set_cell(
-            row,
-            &self.column_name,
-            Value::Array(ArrayValue::from_f64_vec(all_values)),
-        )?;
+        self.table
+            .cell_accessor_mut(row, &self.column_name)?
+            .set(Value::Array(ArrayValue::from_f64_vec(all_values)))?;
         // Write reference from first measure if variable
         if !measures.is_empty() {
             let refer = measure_ref_string(&measures[0]);
@@ -933,19 +931,15 @@ impl<'a> ArrayMeasColumnMut<'a> {
                 MeasRefDesc::VariableInt { ref_column, .. } => {
                     let code = ref_string_to_code(self.desc.measure_type, &refer)?;
                     let ref_column = ref_column.clone();
-                    self.table.set_cell(
-                        row,
-                        &ref_column,
-                        Value::Scalar(ScalarValue::Int32(code)),
-                    )?;
+                    self.table
+                        .cell_accessor_mut(row, &ref_column)?
+                        .set(Value::Scalar(ScalarValue::Int32(code)))?;
                 }
                 MeasRefDesc::VariableString { ref_column } => {
                     let ref_column = ref_column.clone();
-                    self.table.set_cell(
-                        row,
-                        &ref_column,
-                        Value::Scalar(ScalarValue::String(refer)),
-                    )?;
+                    self.table
+                        .cell_accessor_mut(row, &ref_column)?
+                        .set(Value::Scalar(ScalarValue::String(refer)))?;
                 }
             }
         }
@@ -956,7 +950,7 @@ impl<'a> ArrayMeasColumnMut<'a> {
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 fn read_array_values(table: &Table, row: usize, column: &str) -> Result<Vec<f64>, TableError> {
-    let arr = table.get_array_cell(row, column)?;
+    let arr = table.cell_accessor(row, column)?.array()?;
     match arr {
         ArrayValue::Float64(a) => Ok(a.iter().copied().collect()),
         ArrayValue::Float32(a) => Ok(a.iter().map(|&v| v as f64).collect()),

--- a/crates/casa-tables/src/table_quantum.rs
+++ b/crates/casa-tables/src/table_quantum.rs
@@ -270,7 +270,7 @@ impl<'a> ScalarQuantColumn<'a> {
     /// For variable-unit columns, the unit is read from the companion column.
     /// If a conversion unit was set at construction, the value is converted.
     pub fn get(&self, row: usize) -> Result<Quantity, TableError> {
-        let scalar = self.table.get_scalar_cell(row, &self.column_name)?;
+        let scalar = self.table.cell_accessor(row, &self.column_name)?.scalar()?;
         let value = scalar_to_f64(scalar, row, &self.column_name)?;
 
         let unit = if let Some(ref u) = self.fixed_unit {
@@ -292,7 +292,7 @@ impl<'a> ScalarQuantColumn<'a> {
 
     fn read_variable_unit(&self, row: usize) -> Result<Unit, TableError> {
         let units_col = self.desc.unit_column_name().unwrap();
-        let scalar = self.table.get_scalar_cell(row, units_col)?;
+        let scalar = self.table.cell_accessor(row, units_col)?.scalar()?;
         match scalar {
             ScalarValue::String(s) => Unit::new(s)
                 .map_err(|e| TableError::Storage(format!("invalid unit '{s}' at row {row}: {e}"))),
@@ -335,18 +335,16 @@ impl<'a> ScalarQuantColumnMut<'a> {
     pub fn put(&mut self, row: usize, q: &Quantity) -> Result<(), TableError> {
         if self.desc.is_unit_variable() {
             // Write value as-is.
-            self.table.set_cell(
-                row,
-                &self.column_name,
-                Value::Scalar(ScalarValue::Float64(q.value())),
-            )?;
+            self.table
+                .cell_accessor_mut(row, &self.column_name)?
+                .set(Value::Scalar(ScalarValue::Float64(q.value())))?;
             // Write unit string.
             let units_col = self.desc.unit_column_name().unwrap().to_owned();
-            self.table.set_cell(
-                row,
-                &units_col,
-                Value::Scalar(ScalarValue::String(q.unit().name().to_owned())),
-            )?;
+            self.table
+                .cell_accessor_mut(row, &units_col)?
+                .set(Value::Scalar(ScalarValue::String(
+                    q.unit().name().to_owned(),
+                )))?;
         } else {
             // Convert to column's fixed unit.
             let col_unit_str = &self.desc.units[0];
@@ -356,11 +354,9 @@ impl<'a> ScalarQuantColumnMut<'a> {
             let converted = q
                 .get_value_in(&col_unit)
                 .map_err(|e| TableError::Storage(format!("unit conversion failed: {e}")))?;
-            self.table.set_cell(
-                row,
-                &self.column_name,
-                Value::Scalar(ScalarValue::Float64(converted)),
-            )?;
+            self.table
+                .cell_accessor_mut(row, &self.column_name)?
+                .set(Value::Scalar(ScalarValue::Float64(converted)))?;
         }
         Ok(())
     }
@@ -432,7 +428,7 @@ impl<'a> ArrayQuantColumn<'a> {
     ///
     /// The array is flattened to a vector of quantities in row-major order.
     pub fn get(&self, row: usize) -> Result<Vec<Quantity>, TableError> {
-        let arr = self.table.get_array_cell(row, &self.column_name)?;
+        let arr = self.table.cell_accessor(row, &self.column_name)?.array()?;
         let values = array_to_f64_vec(arr, row, &self.column_name)?;
 
         if self.desc.is_unit_variable() {
@@ -469,7 +465,7 @@ impl<'a> ArrayQuantColumn<'a> {
         let units_col = self.desc.unit_column_name().unwrap();
 
         // Try array units column first (per-element), then scalar (per-row).
-        let cell = self.table.cell(row, units_col)?;
+        let cell = self.table.cell_accessor(row, units_col)?.value()?;
         match cell {
             Some(Value::Array(ArrayValue::String(arr))) => {
                 let unit_strs: Vec<&str> = arr.iter().map(|s| s.as_str()).collect();
@@ -569,11 +565,9 @@ impl<'a> ArrayQuantColumnMut<'a> {
             let values: Vec<f64> = quanta.iter().map(|q| q.value()).collect();
             let units: Vec<String> = quanta.iter().map(|q| q.unit().name().to_owned()).collect();
 
-            self.table.set_cell(
-                row,
-                &self.column_name,
-                Value::Array(ArrayValue::from_f64_vec(values)),
-            )?;
+            self.table
+                .cell_accessor_mut(row, &self.column_name)?
+                .set(Value::Array(ArrayValue::from_f64_vec(values)))?;
 
             let units_col = self.desc.unit_column_name().unwrap().to_owned();
             // Determine if units column is scalar or array from schema,
@@ -582,27 +576,21 @@ impl<'a> ArrayQuantColumnMut<'a> {
             let is_scalar = self.units_col_is_scalar.unwrap_or(true);
 
             if is_scalar && quanta.len() == 1 {
-                self.table.set_cell(
-                    row,
-                    &units_col,
-                    Value::Scalar(ScalarValue::String(units[0].clone())),
-                )?;
+                self.table
+                    .cell_accessor_mut(row, &units_col)?
+                    .set(Value::Scalar(ScalarValue::String(units[0].clone())))?;
             } else {
                 // Check if the existing cell at this position is scalar
                 // (per-row mode: all elements share one unit).
                 // If so, write the first unit as the per-row unit.
                 if is_scalar {
-                    self.table.set_cell(
-                        row,
-                        &units_col,
-                        Value::Scalar(ScalarValue::String(units[0].clone())),
-                    )?;
+                    self.table
+                        .cell_accessor_mut(row, &units_col)?
+                        .set(Value::Scalar(ScalarValue::String(units[0].clone())))?;
                 } else {
-                    self.table.set_cell(
-                        row,
-                        &units_col,
-                        Value::Array(ArrayValue::from_string_vec(units)),
-                    )?;
+                    self.table
+                        .cell_accessor_mut(row, &units_col)?
+                        .set(Value::Array(ArrayValue::from_string_vec(units)))?;
                 }
             }
         } else {
@@ -617,13 +605,11 @@ impl<'a> ArrayQuantColumnMut<'a> {
                 })
                 .collect::<Result<Vec<_>, _>>()?;
             if col_units.is_empty() {
-                self.table.set_cell(
-                    row,
-                    &self.column_name,
-                    Value::Array(ArrayValue::from_f64_vec(
+                self.table
+                    .cell_accessor_mut(row, &self.column_name)?
+                    .set(Value::Array(ArrayValue::from_f64_vec(
                         quanta.iter().map(|q| q.value()).collect(),
-                    )),
-                )?;
+                    )))?;
                 return Ok(());
             }
             let unit_count = col_units.len();
@@ -637,11 +623,9 @@ impl<'a> ArrayQuantColumnMut<'a> {
                 })
                 .collect();
 
-            self.table.set_cell(
-                row,
-                &self.column_name,
-                Value::Array(ArrayValue::from_f64_vec(values?)),
-            )?;
+            self.table
+                .cell_accessor_mut(row, &self.column_name)?
+                .set(Value::Array(ArrayValue::from_f64_vec(values?)))?;
         }
         Ok(())
     }
@@ -708,7 +692,9 @@ mod tests {
         }
 
         // Read back: the units column should be an array, not a scalar
-        let cell = table.cell(0, "DATA_UNITS");
+        let cell = table
+            .cell_accessor(0, "DATA_UNITS")
+            .and_then(|cell| cell.value());
         assert!(
             matches!(cell, Ok(Some(Value::Array(ArrayValue::String(_))))),
             "expected array units but got: {cell:?}"

--- a/crates/casa-tables/src/tablebrowser.rs
+++ b/crates/casa-tables/src/tablebrowser.rs
@@ -1022,7 +1022,8 @@ impl TableBrowser {
         let value = self
             .current()
             .table
-            .cell(self.cells_row_selected, &column.name)
+            .cell_accessor(self.cells_row_selected, &column.name)
+            .and_then(|cell| cell.value())
             .ok()
             .flatten();
         let (node, trail, value_path) =
@@ -1187,7 +1188,8 @@ impl TableBrowser {
                 let value = self
                     .current()
                     .table
-                    .cell(row_index, &column.name)
+                    .cell_accessor(row_index, &column.name)
+                    .and_then(|cell| cell.value())
                     .ok()
                     .flatten();
                 let summary =
@@ -1459,7 +1461,7 @@ fn build_columns(table: &Table) -> Result<Vec<ColumnEntry>, TableBrowserError> {
             format_cell_header(&name, type_label.as_deref(), unit_info.heading.as_deref());
         let mut width = cell_header.chars().count().max(MIN_COLUMN_WIDTH);
         for row_index in 0..sample_limit {
-            let value = table.cell(row_index, &name)?;
+            let value = table.cell_accessor(row_index, &name)?.value()?;
             let rendered =
                 compact_optional_value_with_unit(value, unit_info.display_unit.as_deref());
             width = width.max(rendered.chars().count().min(MAX_COLUMN_WIDTH));
@@ -3011,7 +3013,12 @@ subtable_back={subtable_back_elapsed:?}"
             .collect::<Vec<_>>();
         for row in 0..row_count {
             for column in &column_names {
-                let value = match browser.current().table.cell(row, column) {
+                let value = match browser
+                    .current()
+                    .table
+                    .cell_accessor(row, column)
+                    .and_then(|cell| cell.value())
+                {
                     Ok(Some(value)) => value,
                     Ok(None) | Err(_) => continue,
                 };

--- a/crates/casa-tables/src/taql/exec.rs
+++ b/crates/casa-tables/src/taql/exec.rs
@@ -114,6 +114,7 @@ fn execute_select(sel: &SelectStatement, table: &crate::Table) -> Result<TaqlRes
         let mut indices = Vec::new();
         for i in 0..row_count {
             let row = table
+                .row_accessor()
                 .row(i)
                 .map_err(|err| TaqlError::Table(err.to_string()))?;
             let ctx = EvalContext {
@@ -229,6 +230,7 @@ fn materialize_select(
     let mut result_rows: Vec<RecordValue> = Vec::with_capacity(row_indices.len());
     for &row_idx in row_indices {
         let row = table
+            .row_accessor()
             .row(row_idx)
             .map_err(|err| TaqlError::Table(err.to_string()))?;
         let ctx = EvalContext {
@@ -340,6 +342,7 @@ fn execute_joins(
 
         for &left_idx in &result_rows {
             let left_row = table
+                .row_accessor()
                 .row(left_idx)
                 .map_err(|err| TaqlError::Table(err.to_string()))?;
             let mut found_match = false;
@@ -355,6 +358,7 @@ fn execute_joins(
 
             for right_idx in 0..right_count {
                 let right_row = table
+                    .row_accessor()
                     .row(right_idx)
                     .map_err(|err| TaqlError::Table(err.to_string()))?;
 
@@ -431,6 +435,7 @@ fn execute_update(
         let mut indices = Vec::new();
         for i in 0..row_count {
             let row = table
+                .row_accessor()
                 .row(i)
                 .map_err(|err| TaqlError::Table(err.to_string()))?;
             let ctx = EvalContext {
@@ -458,6 +463,7 @@ fn execute_update(
     let mut updates: Vec<Vec<(String, Value)>> = Vec::with_capacity(matching_rows.len());
     for &row_idx in &matching_rows {
         let row = table
+            .row_accessor()
             .row(row_idx)
             .map_err(|err| TaqlError::Table(err.to_string()))?;
         let ctx = EvalContext {
@@ -479,7 +485,8 @@ fn execute_update(
     for (row_idx, row_updates) in matching_rows.into_iter().zip(updates) {
         for (column, value) in row_updates {
             table
-                .set_cell(row_idx, &column, value)
+                .cell_accessor_mut(row_idx, &column)
+                .and_then(|mut cell| cell.set(value))
                 .map_err(|e| TaqlError::Table(e.to_string()))?;
         }
     }
@@ -557,6 +564,7 @@ fn execute_delete(
         let mut indices = Vec::new();
         for i in 0..row_count {
             let row = table
+                .row_accessor()
                 .row(i)
                 .map_err(|err| TaqlError::Table(err.to_string()))?;
             let ctx = EvalContext {
@@ -602,7 +610,7 @@ fn execute_calc(calc: &CalcStatement, table: &crate::Table) -> Result<TaqlResult
     // Use row 0 if the table has rows, otherwise an empty context
     let empty_row = casa_types::RecordValue::default();
     let row = if table.row_count() > 0 {
-        table.row(0).unwrap_or(&empty_row)
+        table.row_accessor().row(0).unwrap_or(&empty_row)
     } else {
         &empty_row
     };
@@ -793,6 +801,7 @@ fn execute_group_by(sel: &SelectStatement, table: &crate::Table) -> Result<TaqlR
         let mut indices = Vec::new();
         for i in 0..row_count {
             let row = table
+                .row_accessor()
                 .row(i)
                 .map_err(|err| TaqlError::Table(err.to_string()))?;
             let ctx = EvalContext {
@@ -892,6 +901,7 @@ fn group_rows(
 
     for &row_idx in row_indices {
         let row = table
+            .row_accessor()
             .row(row_idx)
             .map_err(|err| TaqlError::Table(err.to_string()))?;
         let ctx = EvalContext {
@@ -1013,6 +1023,7 @@ fn eval_aggregate_column(
             // For non-aggregate columns in GROUP BY, use the first row's value
             if let Some(&first_row) = group.first() {
                 let row = table
+                    .row_accessor()
                     .row(first_row)
                     .map_err(|err| TaqlError::Table(err.to_string()))?;
                 let ctx = EvalContext {
@@ -1029,6 +1040,7 @@ fn eval_aggregate_column(
             // For expression columns, try evaluating with first row
             if let Some(&first_row) = group.first() {
                 let row = table
+                    .row_accessor()
                     .row(first_row)
                     .map_err(|err| TaqlError::Table(err.to_string()))?;
                 let ctx = EvalContext {
@@ -1122,6 +1134,7 @@ fn sort_rows(
     let mut sort_keys: Vec<Vec<ExprValue>> = Vec::with_capacity(row_indices.len());
     for &row_idx in row_indices.iter() {
         let row = table
+            .row_accessor()
             .row(row_idx)
             .map_err(|err| TaqlError::Table(err.to_string()))?;
         let ctx = EvalContext {
@@ -1171,6 +1184,7 @@ fn deduplicate_rows(
 
     for &row_idx in row_indices.iter() {
         let row = table
+            .row_accessor()
             .row(row_idx)
             .map_err(|err| TaqlError::Table(err.to_string()))?;
         let ctx = EvalContext {
@@ -1611,7 +1625,10 @@ mod tests {
             }
             _ => panic!("expected Update"),
         }
-        let val = table.cell(5, "flux").unwrap();
+        let val = table
+            .cell_accessor(5, "flux")
+            .and_then(|cell| cell.value())
+            .unwrap();
         assert_eq!(val, Some(&Value::Scalar(ScalarValue::Float64(99.0))));
     }
 
@@ -1626,7 +1643,10 @@ mod tests {
             }
             _ => panic!("expected Update"),
         }
-        let val = table.cell(3, "flux").unwrap();
+        let val = table
+            .cell_accessor(3, "flux")
+            .and_then(|cell| cell.value())
+            .unwrap();
         assert_eq!(val, Some(&Value::Scalar(ScalarValue::Float64(9.0)))); // 3 * 1.5 * 2.0
     }
 
@@ -1643,7 +1663,10 @@ mod tests {
             _ => panic!("expected Insert"),
         }
         assert_eq!(table.row_count(), 11);
-        let val = table.cell(10, "id").unwrap();
+        let val = table
+            .cell_accessor(10, "id")
+            .and_then(|cell| cell.value())
+            .unwrap();
         assert_eq!(val, Some(&Value::Scalar(ScalarValue::Int32(10))));
     }
 

--- a/crates/casa-tables/tests/taql.rs
+++ b/crates/casa-tables/tests/taql.rs
@@ -197,7 +197,10 @@ fn update_with_where() {
         TaqlResult::Update { rows_affected } => assert_eq!(rows_affected, 1),
         _ => panic!("expected Update"),
     }
-    let val = table.cell(25, "flux").unwrap();
+    let val = table
+        .cell_accessor(25, "flux")
+        .and_then(|cell| cell.value())
+        .unwrap();
     assert_eq!(val, Some(&Value::Scalar(ScalarValue::Float64(999.0))));
 }
 
@@ -211,7 +214,10 @@ fn update_expression() {
         TaqlResult::Update { rows_affected } => assert_eq!(rows_affected, 1),
         _ => panic!("expected Update"),
     }
-    let val = table.cell(0, "flux").unwrap();
+    let val = table
+        .cell_accessor(0, "flux")
+        .and_then(|cell| cell.value())
+        .unwrap();
     assert_eq!(val, Some(&Value::Scalar(ScalarValue::Float64(1.0)))); // 0.1 * 10.0
 }
 

--- a/crates/casa-test-support/src/table_interop.rs
+++ b/crates/casa-test-support/src/table_interop.rs
@@ -534,7 +534,9 @@ fn compare_table_to_fixture(table: &Table, fixture: &TableFixture) -> Result<(),
         for col_schema in fixture.schema.columns() {
             let col_name = col_schema.name();
             let expected = expected_row.get(col_name);
-            let actual = table.cell(row_idx, col_name);
+            let actual = table
+                .cell_accessor(row_idx, col_name)
+                .and_then(|cell| cell.value());
 
             match (expected, actual) {
                 (None, Ok(None)) => {} // Both undefined — OK

--- a/crates/casa-test-support/src/taql_interop.rs
+++ b/crates/casa-test-support/src/taql_interop.rs
@@ -833,7 +833,12 @@ mod tests {
         let arrays = build_array_fixture();
         assert_eq!(arrays.row_count(), 10);
         assert_eq!(
-            match arrays.cell(0, "idata").unwrap().unwrap() {
+            match arrays
+                .cell_accessor(0, "idata")
+                .and_then(|cell| cell.value())
+                .unwrap()
+                .unwrap()
+            {
                 Value::Array(array) => array.shape().to_vec(),
                 other => panic!("expected array value, got {other:?}"),
             },
@@ -843,7 +848,12 @@ mod tests {
         let varshape = build_varshape_fixture();
         assert_eq!(varshape.row_count(), 10);
         assert_eq!(
-            match varshape.cell(9, "vardata").unwrap().unwrap() {
+            match varshape
+                .cell_accessor(9, "vardata")
+                .and_then(|cell| cell.value())
+                .unwrap()
+                .unwrap()
+            {
                 Value::Array(array) => array.shape().to_vec(),
                 other => panic!("expected array value, got {other:?}"),
             },
@@ -856,7 +866,12 @@ mod tests {
         let arrays_n = build_array_fixture_n(3, &[2, 2, 2]);
         assert_eq!(arrays_n.row_count(), 3);
         assert_eq!(
-            match arrays_n.cell(2, "data").unwrap().unwrap() {
+            match arrays_n
+                .cell_accessor(2, "data")
+                .and_then(|cell| cell.value())
+                .unwrap()
+                .unwrap()
+            {
                 Value::Array(array) => array.shape().to_vec(),
                 other => panic!("expected array value, got {other:?}"),
             },

--- a/crates/casa-test-support/tests/tables_cross_matrix_stman_aipsio.rs
+++ b/crates/casa-test-support/tests/tables_cross_matrix_stman_aipsio.rs
@@ -943,7 +943,9 @@ fn stride_read_on_rust_written_table() {
 
     // Read every other row (stride=2): should get rows 0 and 2
     let strided: Vec<_> = reopened
-        .get_column_range("col_i32", RowRange::with_stride(0, 3, 2))
+        .column_accessor("col_i32")
+        .unwrap()
+        .iter_range(RowRange::with_stride(0, 3, 2))
         .unwrap()
         .collect();
     assert_eq!(strided.len(), 2, "stride=2 should select 2 rows");
@@ -962,14 +964,18 @@ fn stride_read_on_rust_written_table() {
 
     // Read stride=1 (all rows)
     let all: Vec<_> = reopened
-        .get_column_range("col_i32", RowRange::new(0, 3))
+        .column_accessor("col_i32")
+        .unwrap()
+        .iter_range(RowRange::new(0, 3))
         .unwrap()
         .collect();
     assert_eq!(all.len(), 3, "stride=1 should select all 3 rows");
 
     // Read starting from row 1 with stride=1
     let tail: Vec<_> = reopened
-        .get_column_range("col_i32", RowRange::new(1, 3))
+        .column_accessor("col_i32")
+        .unwrap()
+        .iter_range(RowRange::new(1, 3))
         .unwrap()
         .collect();
     assert_eq!(tail.len(), 2, "offset range should select 2 rows");
@@ -999,7 +1005,9 @@ fn stride_read_on_cpp_written_table() {
 
     // Read every other row
     let strided: Vec<_> = table
-        .get_column_range("col_i32", RowRange::with_stride(0, 3, 2))
+        .column_accessor("col_i32")
+        .unwrap()
+        .iter_range(RowRange::with_stride(0, 3, 2))
         .unwrap()
         .collect();
     assert_eq!(strided.len(), 2, "stride=2 on C++-written table");
@@ -1084,7 +1092,12 @@ fn record_column_round_trip_values() {
     assert_eq!(table.rows().unwrap().len(), 3);
 
     // Read record cells via the record column API.
-    let records: Vec<_> = table.get_record_column("meta").unwrap().collect();
+    let records: Vec<_> = table
+        .column_accessor("meta")
+        .unwrap()
+        .record_iter()
+        .unwrap()
+        .collect();
     assert_eq!(records.len(), 3);
 
     // Row 0: {unit: "Jy", value: 2.5}

--- a/crates/casa-vla/src/importer.rs
+++ b/crates/casa-vla/src/importer.rs
@@ -3259,7 +3259,7 @@ mod tests {
     }
 
     fn main_scan_number(ms: &MeasurementSet, row: usize) -> i32 {
-        let table_row = ms.main_table().row(row).unwrap();
+        let table_row = ms.main_table().row_accessor().row(row).unwrap();
         let Value::Scalar(ScalarValue::Int32(scan_number)) = table_row.get("SCAN_NUMBER").unwrap()
         else {
             panic!("expected SCAN_NUMBER scalar");
@@ -3455,6 +3455,7 @@ mod tests {
         assert_eq!(reopened.data_description().unwrap().row_count(), 1);
         let dd0 = reopened
             .main_table()
+            .row_accessor()
             .row(0)
             .unwrap()
             .get("DATA_DESC_ID")
@@ -3462,6 +3463,7 @@ mod tests {
             .clone();
         let dd1 = reopened
             .main_table()
+            .row_accessor()
             .row(1)
             .unwrap()
             .get("DATA_DESC_ID")
@@ -3682,7 +3684,7 @@ mod tests {
                 .schema()
                 .is_some_and(|schema| schema.contains_column("DOPPLER_ID"))
         );
-        let spw_row = spw_table.row(0).unwrap();
+        let spw_row = spw_table.row_accessor().row(0).unwrap();
         assert_eq!(optional_i32_scalar(spw_row, "DOPPLER_ID"), Some(0));
     }
 
@@ -3871,7 +3873,7 @@ mod tests {
         let reopened = MeasurementSet::open(&ms_path).unwrap();
         let doppler = reopened.doppler().unwrap();
         assert_eq!(doppler.table().row_count(), 2);
-        let row = doppler.table().row(1).unwrap();
+        let row = doppler.table().row_accessor().row(1).unwrap();
         let Value::Scalar(ScalarValue::Int32(source_id)) = row.get("SOURCE_ID").unwrap() else {
             panic!("expected SOURCE_ID scalar");
         };

--- a/crates/casars-imager/src/lib.rs
+++ b/crates/casars-imager/src/lib.rs
@@ -2132,7 +2132,8 @@ impl SelectedMainArrayColumn {
     ) -> Result<Self, String> {
         let values = ms
             .main_table()
-            .get_array_cells_owned(column_name, row_indices)
+            .column_accessor(column_name)
+            .and_then(|column| column.array_cells_owned(row_indices))
             .map_err(|error| format!("load selected {column_name} rows: {error}"))?;
         Ok(Self {
             column_name,
@@ -2290,10 +2291,11 @@ impl PointingDirectionResolver {
         let mut by_row_index = HashMap::<usize, PointingDirectionRow>::new();
         for row_index in 0..table.row_count() {
             let antenna_id = match table
-                .get_scalar_cell(row_index, "ANTENNA_ID")
+                .cell_accessor(row_index, "ANTENNA_ID")
+                .and_then(|cell| cell.scalar())
                 .map_err(|error| format!("read POINTING.ANTENNA_ID row {row_index}: {error}"))?
             {
-                ScalarValue::Int32(value) => *value,
+                &ScalarValue::Int32(value) => value,
                 other => {
                     return Err(format!(
                         "POINTING.ANTENNA_ID row {row_index} must be Int32, found {:?}",
@@ -2302,10 +2304,11 @@ impl PointingDirectionResolver {
                 }
             };
             let time_mjd_seconds = match table
-                .get_scalar_cell(row_index, "TIME")
+                .cell_accessor(row_index, "TIME")
+                .and_then(|cell| cell.scalar())
                 .map_err(|error| format!("read POINTING.TIME row {row_index}: {error}"))?
             {
-                ScalarValue::Float64(value) => *value,
+                &ScalarValue::Float64(value) => value,
                 other => {
                     return Err(format!(
                         "POINTING.TIME row {row_index} must be Float64, found {:?}",
@@ -2314,10 +2317,11 @@ impl PointingDirectionResolver {
                 }
             };
             let interval_seconds = match table
-                .get_scalar_cell(row_index, "INTERVAL")
+                .cell_accessor(row_index, "INTERVAL")
+                .and_then(|cell| cell.scalar())
                 .map_err(|error| format!("read POINTING.INTERVAL row {row_index}: {error}"))?
             {
-                ScalarValue::Float64(value) => *value,
+                &ScalarValue::Float64(value) => value,
                 other => {
                     return Err(format!(
                         "POINTING.INTERVAL row {row_index} must be Float64, found {:?}",
@@ -2327,7 +2331,8 @@ impl PointingDirectionResolver {
             };
             let angles_rad = extract_constant_direction_angles(
                 table
-                    .get_array_cell(row_index, "DIRECTION")
+                    .cell_accessor(row_index, "DIRECTION")
+                    .and_then(|cell| cell.array())
                     .map_err(|error| format!("read POINTING.DIRECTION row {row_index}: {error}"))?,
                 "POINTING.DIRECTION",
                 row_index,
@@ -2485,11 +2490,13 @@ fn select_main_rows(
         || needs_pointing_times;
     let field_column = ms
         .main_table()
-        .get_column("FIELD_ID")
+        .column_accessor("FIELD_ID")
+        .and_then(|column| column.iter())
         .map_err(|error| format!("open FIELD_ID column: {error}"))?;
     let ddid_column = ms
         .main_table()
-        .get_column("DATA_DESC_ID")
+        .column_accessor("DATA_DESC_ID")
+        .and_then(|column| column.iter())
         .map_err(|error| format!("open DATA_DESC_ID column: {error}"))?;
     let allowed_ddids = allowed_ddids(config, ddid_info)?;
     let time_column = TimeColumn::new(ms.main_table());
@@ -2616,7 +2623,11 @@ fn load_optional_i32_main_column(
     ms: &MeasurementSet,
     column_name: &'static str,
 ) -> Result<Option<Vec<Option<i32>>>, String> {
-    let Ok(column) = ms.main_table().get_column(column_name) else {
+    let Ok(column) = ms
+        .main_table()
+        .column_accessor(column_name)
+        .and_then(|column| column.iter())
+    else {
         return Ok(None);
     };
     let mut values = vec![None; ms.main_table().row_count()];
@@ -8615,13 +8626,11 @@ mod tests {
             &[Complex32::new(1.0, 0.0), Complex32::new(3.0, 0.5)],
         );
         ms.main_table_mut()
-            .set_cell(
-                0,
-                "FLAG",
-                Value::Array(ArrayValue::Bool(
-                    ArrayD::from_shape_vec(vec![2, 1], vec![true, false]).unwrap(),
-                )),
-            )
+            .cell_accessor_mut(0, "FLAG")
+            .unwrap()
+            .set(Value::Array(ArrayValue::Bool(
+                ArrayD::from_shape_vec(vec![2, 1], vec![true, false]).unwrap(),
+            )))
             .unwrap();
         ms.save().unwrap();
 
@@ -10467,8 +10476,18 @@ mod tests {
         let polarization = ms.polarization().unwrap();
         let engine = MsCalEngine::new(&ms).unwrap();
         let time_column = TimeColumn::new(ms.main_table());
-        let field_column = ms.main_table().get_column("FIELD_ID").unwrap();
-        let ddid_column = ms.main_table().get_column("DATA_DESC_ID").unwrap();
+        let field_column = ms
+            .main_table()
+            .column_accessor("FIELD_ID")
+            .unwrap()
+            .iter()
+            .unwrap();
+        let ddid_column = ms
+            .main_table()
+            .column_accessor("DATA_DESC_ID")
+            .unwrap()
+            .iter()
+            .unwrap();
         let mut reference_time = None::<f64>;
         let mut bounds = None::<[f64; 2]>;
         for (field_cell, ddid_cell) in field_column.zip(ddid_column) {
@@ -11955,8 +11974,18 @@ mod tests {
         let polarization = ms.polarization().unwrap();
         let engine = MsCalEngine::new(&ms).unwrap();
         let time_column = TimeColumn::new(ms.main_table());
-        let field_column = ms.main_table().get_column("FIELD_ID").unwrap();
-        let ddid_column = ms.main_table().get_column("DATA_DESC_ID").unwrap();
+        let field_column = ms
+            .main_table()
+            .column_accessor("FIELD_ID")
+            .unwrap()
+            .iter()
+            .unwrap();
+        let ddid_column = ms
+            .main_table()
+            .column_accessor("DATA_DESC_ID")
+            .unwrap()
+            .iter()
+            .unwrap();
         let mut reference_time = None::<f64>;
         let mut bounds = None::<[f64; 2]>;
         let mut selected_rows = Vec::new();
@@ -12127,8 +12156,18 @@ mod tests {
         let polarization = ms.polarization().unwrap();
         let engine = MsCalEngine::new(&ms).unwrap();
         let time_column = TimeColumn::new(ms.main_table());
-        let field_column = ms.main_table().get_column("FIELD_ID").unwrap();
-        let ddid_column = ms.main_table().get_column("DATA_DESC_ID").unwrap();
+        let field_column = ms
+            .main_table()
+            .column_accessor("FIELD_ID")
+            .unwrap()
+            .iter()
+            .unwrap();
+        let ddid_column = ms
+            .main_table()
+            .column_accessor("DATA_DESC_ID")
+            .unwrap()
+            .iter()
+            .unwrap();
         let mut reference_time = None::<f64>;
         let mut bounds = None::<[f64; 2]>;
         let mut selected_rows = Vec::new();

--- a/crates/casars-python/python/tests/test_data.py
+++ b/crates/casars-python/python/tests/test_data.py
@@ -154,7 +154,8 @@ def test_table_reads_and_writes(tmp_path: Path) -> None:
     assert written == 3
     assert table.get_column("label") == ["delta", "epsilon", "zeta"]
 
-    table.set_cell(0, "meta", {"label": "delta", "weight": 100})
+    written = table.put_column("meta", [{"label": "delta", "weight": 100}], start=0)
+    assert written == 1
     assert table.get_cell(0, "meta") == {"label": "delta", "weight": 100}
 
     table.set_column_keywords("gain", {"unit": "arb", "stage": "python"})

--- a/crates/casars-python/src/lib.rs
+++ b/crates/casars-python/src/lib.rs
@@ -232,7 +232,7 @@ impl PyTable {
 
         let mut names = BTreeSet::new();
         for row_index in 0..self.inner.row_count() {
-            if let Ok(row) = self.inner.row(row_index) {
+            if let Ok(row) = self.inner.row_accessor().row(row_index) {
                 for field in row.fields() {
                     names.insert(field.name.clone());
                 }
@@ -254,7 +254,12 @@ impl PyTable {
     }
 
     fn get_cell(&self, py: Python<'_>, row: usize, column: &str) -> PyResult<Py<PyAny>> {
-        match self.inner.cell(row, column).map_err(table_err)? {
+        match self
+            .inner
+            .cell_accessor(row, column)
+            .and_then(|cell| cell.value())
+            .map_err(table_err)?
+        {
             Some(value) => value_to_py(py, value),
             None => Ok(py.None()),
         }
@@ -269,7 +274,10 @@ impl PyTable {
     ) -> PyResult<()> {
         require_writable(self.writable, "table")?;
         let value = py_to_value(py, value)?;
-        self.inner.set_cell(row, column, value).map_err(table_err)?;
+        self.inner
+            .cell_accessor_mut(row, column)
+            .and_then(|mut cell| cell.set(value))
+            .map_err(table_err)?;
         self.inner
             .save(TableOptions::new(&self.path))
             .map_err(table_err)
@@ -287,7 +295,8 @@ impl PyTable {
         let row_range = build_row_range(self.inner.row_count(), start, count, step)?;
         let cells = self
             .inner
-            .get_column_range(column, row_range)
+            .column_accessor(column)
+            .and_then(|column| column.iter_range(row_range))
             .map_err(table_err)?
             .map(|cell| cell.value.cloned())
             .collect::<Vec<_>>();
@@ -308,7 +317,8 @@ impl PyTable {
         let row_range = build_row_range_for_values(start, values.len(), step)?;
         let written = self
             .inner
-            .put_column_range(column, row_range, values)
+            .column_accessor_mut(column)
+            .and_then(|mut column| column.put_range(row_range, values))
             .map_err(table_err)?;
         self.inner
             .save(TableOptions::new(&self.path))

--- a/crates/casars/src/tests.rs
+++ b/crates/casars/src/tests.rs
@@ -11254,13 +11254,15 @@ fn add_main_row(
 
 fn set_main_row_flag_matrix(ms: &mut MeasurementSet, row: usize, flags: ArrayD<bool>) {
     ms.main_table_mut()
-        .set_cell(row, "FLAG", Value::Array(ArrayValue::Bool(flags)))
+        .cell_accessor_mut(row, "FLAG")
+        .and_then(|mut cell| cell.set(Value::Array(ArrayValue::Bool(flags))))
         .unwrap();
 }
 
 fn set_main_row_data_matrix(ms: &mut MeasurementSet, row: usize, data: ArrayD<Complex32>) {
     ms.main_table_mut()
-        .set_cell(row, "DATA", Value::Array(ArrayValue::Complex32(data)))
+        .cell_accessor_mut(row, "DATA")
+        .and_then(|mut cell| cell.set(Value::Array(ArrayValue::Complex32(data))))
         .unwrap();
 }
 


### PR DESCRIPTION
Wave issue: #102

## Summary
- remove the deprecated table-level convenience methods from the public `casa-tables` API by making them crate-private
- migrate the remaining workspace library, app, demo, benchmark, and test callers onto row/column/cell accessor APIs
- update docs and examples so accessor objects are the documented public table-data surface

## Verification
- `cargo test -p casa-tables`
- `just verify`

## Notes
- a small crate-private helper layer remains inside `casa-tables` as an internal implementation detail; the public compatibility surface is removed
