### PR TITLE
Relax casars importvla workflow timeout

### DIFF
--- a/crates/casars/src/tests.rs
+++ b/crates/casars/src/tests.rs
@@ -8764,7 +8764,9 @@ fn importvla_workflow_runs_against_real_archive_and_renders_stdout() {
     app.set_text_value("vis", vis_path.to_string_lossy().as_ref());
 
     start_run_with_default_importvla_launcher(&mut app);
-    assert!(app.wait_for_idle_for_test(Duration::from_secs(120)));
+    // The shared real-world archive is large enough that a successful import can
+    // slightly exceed two minutes on slower or busier developer machines.
+    assert!(app.wait_for_idle_for_test(Duration::from_secs(180)));
     assert!(
         app.stderr_for_test().trim().is_empty(),
         "status={} stderr={}",


### PR DESCRIPTION
Wave source: automation long-gates-pr-fixer

## Root cause
- `cargo test --workspace` failed because `tests::importvla_workflow_runs_against_real_archive_and_renders_stdout` assumed the shared real archive import would finish within 120 seconds.
- On this machine, the underlying `casars-importvla` command completed successfully but took about 121 seconds by itself, and the full workspace run stretched the same workflow to about 149 seconds under load.

## Files changed
- `crates/casars/src/tests.rs`

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `scripts/test-slow.sh`
- `scripts/run-coverage.sh --ci-like`

## Coverage
- Final CI-like coverage: `78.00%` (`72004/92314`)

## Residual risks / follow-up
- This keeps the regression test tied to a real large archive, so runtime may still vary by machine load; the new timeout only widens the budget enough to cover the measured successful path rather than changing execution behavior.