### PR TITLE
Wave 0 expansion readiness audit

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ This directory holds stable project documentation.
 
 Historical phase plans and program-reference docs live under:
 
+- `docs/tutorial-parity/`
 - `docs/Planning/Phase 2 - Table fillout/`
 - `docs/Planning/Phase 3 - Quanta Measures Coordinates/`
 - `docs/Planning/Phase 4 - MeasurementSet and Derived Calibration Workflows/`

--- a/docs/tutorial-parity/README.md
+++ b/docs/tutorial-parity/README.md
@@ -1,0 +1,32 @@
+# CASA Tutorial Parity Program
+
+Truth class: current descriptive
+Last reality check: 2026-04-26
+Verification: just docs-check
+
+This directory contains stable reference artifacts for the CASA Guide tutorial
+parity program. GitHub Issues and the casa-rs project board remain the active
+planning and wave-status surface.
+
+Wave 0 is the expansion-readiness audit. It maps what needs to be understood
+or tightened before implementing ALMA, VLA, and Simulation tutorial
+functionality.
+
+## Wave 0 Artifacts
+
+- [Expansion readiness summary](wave-0-expansion-readiness.md)
+- [Code-quality map](code-quality-map.md)
+- [Current tutorial and dataset inventory](current-tutorial-inventory.md)
+- [Tutorial capability matrix](capability-matrix.md)
+
+## Source Pages
+
+- CASA Guides main page:
+  <https://casaguides.nrao.edu/index.php/Main_Page>
+- ALMA tutorials:
+  <https://casaguides.nrao.edu/index.php/ALMA_Tutorials>
+- VLA tutorials:
+  <https://casaguides.nrao.edu/index.php?title=Karl_G._Jansky_VLA_Tutorials>
+- Simulation tutorials:
+  <https://casaguides.nrao.edu/index.php/Simulating_Observations_in_CASA>
+

