### PR TITLE
Stabilize long release gates

### DIFF
--- a/crates/casa-ms/tests/msexplore_casa_parity.rs
+++ b/crates/casa-ms/tests/msexplore_casa_parity.rs
@@ -2247,6 +2247,7 @@ fn apply_casa_flag_preview(
     ms_path: &Path,
     preview: &casa_ms::MsFlagEditPreview,
 ) -> Result<(), String> {
+    let _guard = casa_plotms_lock().lock().expect("lock CASA plotms");
     let casa = discover_casa_python().ok_or_else(|| skip_reason(false))?;
     let temp = tempdir().map_err(|error| format!("tempdir: {error}"))?;
     let preview_path = temp.path().join("flag-preview.json");

--- a/crates/casars-imagebrowser-protocol/src/lib.rs
+++ b/crates/casars-imagebrowser-protocol/src/lib.rs
@@ -780,6 +780,13 @@ mod tests {
                 .unwrap()
                 .contains("ImageBrowserResponseEnvelope")
         );
+        let schema_bundle = schema_bundle_json(serde_json::json!({
+            "schema_version": 1,
+            "command_id": "imexplore",
+        }))
+        .unwrap();
+        assert!(schema_bundle.contains("casa_imagebrowser_session"));
+        assert!(schema_bundle.contains("jsonl_stdio"));
     }
 
     #[test]

--- a/crates/ratatui-graphics/src/bitmap.rs
+++ b/crates/ratatui-graphics/src/bitmap.rs
@@ -91,6 +91,17 @@ mod tests {
     }
 
     #[test]
+    fn backend_and_dynamic_image_use_the_owned_rgb_buffer() {
+        let mut bitmap = PlottersBitmap::new(2, 2).unwrap();
+        {
+            let _backend = bitmap.backend();
+        }
+        let image = bitmap.into_dynamic_image().unwrap();
+        assert_eq!(image.width(), 2);
+        assert_eq!(image.height(), 2);
+    }
+
+    #[test]
     fn rejects_buffer_size_overflow() {
         let err = PlottersBitmap::new(u32::MAX, u32::MAX).unwrap_err();
         assert!(matches!(

--- a/crates/ratatui-graphics/src/terminal.rs
+++ b/crates/ratatui-graphics/src/terminal.rs
@@ -143,6 +143,18 @@ mod tests {
         assert!(caps.direct_kitty_layers);
         assert!(!caps.direct_kitty_animations);
 
+        unsafe {
+            env::remove_var("TERM_PROGRAM");
+            env::set_var("GHOSTTY_RESOURCES_DIR", "/tmp/ghostty-resources");
+        }
+        assert!(is_ghostty_terminal());
+
+        unsafe {
+            env::remove_var("GHOSTTY_RESOURCES_DIR");
+            env::set_var("GHOSTTY_BIN_DIR", "/tmp/ghostty-bin");
+        }
+        assert!(is_ghostty_terminal());
+
         match old_term_program {
             Some(value) => unsafe { env::set_var("TERM_PROGRAM", value) },
             None => unsafe { env::remove_var("TERM_PROGRAM") },


### PR DESCRIPTION
Wave source: automation long-gates-pr-fixer

## Root causes
- CI-like coverage on latest `origin/main` dipped below the automation threshold at `77.99%` (`71998/92314` lines), leaving little margin around protocol and terminal/bitmap helper branches.
- `scripts/test-slow.sh` exposed a flaky msexplore CASA parity failure where CASA flag-edit application could run concurrently with another CASA `plotms` export. In the failing run, two post-edit CASA txt exports were empty even though the same cases passed in isolation.

## Files changed
- `crates/casa-ms/tests/msexplore_casa_parity.rs`: serialize CASA flag-preview application with the existing CASA plotms lock.
- `crates/casars-imagebrowser-protocol/src/lib.rs`: cover schema bundle JSON generation in the existing schema test.
- `crates/ratatui-graphics/src/bitmap.rs`: cover converting a bitmap after backend creation.
- `crates/ratatui-graphics/src/terminal.rs`: cover Ghostty detection via `GHOSTTY_RESOURCES_DIR` and `GHOSTTY_BIN_DIR`.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p casars-imagebrowser-protocol schemas_generate`
- `cargo test -p ratatui-graphics backend_and_dynamic_image_use_the_owned_rgb_buffer`
- `cargo test -p ratatui-graphics terminal_capabilities_follow_picker_protocol_and_ghostty_env`
- `cargo test -p casa-ms --test msexplore_casa_parity flag_edit_extcorr_extchannel_matches_casa_table_writeback_and_post_edit_plot --features slow-tests -- --nocapture`
- `cargo test -p casa-ms --test msexplore_casa_parity flag_edit_iterated_scan_panel_matches_casa_table_writeback_and_post_edit_plot --features slow-tests -- --nocapture`
- `scripts/test-slow.sh`
- `scripts/run-coverage.sh --ci-like`

Final CI-like coverage: `78.01%` (`72011/92314` lines).

## Residual risks / follow-up
- Coverage remains close to the 78.0% automation floor, so future unrelated line-count growth may still need real branch coverage.
- The CASA lock is intentionally test-harness scoped; it may lengthen the slow parity suite slightly, but avoids shared CASA process interference during flag-edit validation.