--- a/docs/tutorial-parity/capability-matrix.md
+++ b/docs/tutorial-parity/capability-matrix.md
@@ -1,0 +1,121 @@
+# CASA Tutorial Capability Matrix
+
+Truth class: current descriptive
+Last reality check: 2026-04-26
+Verification: just docs-check
+
+Wave issue: #137
+Child issue: #116
+
+This matrix maps the extracted CASA task/tool surface from current CASA Guide
+pages to casa-rs ownership and planned implementation waves. It is a planning
+and oracle map; it does not add public APIs.
+
+Status legend:
+
+- `available`: substantial current casa-rs capability exists.
+- `partial`: a real subset exists, but tutorial parameters or output products
+  need expansion.
+- `missing`: no tutorial-ready implementation exists.
+- `external`: external CASA/pipeline/viewer behavior is not an implementation
+  target.
+
+## Current Supported Surfaces Used By The Matrix
+
+- `casa-tables`: persistent tables, storage, TaQL, table browsing.
+- `casa-ms`: MeasurementSet summaries, selectors, plotting, derived MS support.
+- `casa-calibration`: summary/stats/apply/gain/bandpass/fluxscale workflows.
+- `casa-imaging` and `casars-imager`: MFS/cube imaging task surface and CASA
+  `tclean` parity harnesses for existing deterministic cases.
+- `casa-images`, `casa-lattices`, `casa-coordinates`: image/lattice/coordinate
+  storage and analysis substrate.
+- `casa-vla` and `casars-importvla`: VLA archive import surface.
+- `casars-python`: `casars.data` object layer and calibration/importvla task
+  projections; broader imager/MS/image-creation bindings are not yet complete.
+
+## Capability Matrix
+
+| CASA task/tool | Current casa-rs status | Library owner | App / Python exposure | Known tutorial gaps | Correctness oracle | Performance oracle | Owning issue / wave |
+|---|---|---|---|---|---|---|---|
+| `listobs` | partial | `casa-ms` | `msexplore` / future Python MS surface | selector grammar and TAQL extraction, reusable selector seam | CASA `listobs` on tutorial MS | timing for summary plus selected-row resolution | #75, #117, #121 |
+| `plotms` | partial | `casa-ms` | `msexplore`, calibration plots | long-tail axes, corrected-data diagnostics, polarization/P-band plots | CASA `plotms` or exported plot data where available | `scripts/bench-msexplore-vs-casa.sh` plus tutorial plot timings | #73, #117, #121 |
+| `tclean` MFS | partial/available | `casa-imaging`, `casars-imager` | `casars-imager`; Python projection incomplete | tutorial parameter mapping, automasking, pbcor/outlier/startmodel tails | CASA `tclean` image products | imager parity scripts and tutorial timings | #117, #127 |
+| `tclean` cube / spectral | partial | `casa-imaging`, `casars-imager` | `casars-imager`; Python projection incomplete | cube seam coverage, spectral transform integration, large-cube controls | CASA `tclean` cube outputs | cube parity scripts and tutorial timings | #74, #76, #119, #123 |
+| `split` | partial | `casa-ms`, `casa-tables` | no dedicated task surface yet | corrected-data split, selected column/subset output, metadata preservation | CASA `split` output MS, 2x2 MS interop as needed | tutorial split timings | #118, #121 |
+| `mstransform` | missing/limited | `casa-ms` | none | spectral regrid/channel selection tutorial subset | CASA `mstransform` output MS | transform timing on VLA tutorials | #123 |
+| `uvcontsub` | missing | `casa-ms` | none | line-free channel fitting, output MS semantics | CASA `uvcontsub` output MS and downstream image products | tutorial uvcontsub timings | #119, #123 |
+| `imcontsub` | missing | `casa-images` | none | image-domain continuum subtraction for VLA HI breadth | CASA image products | breadth-wave timings | #128 |
+| `gaincal` | partial/available | `casa-calibration` | `calibrate`, Python calibration tasks | selfcal loops, selection tails, solution diagnostics | CASA caltables and apply results | calibration benchmark scripts | #118, #122 |
+| `applycal` | partial/available | `casa-calibration`, `casa-tables` | `calibrate`, Python calibration tasks | apply-path performance, tutorial selection tails, corrected split handoff | CASA corrected MS columns | `scripts/bench-calibrate-vs-casa.sh` | #94, #118, #122 |
+| `bandpass` | partial/available | `casa-calibration` | `calibrate` | VLA tutorial parameter coverage, BPOLY tails | CASA bandpass caltables | calibration benchmark scripts | #122, #128 |
+| `fluxscale` | partial/available | `casa-calibration` | `calibrate` | VLA tutorial models/fields, selection tails | CASA fluxscale tables/results | calibration benchmark scripts | #122 |
+| `setjy` | missing/partial model setup | `casa-calibration`, `casa-ms` | no first-class task stage | calibrator model setup, component/image model writes | CASA model columns/caltable downstream parity | tutorial calibration timings | #122 |
+| `gencal` | missing/partial | `casa-calibration` | none | antenna-position, opacity, gaincurve, prior-cal tutorial subset | CASA generated caltables | tutorial prior-cal timings | #121 |
+| `flagdata` | missing/partial | `casa-ms` | no tutorial task surface | manual/list/rflag/tfcrop subsets used by VLA/ALMA breadth | CASA FLAG column deltas | flagging timing on tutorial MS | #121, #128 |
+| `flagmanager` | missing | `casa-ms` | none | save/restore flag versions | CASA flag version products | VLA/ALMA breadth timing | #127, #128 |
+| `statwt` | missing | `casa-ms` | none | weight recomputation for data-combination tutorials | CASA WEIGHT/SIGMA columns | tutorial timing | #127, #128 |
+| `concat` | missing/partial | `casa-ms`, `casa-tables` | none | MS concatenation metadata and weights | CASA `concat` output MS | data-combination timings | #127, #128 |
+| `hanningsmooth` | missing | `casa-ms` | none | P-band tutorial subset | CASA smoothed MS | breadth timing | #128 |
+| `clearcal` / `delmod` | missing/partial | `casa-ms`, `casa-calibration` | none | model/corrected column lifecycle | CASA MS column state | calibration/imaging timings | #128 |
+| `ft` | missing/partial | `casa-imaging`, `casa-ms` | none | model prediction for source subtraction | CASA MODEL_DATA comparison | source-subtraction timing | #128 |
+| component list tool `cl.addcomponent` | missing | future model/component owner | none | source subtraction and simulation component-list support | CASA component list / predicted MS | source-subtraction/simulation timings | #128, #129 |
+| `imhead` | partial | `casa-images`, `casa-coordinates` | `casars.data` image objects / future task | CASA task-style summaries and edit modes | CASA `imhead` output and image keywords | image-analysis timing | #120, #125 |
+| `imstat` | partial | `casa-images`, `casa-lattices` | future task/Python projection | region/channel/mask parameter coverage | CASA `imstat` numeric output | image-analysis timing | #120, #125 |
+| `immoments` | missing/partial | `casa-images`, `casa-lattices`, `casa-coordinates` | none | moment-map generation and metadata | CASA moment images | image-analysis timing | #120, #123 |
+| `exportfits` | partial | `casa-images`, `casa-coordinates` | future task/Python projection | tutorial FITS export metadata fidelity | CASA FITS headers and WCS | export timing | #120 |
+| `importfits` | partial | `casa-images`, `casa-coordinates` | future task/Python projection | simulation model-image ingestion | CASA imported image metadata | simulation setup timing | #124 |
+| `imregrid` | missing/partial | `casa-images`, `casa-coordinates` | none | data-combination and feathering image alignment | CASA regridded image | breadth timing | #127 |
+| `immath` | partial via expression work | `casa-images` | future task/Python projection | expression syntax and image output parity | CASA image products | breadth timing | #120, #127 |
+| `imsubimage` / `imcollapse` | missing/partial | `casa-images`, `casa-lattices` | future task/Python projection | region/channel slicing and collapsed outputs | CASA output images | breadth timing | #127 |
+| `imfit` | missing | `casa-images` | none | Gaussian/source fitting for polarization/source-subtraction tutorials | CASA fit records | breadth timing | #127, #128 |
+| `impv` | missing | `casa-images`, `casa-coordinates` | none | position-velocity extraction and metadata | CASA PV image output | VLA IRC timing | #123 |
+| image tool `ia.open` | partial via object layer | `casa-images`, `casars-python` | `casars.data.Image` | CASA tool-method parity is not direct API target | CASA tool output where needed | image object timing | #120, #127 |
+| viewer / CARTA flows | external | none | none | do not implement viewer; support exported products | product-open/read checks only | none | classified external |
+| `simobserve` | missing | simulation owner, likely `casa-ms` plus image/coordinate support | future simulation task/Python surface | model prediction, antenna configs, time/frequency sampling, MS writes | CASA `simobserve` output MS | simulation generation timing | #124 |
+| `simanalyze` | missing as workflow | composition of simulation, imaging, image analysis | future simulation task/Python surface | workflow orchestration without cloning CASA pipeline semantics | CASA `simanalyze` products | simulation analysis timing | #125 |
+| `simalma` | missing | simulation owner | future task | ALMA/ACA array combinations | CASA `simalma` products | breadth timing | #129 |
+| simulator tool `sm.open` / `sm.predict` | missing | simulation owner, `casa-ms` | future task/object projection | synthetic MS lifecycle and prediction | CASA simulator-tool output MS | simulation timing | #124, #129 |
+| simulator tool `sm.setnoise` / `sm.setgain` / `sm.corrupt` | missing | simulation owner, calibration/noise models | future simulation controls | deterministic noise/gain/bandpass/pointing/polarization corruptions | seeded CASA simulator outputs | corrupted vs uncorrupted timing | #126 |
+| `rmtables` | available through filesystem/task orchestration | app/test support | none as public task | cleanup convenience only | file existence behavior | none | no feature issue |
+
+## Unsupported Parameter Families To Track Explicitly
+
+Do not mark broad task names as done until these tutorial-visible parameter
+families are either implemented or deliberately split:
+
+- MS selectors: field, spw/channel, timerange, uvrange, intent, correlation,
+  scan/antenna, datacolumn.
+- Calibration selectors: field/spw/intent/uvrange/correlation support across
+  solve/apply/diagnostics.
+- Imaging controls: cube spectral mode, automasking, pbcor, startmodel,
+  outlier fields, mosaics, polarization, usepointing, large-cube runtime
+  controls.
+- Image analysis selectors: region, mask, channel/stokes slicing, spectral
+  coordinate metadata, output coordinate systems.
+- Simulation controls: model image scaling, antenna/configuration files,
+  observatory metadata, pointing, integration/time sampling, spectral setup,
+  random seeds, thermal noise, gain/phase/bandpass/pointing/polarization
+  corruptions.
+
+## Oracle Harness Plan
+
+Correctness:
+
+- Use local CASA 6.7.5-9 as the primary oracle when available.
+- Record each tutorial's declared CASA version in dataset/test manifests.
+- Compare persisted products with CASA/casacore C++ where bytes or metadata
+  matter: MS tables, caltables, images, FITS products.
+- Heavy parity tests must skip cleanly when CASA/casacore or tutorial datasets
+  are unavailable.
+
+Performance:
+
+- Record timings per vertical for CLI/app path and Python path where exposed.
+- Use existing benchmark scripts when available:
+  - `scripts/bench-calibrate-vs-casa.sh`
+  - `scripts/bench-msexplore-vs-casa.sh`
+- Add tutorial-specific timing scripts only in the wave that implements the
+  relevant functionality.
+- Severe regressions block a wave; non-severe gaps become shaped follow-ups
+  unless the wave's acceptance says match/exceed is required.
+

--- a/docs/tutorial-parity/capability-matrix.md
+++ b/docs/tutorial-parity/capability-matrix.md
@@ -39,8 +39,10 @@ Status legend:
 |---|---|---|---|---|---|---|---|
 | `listobs` | partial | `casa-ms` | `msexplore` / future Python MS surface | selector grammar and TAQL extraction, reusable selector seam | CASA `listobs` on tutorial MS | timing for summary plus selected-row resolution | #75, #117, #121 |
 | `plotms` | partial | `casa-ms` | `msexplore`, calibration plots | long-tail axes, corrected-data diagnostics, polarization/P-band plots | CASA `plotms` or exported plot data where available | `scripts/bench-msexplore-vs-casa.sh` plus tutorial plot timings | #73, #117, #121 |
+| `plotcal` | partial | `casa-calibration` | `calibrate` diagnostic plots | CASA task-name compatibility is not a target; VLA pages need gain/bandpass/fluxscale diagnostic plot presets and export parity | CASA `plotcal` plots or exported caltable plot data where available | calibration plot timing on VLA tutorial caltables | #122, #128 |
 | `tclean` MFS | partial/available | `casa-imaging`, `casars-imager` | `casars-imager`; Python projection incomplete | tutorial parameter mapping, automasking, pbcor/outlier/startmodel tails | CASA `tclean` image products | imager parity scripts and tutorial timings | #117, #127 |
 | `tclean` cube / spectral | partial | `casa-imaging`, `casars-imager` | `casars-imager`; Python projection incomplete | cube seam coverage, spectral transform integration, large-cube controls | CASA `tclean` cube outputs | cube parity scripts and tutorial timings | #74, #76, #119, #123 |
+| legacy `clean` | external/compatibility reference | `casa-imaging`, `casars-imager` if comparison needed | no CASA alias planned | VLA imaging page references legacy output for comparison; implement equivalent capability through idiomatic imaging APIs, not a `clean` task clone | CASA legacy `clean` products only as regression inputs/comparison artifacts | compare legacy tutorial timing only if a breadth issue requires it | #128 |
 | `split` | partial | `casa-ms`, `casa-tables` | no dedicated task surface yet | corrected-data split, selected column/subset output, metadata preservation | CASA `split` output MS, 2x2 MS interop as needed | tutorial split timings | #118, #121 |
 | `mstransform` | missing/limited | `casa-ms` | none | spectral regrid/channel selection tutorial subset | CASA `mstransform` output MS | transform timing on VLA tutorials | #123 |
 | `uvcontsub` | missing | `casa-ms` | none | line-free channel fitting, output MS semantics | CASA `uvcontsub` output MS and downstream image products | tutorial uvcontsub timings | #119, #123 |
@@ -118,4 +120,3 @@ Performance:
   relevant functionality.
 - Severe regressions block a wave; non-severe gaps become shaped follow-ups
   unless the wave's acceptance says match/exceed is required.
-

--- a/docs/tutorial-parity/code-quality-map.md
+++ b/docs/tutorial-parity/code-quality-map.md
@@ -1,0 +1,97 @@
+# Expansion-Readiness Code-Quality Map
+
+Truth class: current descriptive
+Last reality check: 2026-04-26
+Verification: just docs-check
+
+Wave issue: #137
+Child issue: #131
+
+This audit is intentionally not a generic cleanup request. It records concrete
+code-quality risks that could make tutorial expansion brittle, then assigns
+them to shaped issues.
+
+## Measurement Snapshot
+
+Local scan command shape:
+
+```bash
+find crates -path '*/target' -prune -o -name '*.rs' -print0 | xargs -0 wc -l
+rg -n 'unwrap\\(|expect\\(|panic!\\(|unimplemented!\\(|todo!\\(' crates --glob '*.rs'
+rg -n '\\.clone\\(|collect::<Vec|collect::<HashMap|collect::<BTreeMap' crates --glob '*.rs'
+rg -n 'pub fn|pub struct|pub enum|pub trait|pub mod' crates/casa-{tables,ms,images,imaging,calibration,vla,lattices,coordinates,types}/src --glob '*.rs'
+```
+
+Snapshot:
+
+- Total Rust LOC under `crates/`: 345,635
+- Product-path Rust LOC: 271,379
+- Test-path Rust LOC: 74,256
+- Product-path panic/unwrap/expect/todo/unimplemented candidates: 6,635
+- Product-path clone/collect candidates: 2,150
+- Public declarations across expansion-critical library crates: 2,480+
+
+These counts are triage signals only. They are not acceptance metrics. The
+important question is whether a candidate is reachable from external CASA data,
+tutorial-scale data volume, or public API expansion.
+
+## Expansion-Critical Crate Map
+
+| Crate / area | Expansion role | Current signal | Classification | Owner |
+|---|---|---:|---|---|
+| `casa-tables` | Persistent table/MS/image storage substrate | 1,416 panic candidates, 434 clone/collect candidates, several storage modules over 2k LOC | Needs focused audit and memory-bounded design before larger MS workflows | #94, #132, #135 |
+| `casa-ms` | MS summaries, selectors, plotting, tutorial `listobs` / `plotms` parity | `msexplore.rs` 9,440 LOC, `listobs.rs` 3,810 LOC, `spectral_selection.rs` 3,065 LOC | Needs selector and plot seams before tutorial expansion | #73, #75, #132, #135 |
+| `casa-calibration` | `gaincal`, `bandpass`, `fluxscale`, `applycal` workflow owner | `execute.rs` 3,457 LOC, CLI 3,942 LOC, performance-sensitive apply path | Needs table-access/performance audit and panic-path hardening | #94, #132, #135 |
+| `casa-imaging` | Core imaging algorithms for tutorial `tclean` paths | `lib.rs` 8,850 LOC | Already has focused split and cube coverage issues | #76, #74 |
+| `casars-imager` | App/task orchestration for imaging | `lib.rs` 12,847 LOC | Large but app-facing; split only when tutorial work touches it | #133 if needed later |
+| `casa-images` | Image analysis, FITS export, image objects | 1,652 panic candidates, 297 clone/collect candidates, `image_expr.rs` 4,753 LOC, `image_view.rs` 4,363 LOC | Needs public API and error-path audit before image-analysis expansion | #132, #134, #135 |
+| `casa-vla` | VLA import/archive support and possible VLA tutorial inputs | `importer.rs` 4,171 LOC | Healthy enough for existing importvla surface; harden only paths used by VLA verticals | #132 if reached by #121 |
+| `casa-lattices` / `casa-coordinates` | Image coordinate/statistics substrate | Moderate public and panic candidate counts | Audit public surface and user-data error paths before image-analysis breadth | #132, #134 |
+| `casa-test-support` | CASA/casacore oracles, fixture staging, parity helpers | `lib.rs` 5,487 LOC, heavily reused by parity tests | Needs consolidation before tutorial regression growth | #136 |
+
+## Hotspot Classification
+
+| File | LOC | Classification | Reason | Owner |
+|---|---:|---|---|---|
+| `crates/casars/src/app.rs` | 17,421 | Defer | TUI shell hotspot, but Wave 0 tutorial expansion starts in libraries/oracles | none now |
+| `crates/casars-imager/src/lib.rs` | 12,847 | Watch | App/task orchestration hotspot; split only when a tutorial issue touches it | #133 if needed |
+| `crates/casa-ms/src/msexplore.rs` | 9,440 | Needs seam extraction | Plotting surface is tutorial-critical and currently coupled to generic scatter logic | #73, #135 |
+| `crates/casa-imaging/src/lib.rs` | 8,850 | Already shaped | Imaging cube/trace ownership must be clearer before cube tutorial expansion | #76, #74 |
+| `crates/casa-tables/src/storage/tiled_stman.rs` | 6,643 | Needs audit | Storage behavior underpins large MS/image workflows; avoid incidental churn | #94, #135 |
+| `crates/casa-test-support/src/lib.rs` | 5,487 | Needs consolidation | Tutorial parity tests will otherwise duplicate staging/oracle helpers | #136 |
+| `crates/casa-images/src/image_expr.rs` | 4,753 | Defer unless touched | Expression expansion is not in the first vertical spine | #134/#135 if image-analysis requires it |
+| `crates/casa-images/src/image_view.rs` | 4,363 | Needs public/error audit | Image-analysis tutorial paths will use image views/statistics/regions | #132, #134 |
+| `crates/casa-vla/src/importer.rs` | 4,171 | Watch | Important for VLA data handling, but first VLA spine starts from tutorial MS archives | #132 if user-data failures appear |
+| `crates/casa-calibration/src/execute.rs` | 3,457 | Needs performance/error audit | Calibration apply/solve is central to ALMA/VLA verticals | #94, #132, #135 |
+
+## First Cleanup Map
+
+The audit produced these implementation-ready stabilization waves:
+
+- #132 harden reachable product-path panics/errors.
+- #133 split expansion-critical hotspots not already covered by #73/#75/#76.
+- #134 audit public library surface and boundary hygiene.
+- #135 audit allocation/copy patterns on tutorial-scale paths.
+- #136 consolidate shared test-support seams.
+
+Existing localized issues remain valid:
+
+- #73 decouple curated visibility plots from generic `msexplore` scatter.
+- #74 add cube trace seam regression coverage.
+- #75 extract `listobs` selector parsing and TAQL building.
+- #76 split `casa-imaging` trace/cube orchestration.
+- #78 split and regression-test provider-contract core.
+- #94 study fast, memory-bounded table access.
+- #97 stabilize shared test-data discovery.
+
+## Stop Conditions For Later Waves
+
+Stop before implementation if a cleanup requires:
+
+- a public API or persisted-format change;
+- a provider-contract schema bundle change;
+- a new top-level crate or app family;
+- a substantial dependency;
+- runtime/concurrency model changes;
+- weakening or deleting tests without replacement.
+

--- a/docs/tutorial-parity/current-tutorial-inventory.md
+++ b/docs/tutorial-parity/current-tutorial-inventory.md
@@ -1,0 +1,106 @@
+# Current CASA Guide Tutorial And Dataset Inventory
+
+Truth class: current descriptive
+Last reality check: 2026-04-26
+Verification: just docs-check
+
+Wave issue: #137
+Child issue: #115
+
+This inventory records the current CASA Guide tutorial surface that drives the
+first tutorial-parity waves. It does not download datasets or implement the
+dataset registry.
+
+Registry keys are proposed stable logical keys for the later #97 resolver and
+manifest work. Actual checksums and mirrored local paths should be populated
+when datasets are downloaded into the shared tutorial dataset mirror.
+
+## Inventory Policy
+
+- Current ALMA pages on the ALMA tutorials page are primary.
+- Current VLA CASA 6.7.2 pages on the VLA tutorials page are primary.
+- The Simulation index's current VLA protoplanetary disk guide is primary.
+- Older Simulation pages such as CASA 6.6.6 `simalma` and ACA guides are
+  breadth/deferred unless a later wave promotes them.
+- Pipeline reprocessing and external tools are inventoried but not treated as
+  engine-implementation targets.
+
+## ALMA Current Pages
+
+| Registry area | Guide | CASA version | URL | Extracted CASA surface | Input artifacts / data source | Classification |
+|---|---|---:|---|---|---|---|
+| `alma/getting-started` | Getting Started in CASA | 6.6.6 | <https://casaguides.nrao.edu/index.php/Getting_Started_in_CASA> | `rmtables` | none identified | orientation |
+| `alma/first-look/index` | ALMA First Look | current index | <https://casaguides.nrao.edu/index.php/ALMA_First_Look> | index page | none identified | index |
+| `alma/first-look/twhya/imaging` | First Look at Imaging | 6.6.6 | <https://casaguides.nrao.edu/index.php/First_Look_at_Imaging> | `listobs`, `plotms`, `tclean`, `split` | `twhya_calibrated.ms.tar`, `twhya_uncalibrated.ms.tar`, `twhya_calibrated_unflagged.ms.tar` under `FirstLook_TWHya_Band7_*` | Wave 3 spine |
+| `alma/first-look/twhya/selfcal` | First Look at Self Calibration | 6.6.6 | <https://casaguides.nrao.edu/index.php/First_Look_at_Self_Calibration> | `listobs`, `plotms`, `tclean`, `gaincal`, `applycal`, `split` | uses TW Hydra first-look MS products | Wave 3 spine |
+| `alma/first-look/twhya/line-imaging` | First Look at Line Imaging | 6.6.6 | <https://casaguides.nrao.edu/index.php/First_Look_at_Line_Imaging> | `plotms`, `uvcontsub`, `tclean` | `twhya_selfcal.ms.tgz` | Wave 3 spine |
+| `alma/first-look/twhya/image-analysis` | First Look at Image Analysis | 6.6.6 | <https://casaguides.nrao.edu/index.php/First_Look_at_Image_Analysis> | `imhead`, `imstat`, `immoments`, `exportfits` | `twhya_cont.image`, `twhya_n2hp.image` | Wave 3 spine |
+| `alma/antennae/band7` | Antennae Band 7 Imaging | 6.6.6 | <https://casaguides.nrao.edu/index.php/AntennaeBand7_Imaging> | `plotms`, `tclean`, `uvcontsub`, `imstat`, `immoments`, `exportfits`, `gaincal`, `applycal`, `rmtables` | ALMA science-verification package; page links support docs more than direct archives | Wave 6 breadth |
+| `alma/iras16293/band9` | IRAS16293 Band 9 Imaging | 6.6.6 | <https://casaguides.nrao.edu/index.php/IRAS16293_Band9_-_Imaging> | `listobs`, `plotms`, `tclean`, `split`, `uvcontsub`, `immoments`, `exportfits`, `immath`, `gaincal`, `applycal`, `flagdata`, `flagmanager` | `https://bulk.cv.nrao.edu/almadata/public/casaguides/IRAS16293_Band9_6.6.6` | Wave 6 breadth |
+| `alma/m100/band3-combine` | M100 Band 3 Combine | mixed page history, current ALMA topical | <https://casaguides.nrao.edu/index.php/M100_Band3_Combine> | `listobs`, `tclean`, `split`, `imhead`, `imstat`, `immoments`, `exportfits`, `imregrid`, `immath`, `imsubimage`, image tool `ia.open` | ALMA science-verification data source | Wave 6 breadth |
+| `alma/3c286/band6-pol` | 3C286 Band 6 Polarization Imaging | 6.6.6 | <https://casaguides.nrao.edu/index.php/3C286_Band6Pol_Imaging> | `plotms`, `tclean`, `imhead`, `imstat`, `exportfits`, `immath`, `imfit`, `gaincal`, `applycal` | ALMA polarization products / pipeline docs | Wave 6 breadth |
+| `alma/sunspot/band6-feathering` | Sunspot Band 6 Feathering | 6.6.6 | <https://casaguides.nrao.edu/index.php/Sunspot_Band6_Feathering> | `imhead`, `exportfits`, `imregrid`, `immath`, `imsubimage` | guide page does not expose direct archive in API scan | Wave 6 breadth |
+| `alma/renormalization` | ALMA Renormalization Correction | 6.6.x | <https://casaguides.nrao.edu/index.php/ALMA_Renormalization_Correction> | `applycal` plus calibration-product handling | ALMA help/science-pipeline references | Wave 6 breadth |
+| `alma/automasking` | Automasking Guide | 6.6.6 | <https://casaguides.nrao.edu/index.php/Automasking_Guide> | `listobs`, `tclean` with automasking controls | `twhya_selfcal.ms.contsub.tgz` | Wave 6 breadth |
+| `alma/data-weights` | Data Weights And Combination | older page, still topical | <https://casaguides.nrao.edu/index.php/DataWeightsAndCombination> | `listobs`, `plotms`, `applycal`, `concat`, `statwt` | ALMA help/science archive references | Wave 6 breadth |
+| `alma/na-imaging-template` | Guide to the NA Imaging Template | current topical | <https://casaguides.nrao.edu/index.php/Guide_NA_ImagingTemplate> | pipeline/script template mapping | ALMA QA2/product references | mapping only |
+| `alma/pipeline-reprocessing` | ALMA Imaging Pipeline Reprocessing | current topical | <https://casaguides.nrao.edu/index.php/ALMA_Imaging_Pipeline_Reprocessing> | pipeline execution | pipeline products | external pipeline workflow |
+| `alma/pipeline-known-issues` | ALMA Pipeline Known Issues | current topical | <https://casaguides.nrao.edu/index.php/ALMA_Pipeline_Known_Issues> | issue reference | ALMA help pages | reference only |
+
+## VLA Current Pages
+
+| Registry area | Guide | CASA version | URL | Extracted CASA surface | Input artifacts / data source | Classification |
+|---|---|---:|---|---|---|---|
+| `vla/irc10216` | High frequency spectral line data reduction: IRC+10216 | 6.7.2 | <https://casaguides.nrao.edu/index.php?title=VLA_high_frequency_Spectral_Line_tutorial_-_IRC%2B10216> | `listobs`, `plotms`, `gencal`, `applycal`, `split`, `flagdata`, `setjy`, `gaincal`, `bandpass`, `fluxscale`, `mstransform`, `uvcontsub`, `tclean`, `imstat`, `immoments`, `impv`, `statwt`, `plotcal` | `TDRW0001_10s.ms.tgz`, `irc_fors1_dec_header.fits` | Wave 4 spine |
+| `vla/3c391` | Continuum Imaging, Mosaicking: 3C391 | 6.7.2 | <https://casaguides.nrao.edu/index.php/VLA_Continuum_Tutorial_3C391-CASA6.7.2> | `listobs`, `plotms`, `tclean`, `split`, `imstat`, `gaincal`, `applycal`, `bandpass`, `fluxscale`, `setjy`, `gencal`, `flagdata`, `delmod`, `statwt`, `plotcal` | `3c391_ctm_mosaic_10s_spw0.ms.tgz`, `AdvancedEVLAcont.tgz`, script archive | Wave 6 breadth |
+| `vla/3c75-pol` | Polarization Calibration: 3C75 | 6.7.2 | <https://casaguides.nrao.edu/index.php/Polarization_Calibration_based_on_CASA_pipeline_standard_reduction:_The_radio_galaxy_3C75> | `plotms`, `tclean`, `split`, `imstat`, `immath`, `imsubimage`, `gaincal`, `applycal`, `bandpass`, `setjy`, `flagdata`, `flagmanager`, `delmod`, `statwt` | `CASA6.7.2_Polarization_Guide_Files.tgz`, calibrated MS, pipeline products | Wave 6 breadth |
+| `vla/3c129-pband` | Radio galaxy 3C129 P-band continuum | 6.7.2 | <https://casaguides.nrao.edu/index.php/VLA_Radio_galaxy_3C_129:_P-band_continuum_tutorial> | `listobs`, `plotms`, `tclean`, `split`, `gaincal`, `applycal`, `bandpass`, `setjy`, `gencal`, `flagdata`, `hanningsmooth`, `clearcal`, `statwt` | `P_band_3C129.tgz`, ionosphere file, older tar bundle | Wave 6 breadth |
+| `vla/mg0414-pband-line` | MG0414+0534 P-band Spectral Line | 6.7.2 | <https://casaguides.nrao.edu/index.php?title=MG0414%2B0534_P-band_Spectral_Line_Tutorial> | `listobs`, `plotms`, `tclean`, `split`, `mstransform`, `gaincal`, `applycal`, `bandpass`, `setjy`, `gencal`, `flagdata`, `hanningsmooth` | `MG0414_d1_data.ms.tgz`, ionosphere file, tutorial script | Wave 6 breadth |
+| `vla/hi21-leda44055` | HI 21 cm spectral line: LEDA 44055 | 6.7.2 | <https://casaguides.nrao.edu/index.php/HI_21cm_(1.4_GHz)_spectral_line_data_reduction:_LEDA_44055-CASA6.7.2> | `listobs`, `plotms`, `tclean`, `split`, `imcontsub`, `gaincal`, `applycal`, `bandpass`, `fluxscale`, `setjy`, `gencal`, `flagdata` | NRAO archive / baseline references | Wave 6 breadth |
+| `vla/flagging` | VLA CASA Flagging | 6.7.2 | <https://casaguides.nrao.edu/index.php/VLA_CASA_Flagging> | `listobs`, `plotms`, `split`, `gaincal`, `applycal`, `bandpass`, `flagdata`, `flagmanager`, `hanningsmooth`, `plotcal` | `SNR_G55_10s.tar.gz` | Wave 6 breadth |
+| `vla/imaging` | VLA CASA Imaging | 6.7.2 | <https://casaguides.nrao.edu/index.php/VLA_CASA_Imaging> | `tclean`, legacy `clean`, `imhead`, `immath`, image tool `ia.open`, `rmtables` | `SNR_G55_10s.calib.tar.gz` | Wave 6 breadth |
+| `vla/selfcal` | VLA Self-calibration Tutorial | 6.7.2 | <https://casaguides.nrao.edu/index.php/VLA_Self-calibration_Tutorial> | `listobs`, `plotms`, `tclean`, `split`, `gaincal`, `applycal`, `plotcal` | `17B-197...tar`, `VLASelf-calibrationTutorial.tar` | Wave 6 breadth |
+| `vla/data-combination` | VLA Data Combination - W49A | 6.7.2 | <https://casaguides.nrao.edu/index.php/VLA_Data_Combination> | `listobs`, `plotms`, `tclean`, `concat`, `statwt` | `VLA-combination-W49A.tar.gz` | Wave 6 breadth |
+| `vla/source-subtraction` | Source Subtraction in VLA data | 6.7.2 | <https://casaguides.nrao.edu/index.php/VLA_Source_Subtraction_Topical_Guide> | `listobs`, `plotms`, `tclean`, `imhead`, `imfit`, `ft`, component-list `cl.addcomponent` | `VLA-combination-SgrA-files.tar.gz` | Wave 6 breadth |
+| `vla/bandpass-slope` | Correcting for a Spectral Index in Bandpass Calibration | 6.7.2 | <https://casaguides.nrao.edu/index.php/VLA_CASA_Bandpass_Slope> | `listobs`, `plotms`, `gaincal`, `bandpass`, `fluxscale`, `setjy` | `G192-BP.ms.tar.gz` | Wave 6 breadth |
+
+## Simulation Pages
+
+| Registry area | Guide | CASA version | URL | Extracted CASA surface | Input artifacts / data source | Classification |
+|---|---|---:|---|---|---|---|
+| `simulation/vla-ppdisk` | Protoplanetary Disk Simulation - VLA | 6.7.2 | <https://casaguides.nrao.edu/index.php?title=Protoplanetary_Disk_Simulation_-_VLA-CASA6.7.2> | `importfits`, `immath`, `simobserve`, `simanalyze`, `plotms`, `tclean`, `imhead`, `imstat` | `ppdisk672_GHz_50pc.fits` | Wave 5 spine |
+| `simulation/ppdisk-alma-former` | Protoplanetary Disk Simulation | 6.6.6 | <https://casaguides.nrao.edu/index.php/Protoplanetary_Disk_Simulation_CASA_6.6.6> | `simobserve`, `simanalyze`, `imhead`, image tool `ia.open` | `ppdisk672_GHz_50pc.fits` under ALMA sim inputs | breadth/deferred |
+| `simulation/simalma` | Simalma | 6.6.6 | <https://casaguides.nrao.edu/index.php/Simalma> | `simalma` task surface | `https://bulk.cv.nrao.edu/almadata/public/casaguides/SimALMA` | Wave 6 breadth candidate |
+| `simulation/aca` | ACA Simulation | 6.5.4 | <https://casaguides.nrao.edu/index.php/ACA_Simulation> | `simobserve`, `simanalyze` | no direct data artifact found in API scan | breadth/deferred |
+| `simulation/antenna-configs` | Antenna Configurations Models in CASA | 6.6.x | <https://casaguides.nrao.edu/index.php/Antenna_Configurations_Models_in_CASA> | antenna-configuration reference | ALMA simulator/configuration references | support reference |
+| `simulation/corruptions` | Corrupting Simulated Data (Simulator Tool) | archived/tool reference | <https://casaguides.nrao.edu/index.php/Corrupting_Simulated_Data_(Simulator_Tool)> | simulator tool `sm.open`, `sm.setnoise`, `sm.setgain`, `sm.corrupt` | none identified | Wave 5/6 corruption reference |
+
+## First Dataset Registry Candidates
+
+| Proposed key | Source URL | Expected filename | Tier | First owning wave |
+|---|---|---|---|---|
+| `alma/first-look/twhya/calibrated-ms` | <https://bulk.cv.nrao.edu/almadata/public/casaguides/FirstLook_TWHya_Band7_6.6.1/twhya_calibrated.ms.tar> | `twhya_calibrated.ms.tar` | tutorial-parity | #140 |
+| `alma/first-look/twhya/uncalibrated-ms` | <https://bulk.cv.nrao.edu/almadata/public/casaguides/FirstLook_TWHya_Band7_6.6.6/twhya_uncalibrated.ms.tar> | `twhya_uncalibrated.ms.tar` | tutorial-parity | #140 |
+| `alma/first-look/twhya/calibrated-unflagged-ms` | <https://bulk.cv.nrao.edu/almadata/public/casaguides/FirstLook_TWHya_Band7_6.6.6/twhya_calibrated_unflagged.ms.tar> | `twhya_calibrated_unflagged.ms.tar` | tutorial-parity | #140 |
+| `alma/first-look/twhya/selfcal-ms` | <https://bulk.cv.nrao.edu/almadata/public/casaguides/FirstLook_TWHya_Band7_6.6.6/twhya_selfcal.ms.tgz> | `twhya_selfcal.ms.tgz` | tutorial-parity | #140 |
+| `alma/first-look/twhya/continuum-image` | <https://bulk.cv.nrao.edu/almadata/public/casaguides/FirstLook_TWHya_Band7_6.6.6/twhya_cont.image> | `twhya_cont.image` | tutorial-parity | #140 |
+| `alma/first-look/twhya/n2hp-image` | <https://bulk.cv.nrao.edu/almadata/public/casaguides/FirstLook_TWHya_Band7_6.6.6/twhya_n2hp.image> | `twhya_n2hp.image` | tutorial-parity | #140 |
+| `vla/irc10216/ms-10s` | <http://casa.nrao.edu/Data/EVLA/IRC10216/TDRW0001_10s.ms.tgz> | `TDRW0001_10s.ms.tgz` | tutorial-parity | #141 |
+| `vla/irc10216/fors1-fits` | <http://casa.nrao.edu/Data/EVLA/IRC10216/irc_fors1_dec_header.fits> | `irc_fors1_dec_header.fits` | tutorial-parity | #141 |
+| `simulation/vla-ppdisk/model-fits` | <https://casa.nrao.edu/Data/EVLA/simulation/ppdisk672_GHz_50pc.fits> | `ppdisk672_GHz_50pc.fits` | tutorial-parity | #142 |
+
+## Registry Fields For #97
+
+Each future registry entry should include:
+
+- logical key;
+- source page URL and source artifact URL;
+- expected filename and unpacked root name;
+- declared CASA Guide version;
+- checksum and size once mirrored;
+- dataset tier (`default-fixture`, `tutorial-parity`, `slow-parity`,
+  `performance`);
+- local path under `CASA_RS_TESTDATA_ROOT`;
+- optional local staging root for removable/NAS-backed mirrors;
+- first owning wave and downstream dependent waves.
+

--- a/docs/tutorial-parity/current-tutorial-inventory.md
+++ b/docs/tutorial-parity/current-tutorial-inventory.md
@@ -12,8 +12,9 @@ first tutorial-parity waves. It does not download datasets or implement the
 dataset registry.
 
 Registry keys are proposed stable logical keys for the later #97 resolver and
-manifest work. Actual checksums and mirrored local paths should be populated
-when datasets are downloaded into the shared tutorial dataset mirror.
+manifest work. Local path policies are expressed relative to
+`CASA_RS_TESTDATA_ROOT`; actual local paths should be populated by the dataset
+registry when artifacts are mirrored into shared tutorial storage.
 
 ## Inventory Policy
 
@@ -75,19 +76,80 @@ when datasets are downloaded into the shared tutorial dataset mirror.
 | `simulation/antenna-configs` | Antenna Configurations Models in CASA | 6.6.x | <https://casaguides.nrao.edu/index.php/Antenna_Configurations_Models_in_CASA> | antenna-configuration reference | ALMA simulator/configuration references | support reference |
 | `simulation/corruptions` | Corrupting Simulated Data (Simulator Tool) | archived/tool reference | <https://casaguides.nrao.edu/index.php/Corrupting_Simulated_Data_(Simulator_Tool)> | simulator tool `sm.open`, `sm.setnoise`, `sm.setgain`, `sm.corrupt` | none identified | Wave 5/6 corruption reference |
 
+## Expected Output Products
+
+These product families are the inventory target for tutorial parity. Later
+implementation waves should turn each row into exact product manifests and
+CASA/casacore comparison artifacts for the specific dataset version used.
+
+### ALMA
+
+| Registry area | Expected output products |
+|---|---|
+| `alma/getting-started` | cleanup behavior only; no durable science product |
+| `alma/first-look/index` | index only; no durable science product |
+| `alma/first-look/twhya/imaging` | continuum `.image`, `.model`, `.residual`, `.pb`, `.psf`, `.sumwt`, selected split MS products |
+| `alma/first-look/twhya/selfcal` | gain calibration tables, corrected/selfcal split MS products, selfcal continuum image products |
+| `alma/first-look/twhya/line-imaging` | continuum-subtracted MS, spectral cube `.image` products, masks/residual/model sidecars |
+| `alma/first-look/twhya/image-analysis` | image header/stat records, moment maps, FITS exports |
+| `alma/antennae/band7` | continuum/line image products, continuum-subtracted MS products, moments, FITS exports, selfcal caltables |
+| `alma/iras16293/band9` | split/flagged MS products, calibration tables, continuum and line cubes, moment maps, FITS exports |
+| `alma/m100/band3-combine` | combined image cubes, regridded images, subimages, moment maps, FITS exports |
+| `alma/3c286/band6-pol` | polarization image products, statistics, FITS exports, fit records, calibration tables |
+| `alma/sunspot/band6-feathering` | regridded/subimage products and FITS exports |
+| `alma/renormalization` | corrected calibration/MS products from renormalized apply workflow |
+| `alma/automasking` | automasked continuum images and mask products |
+| `alma/data-weights` | concatenated/reweighted MS products and comparison plots |
+| `alma/na-imaging-template` | mapping-only scripts/templates; no direct parity product |
+| `alma/pipeline-reprocessing` | external pipeline products; interop target only |
+| `alma/pipeline-known-issues` | reference-only; no parity product |
+
+### VLA
+
+| Registry area | Expected output products |
+|---|---|
+| `vla/irc10216` | prior-cal/gain/bandpass/fluxscale tables, corrected and transformed MS products, continuum-subtracted MS, spectral cube images, moment maps, PV image, statistics |
+| `vla/3c391` | calibrated/split MS products, continuum mosaic images, statistics, selfcal/calibration tables |
+| `vla/3c75-pol` | calibrated polarization MS products, Stokes image products, subimages/math outputs, statistics |
+| `vla/3c129-pband` | smoothed/flagged/calibrated P-band MS products, calibration tables, continuum images |
+| `vla/mg0414-pband-line` | smoothed/transformed/calibrated MS products, line cube images, calibration tables |
+| `vla/hi21-leda44055` | calibrated MS products, image-domain continuum subtraction products, HI cube and moment products |
+| `vla/flagging` | flag-version products, flagged MS state, diagnostic plot/calibration products |
+| `vla/imaging` | legacy `clean` comparison products where referenced, `tclean` image sidecars, header/math products |
+| `vla/selfcal` | selfcal gain tables, corrected split MS products, successive image products |
+| `vla/data-combination` | concatenated/reweighted MS products and combined image products |
+| `vla/source-subtraction` | component-list/model products, predicted/model MS state, subtracted image products, fit records |
+| `vla/bandpass-slope` | bandpass/gain/fluxscale calibration tables and diagnostic plot products |
+
+### Simulation
+
+| Registry area | Expected output products |
+|---|---|
+| `simulation/vla-ppdisk` | imported/scaled model image, synthetic MS, simulation report products, dirty/clean image products, image statistics |
+| `simulation/ppdisk-alma-former` | synthetic ALMA MS and image-analysis products |
+| `simulation/simalma` | ALMA/ACA synthetic MS products and combined images |
+| `simulation/aca` | ACA synthetic MS products and analyzed images |
+| `simulation/antenna-configs` | support reference only; no direct parity product |
+| `simulation/corruptions` | corrupted synthetic MS variants and seeded comparison products |
+
 ## First Dataset Registry Candidates
 
-| Proposed key | Source URL | Expected filename | Tier | First owning wave |
-|---|---|---|---|---|
-| `alma/first-look/twhya/calibrated-ms` | <https://bulk.cv.nrao.edu/almadata/public/casaguides/FirstLook_TWHya_Band7_6.6.1/twhya_calibrated.ms.tar> | `twhya_calibrated.ms.tar` | tutorial-parity | #140 |
-| `alma/first-look/twhya/uncalibrated-ms` | <https://bulk.cv.nrao.edu/almadata/public/casaguides/FirstLook_TWHya_Band7_6.6.6/twhya_uncalibrated.ms.tar> | `twhya_uncalibrated.ms.tar` | tutorial-parity | #140 |
-| `alma/first-look/twhya/calibrated-unflagged-ms` | <https://bulk.cv.nrao.edu/almadata/public/casaguides/FirstLook_TWHya_Band7_6.6.6/twhya_calibrated_unflagged.ms.tar> | `twhya_calibrated_unflagged.ms.tar` | tutorial-parity | #140 |
-| `alma/first-look/twhya/selfcal-ms` | <https://bulk.cv.nrao.edu/almadata/public/casaguides/FirstLook_TWHya_Band7_6.6.6/twhya_selfcal.ms.tgz> | `twhya_selfcal.ms.tgz` | tutorial-parity | #140 |
-| `alma/first-look/twhya/continuum-image` | <https://bulk.cv.nrao.edu/almadata/public/casaguides/FirstLook_TWHya_Band7_6.6.6/twhya_cont.image> | `twhya_cont.image` | tutorial-parity | #140 |
-| `alma/first-look/twhya/n2hp-image` | <https://bulk.cv.nrao.edu/almadata/public/casaguides/FirstLook_TWHya_Band7_6.6.6/twhya_n2hp.image> | `twhya_n2hp.image` | tutorial-parity | #140 |
-| `vla/irc10216/ms-10s` | <http://casa.nrao.edu/Data/EVLA/IRC10216/TDRW0001_10s.ms.tgz> | `TDRW0001_10s.ms.tgz` | tutorial-parity | #141 |
-| `vla/irc10216/fors1-fits` | <http://casa.nrao.edu/Data/EVLA/IRC10216/irc_fors1_dec_header.fits> | `irc_fors1_dec_header.fits` | tutorial-parity | #141 |
-| `simulation/vla-ppdisk/model-fits` | <https://casa.nrao.edu/Data/EVLA/simulation/ppdisk672_GHz_50pc.fits> | `ppdisk672_GHz_50pc.fits` | tutorial-parity | #142 |
+Size values come from HTTP `Content-Length` when the source server advertises
+one. Checksum is `not advertised` unless the source page/server exposes one;
+the registry should compute and store SHA-256 at mirror time without making this
+inventory issue download every artifact.
+
+| Proposed key | Source page | Source artifact URL | Expected filename | Advertised size | Checksum status | Tier | Local path policy | First owning wave |
+|---|---|---|---|---:|---|---|---|---|
+| `alma/first-look/twhya/calibrated-ms` | <https://casaguides.nrao.edu/index.php/First_Look_at_Imaging> | <https://bulk.cv.nrao.edu/almadata/public/casaguides/FirstLook_TWHya_Band7_6.6.1/twhya_calibrated.ms.tar> | `twhya_calibrated.ms.tar` | not advertised | not advertised; compute SHA-256 after mirror | tutorial-parity | `${CASA_RS_TESTDATA_ROOT}/tutorial-parity/alma/first-look/twhya/twhya_calibrated.ms.tar` | #140 |
+| `alma/first-look/twhya/uncalibrated-ms` | <https://casaguides.nrao.edu/index.php/First_Look_at_Imaging> | <https://bulk.cv.nrao.edu/almadata/public/casaguides/FirstLook_TWHya_Band7_6.6.6/twhya_uncalibrated.ms.tar> | `twhya_uncalibrated.ms.tar` | not advertised | not advertised; compute SHA-256 after mirror | slow-parity | `${CASA_RS_TESTDATA_ROOT}/tutorial-parity/alma/first-look/twhya/twhya_uncalibrated.ms.tar` | #140 |
+| `alma/first-look/twhya/calibrated-unflagged-ms` | <https://casaguides.nrao.edu/index.php/First_Look_at_Imaging> | <https://bulk.cv.nrao.edu/almadata/public/casaguides/FirstLook_TWHya_Band7_6.6.6/twhya_calibrated_unflagged.ms.tar> | `twhya_calibrated_unflagged.ms.tar` | not advertised | not advertised; compute SHA-256 after mirror | tutorial-parity | `${CASA_RS_TESTDATA_ROOT}/tutorial-parity/alma/first-look/twhya/twhya_calibrated_unflagged.ms.tar` | #140 |
+| `alma/first-look/twhya/selfcal-ms` | <https://casaguides.nrao.edu/index.php/First_Look_at_Line_Imaging> | <https://bulk.cv.nrao.edu/almadata/public/casaguides/FirstLook_TWHya_Band7_6.6.6/twhya_selfcal.ms.tgz> | `twhya_selfcal.ms.tgz` | not advertised | not advertised; compute SHA-256 after mirror | tutorial-parity | `${CASA_RS_TESTDATA_ROOT}/tutorial-parity/alma/first-look/twhya/twhya_selfcal.ms.tgz` | #140 |
+| `alma/first-look/twhya/continuum-image` | <https://casaguides.nrao.edu/index.php/First_Look_at_Image_Analysis> | <https://bulk.cv.nrao.edu/almadata/public/casaguides/FirstLook_TWHya_Band7_6.6.6/twhya_cont.image> | `twhya_cont.image` | not advertised | not advertised; compute SHA-256 after mirror | tutorial-parity | `${CASA_RS_TESTDATA_ROOT}/tutorial-parity/alma/first-look/twhya/twhya_cont.image` | #140 |
+| `alma/first-look/twhya/n2hp-image` | <https://casaguides.nrao.edu/index.php/First_Look_at_Image_Analysis> | <https://bulk.cv.nrao.edu/almadata/public/casaguides/FirstLook_TWHya_Band7_6.6.6/twhya_n2hp.image> | `twhya_n2hp.image` | not advertised | not advertised; compute SHA-256 after mirror | tutorial-parity | `${CASA_RS_TESTDATA_ROOT}/tutorial-parity/alma/first-look/twhya/twhya_n2hp.image` | #140 |
+| `vla/irc10216/ms-10s` | <https://casaguides.nrao.edu/index.php?title=VLA_high_frequency_Spectral_Line_tutorial_-_IRC%2B10216> | <http://casa.nrao.edu/Data/EVLA/IRC10216/TDRW0001_10s.ms.tgz> | `TDRW0001_10s.ms.tgz` | 1068298240 bytes | not advertised; compute SHA-256 after mirror | slow-parity | `${CASA_RS_TESTDATA_ROOT}/tutorial-parity/vla/irc10216/TDRW0001_10s.ms.tgz` | #141 |
+| `vla/irc10216/fors1-fits` | <https://casaguides.nrao.edu/index.php?title=VLA_high_frequency_Spectral_Line_tutorial_-_IRC%2B10216> | <http://casa.nrao.edu/Data/EVLA/IRC10216/irc_fors1_dec_header.fits> | `irc_fors1_dec_header.fits` | 16784640 bytes | not advertised; compute SHA-256 after mirror | tutorial-parity | `${CASA_RS_TESTDATA_ROOT}/tutorial-parity/vla/irc10216/irc_fors1_dec_header.fits` | #141 |
+| `simulation/vla-ppdisk/model-fits` | <https://casaguides.nrao.edu/index.php?title=Protoplanetary_Disk_Simulation_-_VLA-CASA6.7.2> | <https://casa.nrao.edu/Data/EVLA/simulation/ppdisk672_GHz_50pc.fits> | `ppdisk672_GHz_50pc.fits` | 276480 bytes | not advertised; compute SHA-256 after mirror | tutorial-parity | `${CASA_RS_TESTDATA_ROOT}/tutorial-parity/simulation/vla-ppdisk/ppdisk672_GHz_50pc.fits` | #142 |
 
 ## Registry Fields For #97
 
@@ -103,4 +165,3 @@ Each future registry entry should include:
 - local path under `CASA_RS_TESTDATA_ROOT`;
 - optional local staging root for removable/NAS-backed mirrors;
 - first owning wave and downstream dependent waves.
-

--- a/docs/tutorial-parity/wave-0-expansion-readiness.md
+++ b/docs/tutorial-parity/wave-0-expansion-readiness.md
@@ -1,0 +1,62 @@
+# Wave 0 Expansion Readiness
+
+Truth class: current descriptive
+Last reality check: 2026-04-26
+Verification: just docs-check
+
+Wave issue: #137
+
+Wave 0 decides what must be cleaned up or mapped before tutorial feature
+implementation starts. It implements the audit portions of:
+
+- #131 Library expansion-readiness code-quality audit and cleanup map
+- #115 Inventory current CASA Guide tutorials and datasets
+- #116 Build tutorial capability matrix and CASA parity oracle harness
+
+No Rust public API, persisted format, provider-contract bundle, dependency, or
+runtime behavior is changed by this wave.
+
+## Outputs
+
+- [Code-quality map](code-quality-map.md)
+  - classifies expansion-critical library hotspots and identifies whether
+    existing or new shaped issues own the cleanup.
+- [Current tutorial and dataset inventory](current-tutorial-inventory.md)
+  - records current ALMA, VLA, and Simulation guide pages, versions, data
+    artifacts, extracted task surfaces, and dataset registry keys.
+- [Tutorial capability matrix](capability-matrix.md)
+  - maps extracted CASA task/tool capabilities to current casa-rs support,
+    library owners, app/Python exposure, correctness oracle, performance
+    oracle, and owning waves/issues.
+
+## Expansion-Readiness Decisions
+
+- Keep active planning in GitHub Issues / Project. These docs are durable
+  reference material, not the canonical backlog.
+- Use numbered wave umbrellas for implementation order. Do not overload the
+  project `Horizon` field as a wave sequence.
+- Treat current CASA Guide pages as primary. Former/archived guide pages are
+  regression candidates, not blockers for first-pass parity.
+- Implement functionality in reusable `casa-*` libraries first, then expose it
+  through `casars-*` applications and Python bindings following existing
+  provider-contract patterns.
+- Do not introduce CASA task-name aliases as the public API. Document mappings
+  from CASA tasks/tools to casa-rs names instead.
+
+## Follow-Up Waves
+
+Wave 0 found no reason to stop for a new top-level crate, public persisted
+format, provider-contract redesign, substantial dependency, or runtime model
+change before the next wave. Those decisions may still arise in later
+implementation waves and must follow the stop-and-ask process in `AGENTS.md`.
+
+The immediate implementation queue is:
+
+- Wave 1: #138 Core stabilization for tutorial work
+- Wave 2: #139 Local seam stabilization
+- Wave 3: #140 ALMA First Look / TW Hydra vertical
+- Wave 4: #141 VLA IRC+10216 vertical
+- Wave 5: #142 Simulation Protoplanetary Disk - VLA vertical
+- Wave 6: #143 Breadth expansion
+- Wave 7: #144 Performance parity closeout
+


### PR DESCRIPTION
Wave issue: #137

## Summary
- Add docs/tutorial-parity as the Wave 0 truth surface for the CASA tutorial expansion program.
- Record the current ALMA, VLA, and Simulation tutorial/dataset inventory with source URLs, tutorial-declared CASA versions, extracted task surfaces, and proposed dataset registry keys.
- Add the current casa-rs capability matrix and code-quality expansion map, tying gaps to existing stabilization and tutorial-wave issues.

## Verification
- just docs-check
- LC_ALL=C rg -n "[^[:ascii:]]" docs/tutorial-parity docs/README.md || true
- just quick
- just verify

## Notes
- Documentation-only change.
- No public API, persisted format, provider contract, dependency, runtime model, or major algorithm changes.
- Completes child issues #131, #115, and #116 for review.