### PR TITLE
Wave 4: VLA IRC+10216 vertical

### DIFF
--- a/crates/casa-calibration/src/cli.rs
+++ b/crates/casa-calibration/src/cli.rs
@@ -20,8 +20,9 @@ use crate::{
     ContinuumSubtractionReport, ContinuumSubtractionTaskRequest, ExecuteApplyTaskRequest,
     ExportCorrectedDataReport, ExportCorrectedDataTaskRequest, FluxScaleReport, FluxScaleRequest,
     GainFieldSelector, GainSolveCombine, GainSolveInterval, GainSolveMode, GainSolveModelSource,
-    GainSolveReport, GainType, PlanApplyTaskRequest, RefAntSelector, SolveBandpassTaskRequest,
-    SolveGainTaskRequest, StatsTaskRequest, SummaryTaskRequest, load_apply_specs_from_callib,
+    GainSolveReport, GainType, GencalReport, GencalTaskRequest, GencalType, PlanApplyTaskRequest,
+    RefAntSelector, SolveBandpassTaskRequest, SolveGainTaskRequest, StatsTaskRequest,
+    SummaryTaskRequest, load_apply_specs_from_callib,
 };
 
 const UI_SCHEMA_VERSION: u32 = 1;
@@ -157,6 +158,20 @@ struct FluxScaleOptions {
 }
 
 #[derive(Debug)]
+struct GencalOptions {
+    measurement_set: PathBuf,
+    output_table: PathBuf,
+    caltype: GencalType,
+    antenna: String,
+    spw: String,
+    parameter: Vec<f64>,
+    gaincurve_table: Option<PathBuf>,
+    format: OutputFormat,
+    output: Option<PathBuf>,
+    overwrite: bool,
+}
+
+#[derive(Debug)]
 enum Command {
     Apply(ApplyOptions),
     Summarize(SummaryOptions),
@@ -167,6 +182,7 @@ enum Command {
     SolveGain(SolveGainOptions),
     SolveBandpass(SolveBandpassOptions),
     FluxScale(FluxScaleOptions),
+    Gencal(GencalOptions),
 }
 
 impl Command {
@@ -181,6 +197,7 @@ impl Command {
             Self::SolveGain(options) => options.format,
             Self::SolveBandpass(options) => options.format,
             Self::FluxScale(options) => options.format,
+            Self::Gencal(options) => options.format,
         }
     }
 
@@ -195,6 +212,7 @@ impl Command {
             Self::SolveGain(options) => options.output.as_deref(),
             Self::SolveBandpass(options) => options.output.as_deref(),
             Self::FluxScale(options) => options.output.as_deref(),
+            Self::Gencal(options) => options.output.as_deref(),
         }
     }
 
@@ -209,6 +227,7 @@ impl Command {
             Self::SolveGain(options) => options.overwrite,
             Self::SolveBandpass(options) => options.overwrite,
             Self::FluxScale(options) => options.overwrite,
+            Self::Gencal(options) => options.overwrite,
         }
     }
 
@@ -294,6 +313,15 @@ impl Command {
                 refspwmap: options.refspwmap,
                 gainthreshold: options.gainthreshold,
                 incremental: options.incremental,
+            }),
+            Self::Gencal(options) => CalibrationTaskRequest::Gencal(GencalTaskRequest {
+                measurement_set: options.measurement_set,
+                output_table: options.output_table,
+                caltype: options.caltype,
+                antenna: options.antenna,
+                spw: options.spw,
+                parameter: options.parameter,
+                gaincurve_table: options.gaincurve_table,
             }),
         }
     }
@@ -434,6 +462,7 @@ pub fn command_schema(program_name: &str) -> UiCommandSchema {
                     "solve_gain",
                     "solve_bandpass",
                     "fluxscale",
+                    "gencal",
                 ],
                 help: "Calibration workflow to run from the launcher form",
                 group: "Workflow",
@@ -720,7 +749,7 @@ pub fn command_schema(program_name: &str) -> UiCommandSchema {
                 value_kind: UiValueKind::Path,
                 default: None,
                 choices: &[],
-                help: "Output calibration-table path for solve and fluxscale workflows",
+                help: "Output calibration-table path for solve, fluxscale, and gencal workflows",
                 group: "Solve",
                 required: false,
                 advanced: false,
@@ -1168,6 +1197,7 @@ fn parse_args(args: impl IntoIterator<Item = OsString>) -> Result<CliAction, Str
         Some("solve-gain") => parse_solve_gain_args(&args[1..], managed_output),
         Some("solve-bandpass") => parse_solve_bandpass_args(&args[1..], managed_output),
         Some("fluxscale") => parse_fluxscale_args(&args[1..], managed_output),
+        Some("gencal") => parse_gencal_args(&args[1..], managed_output),
         Some("apply") => parse_apply_args(&args[1..], managed_output),
         _ => {
             let (workflow_mode, remaining_args) = extract_option_value(&args, "--mode")?;
@@ -1186,8 +1216,9 @@ fn parse_args(args: impl IntoIterator<Item = OsString>) -> Result<CliAction, Str
                     parse_solve_bandpass_args(&remaining_args, managed_output)
                 }
                 Some("fluxscale") => parse_fluxscale_args(&remaining_args, managed_output),
+                Some("gencal") => parse_gencal_args(&remaining_args, managed_output),
                 Some(other) => Err(format!(
-                    "unsupported --mode {other:?}; expected apply, summary, stats, export_corrected_data, continuum_subtract, solve_gain, solve_bandpass, or fluxscale"
+                    "unsupported --mode {other:?}; expected apply, summary, stats, export_corrected_data, continuum_subtract, solve_gain, solve_bandpass, fluxscale, or gencal"
                 )),
                 None => parse_apply_args(&args, managed_output),
             }
@@ -2346,6 +2377,106 @@ fn parse_fluxscale_args(args: &[OsString], managed_output: bool) -> Result<CliAc
     })))
 }
 
+fn parse_gencal_args(args: &[OsString], managed_output: bool) -> Result<CliAction, String> {
+    let mut measurement_set = None;
+    let mut output_table = None;
+    let mut caltype = None;
+    let mut antenna = String::new();
+    let mut spw = String::new();
+    let mut parameter = Vec::new();
+    let mut gaincurve_table = None;
+    let mut format = OutputFormat::Text;
+    let mut output = None;
+    let mut overwrite = false;
+
+    let mut index = 0;
+    while index < args.len() {
+        let raw = args[index]
+            .to_str()
+            .ok_or_else(|| "arguments must be valid UTF-8".to_string())?;
+        match raw {
+            "--ms" | "--vis" => {
+                index += 1;
+                measurement_set = Some(PathBuf::from(
+                    args.get(index)
+                        .ok_or_else(|| format!("missing value for {raw}"))?,
+                ));
+            }
+            "--out" | "--caltable" => {
+                index += 1;
+                output_table = Some(PathBuf::from(
+                    args.get(index)
+                        .ok_or_else(|| format!("missing value for {raw}"))?,
+                ));
+            }
+            "--caltype" => {
+                index += 1;
+                caltype = Some(
+                    take_string_value(index, args, "--caltype")?
+                        .parse::<GencalType>()
+                        .map_err(|error| format!("parse --caltype: {error}"))?,
+                );
+            }
+            "--antenna" => {
+                index += 1;
+                antenna = take_string_value(index, args, "--antenna")?;
+            }
+            "--spw" => {
+                index += 1;
+                spw = take_string_value(index, args, "--spw")?;
+            }
+            "--parameter" => {
+                index += 1;
+                parameter = parse_f64_list(
+                    "--parameter",
+                    &take_string_value(index, args, "--parameter")?,
+                )?;
+            }
+            "--gaincurve-table" => {
+                index += 1;
+                gaincurve_table =
+                    Some(PathBuf::from(args.get(index).ok_or_else(|| {
+                        "missing value for --gaincurve-table".to_string()
+                    })?));
+            }
+            "--format" => {
+                index += 1;
+                format =
+                    parse_output_format("--format", &take_string_value(index, args, "--format")?)?;
+            }
+            "-o" | "--output" => {
+                index += 1;
+                output = Some(PathBuf::from(
+                    args.get(index)
+                        .ok_or_else(|| "missing value for --output".to_string())?,
+                ));
+            }
+            "--overwrite" => overwrite = true,
+            _ if raw.starts_with('-') => return Err(format!("unsupported argument {raw:?}")),
+            _ => return Err(format!("unexpected positional argument {raw:?}")),
+        }
+        index += 1;
+    }
+
+    Ok(CliAction::Run(Box::new(RunRequest {
+        managed_output,
+        command: Command::Gencal(GencalOptions {
+            measurement_set: measurement_set
+                .ok_or_else(|| "gencal requires --ms <measurement-set>".to_string())?,
+            output_table: output_table
+                .ok_or_else(|| "gencal requires --out <caltable>".to_string())?,
+            caltype: caltype.ok_or_else(|| "gencal requires --caltype TYPE".to_string())?,
+            antenna,
+            spw,
+            parameter,
+            gaincurve_table,
+            format,
+            output,
+            overwrite,
+        }),
+    })))
+}
+
 fn parse_output_format(flag: &str, value: &str) -> Result<OutputFormat, String> {
     match value {
         "text" => Ok(OutputFormat::Text),
@@ -2780,6 +2911,18 @@ fn parse_i32_list(flag: &str, value: &str) -> Result<Vec<i32>, String> {
         .collect()
 }
 
+fn parse_f64_list(flag: &str, value: &str) -> Result<Vec<f64>, String> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|item| {
+            item.parse::<f64>()
+                .map_err(|error| format!("parse {flag} value {item:?}: {error}"))
+        })
+        .collect()
+}
+
 fn parse_bool_list(flag: &str, value: &str) -> Result<Vec<bool>, String> {
     value
         .split(',')
@@ -2815,8 +2958,9 @@ fn parse_time_range(value: &str) -> Result<(f64, f64), String> {
 
 fn render_help(schema: &UiCommandSchema) -> String {
     format!(
-        "{}\n\nMachine-readable:\n  --ui-schema              Emit the launcher/TUI schema\n  --json-schema            Emit the canonical calibration task JSON schema\n  --protocol-info          Emit the calibration task protocol descriptor\n  --json-run <SOURCE>      Execute one JSON CalibrationTaskRequest from SOURCE or - for stdin\n\nDeveloper subcommands:\n  {} summary [SUMMARY OPTIONS] <caltable>...\n  {} stats [STATS OPTIONS] <caltable>\n  {} plan-apply --ms <measurement-set> [PLAN OPTIONS] <caltable>...\n  {} uvcontsub --ms <measurement-set> --out <measurement-set> --fitspw <spw:channels> [UVCONTSUB OPTIONS]\n  {} solve-gain --ms <measurement-set> --out <caltable> --refant <antenna> [SOLVE OPTIONS]\n  {} solve-bandpass --ms <measurement-set> --out <caltable> --refant <antenna> [BANDPASS OPTIONS]\n  {} fluxscale --in <gain-table> --out <flux-table> --reference FIELD[,FIELD...] [FLUXSCALE OPTIONS]\n",
+        "{}\n\nMachine-readable:\n  --ui-schema              Emit the launcher/TUI schema\n  --json-schema            Emit the canonical calibration task JSON schema\n  --protocol-info          Emit the calibration task protocol descriptor\n  --json-run <SOURCE>      Execute one JSON CalibrationTaskRequest from SOURCE or - for stdin\n\nDeveloper subcommands:\n  {} summary [SUMMARY OPTIONS] <caltable>...\n  {} stats [STATS OPTIONS] <caltable>\n  {} plan-apply --ms <measurement-set> [PLAN OPTIONS] <caltable>...\n  {} uvcontsub --ms <measurement-set> --out <measurement-set> --fitspw <spw:channels> [UVCONTSUB OPTIONS]\n  {} solve-gain --ms <measurement-set> --out <caltable> --refant <antenna> [SOLVE OPTIONS]\n  {} solve-bandpass --ms <measurement-set> --out <caltable> --refant <antenna> [BANDPASS OPTIONS]\n  {} fluxscale --in <gain-table> --out <flux-table> --reference FIELD[,FIELD...] [FLUXSCALE OPTIONS]\n  {} gencal --ms <measurement-set> --out <caltable> --caltype antpos|gceff|opac [GENCAL OPTIONS]\n",
         schema.render_help(),
+        schema.invocation_name,
         schema.invocation_name,
         schema.invocation_name,
         schema.invocation_name,
@@ -3225,6 +3369,23 @@ fn render_fluxscale_report_text(report: &FluxScaleReport) -> String {
     out
 }
 
+fn render_gencal_report_text(report: &GencalReport) -> String {
+    use std::fmt::Write;
+
+    let mut out = String::new();
+    let _ = writeln!(out, "Gencal Report: {}", report.output_table.display());
+    let _ = writeln!(out, "  caltype={:?}", report.caltype);
+    let _ = writeln!(out, "  table_subtype={}", report.table_subtype);
+    let _ = writeln!(out, "  rows={}", report.row_count);
+    let _ = writeln!(
+        out,
+        "  spectral_window_ids={:?}",
+        report.spectral_window_ids
+    );
+    let _ = writeln!(out, "  antenna_ids={:?}", report.antenna_ids);
+    out
+}
+
 fn render_value_stats_block(out: &mut String, stats: &crate::CalibrationValueStats, indent: usize) {
     use std::fmt::Write;
 
@@ -3300,6 +3461,8 @@ fn render_json_task_result(
                 .map_err(|error| format!("serialize bandpass solve report: {error}")),
             CalibrationTaskResult::FluxScale(report) => serde_json::to_string_pretty(report)
                 .map_err(|error| format!("serialize fluxscale report: {error}")),
+            CalibrationTaskResult::Gencal(report) => serde_json::to_string_pretty(report)
+                .map_err(|error| format!("serialize gencal report: {error}")),
         }
     }
 }
@@ -3319,6 +3482,7 @@ fn render_text_task_result(result: &CalibrationTaskResult) -> String {
         CalibrationTaskResult::SolveGain(report) => render_gain_solve_report_text(report),
         CalibrationTaskResult::SolveBandpass(report) => render_bandpass_solve_report_text(report),
         CalibrationTaskResult::FluxScale(report) => render_fluxscale_report_text(report),
+        CalibrationTaskResult::Gencal(report) => render_gencal_report_text(report),
     }
 }
 
@@ -3425,7 +3589,8 @@ mod tests {
         CalibrationValidationIssue, CalibrationValueStats, ExecuteApplyTaskRequest,
         FluxScaleFieldResult, FluxScaleReport, FluxScaleSpwResult, GainFieldSelector,
         GainSolveInterval, GainSolveMode, GainSolveModelSource, GainSolveReport, GainType,
-        RefAntSelector, ResolvedGainField, ResolvedNearestGainField, TimeCoverageSummary,
+        GencalType, RefAntSelector, ResolvedGainField, ResolvedNearestGainField,
+        TimeCoverageSummary,
     };
 
     fn sample_keywords() -> CalibrationKeywordSummary {
@@ -4253,6 +4418,40 @@ mod tests {
                 assert_eq!(options.reference_fields, vec!["1331+305".to_string()]);
             }
             _ => panic!("expected fluxscale action"),
+        }
+    }
+
+    #[test]
+    fn parse_args_accepts_gencal_command() {
+        let action = parse_args([
+            "gencal".into(),
+            "--ms".into(),
+            "tutorial.ms".into(),
+            "--out".into(),
+            "cal.tau".into(),
+            "--caltype".into(),
+            "opac".into(),
+            "--spw".into(),
+            "0,1".into(),
+            "--parameter".into(),
+            "0.1,0.2".into(),
+            "--format".into(),
+            "json".into(),
+        ])
+        .expect("parse succeeds");
+        match action {
+            CliAction::Run(request) => {
+                let Command::Gencal(options) = request.command else {
+                    panic!("expected gencal action");
+                };
+                assert_eq!(options.measurement_set, PathBuf::from("tutorial.ms"));
+                assert_eq!(options.output_table, PathBuf::from("cal.tau"));
+                assert_eq!(options.caltype, GencalType::Opac);
+                assert_eq!(options.spw, "0,1");
+                assert_eq!(options.parameter, vec![0.1, 0.2]);
+                assert_eq!(options.format, OutputFormat::Json);
+            }
+            _ => panic!("expected gencal action"),
         }
     }
 

--- a/crates/casa-calibration/src/cli.rs
+++ b/crates/casa-calibration/src/cli.rs
@@ -93,6 +93,7 @@ struct SolveGainOptions {
     prior_calibration_tables: Vec<ApplyCalibrationTableSpec>,
     parang: bool,
     model_source: GainSolveModelSource,
+    smodel: [f32; 4],
     normalize_average_amplitude: bool,
     min_snr: f32,
     min_baselines_per_antenna: usize,
@@ -134,6 +135,7 @@ struct SolveBandpassOptions {
     parang: bool,
     combine: BandpassSolveCombine,
     band_type: BandpassType,
+    smodel: [f32; 4],
     normalize_average_amplitude: bool,
     amplitude_degree: usize,
     phase_degree: usize,
@@ -287,7 +289,7 @@ impl Command {
                 normalize_average_amplitude: options.normalize_average_amplitude,
                 min_snr: options.min_snr,
                 min_baselines_per_antenna: options.min_baselines_per_antenna,
-                smodel: [1.0, 0.0, 0.0, 0.0],
+                smodel: options.smodel,
             }),
             Self::SolveBandpass(options) => {
                 CalibrationTaskRequest::SolveBandpass(SolveBandpassTaskRequest {
@@ -302,7 +304,7 @@ impl Command {
                     normalize_average_amplitude: options.normalize_average_amplitude,
                     amplitude_degree: options.amplitude_degree,
                     phase_degree: options.phase_degree,
-                    smodel: [1.0, 0.0, 0.0, 0.0],
+                    smodel: options.smodel,
                 })
             }
             Self::FluxScale(options) => CalibrationTaskRequest::FluxScale(FluxScaleRequest {
@@ -835,6 +837,20 @@ pub fn command_schema(program_name: &str) -> UiCommandSchema {
                 choices: &["point", "model-column"],
                 help: "Visibility model source for solve-gain mode",
                 group: "Solve Gain",
+                required: false,
+                advanced: false,
+            }),
+            option_argument(OptionArgumentConfig {
+                id: "smodel",
+                label: "Point Source Stokes",
+                order: 21,
+                flags: &["--smodel"],
+                metavar: "I,Q,U,V",
+                value_kind: UiValueKind::String,
+                default: Some("1,0,0,0"),
+                choices: &[],
+                help: "Point-source Stokes model for solve-gain and solve-bandpass",
+                group: "Solve",
                 required: false,
                 advanced: false,
             }),
@@ -1892,6 +1908,7 @@ fn parse_solve_gain_args(args: &[OsString], managed_output: bool) -> Result<CliA
     let mut refant = None;
     let mut parang = false;
     let mut model_source = GainSolveModelSource::PointSource;
+    let mut smodel = [1.0, 0.0, 0.0, 0.0];
     let mut normalize_average_amplitude = false;
     let mut min_snr = 3.0_f32;
     let mut min_baselines_per_antenna = 4_usize;
@@ -1971,6 +1988,10 @@ fn parse_solve_gain_args(args: &[OsString], managed_output: bool) -> Result<CliA
                 index += 1;
                 model_source =
                     parse_gain_solve_model_source(&take_string_value(index, args, raw)?)?;
+            }
+            "--smodel" => {
+                index += 1;
+                smodel = parse_stokes_smodel(&take_string_value(index, args, "--smodel")?)?;
             }
             "--model-column" => model_source = GainSolveModelSource::ModelColumn,
             "--point-model" => model_source = GainSolveModelSource::PointSource,
@@ -2079,6 +2100,7 @@ fn parse_solve_gain_args(args: &[OsString], managed_output: bool) -> Result<CliA
             prior_calibration_tables,
             parang,
             model_source,
+            smodel,
             normalize_average_amplitude,
             min_snr,
             min_baselines_per_antenna,
@@ -2102,6 +2124,7 @@ fn parse_solve_bandpass_args(args: &[OsString], managed_output: bool) -> Result<
     let mut parang = false;
     let mut combine = BandpassSolveCombine::default();
     let mut band_type = BandpassType::B;
+    let mut smodel = [1.0, 0.0, 0.0, 0.0];
     let mut normalize_average_amplitude = false;
     let mut amplitude_degree = 3_usize;
     let mut phase_degree = 3_usize;
@@ -2173,6 +2196,10 @@ fn parse_solve_bandpass_args(args: &[OsString], managed_output: bool) -> Result<
             "--bandtype" => {
                 index += 1;
                 band_type = parse_bandpass_type(&take_string_value(index, args, "--bandtype")?)?;
+            }
+            "--smodel" => {
+                index += 1;
+                smodel = parse_stokes_smodel(&take_string_value(index, args, "--smodel")?)?;
             }
             "--solnorm" => normalize_average_amplitude = true,
             "--no-solnorm" => normalize_average_amplitude = false,
@@ -2264,6 +2291,7 @@ fn parse_solve_bandpass_args(args: &[OsString], managed_output: bool) -> Result<
             parang,
             combine,
             band_type,
+            smodel,
             normalize_average_amplitude,
             amplitude_degree,
             phase_degree,
@@ -2921,6 +2949,19 @@ fn parse_f64_list(flag: &str, value: &str) -> Result<Vec<f64>, String> {
                 .map_err(|error| format!("parse {flag} value {item:?}: {error}"))
         })
         .collect()
+}
+
+fn parse_stokes_smodel(value: &str) -> Result<[f32; 4], String> {
+    let values = parse_f64_list("--smodel", value)?;
+    let [i, q, u, v]: [f64; 4] = values.try_into().map_err(|values: Vec<f64>| {
+        format!("--smodel requires exactly 4 values, got {}", values.len())
+    })?;
+    let smodel = [i as f32, q as f32, u as f32, v as f32];
+    if smodel.iter().all(|value| value.is_finite()) {
+        Ok(smodel)
+    } else {
+        Err("--smodel values must be finite".to_string())
+    }
 }
 
 fn parse_bool_list(flag: &str, value: &str) -> Result<Vec<bool>, String> {
@@ -4135,6 +4176,8 @@ mod tests {
             "--combine".into(),
             "scan,field".into(),
             "--model-column".into(),
+            "--smodel".into(),
+            "2.5,0.1,0.0,-0.2".into(),
             "--minsnr".into(),
             "2.5".into(),
             "--gaintables".into(),
@@ -4158,6 +4201,7 @@ mod tests {
                 assert!(options.combine.scans);
                 assert!(options.combine.fields);
                 assert_eq!(options.model_source, GainSolveModelSource::ModelColumn);
+                assert_eq!(options.smodel, [2.5, 0.1, 0.0, -0.2]);
                 assert_eq!(options.min_snr, 2.5);
                 assert_eq!(options.min_baselines_per_antenna, 4);
                 assert_eq!(
@@ -4292,6 +4336,8 @@ mod tests {
             "--degphase".into(),
             "4".into(),
             "--solnorm".into(),
+            "--smodel".into(),
+            "3,0,0,0".into(),
             "--gaintables".into(),
             "prior.gcal".into(),
         ])
@@ -4315,6 +4361,7 @@ mod tests {
                 assert!(options.normalize_average_amplitude);
                 assert_eq!(options.amplitude_degree, 5);
                 assert_eq!(options.phase_degree, 4);
+                assert_eq!(options.smodel, [3.0, 0.0, 0.0, 0.0]);
                 assert_eq!(options.prior_calibration_tables.len(), 1);
             }
             _ => panic!("expected solve-bandpass action"),

--- a/crates/casa-calibration/src/corrected_export.rs
+++ b/crates/casa-calibration/src/corrected_export.rs
@@ -173,14 +173,25 @@ pub fn export_corrected_data(
             source: Box::new(source),
         })?;
     for (&row_index, corrected) in selected_rows.iter().zip(corrected_rows) {
-        let corrected =
-            corrected.ok_or_else(|| ExportCorrectedDataError::MutateMeasurementSet {
-                path: request.input_ms.display().to_string(),
-                source: Box::new(TableError::ColumnNotFound {
-                    row_index,
-                    column: VisibilityDataColumn::CorrectedData.name().to_string(),
-                }),
-            })?;
+        let corrected = match corrected {
+            Some(corrected) if !corrected.is_empty() => corrected,
+            None => ms
+                .main_table()
+                .column_accessor(VisibilityDataColumn::Data.name())
+                .and_then(|column| column.array_cell(row_index).cloned())
+                .map_err(|source| ExportCorrectedDataError::MutateMeasurementSet {
+                    path: request.input_ms.display().to_string(),
+                    source: Box::new(source),
+                })?,
+            Some(_) => ms
+                .main_table()
+                .column_accessor(VisibilityDataColumn::Data.name())
+                .and_then(|column| column.array_cell(row_index).cloned())
+                .map_err(|source| ExportCorrectedDataError::MutateMeasurementSet {
+                    path: request.input_ms.display().to_string(),
+                    source: Box::new(source),
+                })?,
+        };
         ms.main_table_mut()
             .column_accessor_mut(VisibilityDataColumn::Data.name())
             .and_then(|mut column| column.set_array_assuming_valid(row_index, corrected))
@@ -251,14 +262,25 @@ fn export_all_corrected_data_by_copy(
             source: Box::new(source),
         })?;
     for (row_index, corrected) in row_indices.iter().copied().zip(corrected_rows) {
-        let corrected =
-            corrected.ok_or_else(|| ExportCorrectedDataError::MutateMeasurementSet {
-                path: output_ms.display().to_string(),
-                source: Box::new(TableError::ColumnNotFound {
-                    row_index,
-                    column: VisibilityDataColumn::CorrectedData.name().to_string(),
-                }),
-            })?;
+        let corrected = match corrected {
+            Some(corrected) if !corrected.is_empty() => corrected,
+            None => output
+                .main_table()
+                .column_accessor(VisibilityDataColumn::Data.name())
+                .and_then(|column| column.array_cell(row_index).cloned())
+                .map_err(|source| ExportCorrectedDataError::MutateMeasurementSet {
+                    path: output_ms.display().to_string(),
+                    source: Box::new(source),
+                })?,
+            Some(_) => output
+                .main_table()
+                .column_accessor(VisibilityDataColumn::Data.name())
+                .and_then(|column| column.array_cell(row_index).cloned())
+                .map_err(|source| ExportCorrectedDataError::MutateMeasurementSet {
+                    path: output_ms.display().to_string(),
+                    source: Box::new(source),
+                })?,
+        };
         output
             .main_table_mut()
             .column_accessor_mut(VisibilityDataColumn::Data.name())

--- a/crates/casa-calibration/src/execute.rs
+++ b/crates/casa-calibration/src/execute.rs
@@ -559,7 +559,7 @@ pub(crate) fn evaluate_apply_rows(
             ExecutionRowInputs {
                 correlation_types,
                 data,
-                original_flags,
+                original_flags: Some(original_flags),
                 original_weight: None,
                 has_weight_spectrum: false,
             },
@@ -809,14 +809,19 @@ fn execute_apply_plan(
                 path: ms_path.clone(),
                 source: MsError::from(source),
             })?;
-        let flag_values = ms
-            .main_table()
-            .column_accessor("FLAG")
-            .and_then(|column| column.array_cells_owned(&selected_row_indices))
-            .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
-                path: ms_path.clone(),
-                source: MsError::from(source),
-            })?;
+        let flag_values = if plan.apply_mode == ApplyMode::CalFlag {
+            Some(
+                ms.main_table()
+                    .column_accessor("FLAG")
+                    .and_then(|column| column.array_cells_owned(&selected_row_indices))
+                    .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                        path: ms_path.clone(),
+                        source: MsError::from(source),
+                    })?,
+            )
+        } else {
+            None
+        };
         let weight_values = if any_calwt {
             Some(
                 ms.main_table()
@@ -834,7 +839,7 @@ fn execute_apply_plan(
         row_read_total_ns += row_read_started_at.elapsed().as_nanos() as u64;
         let mut prefetched_inputs = Vec::with_capacity(plan.selected_rows.len());
         let mut data_values = data_values.into_iter();
-        let mut flag_values = flag_values.into_iter();
+        let mut flag_values = flag_values.map(Vec::into_iter);
         let mut weight_values = weight_values.map(Vec::into_iter);
 
         for row in &plan.selected_rows {
@@ -847,15 +852,20 @@ fn execute_apply_plan(
                     }),
                 }
             })?;
-            let original_flags = flag_values.next().flatten().ok_or_else(|| {
-                ApplyExecutionError::MutateMeasurementSet {
-                    path: ms_path.clone(),
-                    source: MsError::from(TableError::ColumnNotFound {
-                        row_index: row.row_index,
-                        column: "FLAG".to_string(),
-                    }),
-                }
-            })?;
+            let original_flags = flag_values
+                .as_mut()
+                .map(|flags| {
+                    flags.next().flatten().ok_or_else(|| {
+                        ApplyExecutionError::MutateMeasurementSet {
+                            path: ms_path.clone(),
+                            source: MsError::from(TableError::ColumnNotFound {
+                                row_index: row.row_index,
+                                column: "FLAG".to_string(),
+                            }),
+                        }
+                    })
+                })
+                .transpose()?;
             let original_weight = weight_values
                 .as_mut()
                 .map(|weights| {
@@ -1243,14 +1253,14 @@ struct ExecutionRowResult {
 struct ExecutionRowInputs<'a> {
     correlation_types: &'a [i32],
     data: &'a ArrayValue,
-    original_flags: &'a ArrayValue,
+    original_flags: Option<&'a ArrayValue>,
     original_weight: Option<&'a ArrayValue>,
     has_weight_spectrum: bool,
 }
 
 struct PrefetchedExecutionRowInputs {
     data: ArrayValue,
-    original_flags: ArrayValue,
+    original_flags: Option<ArrayValue>,
     original_weight: Option<ArrayValue>,
 }
 
@@ -1426,13 +1436,20 @@ fn apply_row(
             shape: data.shape().to_vec(),
         });
     };
-    let ArrayValue::Bool(flag_array) = original_flags else {
-        return Err(ApplyExecutionError::UnsupportedParameterShape {
-            path: "<measurement-set FLAG>".to_string(),
-            shape: original_flags.shape().to_vec(),
-        });
+    let flag_array = match original_flags {
+        Some(ArrayValue::Bool(flag_array)) => Some(flag_array),
+        Some(other) => {
+            return Err(ApplyExecutionError::UnsupportedParameterShape {
+                path: "<measurement-set FLAG>".to_string(),
+                shape: other.shape().to_vec(),
+            });
+        }
+        None => None,
     };
-    if data.ndim() != 2 || flag_array.ndim() != 2 || data.shape() != flag_array.shape() {
+    if data.ndim() != 2
+        || flag_array
+            .is_some_and(|flag_array| flag_array.ndim() != 2 || data.shape() != flag_array.shape())
+    {
         return Err(ApplyExecutionError::UnsupportedParameterShape {
             path: "<measurement-set row>".to_string(),
             shape: data.shape().to_vec(),
@@ -1449,7 +1466,19 @@ fn apply_row(
     }
 
     let mut corrected = data.clone();
-    let mut flags = flag_array.clone();
+    let mut flags = if plan.apply_mode == ApplyMode::CalFlag {
+        flag_array
+            .ok_or_else(|| ApplyExecutionError::MutateMeasurementSet {
+                path: "<measurement-set FLAG>".to_string(),
+                source: MsError::from(TableError::ColumnNotFound {
+                    row_index: row.row_index,
+                    column: "FLAG".to_string(),
+                }),
+            })?
+            .clone()
+    } else {
+        ArrayD::from_elem(IxDyn(&[0]).f(), false)
+    };
     let mut newly_flagged_samples = 0;
     let any_calwt = plan.calibration_tables.iter().any(|table| table.calwt);
     let mut weight = match original_weight {
@@ -1578,6 +1607,25 @@ fn apply_row(
             engine: loaded_table.engine.as_deref(),
         };
 
+        if !(table_plan.calwt && loaded_table.supports_calwt)
+            && let (CalibrationGrid::Complex(ant1_grid), CalibrationGrid::Complex(ant2_grid)) =
+                (&ant1, &ant2)
+        {
+            apply_complex_gain_pair_fast(
+                ant1_grid,
+                ant2_grid,
+                FastGainApply {
+                    data_desc_id: row.data_desc_id,
+                    correlation_types,
+                    corrected: &mut corrected,
+                    flags: &mut flags,
+                    apply_mode: plan.apply_mode,
+                    newly_flagged_samples: &mut newly_flagged_samples,
+                },
+            )?;
+            continue;
+        }
+
         for corr_index in 0..data.shape()[0] {
             let receptors =
                 correlation_receptors(correlation_types[corr_index]).ok_or_else(|| {
@@ -1699,6 +1747,99 @@ fn apply_row(
     })
 }
 
+struct FastGainApply<'a> {
+    data_desc_id: i32,
+    correlation_types: &'a [i32],
+    corrected: &'a mut ArrayD<Complex32>,
+    flags: &'a mut ArrayD<bool>,
+    apply_mode: ApplyMode,
+    newly_flagged_samples: &'a mut usize,
+}
+
+fn apply_complex_gain_pair_fast(
+    ant1: &GainGrid,
+    ant2: &GainGrid,
+    ctx: FastGainApply<'_>,
+) -> Result<(), ApplyExecutionError> {
+    let shape = ctx.corrected.shape();
+    let corr_count = shape[0];
+    let channel_count = shape[1];
+    let ant1_scalar = ant1.channel_count <= 1;
+    let ant2_scalar = ant2.channel_count <= 1;
+
+    for corr_index in 0..corr_count {
+        let receptors =
+            correlation_receptors(ctx.correlation_types[corr_index]).ok_or_else(|| {
+                ApplyExecutionError::UnsupportedCorrelationLayout {
+                    data_desc_id: ctx.data_desc_id,
+                    correlation_types: ctx
+                        .correlation_types
+                        .iter()
+                        .map(|code| stokes_name(*code).to_string())
+                        .collect(),
+                }
+            })?;
+        let receptor1 = receptors.0.min(ant1.receptor_count.saturating_sub(1));
+        let receptor2 = receptors.1.min(ant2.receptor_count.saturating_sub(1));
+
+        if ant1_scalar && ant2_scalar {
+            let gain1 = ant1.value_at(receptor1, 0);
+            let gain2 = ant2.value_at(receptor2, 0);
+            let invalid = ant1.flag_at(receptor1, 0)
+                || ant2.flag_at(receptor2, 0)
+                || gain1 == Complex32::new(0.0, 0.0)
+                || gain2 == Complex32::new(0.0, 0.0);
+            if invalid {
+                if ctx.apply_mode == ApplyMode::CalFlag {
+                    for chan_index in 0..channel_count {
+                        if !ctx.flags[[corr_index, chan_index]] {
+                            ctx.flags[[corr_index, chan_index]] = true;
+                            *ctx.newly_flagged_samples += 1;
+                        }
+                    }
+                }
+                continue;
+            }
+            let denom = gain1 * gain2.conj();
+            for chan_index in 0..channel_count {
+                ctx.corrected[[corr_index, chan_index]] /= denom;
+            }
+            continue;
+        }
+
+        for chan_index in 0..channel_count {
+            let ant1_chan = if ant1_scalar {
+                0
+            } else {
+                chan_index.min(ant1.channel_count.saturating_sub(1))
+            };
+            let ant2_chan = if ant2_scalar {
+                0
+            } else {
+                chan_index.min(ant2.channel_count.saturating_sub(1))
+            };
+            let gain1 = ant1.value_at(receptor1, ant1_chan);
+            let gain2 = ant2.value_at(receptor2, ant2_chan);
+            if ant1.flag_at(receptor1, ant1_chan)
+                || ant2.flag_at(receptor2, ant2_chan)
+                || gain1 == Complex32::new(0.0, 0.0)
+                || gain2 == Complex32::new(0.0, 0.0)
+            {
+                if ctx.apply_mode == ApplyMode::CalFlag && !ctx.flags[[corr_index, chan_index]] {
+                    ctx.flags[[corr_index, chan_index]] = true;
+                    *ctx.newly_flagged_samples += 1;
+                }
+                continue;
+            }
+
+            let denom = gain1 * gain2.conj();
+            ctx.corrected[[corr_index, chan_index]] /= denom;
+        }
+    }
+
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 fn apply_row_prefetched(
     row: &ApplyRowPlan,
@@ -1715,7 +1856,7 @@ fn apply_row_prefetched(
         ExecutionRowInputs {
             correlation_types,
             data: &inputs.data,
-            original_flags: &inputs.original_flags,
+            original_flags: inputs.original_flags.as_ref(),
             original_weight: inputs.original_weight.as_ref(),
             has_weight_spectrum,
         },

--- a/crates/casa-calibration/src/execute.rs
+++ b/crates/casa-calibration/src/execute.rs
@@ -567,6 +567,7 @@ pub(crate) fn evaluate_apply_rows(
             &loaded_tables,
             parang_state.as_ref(),
             Some(&mut geometry_cache),
+            None,
         )?;
         evaluated_rows.insert(
             row.row_index,
@@ -782,6 +783,8 @@ fn execute_apply_plan(
     let mut changed_columns: Vec<&'static str> = vec![VisibilityDataColumn::CorrectedData.name()];
     let row_loop_started_at = Instant::now();
     let mut geometry_cache = RowGeometryCache::default();
+    let mut row_compute_profile =
+        calibration_profile_enabled().then(ApplyRowComputeProfile::default);
     if use_partial_main_save {
         let anticipated_updates = plan.selected_rows.len();
         ms.main_table_mut().reserve_array_cell_updates(
@@ -917,6 +920,7 @@ fn execute_apply_plan(
                 &loaded_tables,
                 parang_state.as_ref(),
                 Some(&mut geometry_cache),
+                row_compute_profile.as_mut(),
             )?;
             row_compute_ns += row_compute_started_at.elapsed().as_nanos() as u64;
 
@@ -1041,6 +1045,7 @@ fn execute_apply_plan(
                 &loaded_tables,
                 parang_state.as_ref(),
                 Some(&mut geometry_cache),
+                row_compute_profile.as_mut(),
             )?;
             row_compute_ns += row_compute_started_at.elapsed().as_nanos() as u64;
 
@@ -1213,6 +1218,13 @@ fn execute_apply_plan(
                 save_ns as f64 / 1_000_000_000.0
             )),
         );
+        if let Some(profile) = row_compute_profile {
+            log_calibration_profile(
+                "apply_row_compute",
+                row_compute_ns as f64 / 1_000_000_000.0,
+                Some(profile.detail_string()),
+            );
+        }
     }
 
     Ok((
@@ -1264,11 +1276,47 @@ struct PrefetchedExecutionRowInputs {
     original_weight: Option<ArrayValue>,
 }
 
+#[derive(Debug, Default)]
+struct ApplyRowComputeProfile {
+    rows: usize,
+    table_applications: usize,
+    setup_ns: u64,
+    table_lookup_ns: u64,
+    row_dependent_grid_ns: u64,
+    fast_gain_apply_ns: u64,
+    generic_sample_apply_ns: u64,
+    parallactic_angle_ns: u64,
+    weight_finalize_ns: u64,
+}
+
+impl ApplyRowComputeProfile {
+    fn add_elapsed(bucket: &mut u64, started_at: Option<Instant>) {
+        if let Some(started_at) = started_at {
+            *bucket += started_at.elapsed().as_nanos() as u64;
+        }
+    }
+
+    fn detail_string(&self) -> String {
+        format!(
+            "rows={} table_apps={} setup={:.3}s lookup={:.3}s row_dependent_grid={:.3}s fast_gain={:.3}s generic_sample={:.3}s parang={:.3}s weight_finalize={:.3}s",
+            self.rows,
+            self.table_applications,
+            self.setup_ns as f64 / 1_000_000_000.0,
+            self.table_lookup_ns as f64 / 1_000_000_000.0,
+            self.row_dependent_grid_ns as f64 / 1_000_000_000.0,
+            self.fast_gain_apply_ns as f64 / 1_000_000_000.0,
+            self.generic_sample_apply_ns as f64 / 1_000_000_000.0,
+            self.parallactic_angle_ns as f64 / 1_000_000_000.0,
+            self.weight_finalize_ns as f64 / 1_000_000_000.0,
+        )
+    }
+}
+
 #[derive(Default)]
 struct RowGeometryCache {
     elevations: HashMap<RowGeometryKey, f64>,
     projected_offsets: HashMap<ProjectedOffsetKey, [f64; 3]>,
-    materialized_grids: HashMap<MaterializedGridKey, CalibrationGrid>,
+    materialized_grids: HashMap<MaterializedGridKey, Arc<CalibrationGrid>>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -1289,7 +1337,7 @@ struct MaterializedGridKey {
     row: RowGeometryKey,
     kind: u8,
     data_spw_id: i32,
-    fingerprint: u64,
+    grid_id: usize,
 }
 
 impl RowGeometryCache {
@@ -1342,11 +1390,11 @@ impl RowGeometryCache {
         Ok(uvw)
     }
 
-    fn materialized_grid(&self, key: MaterializedGridKey) -> Option<CalibrationGrid> {
+    fn materialized_grid(&self, key: MaterializedGridKey) -> Option<Arc<CalibrationGrid>> {
         self.materialized_grids.get(&key).cloned()
     }
 
-    fn insert_materialized_grid(&mut self, key: MaterializedGridKey, grid: CalibrationGrid) {
+    fn insert_materialized_grid(&mut self, key: MaterializedGridKey, grid: Arc<CalibrationGrid>) {
         self.materialized_grids.insert(key, grid);
     }
 }
@@ -1362,43 +1410,23 @@ impl RowGeometryKey {
 }
 
 fn materialized_grid_key(
-    grid: &CalibrationGrid,
+    grid: &Arc<CalibrationGrid>,
     field_id: i32,
     antenna_id: i32,
     time_seconds: f64,
     data_spw_id: i32,
 ) -> Option<MaterializedGridKey> {
-    let (kind, fingerprint) = match grid {
-        CalibrationGrid::Antpos(grid) => {
-            let mut fingerprint = 0xcbf29ce484222325_u64;
-            for value in grid.offsets_m {
-                fingerprint = fingerprint.wrapping_mul(0x100000001b3) ^ u64::from(value.to_bits());
-            }
-            fingerprint = fingerprint.wrapping_mul(0x100000001b3) ^ u64::from(grid.flagged);
-            (1, fingerprint)
-        }
-        CalibrationGrid::GainCurve(grid) => {
-            let mut fingerprint = grid.receptor_count as u64;
-            for value in grid.coefficients.iter() {
-                fingerprint = fingerprint.wrapping_mul(0x100000001b3) ^ u64::from(value.to_bits());
-            }
-            for value in grid.flags.iter() {
-                fingerprint = fingerprint.wrapping_mul(0x100000001b3) ^ u64::from(*value);
-            }
-            (2, fingerprint)
-        }
-        CalibrationGrid::Opacity(grid) => {
-            let fingerprint =
-                u64::from(grid.tau.to_bits()).rotate_left(1) ^ u64::from(grid.flagged);
-            (3, fingerprint)
-        }
+    let kind = match grid.as_ref() {
+        CalibrationGrid::Antpos(_) => 1,
+        CalibrationGrid::GainCurve(_) => 2,
+        CalibrationGrid::Opacity(_) => 3,
         _ => return None,
     };
     Some(MaterializedGridKey {
         row: RowGeometryKey::new(time_seconds, field_id, antenna_id),
         kind,
         data_spw_id,
-        fingerprint,
+        grid_id: Arc::as_ptr(grid) as usize,
     })
 }
 
@@ -1422,7 +1450,10 @@ fn apply_row(
     loaded_tables: &[LoadedCalibrationTable],
     parang_state: Option<&ParallacticAngleState>,
     geometry_cache: Option<&mut RowGeometryCache>,
+    compute_profile: Option<&mut ApplyRowComputeProfile>,
 ) -> Result<ExecutionRowResult, ApplyExecutionError> {
+    let mut compute_profile = compute_profile;
+    let setup_started_at = compute_profile.as_ref().map(|_| Instant::now());
     let ExecutionRowInputs {
         correlation_types,
         data,
@@ -1513,11 +1544,19 @@ fn apply_row(
             weight_spectrum = Some(expand_weight_to_spectrum(weight_values, data.shape()[1]));
         }
     }
+    if let Some(profile) = compute_profile.as_deref_mut() {
+        profile.rows += 1;
+        ApplyRowComputeProfile::add_elapsed(&mut profile.setup_ns, setup_started_at);
+    }
 
     for (table_plan, loaded_table) in plan.calibration_tables.iter().zip(loaded_tables) {
         if !table_plan.spec.apply_to.matches(row) {
             continue;
         }
+        if let Some(profile) = compute_profile.as_deref_mut() {
+            profile.table_applications += 1;
+        }
+        let lookup_started_at = compute_profile.as_ref().map(|_| Instant::now());
         let cal_spw_id = table_plan
             .spw_mapping
             .iter()
@@ -1562,6 +1601,9 @@ fn apply_row(
             row.time_seconds,
             table_plan.interp,
         )?;
+        if let Some(profile) = compute_profile.as_deref_mut() {
+            ApplyRowComputeProfile::add_elapsed(&mut profile.table_lookup_ns, lookup_started_at);
+        }
 
         let (Some(ant1), Some(ant2)) = (ant1, ant2) else {
             if plan.apply_mode == ApplyMode::CalFlag {
@@ -1577,6 +1619,7 @@ fn apply_row(
             continue;
         };
 
+        let materialize_started_at = compute_profile.as_ref().map(|_| Instant::now());
         let ant1 = materialize_row_dependent_grid(
             ant1,
             row.field_id,
@@ -1597,6 +1640,12 @@ fn apply_row(
             &loaded_table.path,
             geometry_cache.as_deref_mut(),
         )?;
+        if let Some(profile) = compute_profile.as_deref_mut() {
+            ApplyRowComputeProfile::add_elapsed(
+                &mut profile.row_dependent_grid_ns,
+                materialize_started_at,
+            );
+        }
 
         let sampling_context = CalibrationSamplingContext {
             data_frequencies_hz: &data_spw.channel_frequencies_hz,
@@ -1609,8 +1658,9 @@ fn apply_row(
 
         if !(table_plan.calwt && loaded_table.supports_calwt)
             && let (CalibrationGrid::Complex(ant1_grid), CalibrationGrid::Complex(ant2_grid)) =
-                (&ant1, &ant2)
+                (ant1.as_ref(), ant2.as_ref())
         {
+            let fast_apply_started_at = compute_profile.as_ref().map(|_| Instant::now());
             apply_complex_gain_pair_fast(
                 ant1_grid,
                 ant2_grid,
@@ -1623,9 +1673,16 @@ fn apply_row(
                     newly_flagged_samples: &mut newly_flagged_samples,
                 },
             )?;
+            if let Some(profile) = compute_profile.as_deref_mut() {
+                ApplyRowComputeProfile::add_elapsed(
+                    &mut profile.fast_gain_apply_ns,
+                    fast_apply_started_at,
+                );
+            }
             continue;
         }
 
+        let generic_apply_started_at = compute_profile.as_ref().map(|_| Instant::now());
         for corr_index in 0..data.shape()[0] {
             let receptors =
                 correlation_receptors(correlation_types[corr_index]).ok_or_else(|| {
@@ -1681,9 +1738,16 @@ fn apply_row(
                 }
             }
         }
+        if let Some(profile) = compute_profile.as_deref_mut() {
+            ApplyRowComputeProfile::add_elapsed(
+                &mut profile.generic_sample_apply_ns,
+                generic_apply_started_at,
+            );
+        }
     }
 
     if let Some(parang_state) = parang_state {
+        let parang_started_at = compute_profile.as_ref().map(|_| Instant::now());
         let ant1_feed_pa = parang_state.feed_parallactic_angle(
             row.time_seconds,
             row.field_id,
@@ -1711,9 +1775,16 @@ fn apply_row(
                 corrected[[corr_index, chan_index]] /= correction;
             }
         }
+        if let Some(profile) = compute_profile.as_deref_mut() {
+            ApplyRowComputeProfile::add_elapsed(
+                &mut profile.parallactic_angle_ns,
+                parang_started_at,
+            );
+        }
     }
 
     if any_calwt {
+        let weight_finalize_started_at = compute_profile.as_ref().map(|_| Instant::now());
         let weight_values = weight
             .as_mut()
             .expect("validated WEIGHT availability when calwt is enabled");
@@ -1731,6 +1802,12 @@ fn apply_row(
                     .collect::<Vec<_>>();
                 weight_values[[corr_index]] *= median_f32(&samples);
             }
+        }
+        if let Some(profile) = compute_profile {
+            ApplyRowComputeProfile::add_elapsed(
+                &mut profile.weight_finalize_ns,
+                weight_finalize_started_at,
+            );
         }
     }
 
@@ -1850,6 +1927,7 @@ fn apply_row_prefetched(
     loaded_tables: &[LoadedCalibrationTable],
     parang_state: Option<&ParallacticAngleState>,
     geometry_cache: Option<&mut RowGeometryCache>,
+    compute_profile: Option<&mut ApplyRowComputeProfile>,
 ) -> Result<ExecutionRowResult, ApplyExecutionError> {
     apply_row(
         row,
@@ -1864,12 +1942,13 @@ fn apply_row_prefetched(
         loaded_tables,
         parang_state,
         geometry_cache,
+        compute_profile,
     )
 }
 
 #[allow(clippy::too_many_arguments)]
 fn materialize_row_dependent_grid(
-    grid: CalibrationGrid,
+    grid: Arc<CalibrationGrid>,
     field_id: i32,
     antenna_id: i32,
     time_seconds: f64,
@@ -1877,7 +1956,7 @@ fn materialize_row_dependent_grid(
     engine: Option<&MsCalEngine>,
     path: &Path,
     geometry_cache: Option<&mut RowGeometryCache>,
-) -> Result<CalibrationGrid, ApplyExecutionError> {
+) -> Result<Arc<CalibrationGrid>, ApplyExecutionError> {
     let mut geometry_cache = geometry_cache;
     let cache_key =
         materialized_grid_key(&grid, field_id, antenna_id, time_seconds, data_spw.spw_id);
@@ -1886,7 +1965,7 @@ fn materialize_row_dependent_grid(
     {
         return Ok(grid);
     }
-    let result = match grid {
+    let result = match grid.as_ref() {
         CalibrationGrid::Antpos(grid) => {
             let Some(engine) = engine else {
                 return Err(ApplyExecutionError::UnsupportedCalibrationTable {
@@ -1932,13 +2011,13 @@ fn materialize_row_dependent_grid(
                 })
                 .collect::<Vec<_>>();
             let channel_count = values.len();
-            Ok(CalibrationGrid::Complex(GainGrid {
+            Ok(Arc::new(CalibrationGrid::Complex(GainGrid {
                 receptor_count: 1,
                 channel_count,
                 values: ArrayD::from_shape_vec(IxDyn(&[1, channel_count]).f(), values)
                     .expect("antpos materialized grid shape is valid"),
                 flags: ArrayD::from_elem(IxDyn(&[1, channel_count]).f(), grid.flagged),
-            }))
+            })))
         }
         CalibrationGrid::GainCurve(grid) => {
             let Some(engine) = engine else {
@@ -1976,14 +2055,14 @@ fn materialize_row_dependent_grid(
                 values.push(Complex32::new(gain, 0.0));
                 flags.push((0..4).any(|coeff_index| grid.flags[[base + coeff_index, 0]]));
             }
-            Ok(CalibrationGrid::Complex(GainGrid {
+            Ok(Arc::new(CalibrationGrid::Complex(GainGrid {
                 receptor_count: grid.receptor_count,
                 channel_count: 1,
                 values: ArrayD::from_shape_vec(IxDyn(&[grid.receptor_count]).f(), values)
                     .expect("gaincurve materialized grid shape is valid"),
                 flags: ArrayD::from_shape_vec(IxDyn(&[grid.receptor_count]).f(), flags)
                     .expect("gaincurve materialized flag shape is valid"),
-            }))
+            })))
         }
         CalibrationGrid::Opacity(grid) => {
             let Some(engine) = engine else {
@@ -2013,21 +2092,21 @@ fn materialize_row_dependent_grid(
             } else {
                 1.0
             };
-            Ok(CalibrationGrid::Complex(GainGrid {
+            Ok(Arc::new(CalibrationGrid::Complex(GainGrid {
                 receptor_count: 1,
                 channel_count: 1,
                 values: ArrayD::from_shape_vec(IxDyn(&[1]).f(), vec![Complex32::new(gain, 0.0)])
                     .expect("opacity materialized grid shape is valid"),
                 flags: ArrayD::from_shape_vec(IxDyn(&[1]).f(), vec![grid.flagged])
                     .expect("opacity materialized flag shape is valid"),
-            }))
+            })))
         }
-        other => Ok(other),
+        _ => Ok(Arc::clone(&grid)),
     };
     if let (Some(cache), Some(key), Ok(materialized)) =
         (&mut geometry_cache, cache_key, result.as_ref())
     {
-        cache.insert_materialized_grid(key, materialized.clone());
+        cache.insert_materialized_grid(key, Arc::clone(materialized));
     }
     result
 }
@@ -2195,7 +2274,7 @@ struct LegacyCalDescEntry {
 
 struct CalibrationSolution {
     time_seconds: f64,
-    grid: CalibrationGrid,
+    grid: Arc<CalibrationGrid>,
 }
 
 #[derive(Clone)]
@@ -2772,7 +2851,7 @@ impl LoadedCalibrationTable {
         antenna_id: i32,
         time_seconds: f64,
         interp: ApplyInterpolationMode,
-    ) -> Result<Option<CalibrationGrid>, ApplyExecutionError> {
+    ) -> Result<Option<Arc<CalibrationGrid>>, ApplyExecutionError> {
         if self.interp != interp {
             return Err(ApplyExecutionError::UnsupportedInterpolation {
                 path: self.path.display().to_string(),
@@ -2842,7 +2921,7 @@ fn interpolate_time_linear(
     path: &Path,
     candidates: &[CalibrationSolution],
     time_seconds: f64,
-) -> Result<CalibrationGrid, ApplyExecutionError> {
+) -> Result<Arc<CalibrationGrid>, ApplyExecutionError> {
     let mut sorted = candidates.iter().collect::<Vec<_>>();
     sorted.sort_by(|a, b| a.time_seconds.total_cmp(&b.time_seconds));
 
@@ -2862,7 +2941,7 @@ fn interpolate_time_linear(
         {
             let fraction = ((time_seconds - lower.time_seconds)
                 / (upper.time_seconds - lower.time_seconds)) as f32;
-            match (&lower.grid, &upper.grid) {
+            match (lower.grid.as_ref(), upper.grid.as_ref()) {
                 (CalibrationGrid::Complex(lower), CalibrationGrid::Complex(upper)) => {
                     if lower.values.shape() != upper.values.shape() {
                         return Err(ApplyExecutionError::UnsupportedInterpolation {
@@ -2880,12 +2959,12 @@ fn interpolate_time_linear(
                     for (flag, upper_flag) in flags.iter_mut().zip(upper.flags.iter()) {
                         *flag = *flag || *upper_flag;
                     }
-                    Ok(CalibrationGrid::Complex(GainGrid {
+                    Ok(Arc::new(CalibrationGrid::Complex(GainGrid {
                         receptor_count: lower.receptor_count,
                         channel_count: lower.channel_count,
                         values,
                         flags,
-                    }))
+                    })))
                 }
                 (CalibrationGrid::Delay(lower), CalibrationGrid::Delay(upper)) => {
                     if lower.values_ns.shape() != upper.values_ns.shape() {
@@ -2904,12 +2983,12 @@ fn interpolate_time_linear(
                     for (flag, upper_flag) in flags.iter_mut().zip(upper.flags.iter()) {
                         *flag = *flag || *upper_flag;
                     }
-                    Ok(CalibrationGrid::Delay(DelayGrid {
+                    Ok(Arc::new(CalibrationGrid::Delay(DelayGrid {
                         receptor_count: lower.receptor_count,
                         channel_count: lower.channel_count,
                         values_ns,
                         flags,
-                    }))
+                    })))
                 }
                 (
                     CalibrationGrid::Antpos(_)
@@ -3108,7 +3187,10 @@ fn load_calibration_table(
         solutions
             .entry((field_id, spw_id, antenna_id))
             .or_default()
-            .push(CalibrationSolution { time_seconds, grid });
+            .push(CalibrationSolution {
+                time_seconds,
+                grid: Arc::new(grid),
+            });
     }
 
     Ok(LoadedCalibrationTable {
@@ -3177,7 +3259,10 @@ fn load_bpoly_calibration_table(
         solutions
             .entry((field_id, cal_desc_entry.spw_id, antenna_id))
             .or_default()
-            .push(CalibrationSolution { time_seconds, grid });
+            .push(CalibrationSolution {
+                time_seconds,
+                grid: Arc::new(grid),
+            });
     }
 
     Ok(LoadedCalibrationTable {
@@ -3933,7 +4018,7 @@ mod tests {
         let complex_pair = [
             CalibrationSolution {
                 time_seconds: 30.0,
-                grid: CalibrationGrid::Complex(GainGrid {
+                grid: Arc::new(CalibrationGrid::Complex(GainGrid {
                     receptor_count: 1,
                     channel_count: 2,
                     values: ArrayD::from_shape_vec(
@@ -3942,11 +4027,11 @@ mod tests {
                     )
                     .unwrap(),
                     flags: ArrayD::from_shape_vec(IxDyn(&[1, 2]).f(), vec![true, false]).unwrap(),
-                }),
+                })),
             },
             CalibrationSolution {
                 time_seconds: 10.0,
-                grid: CalibrationGrid::Complex(GainGrid {
+                grid: Arc::new(CalibrationGrid::Complex(GainGrid {
                     receptor_count: 1,
                     channel_count: 2,
                     values: ArrayD::from_shape_vec(
@@ -3955,11 +4040,14 @@ mod tests {
                     )
                     .unwrap(),
                     flags: ArrayD::from_shape_vec(IxDyn(&[1, 2]).f(), vec![false, false]).unwrap(),
-                }),
+                })),
             },
         ];
 
-        match interpolate_time_linear(path, &complex_pair, 20.0).unwrap() {
+        match interpolate_time_linear(path, &complex_pair, 20.0)
+            .unwrap()
+            .as_ref()
+        {
             CalibrationGrid::Complex(grid) => {
                 assert_complex_close(
                     grid.values[[0, 0]],
@@ -3995,26 +4083,29 @@ mod tests {
         let delay_pair = [
             CalibrationSolution {
                 time_seconds: 1.0,
-                grid: CalibrationGrid::Delay(DelayGrid {
+                grid: Arc::new(CalibrationGrid::Delay(DelayGrid {
                     receptor_count: 1,
                     channel_count: 2,
                     values_ns: ArrayD::from_shape_vec(IxDyn(&[1, 2]).f(), vec![1.0_f32, 3.0])
                         .unwrap(),
                     flags: ArrayD::from_shape_vec(IxDyn(&[1, 2]).f(), vec![false, true]).unwrap(),
-                }),
+                })),
             },
             CalibrationSolution {
                 time_seconds: 3.0,
-                grid: CalibrationGrid::Delay(DelayGrid {
+                grid: Arc::new(CalibrationGrid::Delay(DelayGrid {
                     receptor_count: 1,
                     channel_count: 2,
                     values_ns: ArrayD::from_shape_vec(IxDyn(&[1, 2]).f(), vec![5.0_f32, 7.0])
                         .unwrap(),
                     flags: ArrayD::from_shape_vec(IxDyn(&[1, 2]).f(), vec![true, false]).unwrap(),
-                }),
+                })),
             },
         ];
-        match interpolate_time_linear(path, &delay_pair, 2.0).unwrap() {
+        match interpolate_time_linear(path, &delay_pair, 2.0)
+            .unwrap()
+            .as_ref()
+        {
             CalibrationGrid::Delay(grid) => {
                 assert_eq!(grid.values_ns[[0, 0]], 3.0);
                 assert_eq!(grid.values_ns[[0, 1]], 5.0);
@@ -4028,7 +4119,7 @@ mod tests {
             path,
             &[CalibrationSolution {
                 time_seconds: 10.0,
-                grid: CalibrationGrid::Complex(GainGrid {
+                grid: Arc::new(CalibrationGrid::Complex(GainGrid {
                     receptor_count: 1,
                     channel_count: 2,
                     values: ArrayD::from_shape_vec(
@@ -4037,11 +4128,12 @@ mod tests {
                     )
                     .unwrap(),
                     flags: ArrayD::from_shape_vec(IxDyn(&[1, 2]).f(), vec![false, false]).unwrap(),
-                }),
+                })),
             }],
             0.0,
         )
         .unwrap()
+        .as_ref()
         {
             CalibrationGrid::Complex(grid) => {
                 assert_eq!(grid.values[[0, 0]], Complex32::new(1.0, 0.0))
@@ -4058,7 +4150,7 @@ mod tests {
             &[
                 CalibrationSolution {
                     time_seconds: 10.0,
-                    grid: CalibrationGrid::Complex(GainGrid {
+                    grid: Arc::new(CalibrationGrid::Complex(GainGrid {
                         receptor_count: 1,
                         channel_count: 2,
                         values: ArrayD::from_shape_vec(
@@ -4068,18 +4160,18 @@ mod tests {
                         .unwrap(),
                         flags: ArrayD::from_shape_vec(IxDyn(&[1, 2]).f(), vec![false, false])
                             .unwrap(),
-                    }),
+                    })),
                 },
                 CalibrationSolution {
                     time_seconds: 20.0,
-                    grid: CalibrationGrid::Delay(DelayGrid {
+                    grid: Arc::new(CalibrationGrid::Delay(DelayGrid {
                         receptor_count: 1,
                         channel_count: 2,
                         values_ns: ArrayD::from_shape_vec(IxDyn(&[1, 2]).f(), vec![1.0_f32, 2.0])
                             .unwrap(),
                         flags: ArrayD::from_shape_vec(IxDyn(&[1, 2]).f(), vec![false, false])
                             .unwrap(),
-                    }),
+                    })),
                 },
             ],
             15.0,

--- a/crates/casa-calibration/src/execute.rs
+++ b/crates/casa-calibration/src/execute.rs
@@ -1317,6 +1317,7 @@ struct RowGeometryCache {
     elevations: HashMap<RowGeometryKey, f64>,
     projected_offsets: HashMap<ProjectedOffsetKey, [f64; 3]>,
     materialized_grids: HashMap<MaterializedGridKey, Arc<CalibrationGrid>>,
+    calibration_lookups: HashMap<CalibrationLookupKey, Option<Arc<CalibrationGrid>>>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -1338,6 +1339,16 @@ struct MaterializedGridKey {
     kind: u8,
     data_spw_id: i32,
     grid_id: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct CalibrationLookupKey {
+    table_index: usize,
+    field_id: i32,
+    spw_id: i32,
+    antenna_id: i32,
+    time_bits: u64,
+    interp: u8,
 }
 
 impl RowGeometryCache {
@@ -1397,6 +1408,22 @@ impl RowGeometryCache {
     fn insert_materialized_grid(&mut self, key: MaterializedGridKey, grid: Arc<CalibrationGrid>) {
         self.materialized_grids.insert(key, grid);
     }
+
+    fn calibration_lookup<F>(
+        &mut self,
+        key: CalibrationLookupKey,
+        load: F,
+    ) -> Result<Option<Arc<CalibrationGrid>>, ApplyExecutionError>
+    where
+        F: FnOnce() -> Result<Option<Arc<CalibrationGrid>>, ApplyExecutionError>,
+    {
+        if let Some(grid) = self.calibration_lookups.get(&key) {
+            return Ok(grid.clone());
+        }
+        let grid = load()?;
+        self.calibration_lookups.insert(key, grid.clone());
+        Ok(grid)
+    }
 }
 
 impl RowGeometryKey {
@@ -1428,6 +1455,28 @@ fn materialized_grid_key(
         data_spw_id,
         grid_id: Arc::as_ptr(grid) as usize,
     })
+}
+
+fn calibration_lookup_key(
+    table_index: usize,
+    field_id: i32,
+    spw_id: i32,
+    antenna_id: i32,
+    time_seconds: f64,
+    interp: ApplyInterpolationMode,
+) -> CalibrationLookupKey {
+    CalibrationLookupKey {
+        table_index,
+        field_id,
+        spw_id,
+        antenna_id,
+        time_bits: time_seconds.to_bits(),
+        interp: match interp {
+            ApplyInterpolationMode::Nearest => 1,
+            ApplyInterpolationMode::Linear => 2,
+            ApplyInterpolationMode::NearestLinear => 3,
+        },
+    }
 }
 
 struct ParallacticAngleState {
@@ -1526,6 +1575,7 @@ fn apply_row(
     let mut implicit_weight_spectrum =
         (any_calwt && !has_weight_spectrum).then(|| ArrayD::from_elem(data.raw_dim(), 1.0_f32));
     let mut geometry_cache = geometry_cache;
+    let mut fast_gain_pairs: Vec<(Arc<CalibrationGrid>, Arc<CalibrationGrid>)> = Vec::new();
 
     if any_calwt {
         let Some(weight_values) = weight.as_ref() else {
@@ -1549,7 +1599,12 @@ fn apply_row(
         ApplyRowComputeProfile::add_elapsed(&mut profile.setup_ns, setup_started_at);
     }
 
-    for (table_plan, loaded_table) in plan.calibration_tables.iter().zip(loaded_tables) {
+    for (table_index, (table_plan, loaded_table)) in plan
+        .calibration_tables
+        .iter()
+        .zip(loaded_tables)
+        .enumerate()
+    {
         if !table_plan.spec.apply_to.matches(row) {
             continue;
         }
@@ -1587,26 +1642,87 @@ fn apply_row(
             })
             .unwrap_or(row.field_id);
 
-        let ant1 = loaded_table.lookup(
+        let ant1_key = calibration_lookup_key(
+            table_index,
             field_id,
             cal_spw_id,
             row.antenna1,
             row.time_seconds,
             table_plan.interp,
-        )?;
-        let ant2 = loaded_table.lookup(
+        );
+        let ant2_key = calibration_lookup_key(
+            table_index,
             field_id,
             cal_spw_id,
             row.antenna2,
             row.time_seconds,
             table_plan.interp,
-        )?;
+        );
+        let ant1 = if let Some(cache) = geometry_cache.as_deref_mut() {
+            cache.calibration_lookup(ant1_key, || {
+                loaded_table.lookup(
+                    field_id,
+                    cal_spw_id,
+                    row.antenna1,
+                    row.time_seconds,
+                    table_plan.interp,
+                )
+            })?
+        } else {
+            loaded_table.lookup(
+                field_id,
+                cal_spw_id,
+                row.antenna1,
+                row.time_seconds,
+                table_plan.interp,
+            )?
+        };
+        let ant2 = if let Some(cache) = geometry_cache.as_deref_mut() {
+            cache.calibration_lookup(ant2_key, || {
+                loaded_table.lookup(
+                    field_id,
+                    cal_spw_id,
+                    row.antenna2,
+                    row.time_seconds,
+                    table_plan.interp,
+                )
+            })?
+        } else {
+            loaded_table.lookup(
+                field_id,
+                cal_spw_id,
+                row.antenna2,
+                row.time_seconds,
+                table_plan.interp,
+            )?
+        };
         if let Some(profile) = compute_profile.as_deref_mut() {
             ApplyRowComputeProfile::add_elapsed(&mut profile.table_lookup_ns, lookup_started_at);
         }
 
         let (Some(ant1), Some(ant2)) = (ant1, ant2) else {
             if plan.apply_mode == ApplyMode::CalFlag {
+                if !fast_gain_pairs.is_empty() {
+                    let fast_apply_started_at = compute_profile.as_ref().map(|_| Instant::now());
+                    apply_complex_gain_pairs_fast(
+                        &fast_gain_pairs,
+                        FastGainApply {
+                            data_desc_id: row.data_desc_id,
+                            correlation_types,
+                            corrected: &mut corrected,
+                            flags: &mut flags,
+                            apply_mode: plan.apply_mode,
+                            newly_flagged_samples: &mut newly_flagged_samples,
+                        },
+                    )?;
+                    if let Some(profile) = compute_profile.as_deref_mut() {
+                        ApplyRowComputeProfile::add_elapsed(
+                            &mut profile.fast_gain_apply_ns,
+                            fast_apply_started_at,
+                        );
+                    }
+                    fast_gain_pairs.clear();
+                }
                 for corr_index in 0..data.shape()[0] {
                     for chan_index in 0..data.shape()[1] {
                         if !flags[[corr_index, chan_index]] {
@@ -1657,13 +1773,19 @@ fn apply_row(
         };
 
         if !(table_plan.calwt && loaded_table.supports_calwt)
-            && let (CalibrationGrid::Complex(ant1_grid), CalibrationGrid::Complex(ant2_grid)) =
-                (ant1.as_ref(), ant2.as_ref())
+            && matches!(
+                (ant1.as_ref(), ant2.as_ref()),
+                (CalibrationGrid::Complex(_), CalibrationGrid::Complex(_))
+            )
         {
+            fast_gain_pairs.push((ant1, ant2));
+            continue;
+        }
+
+        if !fast_gain_pairs.is_empty() {
             let fast_apply_started_at = compute_profile.as_ref().map(|_| Instant::now());
-            apply_complex_gain_pair_fast(
-                ant1_grid,
-                ant2_grid,
+            apply_complex_gain_pairs_fast(
+                &fast_gain_pairs,
                 FastGainApply {
                     data_desc_id: row.data_desc_id,
                     correlation_types,
@@ -1679,7 +1801,7 @@ fn apply_row(
                     fast_apply_started_at,
                 );
             }
-            continue;
+            fast_gain_pairs.clear();
         }
 
         let generic_apply_started_at = compute_profile.as_ref().map(|_| Instant::now());
@@ -1742,6 +1864,27 @@ fn apply_row(
             ApplyRowComputeProfile::add_elapsed(
                 &mut profile.generic_sample_apply_ns,
                 generic_apply_started_at,
+            );
+        }
+    }
+
+    if !fast_gain_pairs.is_empty() {
+        let fast_apply_started_at = compute_profile.as_ref().map(|_| Instant::now());
+        apply_complex_gain_pairs_fast(
+            &fast_gain_pairs,
+            FastGainApply {
+                data_desc_id: row.data_desc_id,
+                correlation_types,
+                corrected: &mut corrected,
+                flags: &mut flags,
+                apply_mode: plan.apply_mode,
+                newly_flagged_samples: &mut newly_flagged_samples,
+            },
+        )?;
+        if let Some(profile) = compute_profile.as_deref_mut() {
+            ApplyRowComputeProfile::add_elapsed(
+                &mut profile.fast_gain_apply_ns,
+                fast_apply_started_at,
             );
         }
     }
@@ -1833,19 +1976,37 @@ struct FastGainApply<'a> {
     newly_flagged_samples: &'a mut usize,
 }
 
-fn apply_complex_gain_pair_fast(
-    ant1: &GainGrid,
-    ant2: &GainGrid,
+fn apply_complex_gain_pairs_fast(
+    pairs: &[(Arc<CalibrationGrid>, Arc<CalibrationGrid>)],
     ctx: FastGainApply<'_>,
 ) -> Result<(), ApplyExecutionError> {
     let shape = ctx.corrected.shape();
     let corr_count = shape[0];
     let channel_count = shape[1];
-    let ant1_scalar = ant1.channel_count <= 1;
-    let ant2_scalar = ant2.channel_count <= 1;
+    let corrected_is_fortran = ctx.corrected.ndim() == 2 && ctx.corrected.strides()[0] == 1;
+    let flags_are_fortran = ctx.apply_mode != ApplyMode::CalFlag
+        || (ctx.flags.ndim() == 2 && ctx.flags.strides()[0] == 1);
+    if corrected_is_fortran
+        && flags_are_fortran
+        && let Some(corrected) = ctx.corrected.as_slice_memory_order_mut()
+    {
+        let flags = (ctx.apply_mode == ApplyMode::CalFlag)
+            .then(|| ctx.flags.as_slice_memory_order_mut())
+            .flatten();
+        return apply_complex_gain_pairs_fast_fortran(
+            pairs,
+            ctx.data_desc_id,
+            ctx.correlation_types,
+            corr_count,
+            channel_count,
+            corrected,
+            flags,
+            ctx.newly_flagged_samples,
+        );
+    }
 
-    for corr_index in 0..corr_count {
-        let receptors =
+    let receptors_by_corr = (0..corr_count)
+        .map(|corr_index| {
             correlation_receptors(ctx.correlation_types[corr_index]).ok_or_else(|| {
                 ApplyExecutionError::UnsupportedCorrelationLayout {
                     data_desc_id: ctx.data_desc_id,
@@ -1855,62 +2016,166 @@ fn apply_complex_gain_pair_fast(
                         .map(|code| stokes_name(*code).to_string())
                         .collect(),
                 }
-            })?;
-        let receptor1 = receptors.0.min(ant1.receptor_count.saturating_sub(1));
-        let receptor2 = receptors.1.min(ant2.receptor_count.saturating_sub(1));
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
 
-        if ant1_scalar && ant2_scalar {
-            let gain1 = ant1.value_at(receptor1, 0);
-            let gain2 = ant2.value_at(receptor2, 0);
-            let invalid = ant1.flag_at(receptor1, 0)
-                || ant2.flag_at(receptor2, 0)
-                || gain1 == Complex32::new(0.0, 0.0)
-                || gain2 == Complex32::new(0.0, 0.0);
-            if invalid {
-                if ctx.apply_mode == ApplyMode::CalFlag {
-                    for chan_index in 0..channel_count {
-                        if !ctx.flags[[corr_index, chan_index]] {
-                            ctx.flags[[corr_index, chan_index]] = true;
-                            *ctx.newly_flagged_samples += 1;
+    for (corr_index, &receptors) in receptors_by_corr.iter().enumerate().take(corr_count) {
+        let mut scalar_denom = Complex32::new(1.0, 0.0);
+        for chan_index in 0..channel_count {
+            for (ant1, ant2) in pairs {
+                let (CalibrationGrid::Complex(ant1), CalibrationGrid::Complex(ant2)) =
+                    (ant1.as_ref(), ant2.as_ref())
+                else {
+                    continue;
+                };
+                let receptor1 = receptors.0.min(ant1.receptor_count.saturating_sub(1));
+                let receptor2 = receptors.1.min(ant2.receptor_count.saturating_sub(1));
+                if ant1.channel_count <= 1 && ant2.channel_count <= 1 {
+                    if chan_index == 0 {
+                        let gain1 = ant1.value_at(receptor1, 0);
+                        let gain2 = ant2.value_at(receptor2, 0);
+                        let invalid = ant1.flag_at(receptor1, 0)
+                            || ant2.flag_at(receptor2, 0)
+                            || gain1 == Complex32::new(0.0, 0.0)
+                            || gain2 == Complex32::new(0.0, 0.0);
+                        if invalid {
+                            if ctx.apply_mode == ApplyMode::CalFlag {
+                                for flag_chan_index in 0..channel_count {
+                                    if !ctx.flags[[corr_index, flag_chan_index]] {
+                                        ctx.flags[[corr_index, flag_chan_index]] = true;
+                                        *ctx.newly_flagged_samples += 1;
+                                    }
+                                }
+                            }
+                        } else {
+                            scalar_denom *= gain1 * gain2.conj();
                         }
                     }
+                    continue;
                 }
-                continue;
+                let ant1_chan = if ant1.channel_count <= 1 {
+                    0
+                } else {
+                    chan_index.min(ant1.channel_count.saturating_sub(1))
+                };
+                let ant2_chan = if ant2.channel_count <= 1 {
+                    0
+                } else {
+                    chan_index.min(ant2.channel_count.saturating_sub(1))
+                };
+                let gain1 = ant1.value_at(receptor1, ant1_chan);
+                let gain2 = ant2.value_at(receptor2, ant2_chan);
+                if ant1.flag_at(receptor1, ant1_chan)
+                    || ant2.flag_at(receptor2, ant2_chan)
+                    || gain1 == Complex32::new(0.0, 0.0)
+                    || gain2 == Complex32::new(0.0, 0.0)
+                {
+                    if ctx.apply_mode == ApplyMode::CalFlag && !ctx.flags[[corr_index, chan_index]]
+                    {
+                        ctx.flags[[corr_index, chan_index]] = true;
+                        *ctx.newly_flagged_samples += 1;
+                    }
+                    continue;
+                }
+                ctx.corrected[[corr_index, chan_index]] /= gain1 * gain2.conj();
             }
-            let denom = gain1 * gain2.conj();
-            for chan_index in 0..channel_count {
-                ctx.corrected[[corr_index, chan_index]] /= denom;
-            }
-            continue;
+            ctx.corrected[[corr_index, chan_index]] /= scalar_denom;
         }
+    }
 
-        for chan_index in 0..channel_count {
-            let ant1_chan = if ant1_scalar {
-                0
-            } else {
-                chan_index.min(ant1.channel_count.saturating_sub(1))
-            };
-            let ant2_chan = if ant2_scalar {
-                0
-            } else {
-                chan_index.min(ant2.channel_count.saturating_sub(1))
-            };
-            let gain1 = ant1.value_at(receptor1, ant1_chan);
-            let gain2 = ant2.value_at(receptor2, ant2_chan);
-            if ant1.flag_at(receptor1, ant1_chan)
-                || ant2.flag_at(receptor2, ant2_chan)
-                || gain1 == Complex32::new(0.0, 0.0)
-                || gain2 == Complex32::new(0.0, 0.0)
-            {
-                if ctx.apply_mode == ApplyMode::CalFlag && !ctx.flags[[corr_index, chan_index]] {
-                    ctx.flags[[corr_index, chan_index]] = true;
-                    *ctx.newly_flagged_samples += 1;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn apply_complex_gain_pairs_fast_fortran(
+    pairs: &[(Arc<CalibrationGrid>, Arc<CalibrationGrid>)],
+    data_desc_id: i32,
+    correlation_types: &[i32],
+    corr_count: usize,
+    channel_count: usize,
+    corrected: &mut [Complex32],
+    mut flags: Option<&mut [bool]>,
+    newly_flagged_samples: &mut usize,
+) -> Result<(), ApplyExecutionError> {
+    let receptors_by_corr = (0..corr_count)
+        .map(|corr_index| {
+            correlation_receptors(correlation_types[corr_index]).ok_or_else(|| {
+                ApplyExecutionError::UnsupportedCorrelationLayout {
+                    data_desc_id,
+                    correlation_types: correlation_types
+                        .iter()
+                        .map(|code| stokes_name(*code).to_string())
+                        .collect(),
                 }
-                continue;
-            }
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
 
-            let denom = gain1 * gain2.conj();
-            ctx.corrected[[corr_index, chan_index]] /= denom;
+    for (corr_index, &receptors) in receptors_by_corr.iter().enumerate().take(corr_count) {
+        let mut scalar_denom = Complex32::new(1.0, 0.0);
+        for chan_index in 0..channel_count {
+            let offset = corr_index + chan_index * corr_count;
+            for (ant1, ant2) in pairs {
+                let (CalibrationGrid::Complex(ant1), CalibrationGrid::Complex(ant2)) =
+                    (ant1.as_ref(), ant2.as_ref())
+                else {
+                    continue;
+                };
+                let receptor1 = receptors.0.min(ant1.receptor_count.saturating_sub(1));
+                let receptor2 = receptors.1.min(ant2.receptor_count.saturating_sub(1));
+                if ant1.channel_count <= 1 && ant2.channel_count <= 1 {
+                    if chan_index == 0 {
+                        let gain1 = ant1.value_at(receptor1, 0);
+                        let gain2 = ant2.value_at(receptor2, 0);
+                        let invalid = ant1.flag_at(receptor1, 0)
+                            || ant2.flag_at(receptor2, 0)
+                            || gain1 == Complex32::new(0.0, 0.0)
+                            || gain2 == Complex32::new(0.0, 0.0);
+                        if invalid {
+                            if let Some(flags) = flags.as_deref_mut() {
+                                for flag_chan_index in 0..channel_count {
+                                    let flag_offset = corr_index + flag_chan_index * corr_count;
+                                    if !flags[flag_offset] {
+                                        flags[flag_offset] = true;
+                                        *newly_flagged_samples += 1;
+                                    }
+                                }
+                            }
+                        } else {
+                            scalar_denom *= gain1 * gain2.conj();
+                        }
+                    }
+                    continue;
+                }
+                let ant1_chan = if ant1.channel_count <= 1 {
+                    0
+                } else {
+                    chan_index.min(ant1.channel_count.saturating_sub(1))
+                };
+                let ant2_chan = if ant2.channel_count <= 1 {
+                    0
+                } else {
+                    chan_index.min(ant2.channel_count.saturating_sub(1))
+                };
+                let gain1 = ant1.value_at(receptor1, ant1_chan);
+                let gain2 = ant2.value_at(receptor2, ant2_chan);
+                if ant1.flag_at(receptor1, ant1_chan)
+                    || ant2.flag_at(receptor2, ant2_chan)
+                    || gain1 == Complex32::new(0.0, 0.0)
+                    || gain2 == Complex32::new(0.0, 0.0)
+                {
+                    if let Some(flags) = flags.as_deref_mut()
+                        && !flags[offset]
+                    {
+                        flags[offset] = true;
+                        *newly_flagged_samples += 1;
+                    }
+                    continue;
+                }
+                corrected[offset] /= gain1 * gain2.conj();
+            }
+            corrected[offset] /= scalar_denom;
         }
     }
 

--- a/crates/casa-calibration/src/execute.rs
+++ b/crates/casa-calibration/src/execute.rs
@@ -24,6 +24,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::fs::{File, OpenOptions, create_dir_all};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Instant;
 
@@ -52,6 +53,7 @@ use crate::plan::{
 
 const PERF_ENV: &str = "CASA_RS_CALIBRATION_PERF";
 const PERF_DIR_ENV: &str = "CASA_RS_CALIBRATION_PERF_DIR";
+const SPEED_OF_LIGHT_M_PER_S: f64 = 299_792_458.0;
 
 fn calibration_profile_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
@@ -493,10 +495,11 @@ pub(crate) fn evaluate_apply_rows(
             source,
         }
     })?;
+    let geometry_engine = geometry_engine_for_plan(ms, plan)?;
     let loaded_tables = plan
         .calibration_tables
         .iter()
-        .map(load_calibration_table)
+        .map(|table_plan| load_calibration_table(table_plan, geometry_engine.as_ref()))
         .collect::<Result<Vec<_>, _>>()?;
     let parang_state = if plan.parang {
         Some(load_parallactic_angle_state(ms).map_err(|source| {
@@ -524,6 +527,7 @@ pub(crate) fn evaluate_apply_rows(
     let flag_index = main_rows
         .column_index("FLAG")
         .expect("prepared apply reader includes FLAG");
+    let mut geometry_cache = RowGeometryCache::default();
     for row in &plan.selected_rows {
         let correlation_types = correlation_types_by_ddid
             .get(&row.data_desc_id)
@@ -562,6 +566,7 @@ pub(crate) fn evaluate_apply_rows(
             plan,
             &loaded_tables,
             parang_state.as_ref(),
+            Some(&mut geometry_cache),
         )?;
         evaluated_rows.insert(
             row.row_index,
@@ -716,12 +721,18 @@ fn execute_apply_plan(
     let ms_path = display_ms_path(ms);
     let execute_apply_plan_started_at = Instant::now();
     let ensure_corrected_data_started_at = Instant::now();
-    let created_corrected_data_column = ensure_corrected_data_column(ms).map_err(|source| {
-        ApplyExecutionError::CreateCorrectedData {
-            path: ms_path.clone(),
-            source,
-        }
-    })?;
+    let selected_row_indices = plan
+        .selected_rows
+        .iter()
+        .map(|row| row.row_index)
+        .collect::<BTreeSet<_>>();
+    let created_corrected_data_column =
+        ensure_corrected_data_column(ms, Some(&selected_row_indices)).map_err(|source| {
+            ApplyExecutionError::CreateCorrectedData {
+                path: ms_path.clone(),
+                source,
+            }
+        })?;
     let ensure_corrected_data_ns = ensure_corrected_data_started_at.elapsed().as_nanos() as u64;
 
     let correlation_lookup_started_at = Instant::now();
@@ -733,10 +744,11 @@ fn execute_apply_plan(
     })?;
     let correlation_lookup_ns = correlation_lookup_started_at.elapsed().as_nanos() as u64;
     let calibration_load_started_at = Instant::now();
+    let geometry_engine = geometry_engine_for_plan(ms, &plan)?;
     let loaded_tables = plan
         .calibration_tables
         .iter()
-        .map(load_calibration_table)
+        .map(|table_plan| load_calibration_table(table_plan, geometry_engine.as_ref()))
         .collect::<Result<Vec<_>, _>>()?;
     let parang_state = if plan.parang {
         Some(load_parallactic_angle_state(ms).map_err(|source| {
@@ -766,9 +778,10 @@ fn execute_apply_plan(
         .main_table()
         .schema()
         .is_some_and(|schema| schema.contains_column("WEIGHT_SPECTRUM"));
-    let use_partial_main_save = !created_corrected_data_column;
+    let use_partial_main_save = true;
     let mut changed_columns: Vec<&'static str> = vec![VisibilityDataColumn::CorrectedData.name()];
     let row_loop_started_at = Instant::now();
+    let mut geometry_cache = RowGeometryCache::default();
     if use_partial_main_save {
         let anticipated_updates = plan.selected_rows.len();
         ms.main_table_mut().reserve_array_cell_updates(
@@ -893,6 +906,7 @@ fn execute_apply_plan(
                 &plan,
                 &loaded_tables,
                 parang_state.as_ref(),
+                Some(&mut geometry_cache),
             )?;
             row_compute_ns += row_compute_started_at.elapsed().as_nanos() as u64;
 
@@ -1016,6 +1030,7 @@ fn execute_apply_plan(
                 &plan,
                 &loaded_tables,
                 parang_state.as_ref(),
+                Some(&mut geometry_cache),
             )?;
             row_compute_ns += row_compute_started_at.elapsed().as_nanos() as u64;
 
@@ -1086,12 +1101,41 @@ fn execute_apply_plan(
     if use_partial_main_save {
         let changed_row_indices: Vec<usize> =
             plan.selected_rows.iter().map(|row| row.row_index).collect();
-        ms.main_table()
-            .save_selected_rows_in_place_assuming_valid(&changed_columns, &changed_row_indices)
-            .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
-                path: ms_path.clone(),
-                source: MsError::from(source),
-            })?;
+        if created_corrected_data_column {
+            ms.main_table_mut()
+                .save_added_tiled_shape_column_in_place_assuming_valid(
+                    VisibilityDataColumn::CorrectedData.name(),
+                    &changed_row_indices,
+                    Some(&[4, 64, 32]),
+                )
+                .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                    path: ms_path.clone(),
+                    source: MsError::from(source),
+                })?;
+            let existing_changed_columns: Vec<&str> = changed_columns
+                .iter()
+                .copied()
+                .filter(|column| *column != VisibilityDataColumn::CorrectedData.name())
+                .collect();
+            if !existing_changed_columns.is_empty() {
+                ms.main_table()
+                    .save_selected_rows_in_place_assuming_valid(
+                        &existing_changed_columns,
+                        &changed_row_indices,
+                    )
+                    .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                        path: ms_path.clone(),
+                        source: MsError::from(source),
+                    })?;
+            }
+        } else {
+            ms.main_table()
+                .save_selected_rows_in_place_assuming_valid(&changed_columns, &changed_row_indices)
+                .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                    path: ms_path.clone(),
+                    source: MsError::from(source),
+                })?;
+        }
     } else {
         ms.save_main_table_only_assuming_valid().map_err(|source| {
             ApplyExecutionError::MutateMeasurementSet {
@@ -1210,6 +1254,144 @@ struct PrefetchedExecutionRowInputs {
     original_weight: Option<ArrayValue>,
 }
 
+#[derive(Default)]
+struct RowGeometryCache {
+    elevations: HashMap<RowGeometryKey, f64>,
+    projected_offsets: HashMap<ProjectedOffsetKey, [f64; 3]>,
+    materialized_grids: HashMap<MaterializedGridKey, CalibrationGrid>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct RowGeometryKey {
+    time_bits: u64,
+    field_id: i32,
+    antenna_id: i32,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct ProjectedOffsetKey {
+    row: RowGeometryKey,
+    offset_bits: [u64; 3],
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct MaterializedGridKey {
+    row: RowGeometryKey,
+    kind: u8,
+    data_spw_id: i32,
+    fingerprint: u64,
+}
+
+impl RowGeometryCache {
+    fn elevation(
+        &mut self,
+        engine: &MsCalEngine,
+        time_seconds: f64,
+        field_id: i32,
+        antenna_id: i32,
+    ) -> MsResult<f64> {
+        let key = RowGeometryKey::new(time_seconds, field_id, antenna_id);
+        if let Some(elevation) = self.elevations.get(&key) {
+            return Ok(*elevation);
+        }
+        let (_az, elevation) = engine.azel(
+            time_seconds,
+            usize::try_from(field_id).unwrap_or(usize::MAX),
+            usize::try_from(antenna_id).unwrap_or(usize::MAX),
+        )?;
+        self.elevations.insert(key, elevation);
+        Ok(elevation)
+    }
+
+    fn project_itrf_offset_to_uvw(
+        &mut self,
+        engine: &MsCalEngine,
+        time_seconds: f64,
+        field_id: i32,
+        antenna_id: i32,
+        offset_m: [f64; 3],
+    ) -> MsResult<[f64; 3]> {
+        let key = ProjectedOffsetKey {
+            row: RowGeometryKey::new(time_seconds, field_id, antenna_id),
+            offset_bits: [
+                offset_m[0].to_bits(),
+                offset_m[1].to_bits(),
+                offset_m[2].to_bits(),
+            ],
+        };
+        if let Some(uvw) = self.projected_offsets.get(&key) {
+            return Ok(*uvw);
+        }
+        let uvw = engine.project_itrf_offset_to_uvw(
+            time_seconds,
+            usize::try_from(field_id).unwrap_or(usize::MAX),
+            usize::try_from(antenna_id).unwrap_or(usize::MAX),
+            offset_m,
+        )?;
+        self.projected_offsets.insert(key, uvw);
+        Ok(uvw)
+    }
+
+    fn materialized_grid(&self, key: MaterializedGridKey) -> Option<CalibrationGrid> {
+        self.materialized_grids.get(&key).cloned()
+    }
+
+    fn insert_materialized_grid(&mut self, key: MaterializedGridKey, grid: CalibrationGrid) {
+        self.materialized_grids.insert(key, grid);
+    }
+}
+
+impl RowGeometryKey {
+    fn new(time_seconds: f64, field_id: i32, antenna_id: i32) -> Self {
+        Self {
+            time_bits: time_seconds.to_bits(),
+            field_id,
+            antenna_id,
+        }
+    }
+}
+
+fn materialized_grid_key(
+    grid: &CalibrationGrid,
+    field_id: i32,
+    antenna_id: i32,
+    time_seconds: f64,
+    data_spw_id: i32,
+) -> Option<MaterializedGridKey> {
+    let (kind, fingerprint) = match grid {
+        CalibrationGrid::Antpos(grid) => {
+            let mut fingerprint = 0xcbf29ce484222325_u64;
+            for value in grid.offsets_m {
+                fingerprint = fingerprint.wrapping_mul(0x100000001b3) ^ u64::from(value.to_bits());
+            }
+            fingerprint = fingerprint.wrapping_mul(0x100000001b3) ^ u64::from(grid.flagged);
+            (1, fingerprint)
+        }
+        CalibrationGrid::GainCurve(grid) => {
+            let mut fingerprint = grid.receptor_count as u64;
+            for value in grid.coefficients.iter() {
+                fingerprint = fingerprint.wrapping_mul(0x100000001b3) ^ u64::from(value.to_bits());
+            }
+            for value in grid.flags.iter() {
+                fingerprint = fingerprint.wrapping_mul(0x100000001b3) ^ u64::from(*value);
+            }
+            (2, fingerprint)
+        }
+        CalibrationGrid::Opacity(grid) => {
+            let fingerprint =
+                u64::from(grid.tau.to_bits()).rotate_left(1) ^ u64::from(grid.flagged);
+            (3, fingerprint)
+        }
+        _ => return None,
+    };
+    Some(MaterializedGridKey {
+        row: RowGeometryKey::new(time_seconds, field_id, antenna_id),
+        kind,
+        data_spw_id,
+        fingerprint,
+    })
+}
+
 struct ParallacticAngleState {
     engine: MsCalEngine,
     feed_rows: HashMap<(i32, i32), Vec<FeedAngleRow>>,
@@ -1229,6 +1411,7 @@ fn apply_row(
     plan: &ApplyPlan,
     loaded_tables: &[LoadedCalibrationTable],
     parang_state: Option<&ParallacticAngleState>,
+    geometry_cache: Option<&mut RowGeometryCache>,
 ) -> Result<ExecutionRowResult, ApplyExecutionError> {
     let ExecutionRowInputs {
         correlation_types,
@@ -1282,6 +1465,7 @@ fn apply_row(
     let mut weight_spectrum = None;
     let mut implicit_weight_spectrum =
         (any_calwt && !has_weight_spectrum).then(|| ArrayD::from_elem(data.raw_dim(), 1.0_f32));
+    let mut geometry_cache = geometry_cache;
 
     if any_calwt {
         let Some(weight_values) = weight.as_ref() else {
@@ -1364,12 +1548,34 @@ fn apply_row(
             continue;
         };
 
+        let ant1 = materialize_row_dependent_grid(
+            ant1,
+            row.field_id,
+            row.antenna1,
+            row.time_seconds,
+            data_spw,
+            loaded_table.engine.as_deref(),
+            &loaded_table.path,
+            geometry_cache.as_deref_mut(),
+        )?;
+        let ant2 = materialize_row_dependent_grid(
+            ant2,
+            row.field_id,
+            row.antenna2,
+            row.time_seconds,
+            data_spw,
+            loaded_table.engine.as_deref(),
+            &loaded_table.path,
+            geometry_cache.as_deref_mut(),
+        )?;
+
         let sampling_context = CalibrationSamplingContext {
             data_frequencies_hz: &data_spw.channel_frequencies_hz,
             cal_frequencies_hz: &cal_spw.channel_frequencies_hz,
             cal_ref_frequency_hz: cal_spw_reference_frequency_hz(cal_spw),
             interp: table_plan.interp,
             path: &loaded_table.path,
+            engine: loaded_table.engine.as_deref(),
         };
 
         for corr_index in 0..data.shape()[0] {
@@ -1385,8 +1591,22 @@ fn apply_row(
                 })?;
 
             for chan_index in 0..data.shape()[1] {
-                let gain1 = ant1.sample(receptors.0, chan_index, &sampling_context)?;
-                let gain2 = ant2.sample(receptors.1, chan_index, &sampling_context)?;
+                let gain1 = ant1.sample(
+                    receptors.0,
+                    chan_index,
+                    row.field_id,
+                    row.antenna1,
+                    row.time_seconds,
+                    &sampling_context,
+                )?;
+                let gain2 = ant2.sample(
+                    receptors.1,
+                    chan_index,
+                    row.field_id,
+                    row.antenna2,
+                    row.time_seconds,
+                    &sampling_context,
+                )?;
 
                 if gain1.flagged
                     || gain2.flagged
@@ -1479,6 +1699,7 @@ fn apply_row(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn apply_row_prefetched(
     row: &ApplyRowPlan,
     correlation_types: &[i32],
@@ -1487,6 +1708,7 @@ fn apply_row_prefetched(
     plan: &ApplyPlan,
     loaded_tables: &[LoadedCalibrationTable],
     parang_state: Option<&ParallacticAngleState>,
+    geometry_cache: Option<&mut RowGeometryCache>,
 ) -> Result<ExecutionRowResult, ApplyExecutionError> {
     apply_row(
         row,
@@ -1500,7 +1722,173 @@ fn apply_row_prefetched(
         plan,
         loaded_tables,
         parang_state,
+        geometry_cache,
     )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn materialize_row_dependent_grid(
+    grid: CalibrationGrid,
+    field_id: i32,
+    antenna_id: i32,
+    time_seconds: f64,
+    data_spw: &crate::plan::SpectralWindowPlan,
+    engine: Option<&MsCalEngine>,
+    path: &Path,
+    geometry_cache: Option<&mut RowGeometryCache>,
+) -> Result<CalibrationGrid, ApplyExecutionError> {
+    let mut geometry_cache = geometry_cache;
+    let cache_key =
+        materialized_grid_key(&grid, field_id, antenna_id, time_seconds, data_spw.spw_id);
+    if let (Some(cache), Some(key)) = (&geometry_cache, cache_key)
+        && let Some(grid) = cache.materialized_grid(key)
+    {
+        return Ok(grid);
+    }
+    let result = match grid {
+        CalibrationGrid::Antpos(grid) => {
+            let Some(engine) = engine else {
+                return Err(ApplyExecutionError::UnsupportedCalibrationTable {
+                    path: path.display().to_string(),
+                    reason: "KAntPos Jones apply requires MeasurementSet geometry".to_string(),
+                });
+            };
+            let uvw = if let Some(cache) = geometry_cache.as_deref_mut() {
+                cache.project_itrf_offset_to_uvw(
+                    engine,
+                    time_seconds,
+                    field_id,
+                    antenna_id,
+                    [
+                        f64::from(grid.offsets_m[0]),
+                        f64::from(grid.offsets_m[1]),
+                        f64::from(grid.offsets_m[2]),
+                    ],
+                )
+            } else {
+                engine.project_itrf_offset_to_uvw(
+                    time_seconds,
+                    usize::try_from(field_id).unwrap_or(usize::MAX),
+                    usize::try_from(antenna_id).unwrap_or(usize::MAX),
+                    [
+                        f64::from(grid.offsets_m[0]),
+                        f64::from(grid.offsets_m[1]),
+                        f64::from(grid.offsets_m[2]),
+                    ],
+                )
+            }
+            .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                path: path.display().to_string(),
+                source,
+            })?;
+            let delay_ns = uvw[2] / SPEED_OF_LIGHT_M_PER_S * 1.0e9;
+            let values = data_spw
+                .channel_frequencies_hz
+                .iter()
+                .map(|frequency_hz| {
+                    let phase_rad = 2.0 * std::f64::consts::PI * delay_ns * (*frequency_hz / 1.0e9);
+                    Complex32::new(phase_rad.cos() as f32, phase_rad.sin() as f32)
+                })
+                .collect::<Vec<_>>();
+            let channel_count = values.len();
+            Ok(CalibrationGrid::Complex(GainGrid {
+                receptor_count: 1,
+                channel_count,
+                values: ArrayD::from_shape_vec(IxDyn(&[1, channel_count]).f(), values)
+                    .expect("antpos materialized grid shape is valid"),
+                flags: ArrayD::from_elem(IxDyn(&[1, channel_count]).f(), grid.flagged),
+            }))
+        }
+        CalibrationGrid::GainCurve(grid) => {
+            let Some(engine) = engine else {
+                return Err(ApplyExecutionError::UnsupportedCalibrationTable {
+                    path: path.display().to_string(),
+                    reason: "EGainCurve apply requires MeasurementSet geometry".to_string(),
+                });
+            };
+            let elevation = if let Some(cache) = geometry_cache.as_deref_mut() {
+                cache.elevation(engine, time_seconds, field_id, antenna_id)
+            } else {
+                engine
+                    .azel(
+                        time_seconds,
+                        usize::try_from(field_id).unwrap_or(usize::MAX),
+                        usize::try_from(antenna_id).unwrap_or(usize::MAX),
+                    )
+                    .map(|(_az, elevation)| elevation)
+            }
+            .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                path: path.display().to_string(),
+                source,
+            })?;
+            let za_degrees = (std::f64::consts::FRAC_PI_2 - elevation).to_degrees() as f32;
+            let mut values = Vec::with_capacity(grid.receptor_count);
+            let mut flags = Vec::with_capacity(grid.receptor_count);
+            for receptor in 0..grid.receptor_count {
+                let base = receptor * 4;
+                let mut gain = grid.coefficients[[base, 0]];
+                let mut angle_power = 1.0_f32;
+                for coeff_index in 1..4 {
+                    angle_power *= za_degrees;
+                    gain += grid.coefficients[[base + coeff_index, 0]] * angle_power;
+                }
+                values.push(Complex32::new(gain, 0.0));
+                flags.push((0..4).any(|coeff_index| grid.flags[[base + coeff_index, 0]]));
+            }
+            Ok(CalibrationGrid::Complex(GainGrid {
+                receptor_count: grid.receptor_count,
+                channel_count: 1,
+                values: ArrayD::from_shape_vec(IxDyn(&[grid.receptor_count]).f(), values)
+                    .expect("gaincurve materialized grid shape is valid"),
+                flags: ArrayD::from_shape_vec(IxDyn(&[grid.receptor_count]).f(), flags)
+                    .expect("gaincurve materialized flag shape is valid"),
+            }))
+        }
+        CalibrationGrid::Opacity(grid) => {
+            let Some(engine) = engine else {
+                return Err(ApplyExecutionError::UnsupportedCalibrationTable {
+                    path: path.display().to_string(),
+                    reason: "TOpac apply requires MeasurementSet geometry".to_string(),
+                });
+            };
+            let elevation = if let Some(cache) = geometry_cache.as_deref_mut() {
+                cache.elevation(engine, time_seconds, field_id, antenna_id)
+            } else {
+                engine
+                    .azel(
+                        time_seconds,
+                        usize::try_from(field_id).unwrap_or(usize::MAX),
+                        usize::try_from(antenna_id).unwrap_or(usize::MAX),
+                    )
+                    .map(|(_az, elevation)| elevation)
+            }
+            .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                path: path.display().to_string(),
+                source,
+            })?;
+            let zenith_angle = std::f64::consts::FRAC_PI_2 - elevation;
+            let gain = if zenith_angle < std::f64::consts::FRAC_PI_2 {
+                (-f64::from(grid.tau) / zenith_angle.cos()).exp().sqrt() as f32
+            } else {
+                1.0
+            };
+            Ok(CalibrationGrid::Complex(GainGrid {
+                receptor_count: 1,
+                channel_count: 1,
+                values: ArrayD::from_shape_vec(IxDyn(&[1]).f(), vec![Complex32::new(gain, 0.0)])
+                    .expect("opacity materialized grid shape is valid"),
+                flags: ArrayD::from_shape_vec(IxDyn(&[1]).f(), vec![grid.flagged])
+                    .expect("opacity materialized flag shape is valid"),
+            }))
+        }
+        other => Ok(other),
+    };
+    if let (Some(cache), Some(key), Ok(materialized)) =
+        (&mut geometry_cache, cache_key, result.as_ref())
+    {
+        cache.insert_materialized_grid(key, materialized.clone());
+    }
+    result
 }
 
 impl ParallacticAngleState {
@@ -1654,6 +2042,7 @@ struct LoadedCalibrationTable {
     path: PathBuf,
     interp: ApplyInterpolationMode,
     supports_calwt: bool,
+    engine: Option<Arc<MsCalEngine>>,
     solutions: HashMap<(i32, i32, i32), Vec<CalibrationSolution>>,
 }
 
@@ -1672,6 +2061,9 @@ struct CalibrationSolution {
 enum CalibrationGrid {
     Complex(GainGrid),
     Delay(DelayGrid),
+    Antpos(AntposGrid),
+    GainCurve(GainCurveGrid),
+    Opacity(OpacityGrid),
 }
 
 #[derive(Clone)]
@@ -1694,6 +2086,7 @@ struct CalibrationSamplingContext<'a> {
     cal_ref_frequency_hz: f64,
     interp: ApplyInterpolationMode,
     path: &'a Path,
+    engine: Option<&'a MsCalEngine>,
 }
 
 #[derive(Clone)]
@@ -1704,11 +2097,35 @@ struct DelayGrid {
     flags: ArrayD<bool>,
 }
 
+#[derive(Clone)]
+struct AntposGrid {
+    offsets_m: [f32; 3],
+    flagged: bool,
+}
+
+#[derive(Clone)]
+struct GainCurveGrid {
+    receptor_count: usize,
+    coefficients: ArrayD<f32>,
+    flags: ArrayD<bool>,
+}
+
+#[derive(Clone)]
+struct OpacityGrid {
+    tau: f32,
+    flagged: bool,
+}
+
 impl CalibrationGrid {
+    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     fn sample(
         &self,
         receptor: usize,
         data_chan_index: usize,
+        field_id: i32,
+        antenna_id: i32,
+        time_seconds: f64,
         context: &CalibrationSamplingContext<'_>,
     ) -> Result<GainSample, ApplyExecutionError> {
         match self {
@@ -1727,6 +2144,19 @@ impl CalibrationGrid {
                 context.cal_ref_frequency_hz,
                 context.path,
             ),
+            Self::Antpos(grid) => grid.sample(
+                data_chan_index,
+                field_id,
+                antenna_id,
+                time_seconds,
+                context.data_frequencies_hz,
+                context.engine,
+                context.path,
+            ),
+            Self::GainCurve(grid) => {
+                grid.sample(receptor, field_id, antenna_id, time_seconds, context)
+            }
+            Self::Opacity(grid) => grid.sample(field_id, antenna_id, time_seconds, context),
         }
     }
 }
@@ -1965,6 +2395,234 @@ impl DelayGrid {
     }
 }
 
+impl AntposGrid {
+    fn from_arrays(
+        path: &Path,
+        offsets: &ArrayValue,
+        flags: &ArrayValue,
+    ) -> Result<Self, ApplyExecutionError> {
+        let values = match offsets {
+            ArrayValue::Float32(values) => values.clone(),
+            ArrayValue::Float64(values) => values.mapv(|value| value as f32),
+            other => {
+                return Err(ApplyExecutionError::UnsupportedParameterShape {
+                    path: path.display().to_string(),
+                    shape: other.shape().to_vec(),
+                });
+            }
+        };
+        let ArrayValue::Bool(flags) = flags else {
+            return Err(ApplyExecutionError::UnsupportedParameterShape {
+                path: path.display().to_string(),
+                shape: flags.shape().to_vec(),
+            });
+        };
+        if values.len() < 3 {
+            return Err(ApplyExecutionError::UnsupportedParameterShape {
+                path: path.display().to_string(),
+                shape: values.shape().to_vec(),
+            });
+        }
+        Ok(Self {
+            offsets_m: [values[[0, 0]], values[[1, 0]], values[[2, 0]]],
+            flagged: flags.iter().any(|flag| *flag),
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn sample(
+        &self,
+        data_chan_index: usize,
+        field_id: i32,
+        antenna_id: i32,
+        time_seconds: f64,
+        data_frequencies_hz: &[f64],
+        engine: Option<&MsCalEngine>,
+        path: &Path,
+    ) -> Result<GainSample, ApplyExecutionError> {
+        let frequency_hz = *data_frequencies_hz.get(data_chan_index).ok_or_else(|| {
+            ApplyExecutionError::UnsupportedInterpolation {
+                path: path.display().to_string(),
+                interp: ApplyInterpolationMode::Nearest,
+                reason: "data channel index is outside the MeasurementSet SPW grid".to_string(),
+            }
+        })?;
+        let Some(engine) = engine else {
+            return Err(ApplyExecutionError::UnsupportedCalibrationTable {
+                path: path.display().to_string(),
+                reason: "KAntPos Jones apply requires MeasurementSet geometry".to_string(),
+            });
+        };
+        let uvw = engine
+            .project_itrf_offset_to_uvw(
+                time_seconds,
+                usize::try_from(field_id).unwrap_or(usize::MAX),
+                usize::try_from(antenna_id).unwrap_or(usize::MAX),
+                [
+                    f64::from(self.offsets_m[0]),
+                    f64::from(self.offsets_m[1]),
+                    f64::from(self.offsets_m[2]),
+                ],
+            )
+            .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                path: path.display().to_string(),
+                source,
+            })?;
+        let delay_ns = uvw[2] / SPEED_OF_LIGHT_M_PER_S * 1.0e9;
+        let phase_rad = 2.0 * std::f64::consts::PI * delay_ns * (frequency_hz / 1.0e9);
+        Ok(GainSample {
+            value: Complex32::new(phase_rad.cos() as f32, phase_rad.sin() as f32),
+            flagged: self.flagged,
+        })
+    }
+}
+
+impl GainCurveGrid {
+    fn from_arrays(
+        path: &Path,
+        coefficients: &ArrayValue,
+        flags: &ArrayValue,
+    ) -> Result<Self, ApplyExecutionError> {
+        let coefficients = match coefficients {
+            ArrayValue::Float32(values) => values.clone(),
+            ArrayValue::Float64(values) => values.mapv(|value| value as f32),
+            other => {
+                return Err(ApplyExecutionError::UnsupportedParameterShape {
+                    path: path.display().to_string(),
+                    shape: other.shape().to_vec(),
+                });
+            }
+        };
+        let ArrayValue::Bool(flags) = flags else {
+            return Err(ApplyExecutionError::UnsupportedParameterShape {
+                path: path.display().to_string(),
+                shape: flags.shape().to_vec(),
+            });
+        };
+        if coefficients.ndim() != 2 || coefficients.shape()[0] % 4 != 0 {
+            return Err(ApplyExecutionError::UnsupportedParameterShape {
+                path: path.display().to_string(),
+                shape: coefficients.shape().to_vec(),
+            });
+        }
+        Ok(Self {
+            receptor_count: coefficients.shape()[0] / 4,
+            coefficients,
+            flags: flags.clone(),
+        })
+    }
+
+    fn sample(
+        &self,
+        receptor: usize,
+        field_id: i32,
+        antenna_id: i32,
+        time_seconds: f64,
+        context: &CalibrationSamplingContext<'_>,
+    ) -> Result<GainSample, ApplyExecutionError> {
+        let Some(engine) = context.engine else {
+            return Err(ApplyExecutionError::UnsupportedCalibrationTable {
+                path: context.path.display().to_string(),
+                reason: "EGainCurve apply requires MeasurementSet geometry".to_string(),
+            });
+        };
+        let (_az, elevation) = engine
+            .azel(
+                time_seconds,
+                usize::try_from(field_id).unwrap_or(usize::MAX),
+                usize::try_from(antenna_id).unwrap_or(usize::MAX),
+            )
+            .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                path: context.path.display().to_string(),
+                source,
+            })?;
+        let za_degrees = (std::f64::consts::FRAC_PI_2 - elevation).to_degrees() as f32;
+        let receptor = receptor.min(self.receptor_count.saturating_sub(1));
+        let base = receptor * 4;
+        let mut gain = self.coefficients[[base, 0]];
+        let mut angle_power = 1.0_f32;
+        for coeff_index in 1..4 {
+            angle_power *= za_degrees;
+            gain += self.coefficients[[base + coeff_index, 0]] * angle_power;
+        }
+        let flagged = (0..4).any(|coeff_index| self.flags[[base + coeff_index, 0]]);
+        Ok(GainSample {
+            value: Complex32::new(gain, 0.0),
+            flagged,
+        })
+    }
+}
+
+impl OpacityGrid {
+    fn from_arrays(
+        path: &Path,
+        tau: &ArrayValue,
+        flags: &ArrayValue,
+    ) -> Result<Self, ApplyExecutionError> {
+        let values = match tau {
+            ArrayValue::Float32(values) => values.clone(),
+            ArrayValue::Float64(values) => values.mapv(|value| value as f32),
+            other => {
+                return Err(ApplyExecutionError::UnsupportedParameterShape {
+                    path: path.display().to_string(),
+                    shape: other.shape().to_vec(),
+                });
+            }
+        };
+        let ArrayValue::Bool(flags) = flags else {
+            return Err(ApplyExecutionError::UnsupportedParameterShape {
+                path: path.display().to_string(),
+                shape: flags.shape().to_vec(),
+            });
+        };
+        if values.is_empty() {
+            return Err(ApplyExecutionError::UnsupportedParameterShape {
+                path: path.display().to_string(),
+                shape: values.shape().to_vec(),
+            });
+        }
+        Ok(Self {
+            tau: values[[0, 0]],
+            flagged: flags.iter().any(|flag| *flag),
+        })
+    }
+
+    fn sample(
+        &self,
+        field_id: i32,
+        antenna_id: i32,
+        time_seconds: f64,
+        context: &CalibrationSamplingContext<'_>,
+    ) -> Result<GainSample, ApplyExecutionError> {
+        let Some(engine) = context.engine else {
+            return Err(ApplyExecutionError::UnsupportedCalibrationTable {
+                path: context.path.display().to_string(),
+                reason: "TOpac apply requires MeasurementSet geometry".to_string(),
+            });
+        };
+        let (_az, elevation) = engine
+            .azel(
+                time_seconds,
+                usize::try_from(field_id).unwrap_or(usize::MAX),
+                usize::try_from(antenna_id).unwrap_or(usize::MAX),
+            )
+            .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                path: context.path.display().to_string(),
+                source,
+            })?;
+        let zenith_angle = std::f64::consts::FRAC_PI_2 - elevation;
+        let gain = if zenith_angle < std::f64::consts::FRAC_PI_2 {
+            (-f64::from(self.tau) / zenith_angle.cos()).exp().sqrt() as f32
+        } else {
+            1.0
+        };
+        Ok(GainSample {
+            value: Complex32::new(gain, 0.0),
+            flagged: self.flagged,
+        })
+    }
+}
+
 impl LoadedCalibrationTable {
     fn lookup(
         &self,
@@ -2112,6 +2770,24 @@ fn interpolate_time_linear(
                         flags,
                     }))
                 }
+                (
+                    CalibrationGrid::Antpos(_)
+                    | CalibrationGrid::GainCurve(_)
+                    | CalibrationGrid::Opacity(_),
+                    _,
+                )
+                | (
+                    _,
+                    CalibrationGrid::Antpos(_)
+                    | CalibrationGrid::GainCurve(_)
+                    | CalibrationGrid::Opacity(_),
+                ) => Err(ApplyExecutionError::UnsupportedInterpolation {
+                    path: path.display().to_string(),
+                    interp: ApplyInterpolationMode::Linear,
+                    reason:
+                        "VLA prior tables are row-geometry dependent and use nearest table rows"
+                            .to_string(),
+                }),
                 _ => Err(ApplyExecutionError::UnsupportedInterpolation {
                     path: path.display().to_string(),
                     interp: ApplyInterpolationMode::Linear,
@@ -2150,8 +2826,32 @@ fn interpolate_gain_amplitude_phase(
     Complex32::new(amp * phase.cos(), amp * phase.sin())
 }
 
+fn geometry_engine_for_plan(
+    ms: &MeasurementSet,
+    plan: &ApplyPlan,
+) -> Result<Option<Arc<MsCalEngine>>, ApplyExecutionError> {
+    let needs_geometry = plan.calibration_tables.iter().any(|table| {
+        matches!(
+            table.summary.table_subtype.as_str(),
+            "KAntPos Jones" | "EGainCurve" | "TOpac"
+        )
+    });
+    if !needs_geometry {
+        return Ok(None);
+    }
+    let ms_path = display_ms_path(ms);
+    MsCalEngine::new(ms)
+        .map(Arc::new)
+        .map(Some)
+        .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+            path: ms_path,
+            source,
+        })
+}
+
 fn load_calibration_table(
     table_plan: &ApplyCalibrationTablePlan,
+    geometry_engine: Option<&Arc<MsCalEngine>>,
 ) -> Result<LoadedCalibrationTable, ApplyExecutionError> {
     if table_plan.summary.table_subtype == "BPOLY" {
         return load_bpoly_calibration_table(table_plan);
@@ -2208,6 +2908,54 @@ fn load_calibration_table(
                     flags,
                 )?)
             }
+            CalibrationParameterFamily::Float
+                if table_plan.summary.table_subtype.as_str() == "KAntPos Jones" =>
+            {
+                let offsets = table
+                    .cell_accessor(row_index, COL_FPARAM)
+                    .and_then(|cell| cell.array())
+                    .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                        path: table_plan.spec.path.display().to_string(),
+                        source: MsError::from(source),
+                    })?;
+                CalibrationGrid::Antpos(AntposGrid::from_arrays(
+                    &table_plan.spec.path,
+                    offsets,
+                    flags,
+                )?)
+            }
+            CalibrationParameterFamily::Float
+                if table_plan.summary.table_subtype.as_str() == "EGainCurve" =>
+            {
+                let coefficients = table
+                    .cell_accessor(row_index, COL_FPARAM)
+                    .and_then(|cell| cell.array())
+                    .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                        path: table_plan.spec.path.display().to_string(),
+                        source: MsError::from(source),
+                    })?;
+                CalibrationGrid::GainCurve(GainCurveGrid::from_arrays(
+                    &table_plan.spec.path,
+                    coefficients,
+                    flags,
+                )?)
+            }
+            CalibrationParameterFamily::Float
+                if table_plan.summary.table_subtype.as_str() == "TOpac" =>
+            {
+                let tau = table
+                    .cell_accessor(row_index, COL_FPARAM)
+                    .and_then(|cell| cell.array())
+                    .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                        path: table_plan.spec.path.display().to_string(),
+                        source: MsError::from(source),
+                    })?;
+                CalibrationGrid::Opacity(OpacityGrid::from_arrays(
+                    &table_plan.spec.path,
+                    tau,
+                    flags,
+                )?)
+            }
             _ => {
                 return Err(ApplyExecutionError::UnsupportedInterpolation {
                     path: table_plan.spec.path.display().to_string(),
@@ -2226,6 +2974,7 @@ fn load_calibration_table(
         path: table_plan.spec.path.clone(),
         interp: table_plan.interp,
         supports_calwt,
+        engine: geometry_engine.cloned(),
         solutions,
     })
 }
@@ -2294,6 +3043,7 @@ fn load_bpoly_calibration_table(
         path: table_plan.spec.path.clone(),
         interp: table_plan.interp,
         supports_calwt: false,
+        engine: None,
         solutions,
     })
 }
@@ -2573,7 +3323,10 @@ fn cal_spw_reference_frequency_hz(cal_spw: &crate::plan::SpectralWindowPlan) -> 
         .unwrap_or(cal_spw.ref_frequency_hz)
 }
 
-fn ensure_corrected_data_column(ms: &mut MeasurementSet) -> Result<bool, TableError> {
+fn ensure_corrected_data_column(
+    ms: &mut MeasurementSet,
+    _rows_overwritten_by_apply: Option<&BTreeSet<usize>>,
+) -> Result<bool, TableError> {
     if ms
         .main_table()
         .schema()
@@ -2590,22 +3343,8 @@ fn ensure_corrected_data_column(ms: &mut MeasurementSet) -> Result<bool, TableEr
         .column(VisibilityDataColumn::CorrectedData.name())
         .expect("corrected data column present")
         .clone();
-    let empty = Value::Array(ArrayValue::Complex32(
-        ArrayD::from_shape_vec(IxDyn(&[0, 0]).f(), Vec::<Complex32>::new()).unwrap(),
-    ));
-    ms.main_table_mut().add_column(column, Some(empty))?;
+    ms.main_table_mut().add_column(column, None)?;
 
-    let row_count = ms.row_count();
-    for row_index in 0..row_count {
-        let data = ms
-            .main_table()
-            .cell_accessor(row_index, VisibilityDataColumn::Data.name())?
-            .array()?
-            .clone();
-        ms.main_table_mut()
-            .cell_accessor_mut(row_index, VisibilityDataColumn::CorrectedData.name())?
-            .set(Value::Array(data))?;
-    }
     Ok(true)
 }
 
@@ -3102,7 +3841,7 @@ mod tests {
                 assert!(grid.flags[[0, 0]]);
                 assert!(!grid.flags[[0, 1]]);
             }
-            CalibrationGrid::Delay(_) => panic!("expected complex interpolation"),
+            _ => panic!("expected complex interpolation"),
         }
 
         let wrapped = interpolate_gain_amplitude_phase(
@@ -3141,7 +3880,7 @@ mod tests {
                 assert!(grid.flags[[0, 0]]);
                 assert!(grid.flags[[0, 1]]);
             }
-            CalibrationGrid::Complex(_) => panic!("expected delay interpolation"),
+            _ => panic!("expected delay interpolation"),
         }
 
         match interpolate_time_linear(
@@ -3166,7 +3905,7 @@ mod tests {
             CalibrationGrid::Complex(grid) => {
                 assert_eq!(grid.values[[0, 0]], Complex32::new(1.0, 0.0))
             }
-            CalibrationGrid::Delay(_) => panic!("expected complex interpolation"),
+            _ => panic!("expected complex interpolation"),
         }
         match interpolate_time_linear(path, &[], 0.0) {
             Ok(_) => panic!("expected empty interpolation to fail"),
@@ -3387,7 +4126,7 @@ mod tests {
                 assert!((grid.values[[0, 1]].norm() - 2.0).abs() < 1.0e-5);
                 assert_ne!(grid.values[[0, 1]], Complex32::new(1.0, 0.0));
             }
-            CalibrationGrid::Delay(_) => panic!("expected complex BPOLY output"),
+            _ => panic!("expected complex BPOLY output"),
         }
 
         let bad_phase_units = scalar_table(vec![
@@ -3463,21 +4202,22 @@ mod tests {
             .add_row(RecordValue::new(fields))
             .unwrap();
 
-        assert!(ensure_corrected_data_column(&mut ms).unwrap());
-        let corrected = ms
-            .main_table()
-            .cell_accessor(0, VisibilityDataColumn::CorrectedData.name())
-            .and_then(|cell| cell.array())
-            .unwrap()
-            .clone();
-        assert_eq!(
-            corrected,
-            *ms.main_table()
-                .cell_accessor(0, VisibilityDataColumn::Data.name())
-                .and_then(|cell| cell.array())
+        assert!(ensure_corrected_data_column(&mut ms, None).unwrap());
+        assert!(
+            ms.main_table()
+                .schema()
                 .unwrap()
+                .contains_column(VisibilityDataColumn::CorrectedData.name())
         );
-        assert!(!ensure_corrected_data_column(&mut ms).unwrap());
+        assert!(
+            ms.main_table()
+                .row_accessor()
+                .row(0)
+                .unwrap()
+                .get(VisibilityDataColumn::CorrectedData.name())
+                .is_none()
+        );
+        assert!(!ensure_corrected_data_column(&mut ms, None).unwrap());
         assert_eq!(display_ms_path(&ms), "<in-memory>");
     }
 }

--- a/crates/casa-calibration/src/execute.rs
+++ b/crates/casa-calibration/src/execute.rs
@@ -1283,6 +1283,8 @@ struct ApplyRowComputeProfile {
     setup_ns: u64,
     table_lookup_ns: u64,
     row_dependent_grid_ns: u64,
+    row_dependent_fast_pairs: usize,
+    row_dependent_materialized_pairs: usize,
     fast_gain_apply_ns: u64,
     generic_sample_apply_ns: u64,
     parallactic_angle_ns: u64,
@@ -1298,12 +1300,14 @@ impl ApplyRowComputeProfile {
 
     fn detail_string(&self) -> String {
         format!(
-            "rows={} table_apps={} setup={:.3}s lookup={:.3}s row_dependent_grid={:.3}s fast_gain={:.3}s generic_sample={:.3}s parang={:.3}s weight_finalize={:.3}s",
+            "rows={} table_apps={} setup={:.3}s lookup={:.3}s row_dependent_grid={:.3}s row_dependent_fast_pairs={} row_dependent_materialized_pairs={} fast_gain={:.3}s generic_sample={:.3}s parang={:.3}s weight_finalize={:.3}s",
             self.rows,
             self.table_applications,
             self.setup_ns as f64 / 1_000_000_000.0,
             self.table_lookup_ns as f64 / 1_000_000_000.0,
             self.row_dependent_grid_ns as f64 / 1_000_000_000.0,
+            self.row_dependent_fast_pairs,
+            self.row_dependent_materialized_pairs,
             self.fast_gain_apply_ns as f64 / 1_000_000_000.0,
             self.generic_sample_apply_ns as f64 / 1_000_000_000.0,
             self.parallactic_angle_ns as f64 / 1_000_000_000.0,
@@ -1318,6 +1322,14 @@ struct RowGeometryCache {
     projected_offsets: HashMap<ProjectedOffsetKey, [f64; 3]>,
     materialized_grids: HashMap<MaterializedGridKey, Arc<CalibrationGrid>>,
     calibration_lookups: HashMap<CalibrationLookupKey, Option<Arc<CalibrationGrid>>>,
+    last_elevation_context: Option<RowGeometryContextKey>,
+    last_elevations: Vec<Option<f64>>,
+    last_projected_context: Option<RowGeometryContextKey>,
+    last_projected_offsets: Vec<Option<LastProjectedOffset>>,
+    last_fast_term_context: Option<RowGeometryContextKey>,
+    last_fast_antpos_delays: Vec<Vec<Option<FastAntposDelay>>>,
+    last_fast_gain_curves: Vec<Vec<Option<FastReceptorGains>>>,
+    last_fast_opacities: Vec<Vec<Option<f32>>>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -1325,6 +1337,24 @@ struct RowGeometryKey {
     time_bits: u64,
     field_id: i32,
     antenna_id: i32,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct RowGeometryContextKey {
+    time_bits: u64,
+    field_id: i32,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct LastProjectedOffset {
+    offset_bits: [u64; 3],
+    uvw: [f64; 3],
+}
+
+#[derive(Clone, Copy, Debug)]
+struct FastAntposDelay {
+    offset_bits: [u64; 3],
+    delay_ns: f64,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -1360,7 +1390,21 @@ impl RowGeometryCache {
         antenna_id: i32,
     ) -> MsResult<f64> {
         let key = RowGeometryKey::new(time_seconds, field_id, antenna_id);
-        if let Some(elevation) = self.elevations.get(&key) {
+        let context = RowGeometryContextKey::new(time_seconds, field_id);
+        if let Ok(antenna_index) = usize::try_from(antenna_id) {
+            if self.last_elevation_context == Some(context) {
+                if let Some(Some(elevation)) = self.last_elevations.get(antenna_index) {
+                    return Ok(*elevation);
+                }
+            } else {
+                self.last_elevation_context = Some(context);
+                self.last_elevations.clear();
+            }
+            if let Some(elevation) = self.elevations.get(&key).copied() {
+                self.remember_last_elevation(antenna_index, elevation);
+                return Ok(elevation);
+            }
+        } else if let Some(elevation) = self.elevations.get(&key) {
             return Ok(*elevation);
         }
         let (_az, elevation) = engine.azel(
@@ -1369,6 +1413,9 @@ impl RowGeometryCache {
             usize::try_from(antenna_id).unwrap_or(usize::MAX),
         )?;
         self.elevations.insert(key, elevation);
+        if let Ok(antenna_index) = usize::try_from(antenna_id) {
+            self.remember_last_elevation(antenna_index, elevation);
+        }
         Ok(elevation)
     }
 
@@ -1380,15 +1427,32 @@ impl RowGeometryCache {
         antenna_id: i32,
         offset_m: [f64; 3],
     ) -> MsResult<[f64; 3]> {
+        let offset_bits = [
+            offset_m[0].to_bits(),
+            offset_m[1].to_bits(),
+            offset_m[2].to_bits(),
+        ];
         let key = ProjectedOffsetKey {
             row: RowGeometryKey::new(time_seconds, field_id, antenna_id),
-            offset_bits: [
-                offset_m[0].to_bits(),
-                offset_m[1].to_bits(),
-                offset_m[2].to_bits(),
-            ],
+            offset_bits,
         };
-        if let Some(uvw) = self.projected_offsets.get(&key) {
+        let context = RowGeometryContextKey::new(time_seconds, field_id);
+        if let Ok(antenna_index) = usize::try_from(antenna_id) {
+            if self.last_projected_context == Some(context) {
+                if let Some(Some(projected)) = self.last_projected_offsets.get(antenna_index)
+                    && projected.offset_bits == offset_bits
+                {
+                    return Ok(projected.uvw);
+                }
+            } else {
+                self.last_projected_context = Some(context);
+                self.last_projected_offsets.clear();
+            }
+            if let Some(uvw) = self.projected_offsets.get(&key).copied() {
+                self.remember_last_projected_offset(antenna_index, offset_bits, uvw);
+                return Ok(uvw);
+            }
+        } else if let Some(uvw) = self.projected_offsets.get(&key) {
             return Ok(*uvw);
         }
         let uvw = engine.project_itrf_offset_to_uvw(
@@ -1398,7 +1462,103 @@ impl RowGeometryCache {
             offset_m,
         )?;
         self.projected_offsets.insert(key, uvw);
+        if let Ok(antenna_index) = usize::try_from(antenna_id) {
+            self.remember_last_projected_offset(antenna_index, offset_bits, uvw);
+        }
         Ok(uvw)
+    }
+
+    fn remember_last_elevation(&mut self, antenna_index: usize, elevation: f64) {
+        if self.last_elevations.len() <= antenna_index {
+            self.last_elevations.resize(antenna_index + 1, None);
+        }
+        self.last_elevations[antenna_index] = Some(elevation);
+    }
+
+    fn remember_last_projected_offset(
+        &mut self,
+        antenna_index: usize,
+        offset_bits: [u64; 3],
+        uvw: [f64; 3],
+    ) {
+        if self.last_projected_offsets.len() <= antenna_index {
+            self.last_projected_offsets.resize(antenna_index + 1, None);
+        }
+        self.last_projected_offsets[antenna_index] = Some(LastProjectedOffset { offset_bits, uvw });
+    }
+
+    fn ensure_fast_term_context(&mut self, time_seconds: f64, field_id: i32) {
+        let context = RowGeometryContextKey::new(time_seconds, field_id);
+        if self.last_fast_term_context != Some(context) {
+            self.last_fast_term_context = Some(context);
+            self.last_fast_antpos_delays.clear();
+            self.last_fast_gain_curves.clear();
+            self.last_fast_opacities.clear();
+        }
+    }
+
+    fn cached_fast_antpos_delay(
+        &mut self,
+        table_index: usize,
+        antenna_index: usize,
+        offset_bits: [u64; 3],
+    ) -> Option<f64> {
+        self.last_fast_antpos_delays
+            .get(table_index)
+            .and_then(|values| values.get(antenna_index))
+            .and_then(|value| *value)
+            .and_then(|value| (value.offset_bits == offset_bits).then_some(value.delay_ns))
+    }
+
+    fn remember_fast_antpos_delay(
+        &mut self,
+        table_index: usize,
+        antenna_index: usize,
+        offset_bits: [u64; 3],
+        delay_ns: f64,
+    ) {
+        let values = resize_nested_vec(
+            &mut self.last_fast_antpos_delays,
+            table_index,
+            antenna_index,
+        );
+        values[antenna_index] = Some(FastAntposDelay {
+            offset_bits,
+            delay_ns,
+        });
+    }
+
+    fn cached_fast_gain_curve(
+        &mut self,
+        table_index: usize,
+        antenna_index: usize,
+    ) -> Option<FastReceptorGains> {
+        self.last_fast_gain_curves
+            .get(table_index)
+            .and_then(|values| values.get(antenna_index))
+            .and_then(|value| *value)
+    }
+
+    fn remember_fast_gain_curve(
+        &mut self,
+        table_index: usize,
+        antenna_index: usize,
+        gains: FastReceptorGains,
+    ) {
+        let values = resize_nested_vec(&mut self.last_fast_gain_curves, table_index, antenna_index);
+        values[antenna_index] = Some(gains);
+    }
+
+    fn cached_fast_opacity(&mut self, table_index: usize, antenna_index: usize) -> Option<f32> {
+        self.last_fast_opacities
+            .get(table_index)
+            .and_then(|values| values.get(antenna_index))
+            .and_then(|value| *value)
+    }
+
+    fn remember_fast_opacity(&mut self, table_index: usize, antenna_index: usize, gain: f32) {
+        let values = resize_nested_vec(&mut self.last_fast_opacities, table_index, antenna_index);
+        values[antenna_index] = Some(gain);
     }
 
     fn materialized_grid(&self, key: MaterializedGridKey) -> Option<Arc<CalibrationGrid>> {
@@ -1434,6 +1594,30 @@ impl RowGeometryKey {
             antenna_id,
         }
     }
+}
+
+impl RowGeometryContextKey {
+    fn new(time_seconds: f64, field_id: i32) -> Self {
+        Self {
+            time_bits: time_seconds.to_bits(),
+            field_id,
+        }
+    }
+}
+
+fn resize_nested_vec<T: Clone>(
+    values: &mut Vec<Vec<Option<T>>>,
+    table_index: usize,
+    antenna_index: usize,
+) -> &mut Vec<Option<T>> {
+    if values.len() <= table_index {
+        values.resize_with(table_index + 1, Vec::new);
+    }
+    let values = &mut values[table_index];
+    if values.len() <= antenna_index {
+        values.resize(antenna_index + 1, None);
+    }
+    values
 }
 
 fn materialized_grid_key(
@@ -1574,8 +1758,13 @@ fn apply_row(
     let mut weight_spectrum = None;
     let mut implicit_weight_spectrum =
         (any_calwt && !has_weight_spectrum).then(|| ArrayD::from_elem(data.raw_dim(), 1.0_f32));
+    let data_spw = plan
+        .measurement_set_spectral_windows
+        .iter()
+        .find(|spw| spw.spw_id == row.data_spw_id)
+        .expect("planner guarantees selected MS spectral windows");
     let mut geometry_cache = geometry_cache;
-    let mut fast_gain_pairs: Vec<(Arc<CalibrationGrid>, Arc<CalibrationGrid>)> = Vec::new();
+    let mut fast_gain_pairs: Vec<FastGainPair> = Vec::new();
 
     if any_calwt {
         let Some(weight_values) = weight.as_ref() else {
@@ -1618,11 +1807,6 @@ fn apply_row(
             .find(|mapping| mapping.data_spw_id == row.data_spw_id)
             .map(|mapping| mapping.calibration_spw_id)
             .expect("planner guarantees spw mapping for selected rows");
-        let data_spw = plan
-            .measurement_set_spectral_windows
-            .iter()
-            .find(|spw| spw.spw_id == row.data_spw_id)
-            .expect("planner guarantees selected MS spectral windows");
         let cal_spw = table_plan
             .calibration_spectral_windows
             .iter()
@@ -1709,6 +1893,7 @@ fn apply_row(
                         FastGainApply {
                             data_desc_id: row.data_desc_id,
                             correlation_types,
+                            data_frequencies_hz: &data_spw.channel_frequencies_hz,
                             corrected: &mut corrected,
                             flags: &mut flags,
                             apply_mode: plan.apply_mode,
@@ -1735,7 +1920,40 @@ fn apply_row(
             continue;
         };
 
+        let sampling_context = CalibrationSamplingContext {
+            data_frequencies_hz: &data_spw.channel_frequencies_hz,
+            cal_frequencies_hz: &cal_spw.channel_frequencies_hz,
+            cal_ref_frequency_hz: cal_spw_reference_frequency_hz(cal_spw),
+            interp: table_plan.interp,
+            path: &loaded_table.path,
+            engine: loaded_table.engine.as_deref(),
+        };
+
         let materialize_started_at = compute_profile.as_ref().map(|_| Instant::now());
+        if !(table_plan.calwt && loaded_table.supports_calwt)
+            && let Some(pair) = build_fast_gain_pair(
+                table_index,
+                &ant1,
+                &ant2,
+                row.field_id,
+                row.antenna1,
+                row.antenna2,
+                row.time_seconds,
+                loaded_table.engine.as_deref(),
+                &loaded_table.path,
+                reborrow_geometry_cache(&mut geometry_cache),
+            )?
+        {
+            if let Some(profile) = compute_profile.as_deref_mut() {
+                ApplyRowComputeProfile::add_elapsed(
+                    &mut profile.row_dependent_grid_ns,
+                    materialize_started_at,
+                );
+                profile.row_dependent_fast_pairs += 1;
+            }
+            fast_gain_pairs.push(pair);
+            continue;
+        }
         let ant1 = materialize_row_dependent_grid(
             ant1,
             row.field_id,
@@ -1761,16 +1979,8 @@ fn apply_row(
                 &mut profile.row_dependent_grid_ns,
                 materialize_started_at,
             );
+            profile.row_dependent_materialized_pairs += 1;
         }
-
-        let sampling_context = CalibrationSamplingContext {
-            data_frequencies_hz: &data_spw.channel_frequencies_hz,
-            cal_frequencies_hz: &cal_spw.channel_frequencies_hz,
-            cal_ref_frequency_hz: cal_spw_reference_frequency_hz(cal_spw),
-            interp: table_plan.interp,
-            path: &loaded_table.path,
-            engine: loaded_table.engine.as_deref(),
-        };
 
         if !(table_plan.calwt && loaded_table.supports_calwt)
             && matches!(
@@ -1778,7 +1988,7 @@ fn apply_row(
                 (CalibrationGrid::Complex(_), CalibrationGrid::Complex(_))
             )
         {
-            fast_gain_pairs.push((ant1, ant2));
+            fast_gain_pairs.push(FastGainPair::Complex(ant1, ant2));
             continue;
         }
 
@@ -1789,6 +1999,7 @@ fn apply_row(
                 FastGainApply {
                     data_desc_id: row.data_desc_id,
                     correlation_types,
+                    data_frequencies_hz: &data_spw.channel_frequencies_hz,
                     corrected: &mut corrected,
                     flags: &mut flags,
                     apply_mode: plan.apply_mode,
@@ -1875,6 +2086,7 @@ fn apply_row(
             FastGainApply {
                 data_desc_id: row.data_desc_id,
                 correlation_types,
+                data_frequencies_hz: &data_spw.channel_frequencies_hz,
                 corrected: &mut corrected,
                 flags: &mut flags,
                 apply_mode: plan.apply_mode,
@@ -1967,22 +2179,159 @@ fn apply_row(
     })
 }
 
+const FAST_GAIN_RECEPTOR_LIMIT: usize = 4;
+
 struct FastGainApply<'a> {
     data_desc_id: i32,
     correlation_types: &'a [i32],
+    data_frequencies_hz: &'a [f64],
     corrected: &'a mut ArrayD<Complex32>,
     flags: &'a mut ArrayD<bool>,
     apply_mode: ApplyMode,
     newly_flagged_samples: &'a mut usize,
 }
 
+enum FastGainPair {
+    Complex(Arc<CalibrationGrid>, Arc<CalibrationGrid>),
+    Antpos {
+        delay_delta_ns: f64,
+        flagged: bool,
+    },
+    GainCurve {
+        ant1: FastReceptorGains,
+        ant2: FastReceptorGains,
+    },
+    Opacity {
+        denom: Complex32,
+        flagged: bool,
+    },
+}
+
+#[derive(Clone, Copy)]
+struct FastReceptorGains {
+    receptor_count: usize,
+    values: [f32; FAST_GAIN_RECEPTOR_LIMIT],
+    flags: [bool; FAST_GAIN_RECEPTOR_LIMIT],
+}
+
+#[derive(Clone, Copy)]
+struct FastGainSample {
+    denom: Complex32,
+    flagged: bool,
+}
+
+impl FastReceptorGains {
+    fn sample(self, receptor: usize) -> (f32, bool) {
+        let receptor = receptor.min(self.receptor_count.saturating_sub(1));
+        (self.values[receptor], self.flags[receptor])
+    }
+}
+
+impl FastGainPair {
+    fn requires_data_frequencies(&self) -> bool {
+        matches!(self, Self::Antpos { .. })
+    }
+
+    fn scalar_sample(&self, receptors: (usize, usize)) -> Option<FastGainSample> {
+        match self {
+            Self::Complex(ant1, ant2) => {
+                let (CalibrationGrid::Complex(ant1), CalibrationGrid::Complex(ant2)) =
+                    (ant1.as_ref(), ant2.as_ref())
+                else {
+                    return None;
+                };
+                if ant1.channel_count > 1 || ant2.channel_count > 1 {
+                    return None;
+                }
+                let receptor1 = receptors.0.min(ant1.receptor_count.saturating_sub(1));
+                let receptor2 = receptors.1.min(ant2.receptor_count.saturating_sub(1));
+                let gain1 = ant1.value_at(receptor1, 0);
+                let gain2 = ant2.value_at(receptor2, 0);
+                Some(FastGainSample {
+                    denom: gain1 * gain2.conj(),
+                    flagged: ant1.flag_at(receptor1, 0) || ant2.flag_at(receptor2, 0),
+                })
+            }
+            Self::GainCurve { ant1, ant2 } => {
+                let (gain1, flag1) = ant1.sample(receptors.0);
+                let (gain2, flag2) = ant2.sample(receptors.1);
+                Some(FastGainSample {
+                    denom: Complex32::new(gain1 * gain2, 0.0),
+                    flagged: flag1 || flag2,
+                })
+            }
+            Self::Opacity { denom, flagged } => Some(FastGainSample {
+                denom: *denom,
+                flagged: *flagged,
+            }),
+            Self::Antpos { .. } => None,
+        }
+    }
+
+    fn channel_sample(
+        &self,
+        receptors: (usize, usize),
+        chan_index: usize,
+        data_frequencies_hz: &[f64],
+    ) -> Option<FastGainSample> {
+        match self {
+            Self::Complex(ant1, ant2) => {
+                let (CalibrationGrid::Complex(ant1), CalibrationGrid::Complex(ant2)) =
+                    (ant1.as_ref(), ant2.as_ref())
+                else {
+                    return None;
+                };
+                if ant1.channel_count <= 1 && ant2.channel_count <= 1 {
+                    return None;
+                }
+                let receptor1 = receptors.0.min(ant1.receptor_count.saturating_sub(1));
+                let receptor2 = receptors.1.min(ant2.receptor_count.saturating_sub(1));
+                let ant1_chan = if ant1.channel_count <= 1 {
+                    0
+                } else {
+                    chan_index.min(ant1.channel_count.saturating_sub(1))
+                };
+                let ant2_chan = if ant2.channel_count <= 1 {
+                    0
+                } else {
+                    chan_index.min(ant2.channel_count.saturating_sub(1))
+                };
+                let gain1 = ant1.value_at(receptor1, ant1_chan);
+                let gain2 = ant2.value_at(receptor2, ant2_chan);
+                Some(FastGainSample {
+                    denom: gain1 * gain2.conj(),
+                    flagged: ant1.flag_at(receptor1, ant1_chan)
+                        || ant2.flag_at(receptor2, ant2_chan),
+                })
+            }
+            Self::Antpos {
+                delay_delta_ns,
+                flagged,
+            } => {
+                let frequency_hz = data_frequencies_hz[chan_index];
+                let phase_rad =
+                    2.0 * std::f64::consts::PI * *delay_delta_ns * (frequency_hz / 1.0e9);
+                Some(FastGainSample {
+                    denom: Complex32::new(phase_rad.cos() as f32, phase_rad.sin() as f32),
+                    flagged: *flagged,
+                })
+            }
+            Self::GainCurve { .. } | Self::Opacity { .. } => None,
+        }
+    }
+}
+
 fn apply_complex_gain_pairs_fast(
-    pairs: &[(Arc<CalibrationGrid>, Arc<CalibrationGrid>)],
+    pairs: &[FastGainPair],
     ctx: FastGainApply<'_>,
 ) -> Result<(), ApplyExecutionError> {
+    if pairs.is_empty() {
+        return Ok(());
+    }
     let shape = ctx.corrected.shape();
     let corr_count = shape[0];
     let channel_count = shape[1];
+    ensure_fast_pair_frequency_coverage(pairs, ctx.data_frequencies_hz, channel_count)?;
     let corrected_is_fortran = ctx.corrected.ndim() == 2 && ctx.corrected.strides()[0] == 1;
     let flags_are_fortran = ctx.apply_mode != ApplyMode::CalFlag
         || (ctx.flags.ndim() == 2 && ctx.flags.strides()[0] == 1);
@@ -1997,6 +2346,7 @@ fn apply_complex_gain_pairs_fast(
             pairs,
             ctx.data_desc_id,
             ctx.correlation_types,
+            ctx.data_frequencies_hz,
             corr_count,
             channel_count,
             corrected,
@@ -2005,72 +2355,38 @@ fn apply_complex_gain_pairs_fast(
         );
     }
 
-    let receptors_by_corr = (0..corr_count)
-        .map(|corr_index| {
-            correlation_receptors(ctx.correlation_types[corr_index]).ok_or_else(|| {
-                ApplyExecutionError::UnsupportedCorrelationLayout {
-                    data_desc_id: ctx.data_desc_id,
-                    correlation_types: ctx
-                        .correlation_types
-                        .iter()
-                        .map(|code| stokes_name(*code).to_string())
-                        .collect(),
-                }
-            })
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    let receptors_by_corr =
+        fast_pair_receptors(ctx.data_desc_id, ctx.correlation_types, corr_count)?;
 
     for (corr_index, &receptors) in receptors_by_corr.iter().enumerate().take(corr_count) {
         let mut scalar_denom = Complex32::new(1.0, 0.0);
+        for pair in pairs {
+            let Some(sample) = pair.scalar_sample(receptors) else {
+                continue;
+            };
+            if fast_gain_sample_invalid(sample) {
+                if ctx.apply_mode == ApplyMode::CalFlag {
+                    flag_all_channels_generic(
+                        ctx.flags,
+                        corr_index,
+                        channel_count,
+                        ctx.newly_flagged_samples,
+                    );
+                }
+            } else {
+                scalar_denom *= sample.denom;
+            }
+        }
+
         for chan_index in 0..channel_count {
-            for (ant1, ant2) in pairs {
-                let (CalibrationGrid::Complex(ant1), CalibrationGrid::Complex(ant2)) =
-                    (ant1.as_ref(), ant2.as_ref())
+            let mut denom = scalar_denom;
+            for pair in pairs {
+                let Some(sample) =
+                    pair.channel_sample(receptors, chan_index, ctx.data_frequencies_hz)
                 else {
                     continue;
                 };
-                let receptor1 = receptors.0.min(ant1.receptor_count.saturating_sub(1));
-                let receptor2 = receptors.1.min(ant2.receptor_count.saturating_sub(1));
-                if ant1.channel_count <= 1 && ant2.channel_count <= 1 {
-                    if chan_index == 0 {
-                        let gain1 = ant1.value_at(receptor1, 0);
-                        let gain2 = ant2.value_at(receptor2, 0);
-                        let invalid = ant1.flag_at(receptor1, 0)
-                            || ant2.flag_at(receptor2, 0)
-                            || gain1 == Complex32::new(0.0, 0.0)
-                            || gain2 == Complex32::new(0.0, 0.0);
-                        if invalid {
-                            if ctx.apply_mode == ApplyMode::CalFlag {
-                                for flag_chan_index in 0..channel_count {
-                                    if !ctx.flags[[corr_index, flag_chan_index]] {
-                                        ctx.flags[[corr_index, flag_chan_index]] = true;
-                                        *ctx.newly_flagged_samples += 1;
-                                    }
-                                }
-                            }
-                        } else {
-                            scalar_denom *= gain1 * gain2.conj();
-                        }
-                    }
-                    continue;
-                }
-                let ant1_chan = if ant1.channel_count <= 1 {
-                    0
-                } else {
-                    chan_index.min(ant1.channel_count.saturating_sub(1))
-                };
-                let ant2_chan = if ant2.channel_count <= 1 {
-                    0
-                } else {
-                    chan_index.min(ant2.channel_count.saturating_sub(1))
-                };
-                let gain1 = ant1.value_at(receptor1, ant1_chan);
-                let gain2 = ant2.value_at(receptor2, ant2_chan);
-                if ant1.flag_at(receptor1, ant1_chan)
-                    || ant2.flag_at(receptor2, ant2_chan)
-                    || gain1 == Complex32::new(0.0, 0.0)
-                    || gain2 == Complex32::new(0.0, 0.0)
-                {
+                if fast_gain_sample_invalid(sample) {
                     if ctx.apply_mode == ApplyMode::CalFlag && !ctx.flags[[corr_index, chan_index]]
                     {
                         ctx.flags[[corr_index, chan_index]] = true;
@@ -2078,9 +2394,9 @@ fn apply_complex_gain_pairs_fast(
                     }
                     continue;
                 }
-                ctx.corrected[[corr_index, chan_index]] /= gain1 * gain2.conj();
+                denom *= sample.denom;
             }
-            ctx.corrected[[corr_index, chan_index]] /= scalar_denom;
+            ctx.corrected[[corr_index, chan_index]] /= denom;
         }
     }
 
@@ -2089,16 +2405,71 @@ fn apply_complex_gain_pairs_fast(
 
 #[allow(clippy::too_many_arguments)]
 fn apply_complex_gain_pairs_fast_fortran(
-    pairs: &[(Arc<CalibrationGrid>, Arc<CalibrationGrid>)],
+    pairs: &[FastGainPair],
     data_desc_id: i32,
     correlation_types: &[i32],
+    data_frequencies_hz: &[f64],
     corr_count: usize,
     channel_count: usize,
     corrected: &mut [Complex32],
     mut flags: Option<&mut [bool]>,
     newly_flagged_samples: &mut usize,
 ) -> Result<(), ApplyExecutionError> {
-    let receptors_by_corr = (0..corr_count)
+    let receptors_by_corr = fast_pair_receptors(data_desc_id, correlation_types, corr_count)?;
+
+    for (corr_index, &receptors) in receptors_by_corr.iter().enumerate().take(corr_count) {
+        let mut scalar_denom = Complex32::new(1.0, 0.0);
+        for pair in pairs {
+            let Some(sample) = pair.scalar_sample(receptors) else {
+                continue;
+            };
+            if fast_gain_sample_invalid(sample) {
+                if let Some(flags) = flags.as_deref_mut() {
+                    flag_all_channels_fortran(
+                        flags,
+                        corr_index,
+                        corr_count,
+                        channel_count,
+                        newly_flagged_samples,
+                    );
+                }
+            } else {
+                scalar_denom *= sample.denom;
+            }
+        }
+
+        for chan_index in 0..channel_count {
+            let offset = corr_index + chan_index * corr_count;
+            let mut denom = scalar_denom;
+            for pair in pairs {
+                let Some(sample) = pair.channel_sample(receptors, chan_index, data_frequencies_hz)
+                else {
+                    continue;
+                };
+                if fast_gain_sample_invalid(sample) {
+                    if let Some(flags) = flags.as_deref_mut()
+                        && !flags[offset]
+                    {
+                        flags[offset] = true;
+                        *newly_flagged_samples += 1;
+                    }
+                    continue;
+                }
+                denom *= sample.denom;
+            }
+            corrected[offset] /= denom;
+        }
+    }
+
+    Ok(())
+}
+
+fn fast_pair_receptors(
+    data_desc_id: i32,
+    correlation_types: &[i32],
+    corr_count: usize,
+) -> Result<Vec<(usize, usize)>, ApplyExecutionError> {
+    (0..corr_count)
         .map(|corr_index| {
             correlation_receptors(correlation_types[corr_index]).ok_or_else(|| {
                 ApplyExecutionError::UnsupportedCorrelationLayout {
@@ -2110,76 +2481,350 @@ fn apply_complex_gain_pairs_fast_fortran(
                 }
             })
         })
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect::<Result<Vec<_>, _>>()
+}
 
-    for (corr_index, &receptors) in receptors_by_corr.iter().enumerate().take(corr_count) {
-        let mut scalar_denom = Complex32::new(1.0, 0.0);
-        for chan_index in 0..channel_count {
-            let offset = corr_index + chan_index * corr_count;
-            for (ant1, ant2) in pairs {
-                let (CalibrationGrid::Complex(ant1), CalibrationGrid::Complex(ant2)) =
-                    (ant1.as_ref(), ant2.as_ref())
-                else {
-                    continue;
-                };
-                let receptor1 = receptors.0.min(ant1.receptor_count.saturating_sub(1));
-                let receptor2 = receptors.1.min(ant2.receptor_count.saturating_sub(1));
-                if ant1.channel_count <= 1 && ant2.channel_count <= 1 {
-                    if chan_index == 0 {
-                        let gain1 = ant1.value_at(receptor1, 0);
-                        let gain2 = ant2.value_at(receptor2, 0);
-                        let invalid = ant1.flag_at(receptor1, 0)
-                            || ant2.flag_at(receptor2, 0)
-                            || gain1 == Complex32::new(0.0, 0.0)
-                            || gain2 == Complex32::new(0.0, 0.0);
-                        if invalid {
-                            if let Some(flags) = flags.as_deref_mut() {
-                                for flag_chan_index in 0..channel_count {
-                                    let flag_offset = corr_index + flag_chan_index * corr_count;
-                                    if !flags[flag_offset] {
-                                        flags[flag_offset] = true;
-                                        *newly_flagged_samples += 1;
-                                    }
-                                }
-                            }
-                        } else {
-                            scalar_denom *= gain1 * gain2.conj();
-                        }
-                    }
-                    continue;
-                }
-                let ant1_chan = if ant1.channel_count <= 1 {
-                    0
-                } else {
-                    chan_index.min(ant1.channel_count.saturating_sub(1))
-                };
-                let ant2_chan = if ant2.channel_count <= 1 {
-                    0
-                } else {
-                    chan_index.min(ant2.channel_count.saturating_sub(1))
-                };
-                let gain1 = ant1.value_at(receptor1, ant1_chan);
-                let gain2 = ant2.value_at(receptor2, ant2_chan);
-                if ant1.flag_at(receptor1, ant1_chan)
-                    || ant2.flag_at(receptor2, ant2_chan)
-                    || gain1 == Complex32::new(0.0, 0.0)
-                    || gain2 == Complex32::new(0.0, 0.0)
-                {
-                    if let Some(flags) = flags.as_deref_mut()
-                        && !flags[offset]
-                    {
-                        flags[offset] = true;
-                        *newly_flagged_samples += 1;
-                    }
-                    continue;
-                }
-                corrected[offset] /= gain1 * gain2.conj();
-            }
-            corrected[offset] /= scalar_denom;
+fn ensure_fast_pair_frequency_coverage(
+    pairs: &[FastGainPair],
+    data_frequencies_hz: &[f64],
+    channel_count: usize,
+) -> Result<(), ApplyExecutionError> {
+    if pairs.iter().any(FastGainPair::requires_data_frequencies)
+        && data_frequencies_hz.len() < channel_count
+    {
+        return Err(ApplyExecutionError::UnsupportedInterpolation {
+            path: "<measurement-set SPECTRAL_WINDOW>".to_string(),
+            interp: ApplyInterpolationMode::Nearest,
+            reason: "data channel index is outside the MeasurementSet SPW grid".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn fast_gain_sample_invalid(sample: FastGainSample) -> bool {
+    sample.flagged || sample.denom == Complex32::new(0.0, 0.0)
+}
+
+fn flag_all_channels_generic(
+    flags: &mut ArrayD<bool>,
+    corr_index: usize,
+    channel_count: usize,
+    newly_flagged_samples: &mut usize,
+) {
+    for flag_chan_index in 0..channel_count {
+        if !flags[[corr_index, flag_chan_index]] {
+            flags[[corr_index, flag_chan_index]] = true;
+            *newly_flagged_samples += 1;
         }
     }
+}
 
-    Ok(())
+fn flag_all_channels_fortran(
+    flags: &mut [bool],
+    corr_index: usize,
+    corr_count: usize,
+    channel_count: usize,
+    newly_flagged_samples: &mut usize,
+) {
+    for flag_chan_index in 0..channel_count {
+        let flag_offset = corr_index + flag_chan_index * corr_count;
+        if !flags[flag_offset] {
+            flags[flag_offset] = true;
+            *newly_flagged_samples += 1;
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_fast_gain_pair(
+    table_index: usize,
+    ant1: &Arc<CalibrationGrid>,
+    ant2: &Arc<CalibrationGrid>,
+    field_id: i32,
+    antenna1_id: i32,
+    antenna2_id: i32,
+    time_seconds: f64,
+    engine: Option<&MsCalEngine>,
+    path: &Path,
+    geometry_cache: Option<&mut RowGeometryCache>,
+) -> Result<Option<FastGainPair>, ApplyExecutionError> {
+    let mut geometry_cache = geometry_cache;
+    match (ant1.as_ref(), ant2.as_ref()) {
+        (CalibrationGrid::Complex(_), CalibrationGrid::Complex(_)) => Ok(Some(
+            FastGainPair::Complex(Arc::clone(ant1), Arc::clone(ant2)),
+        )),
+        (CalibrationGrid::Antpos(ant1), CalibrationGrid::Antpos(ant2)) => {
+            let delay1_ns = fast_antpos_delay_ns(
+                table_index,
+                ant1,
+                engine,
+                field_id,
+                antenna1_id,
+                time_seconds,
+                path,
+                reborrow_geometry_cache(&mut geometry_cache),
+            )?;
+            let delay2_ns = fast_antpos_delay_ns(
+                table_index,
+                ant2,
+                engine,
+                field_id,
+                antenna2_id,
+                time_seconds,
+                path,
+                reborrow_geometry_cache(&mut geometry_cache),
+            )?;
+            Ok(Some(FastGainPair::Antpos {
+                delay_delta_ns: delay1_ns - delay2_ns,
+                flagged: ant1.flagged || ant2.flagged,
+            }))
+        }
+        (CalibrationGrid::GainCurve(ant1), CalibrationGrid::GainCurve(ant2)) => {
+            let Some(ant1) = fast_gain_curve_values(
+                table_index,
+                ant1,
+                engine,
+                field_id,
+                antenna1_id,
+                time_seconds,
+                path,
+                reborrow_geometry_cache(&mut geometry_cache),
+            )?
+            else {
+                return Ok(None);
+            };
+            let Some(ant2) = fast_gain_curve_values(
+                table_index,
+                ant2,
+                engine,
+                field_id,
+                antenna2_id,
+                time_seconds,
+                path,
+                reborrow_geometry_cache(&mut geometry_cache),
+            )?
+            else {
+                return Ok(None);
+            };
+            Ok(Some(FastGainPair::GainCurve { ant1, ant2 }))
+        }
+        (CalibrationGrid::Opacity(ant1), CalibrationGrid::Opacity(ant2)) => {
+            let gain1 = fast_opacity_gain(
+                table_index,
+                ant1,
+                engine,
+                field_id,
+                antenna1_id,
+                time_seconds,
+                path,
+                reborrow_geometry_cache(&mut geometry_cache),
+            )?;
+            let gain2 = fast_opacity_gain(
+                table_index,
+                ant2,
+                engine,
+                field_id,
+                antenna2_id,
+                time_seconds,
+                path,
+                reborrow_geometry_cache(&mut geometry_cache),
+            )?;
+            Ok(Some(FastGainPair::Opacity {
+                denom: Complex32::new(gain1 * gain2, 0.0),
+                flagged: ant1.flagged || ant2.flagged,
+            }))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn reborrow_geometry_cache<'a>(
+    geometry_cache: &'a mut Option<&mut RowGeometryCache>,
+) -> Option<&'a mut RowGeometryCache> {
+    geometry_cache.as_mut().map(|cache| &mut **cache)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn fast_antpos_delay_ns(
+    table_index: usize,
+    grid: &AntposGrid,
+    engine: Option<&MsCalEngine>,
+    field_id: i32,
+    antenna_id: i32,
+    time_seconds: f64,
+    path: &Path,
+    geometry_cache: Option<&mut RowGeometryCache>,
+) -> Result<f64, ApplyExecutionError> {
+    let mut geometry_cache = geometry_cache;
+    let Some(engine) = engine else {
+        return Err(ApplyExecutionError::UnsupportedCalibrationTable {
+            path: path.display().to_string(),
+            reason: "KAntPos Jones apply requires MeasurementSet geometry".to_string(),
+        });
+    };
+    let offset_m = [
+        f64::from(grid.offsets_m[0]),
+        f64::from(grid.offsets_m[1]),
+        f64::from(grid.offsets_m[2]),
+    ];
+    let offset_bits = [
+        offset_m[0].to_bits(),
+        offset_m[1].to_bits(),
+        offset_m[2].to_bits(),
+    ];
+    let antenna_index = usize::try_from(antenna_id).ok();
+    let uvw = if let Some(cache) = reborrow_geometry_cache(&mut geometry_cache) {
+        cache.ensure_fast_term_context(time_seconds, field_id);
+        if let Some(antenna_index) = antenna_index
+            && let Some(delay_ns) =
+                cache.cached_fast_antpos_delay(table_index, antenna_index, offset_bits)
+        {
+            return Ok(delay_ns);
+        }
+        cache.project_itrf_offset_to_uvw(engine, time_seconds, field_id, antenna_id, offset_m)
+    } else {
+        engine.project_itrf_offset_to_uvw(
+            time_seconds,
+            usize::try_from(field_id).unwrap_or(usize::MAX),
+            usize::try_from(antenna_id).unwrap_or(usize::MAX),
+            offset_m,
+        )
+    }
+    .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+        path: path.display().to_string(),
+        source,
+    })?;
+    let delay_ns = uvw[2] / SPEED_OF_LIGHT_M_PER_S * 1.0e9;
+    if let (Some(cache), Some(antenna_index)) =
+        (reborrow_geometry_cache(&mut geometry_cache), antenna_index)
+    {
+        cache.remember_fast_antpos_delay(table_index, antenna_index, offset_bits, delay_ns);
+    }
+    Ok(delay_ns)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn fast_gain_curve_values(
+    table_index: usize,
+    grid: &GainCurveGrid,
+    engine: Option<&MsCalEngine>,
+    field_id: i32,
+    antenna_id: i32,
+    time_seconds: f64,
+    path: &Path,
+    geometry_cache: Option<&mut RowGeometryCache>,
+) -> Result<Option<FastReceptorGains>, ApplyExecutionError> {
+    let mut geometry_cache = geometry_cache;
+    if grid.receptor_count > FAST_GAIN_RECEPTOR_LIMIT {
+        return Ok(None);
+    }
+    let antenna_index = usize::try_from(antenna_id).ok();
+    let Some(engine) = engine else {
+        return Err(ApplyExecutionError::UnsupportedCalibrationTable {
+            path: path.display().to_string(),
+            reason: "EGainCurve apply requires MeasurementSet geometry".to_string(),
+        });
+    };
+    let elevation = if let Some(cache) = reborrow_geometry_cache(&mut geometry_cache) {
+        cache.ensure_fast_term_context(time_seconds, field_id);
+        if let Some(antenna_index) = antenna_index
+            && let Some(gains) = cache.cached_fast_gain_curve(table_index, antenna_index)
+        {
+            return Ok(Some(gains));
+        }
+        cache.elevation(engine, time_seconds, field_id, antenna_id)
+    } else {
+        engine
+            .azel(
+                time_seconds,
+                usize::try_from(field_id).unwrap_or(usize::MAX),
+                usize::try_from(antenna_id).unwrap_or(usize::MAX),
+            )
+            .map(|(_az, elevation)| elevation)
+    }
+    .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+        path: path.display().to_string(),
+        source,
+    })?;
+    let za_degrees = (std::f64::consts::FRAC_PI_2 - elevation).to_degrees() as f32;
+    let mut values = [0.0_f32; FAST_GAIN_RECEPTOR_LIMIT];
+    let mut flags = [false; FAST_GAIN_RECEPTOR_LIMIT];
+    for receptor in 0..grid.receptor_count {
+        let base = receptor * 4;
+        let mut gain = grid.coefficients[[base, 0]];
+        let mut angle_power = 1.0_f32;
+        for coeff_index in 1..4 {
+            angle_power *= za_degrees;
+            gain += grid.coefficients[[base + coeff_index, 0]] * angle_power;
+        }
+        values[receptor] = gain;
+        flags[receptor] = (0..4).any(|coeff_index| grid.flags[[base + coeff_index, 0]]);
+    }
+    let gains = FastReceptorGains {
+        receptor_count: grid.receptor_count,
+        values,
+        flags,
+    };
+    if let (Some(cache), Some(antenna_index)) =
+        (reborrow_geometry_cache(&mut geometry_cache), antenna_index)
+    {
+        cache.remember_fast_gain_curve(table_index, antenna_index, gains);
+    }
+    Ok(Some(gains))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn fast_opacity_gain(
+    table_index: usize,
+    grid: &OpacityGrid,
+    engine: Option<&MsCalEngine>,
+    field_id: i32,
+    antenna_id: i32,
+    time_seconds: f64,
+    path: &Path,
+    geometry_cache: Option<&mut RowGeometryCache>,
+) -> Result<f32, ApplyExecutionError> {
+    let mut geometry_cache = geometry_cache;
+    let Some(engine) = engine else {
+        return Err(ApplyExecutionError::UnsupportedCalibrationTable {
+            path: path.display().to_string(),
+            reason: "TOpac apply requires MeasurementSet geometry".to_string(),
+        });
+    };
+    let antenna_index = usize::try_from(antenna_id).ok();
+    let elevation = if let Some(cache) = reborrow_geometry_cache(&mut geometry_cache) {
+        cache.ensure_fast_term_context(time_seconds, field_id);
+        if let Some(antenna_index) = antenna_index
+            && let Some(gain) = cache.cached_fast_opacity(table_index, antenna_index)
+        {
+            return Ok(gain);
+        }
+        cache.elevation(engine, time_seconds, field_id, antenna_id)
+    } else {
+        engine
+            .azel(
+                time_seconds,
+                usize::try_from(field_id).unwrap_or(usize::MAX),
+                usize::try_from(antenna_id).unwrap_or(usize::MAX),
+            )
+            .map(|(_az, elevation)| elevation)
+    }
+    .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+        path: path.display().to_string(),
+        source,
+    })?;
+    let zenith_angle = std::f64::consts::FRAC_PI_2 - elevation;
+    let gain = if zenith_angle < std::f64::consts::FRAC_PI_2 {
+        (-f64::from(grid.tau) / zenith_angle.cos()).exp().sqrt() as f32
+    } else {
+        1.0
+    };
+    if let (Some(cache), Some(antenna_index)) =
+        (reborrow_geometry_cache(&mut geometry_cache), antenna_index)
+    {
+        cache.remember_fast_opacity(table_index, antenna_index, gain);
+    }
+    Ok(gain)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/casa-calibration/src/gencal.rs
+++ b/crates/casa-calibration/src/gencal.rs
@@ -1,0 +1,878 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//! Native generation of externally specified CASA calibration tables.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use casa_ms::ms::MeasurementSet;
+use casa_ms::schema::SubtableId;
+use casa_tables::{ColumnSchema, DataManagerKind, Table, TableInfo, TableOptions, TableSchema};
+use casa_types::{ArrayValue, RecordField, RecordValue, ScalarValue, Value};
+use ndarray::{ArrayD, IxDyn, ShapeBuilder};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::constants::{
+    COL_ANTENNA1, COL_ANTENNA2, COL_FIELD_ID, COL_FLAG, COL_FPARAM, COL_INTERVAL,
+    COL_OBSERVATION_ID, COL_PARAMERR, COL_SCAN_NUMBER, COL_SNR, COL_SPECTRAL_WINDOW_ID, COL_TIME,
+    COL_WEIGHT, KEY_CASA_VERSION, KEY_MS_NAME, KEY_PAR_TYPE, KEY_POL_BASIS, KEY_VIS_CAL,
+    STANDARD_SUBTABLE_KEYWORDS, TABLE_INFO_TYPE,
+};
+use crate::solve::writer::{set_fixed_unit_keyword, set_measinfo_keyword, subtable_keyword_value};
+
+const COL_BFREQ: &str = "BFREQ";
+const COL_EFREQ: &str = "EFREQ";
+const COL_BTIME: &str = "BTIME";
+const COL_ETIME: &str = "ETIME";
+const COL_ANTENNA: &str = "ANTENNA";
+const COL_GAIN: &str = "GAIN";
+const COL_BANDNAME: &str = "BANDNAME";
+const COL_NAME: &str = "NAME";
+const COL_TIME_RANGE: &str = "TIME_RANGE";
+
+/// Supported native `gencal` families for the VLA IRC+10216 prior-cal slice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum GencalType {
+    /// Antenna-position delay correction table (`KAntPos Jones`).
+    Antpos,
+    /// VLA gain-curve plus antenna-efficiency table (`EGainCurve`).
+    Gceff,
+    /// Zenith-opacity table (`TOpac`).
+    Opac,
+}
+
+impl GencalType {
+    fn table_subtype(self) -> &'static str {
+        match self {
+            Self::Antpos => "KAntPos Jones",
+            Self::Gceff => "EGainCurve",
+            Self::Opac => "TOpac",
+        }
+    }
+}
+
+impl std::str::FromStr for GencalType {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.to_ascii_lowercase().as_str() {
+            "antpos" => Ok(Self::Antpos),
+            "gceff" | "gc" => Ok(Self::Gceff),
+            "opac" | "opacity" => Ok(Self::Opac),
+            other => Err(format!(
+                "unsupported gencal caltype {other:?}; expected antpos, gceff, or opac"
+            )),
+        }
+    }
+}
+
+/// Request for writing one native prior-cal table.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct GencalRequest {
+    /// Input MeasurementSet root path.
+    pub measurement_set: PathBuf,
+    /// Output calibration-table path.
+    pub output_table: PathBuf,
+    /// Prior calibration family to generate.
+    pub caltype: GencalType,
+    /// CASA-style antenna selector for `antpos`.
+    #[serde(default)]
+    pub antenna: String,
+    /// CASA-style SPW selector for `opac`.
+    #[serde(default)]
+    pub spw: String,
+    /// Numeric parameters. `antpos` expects triples per selected antenna; `opac`
+    /// expects one opacity per selected SPW.
+    #[serde(default)]
+    pub parameter: Vec<f64>,
+    /// Optional explicit VLA GainCurves table path for `gceff`.
+    #[serde(default)]
+    pub gaincurve_table: Option<PathBuf>,
+}
+
+/// Report returned after writing one prior-cal table.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct GencalReport {
+    /// Output calibration-table path.
+    pub output_table: PathBuf,
+    /// Generated calibration family.
+    pub caltype: GencalType,
+    /// CASA-visible table subtype.
+    pub table_subtype: String,
+    /// Number of MAIN rows written.
+    pub row_count: usize,
+    /// SPWs represented in the table.
+    pub spectral_window_ids: Vec<i32>,
+    /// Antennas represented in the table.
+    pub antenna_ids: Vec<i32>,
+}
+
+/// Errors from native prior-cal table generation.
+#[derive(Debug, Error)]
+pub enum GencalError {
+    /// Opening the input MS failed.
+    #[error("failed to open measurement set {path}: {source}")]
+    OpenMeasurementSet {
+        /// Path that failed.
+        path: String,
+        /// Source error.
+        source: Box<casa_ms::MsError>,
+    },
+    /// Opening the VLA GainCurves table failed.
+    #[error("failed to open VLA GainCurves table {path}: {source}")]
+    OpenGainCurves {
+        /// Path that failed.
+        path: String,
+        /// Source error.
+        source: Box<casa_tables::TableError>,
+    },
+    /// Output table preparation failed.
+    #[error("failed to prepare output caltable {path}: {reason}")]
+    PrepareOutput {
+        /// Path that failed.
+        path: String,
+        /// Reason.
+        reason: String,
+    },
+    /// Saving a table failed.
+    #[error("failed to save caltable {path}: {source}")]
+    Save {
+        /// Path that failed.
+        path: String,
+        /// Source error.
+        source: Box<casa_tables::TableError>,
+    },
+    /// Copying an MS subtable failed.
+    #[error("failed to copy {subtable} into caltable {path}: {source}")]
+    CopySubtable {
+        /// Subtable name.
+        subtable: String,
+        /// Caltable root path.
+        path: String,
+        /// Source error.
+        source: Box<casa_tables::TableError>,
+    },
+    /// The request does not match the supported native surface.
+    #[error("{0}")]
+    InvalidRequest(String),
+    /// A needed value in a CASA table had an unsupported type or shape.
+    #[error("{0}")]
+    UnsupportedTableValue(String),
+}
+
+#[derive(Debug, Clone)]
+struct PriorCalRow {
+    field_id: i32,
+    spw_id: i32,
+    antenna_id: i32,
+    observation_id: i32,
+    fparam: Vec<f32>,
+    snr_value: f32,
+}
+
+/// Generate one native prior calibration table.
+pub fn gencal(request: &GencalRequest) -> Result<GencalReport, GencalError> {
+    let ms = MeasurementSet::open(&request.measurement_set).map_err(|source| {
+        GencalError::OpenMeasurementSet {
+            path: request.measurement_set.display().to_string(),
+            source: Box::new(source),
+        }
+    })?;
+    let rows = match request.caltype {
+        GencalType::Antpos => antpos_rows(&ms, request)?,
+        GencalType::Gceff => gaincurve_rows(&ms, request)?,
+        GencalType::Opac => opacity_rows(&ms, request)?,
+    };
+    write_float_caltable(&ms, request, &rows)
+}
+
+fn antpos_rows(
+    ms: &MeasurementSet,
+    request: &GencalRequest,
+) -> Result<Vec<PriorCalRow>, GencalError> {
+    let antenna = ms
+        .antenna()
+        .map_err(|source| GencalError::OpenMeasurementSet {
+            path: "ANTENNA".to_string(),
+            source: Box::new(source),
+        })?;
+    let selected = parse_antenna_offsets(ms, &request.antenna, &request.parameter)?;
+    let mut rows = Vec::with_capacity(antenna.row_count());
+    for antenna_id in 0..antenna.row_count() {
+        let offsets = selected
+            .get(&(antenna_id as i32))
+            .copied()
+            .unwrap_or([0.0, 0.0, 0.0]);
+        rows.push(PriorCalRow {
+            field_id: -1,
+            spw_id: 0,
+            antenna_id: antenna_id as i32,
+            observation_id: 0,
+            fparam: offsets.iter().map(|value| *value as f32).collect(),
+            snr_value: 1.0,
+        });
+    }
+    Ok(rows)
+}
+
+fn gaincurve_rows(
+    ms: &MeasurementSet,
+    request: &GencalRequest,
+) -> Result<Vec<PriorCalRow>, GencalError> {
+    let source_path = request
+        .gaincurve_table
+        .clone()
+        .or_else(default_vla_gaincurve_table)
+        .ok_or_else(|| {
+            GencalError::InvalidRequest(
+                "gceff requires --gaincurve-table or a CASA data tree at ~/.casa/data/nrao/VLA/GainCurves".to_string(),
+            )
+        })?;
+    let gaincurves = Table::open(TableOptions::new(&source_path)).map_err(|source| {
+        GencalError::OpenGainCurves {
+            path: source_path.display().to_string(),
+            source: Box::new(source),
+        }
+    })?;
+    let antenna_count = ms
+        .antenna()
+        .map_err(|source| GencalError::OpenMeasurementSet {
+            path: "ANTENNA".to_string(),
+            source: Box::new(source),
+        })?
+        .row_count();
+    let antenna_keys = vla_gaincurve_antenna_keys(ms)?;
+    let spw = ms
+        .spectral_window()
+        .map_err(|source| GencalError::OpenMeasurementSet {
+            path: "SPECTRAL_WINDOW".to_string(),
+            source: Box::new(source),
+        })?;
+    let obs_time = first_observation_time(ms).or_else(|_| first_main_time(ms))?;
+    let mut rows = Vec::with_capacity(antenna_count * spw.row_count());
+    for spw_id in 0..spw.row_count() {
+        let center_hz = spw_center_frequency_hz(&spw, spw_id)?;
+        let band = vla_spw_band(&spw, spw_id)?;
+        let efficiency = vla_efficiency(center_hz / 1.0e9) as f32;
+        for (antenna_id, antenna_key) in antenna_keys.iter().enumerate().take(antenna_count) {
+            let mut fparam = matching_gaincurve(
+                &gaincurves,
+                obs_time,
+                center_hz,
+                band.as_deref(),
+                antenna_key,
+            )?;
+            for value in &mut fparam {
+                *value *= efficiency;
+            }
+            rows.push(PriorCalRow {
+                field_id: -1,
+                spw_id: spw_id as i32,
+                antenna_id: antenna_id as i32,
+                observation_id: -1,
+                fparam,
+                snr_value: 0.0,
+            });
+        }
+    }
+    Ok(rows)
+}
+
+fn opacity_rows(
+    ms: &MeasurementSet,
+    request: &GencalRequest,
+) -> Result<Vec<PriorCalRow>, GencalError> {
+    let antenna_count = ms
+        .antenna()
+        .map_err(|source| GencalError::OpenMeasurementSet {
+            path: "ANTENNA".to_string(),
+            source: Box::new(source),
+        })?
+        .row_count();
+    let selected_spws = parse_spw_selector(ms, &request.spw)?;
+    if request.parameter.len() != selected_spws.len() {
+        return Err(GencalError::InvalidRequest(format!(
+            "opac requires one parameter per selected SPW (got {} parameters for {} SPWs)",
+            request.parameter.len(),
+            selected_spws.len()
+        )));
+    }
+    let mut rows = Vec::with_capacity(antenna_count * selected_spws.len());
+    for (index, spw_id) in selected_spws.iter().copied().enumerate() {
+        for antenna_id in 0..antenna_count {
+            rows.push(PriorCalRow {
+                field_id: -1,
+                spw_id,
+                antenna_id: antenna_id as i32,
+                observation_id: 0,
+                fparam: vec![request.parameter[index] as f32],
+                snr_value: 1.0,
+            });
+        }
+    }
+    Ok(rows)
+}
+
+fn write_float_caltable(
+    ms: &MeasurementSet,
+    request: &GencalRequest,
+    rows: &[PriorCalRow],
+) -> Result<GencalReport, GencalError> {
+    prepare_output_root(&request.output_table)?;
+    let schema = TableSchema::new(vec![
+        ColumnSchema::scalar(COL_TIME, casa_types::PrimitiveType::Float64),
+        ColumnSchema::scalar(COL_FIELD_ID, casa_types::PrimitiveType::Int32),
+        ColumnSchema::scalar(COL_SPECTRAL_WINDOW_ID, casa_types::PrimitiveType::Int32),
+        ColumnSchema::scalar(COL_ANTENNA1, casa_types::PrimitiveType::Int32),
+        ColumnSchema::scalar(COL_ANTENNA2, casa_types::PrimitiveType::Int32),
+        ColumnSchema::scalar(COL_INTERVAL, casa_types::PrimitiveType::Float64),
+        ColumnSchema::scalar(COL_SCAN_NUMBER, casa_types::PrimitiveType::Int32),
+        ColumnSchema::scalar(COL_OBSERVATION_ID, casa_types::PrimitiveType::Int32),
+        ColumnSchema::array_variable(COL_FPARAM, casa_types::PrimitiveType::Float32, Some(2)),
+        ColumnSchema::array_variable(COL_PARAMERR, casa_types::PrimitiveType::Float32, Some(2)),
+        ColumnSchema::array_variable(COL_FLAG, casa_types::PrimitiveType::Bool, Some(2)),
+        ColumnSchema::array_variable(COL_SNR, casa_types::PrimitiveType::Float32, Some(2)),
+        ColumnSchema::array_variable(COL_WEIGHT, casa_types::PrimitiveType::Float32, Some(2)),
+    ])
+    .expect("valid gencal caltable schema");
+    let subtype = request.caltype.table_subtype();
+    let mut table = Table::with_schema(schema);
+    table.set_info(TableInfo {
+        table_type: TABLE_INFO_TYPE.to_string(),
+        sub_type: subtype.to_string(),
+    });
+    table.keywords_mut().upsert(
+        KEY_PAR_TYPE,
+        Value::Scalar(ScalarValue::String("Float".to_string())),
+    );
+    table.keywords_mut().upsert(
+        KEY_VIS_CAL,
+        Value::Scalar(ScalarValue::String(subtype.to_string())),
+    );
+    table.keywords_mut().upsert(
+        KEY_MS_NAME,
+        Value::Scalar(ScalarValue::String(
+            ms.path()
+                .and_then(Path::file_name)
+                .map(|name| name.to_string_lossy().to_string())
+                .unwrap_or_else(|| "<in-memory>".to_string()),
+        )),
+    );
+    table.keywords_mut().upsert(
+        KEY_POL_BASIS,
+        Value::Scalar(ScalarValue::String("unknown".to_string())),
+    );
+    table.keywords_mut().upsert(
+        KEY_CASA_VERSION,
+        Value::Scalar(ScalarValue::String("casa-rs".to_string())),
+    );
+    set_fixed_unit_keyword(&mut table, COL_TIME, &["s"]);
+    set_measinfo_keyword(&mut table, COL_TIME, "epoch", Some("UTC"));
+    set_fixed_unit_keyword(&mut table, COL_INTERVAL, &["s"]);
+    for name in STANDARD_SUBTABLE_KEYWORDS {
+        table.keywords_mut().upsert(
+            *name,
+            Value::table_ref(subtable_keyword_value(
+                &request.output_table,
+                &request.output_table.join(name),
+            )),
+        );
+    }
+
+    for row in rows {
+        let len = row.fparam.len();
+        let zeros = vec![0.0_f32; len];
+        let flags = vec![false; len];
+        let snr = vec![row.snr_value; len];
+        table
+            .add_row(RecordValue::new(vec![
+                RecordField::new(COL_TIME, Value::Scalar(ScalarValue::Float64(0.0))),
+                RecordField::new(
+                    COL_FIELD_ID,
+                    Value::Scalar(ScalarValue::Int32(row.field_id)),
+                ),
+                RecordField::new(
+                    COL_SPECTRAL_WINDOW_ID,
+                    Value::Scalar(ScalarValue::Int32(row.spw_id)),
+                ),
+                RecordField::new(
+                    COL_ANTENNA1,
+                    Value::Scalar(ScalarValue::Int32(row.antenna_id)),
+                ),
+                RecordField::new(COL_ANTENNA2, Value::Scalar(ScalarValue::Int32(-1))),
+                RecordField::new(COL_INTERVAL, Value::Scalar(ScalarValue::Float64(0.0))),
+                RecordField::new(COL_SCAN_NUMBER, Value::Scalar(ScalarValue::Int32(-1))),
+                RecordField::new(
+                    COL_OBSERVATION_ID,
+                    Value::Scalar(ScalarValue::Int32(row.observation_id)),
+                ),
+                RecordField::new(COL_FPARAM, Value::Array(f32_column(&row.fparam))),
+                RecordField::new(COL_PARAMERR, Value::Array(f32_column(&zeros))),
+                RecordField::new(COL_FLAG, Value::Array(bool_column(&flags))),
+                RecordField::new(COL_SNR, Value::Array(f32_column(&snr))),
+                RecordField::new(COL_WEIGHT, Value::Array(f32_column(&zeros))),
+            ]))
+            .map_err(|source| GencalError::Save {
+                path: request.output_table.display().to_string(),
+                source: Box::new(source),
+            })?;
+    }
+
+    table
+        .save(
+            TableOptions::new(&request.output_table)
+                .with_data_manager(DataManagerKind::StandardStMan),
+        )
+        .map_err(|source| GencalError::Save {
+            path: request.output_table.display().to_string(),
+            source: Box::new(source),
+        })?;
+    copy_standard_subtables(ms, &request.output_table)?;
+
+    let spectral_window_ids = rows
+        .iter()
+        .map(|row| row.spw_id)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    let antenna_ids = rows
+        .iter()
+        .map(|row| row.antenna_id)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    Ok(GencalReport {
+        output_table: request.output_table.clone(),
+        caltype: request.caltype,
+        table_subtype: subtype.to_string(),
+        row_count: rows.len(),
+        spectral_window_ids,
+        antenna_ids,
+    })
+}
+
+fn parse_antenna_offsets(
+    ms: &MeasurementSet,
+    antenna_selector: &str,
+    parameters: &[f64],
+) -> Result<BTreeMap<i32, [f64; 3]>, GencalError> {
+    if antenna_selector.trim().is_empty() {
+        return Err(GencalError::InvalidRequest(
+            "antpos currently requires explicit --antenna and --parameter offsets; automatic VLA baseline lookup is not implemented".to_string(),
+        ));
+    }
+    let antenna = ms
+        .antenna()
+        .map_err(|source| GencalError::OpenMeasurementSet {
+            path: "ANTENNA".to_string(),
+            source: Box::new(source),
+        })?;
+    let mut name_to_id = BTreeMap::new();
+    for row in 0..antenna.row_count() {
+        let name = antenna.name(row).map_err(|source| {
+            GencalError::InvalidRequest(format!("failed to read ANTENNA.NAME row {row}: {source}"))
+        })?;
+        name_to_id.insert(name.to_ascii_lowercase(), row as i32);
+    }
+    let selected = antenna_selector
+        .split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            if let Ok(index) = part.parse::<i32>() {
+                return Ok(index);
+            }
+            name_to_id
+                .get(&part.to_ascii_lowercase())
+                .copied()
+                .ok_or_else(|| GencalError::InvalidRequest(format!("unknown antenna {part:?}")))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if parameters.len() != selected.len() * 3 {
+        return Err(GencalError::InvalidRequest(format!(
+            "antpos requires three parameters per selected antenna (got {} parameters for {} antennas)",
+            parameters.len(),
+            selected.len()
+        )));
+    }
+    let mut offsets = BTreeMap::new();
+    for (index, antenna_id) in selected.iter().copied().enumerate() {
+        offsets.insert(
+            antenna_id,
+            [
+                parameters[index * 3],
+                parameters[index * 3 + 1],
+                parameters[index * 3 + 2],
+            ],
+        );
+    }
+    Ok(offsets)
+}
+
+fn parse_spw_selector(ms: &MeasurementSet, selector: &str) -> Result<Vec<i32>, GencalError> {
+    let count = ms
+        .spectral_window()
+        .map_err(|source| GencalError::OpenMeasurementSet {
+            path: "SPECTRAL_WINDOW".to_string(),
+            source: Box::new(source),
+        })?
+        .row_count() as i32;
+    if selector.trim().is_empty() {
+        return Ok((0..count).collect());
+    }
+    let mut ids = BTreeSet::new();
+    for part in selector.split(',').map(str::trim).filter(|p| !p.is_empty()) {
+        if let Some((start, end)) = part.split_once('~') {
+            let start = start.parse::<i32>().map_err(|_| {
+                GencalError::InvalidRequest(format!("invalid SPW selector {part:?}"))
+            })?;
+            let end = end.parse::<i32>().map_err(|_| {
+                GencalError::InvalidRequest(format!("invalid SPW selector {part:?}"))
+            })?;
+            for id in start.min(end)..=start.max(end) {
+                ids.insert(id);
+            }
+        } else {
+            ids.insert(part.parse::<i32>().map_err(|_| {
+                GencalError::InvalidRequest(format!("invalid SPW selector {part:?}"))
+            })?);
+        }
+    }
+    if ids.iter().any(|id| *id < 0 || *id >= count) {
+        return Err(GencalError::InvalidRequest(format!(
+            "SPW selector {selector:?} is outside 0..{}",
+            count.saturating_sub(1)
+        )));
+    }
+    Ok(ids.into_iter().collect())
+}
+
+fn matching_gaincurve(
+    table: &Table,
+    time_seconds: f64,
+    frequency_hz: f64,
+    band: Option<&str>,
+    antenna_key: &str,
+) -> Result<Vec<f32>, GencalError> {
+    if let Some(band) = band {
+        if let Some(gain) = matching_gaincurve_from_rows(
+            table,
+            time_seconds,
+            |row| {
+                get_string(table, row, COL_BANDNAME)
+                    .map(|row_band| row_band == band)
+                    .unwrap_or(false)
+            },
+            antenna_key,
+        )? {
+            return Ok(gain);
+        }
+    }
+    matching_gaincurve_from_rows(
+        table,
+        time_seconds,
+        |row| {
+            let Ok(bfreq) = get_f64(table, row, COL_BFREQ) else {
+                return false;
+            };
+            let Ok(efreq) = get_f64(table, row, COL_EFREQ) else {
+                return false;
+            };
+            bfreq <= frequency_hz && efreq > frequency_hz
+        },
+        antenna_key,
+    )?
+    .ok_or_else(|| {
+        GencalError::InvalidRequest(format!(
+            "no VLA GainCurves row covers antenna {antenna_key}, time {time_seconds}, frequency {frequency_hz}"
+        ))
+    })
+}
+
+fn matching_gaincurve_from_rows(
+    table: &Table,
+    time_seconds: f64,
+    mut row_matches: impl FnMut(usize) -> bool,
+    antenna_key: &str,
+) -> Result<Option<Vec<f32>>, GencalError> {
+    let nominal_key = "0";
+    let mut nominal = None;
+    for row in 0..table.row_count() {
+        if get_f64(table, row, COL_BTIME)? > time_seconds
+            || get_f64(table, row, COL_ETIME)? <= time_seconds
+            || !row_matches(row)
+        {
+            continue;
+        }
+        let antenna = get_string(table, row, COL_ANTENNA)?;
+        let gain = get_f32_array_fortran(table, row, COL_GAIN)?;
+        if antenna == antenna_key {
+            return Ok(Some(gain));
+        }
+        if antenna == nominal_key {
+            nominal = Some(gain);
+        }
+    }
+    Ok(nominal)
+}
+
+fn spw_center_frequency_hz(
+    spw: &casa_ms::subtables::MsSpectralWindow<'_>,
+    row: usize,
+) -> Result<f64, GencalError> {
+    let freqs = spw.chan_freq(row).map_err(|source| {
+        GencalError::InvalidRequest(format!(
+            "failed to read SPECTRAL_WINDOW row {row}: {source}"
+        ))
+    })?;
+    if freqs.is_empty() {
+        return Err(GencalError::InvalidRequest(format!(
+            "SPECTRAL_WINDOW row {row} has no channel frequencies"
+        )));
+    }
+    Ok(freqs.iter().sum::<f64>() / freqs.len() as f64)
+}
+
+fn vla_spw_band(
+    spw: &casa_ms::subtables::MsSpectralWindow<'_>,
+    row: usize,
+) -> Result<Option<String>, GencalError> {
+    let name = spw.name(row).map_err(|source| {
+        GencalError::InvalidRequest(format!(
+            "failed to read SPECTRAL_WINDOW.NAME row {row}: {source}"
+        ))
+    })?;
+    Ok(name
+        .strip_prefix("EVLA_")
+        .and_then(|rest| rest.split_once('#').map(|(band, _)| band.to_string())))
+}
+
+fn vla_gaincurve_antenna_keys(ms: &MeasurementSet) -> Result<Vec<String>, GencalError> {
+    let table = ms
+        .subtable(SubtableId::Antenna)
+        .ok_or_else(|| GencalError::InvalidRequest("missing ANTENNA subtable".to_string()))?;
+    let mut keys = Vec::with_capacity(table.row_count());
+    for row in 0..table.row_count() {
+        let name = get_string(table, row, COL_NAME)?;
+        let digits = name
+            .chars()
+            .skip_while(|ch| !ch.is_ascii_digit())
+            .collect::<String>();
+        let stripped = digits.trim_start_matches('0');
+        keys.push(if stripped.is_empty() {
+            row.to_string()
+        } else {
+            stripped.to_string()
+        });
+    }
+    Ok(keys)
+}
+
+fn vla_efficiency(frequency_ghz: f64) -> f64 {
+    const FREQ: [f64; 42] = [
+        1.0,
+        1.1,
+        1.2,
+        1.3,
+        1.4,
+        1.5,
+        1.6,
+        1.7,
+        1.8,
+        1.9,
+        2.0,
+        2.0 + 1e-9,
+        2.3,
+        2.7,
+        3.0,
+        3.5,
+        3.7,
+        4.0,
+        4.0 + 1e-9,
+        5.0,
+        6.0,
+        7.0,
+        8.0,
+        8.0 + 1e-9,
+        12.0,
+        12.0 + 1e-9,
+        13.0,
+        14.0,
+        15.0,
+        16.0,
+        17.0,
+        18.0,
+        19.0,
+        24.0,
+        26.0,
+        26.5,
+        28.0,
+        33.0,
+        38.0,
+        40.0,
+        43.0,
+        48.0,
+    ];
+    const EFF: [f64; 42] = [
+        0.45, 0.48, 0.48, 0.45, 0.46, 0.45, 0.43, 0.44, 0.44, 0.49, 0.48, 0.52, 0.52, 0.51, 0.53,
+        0.55, 0.53, 0.54, 0.55, 0.54, 0.56, 0.62, 0.64, 0.60, 0.60, 0.65, 0.65, 0.62, 0.58, 0.59,
+        0.60, 0.60, 0.57, 0.52, 0.48, 0.50, 0.49, 0.42, 0.35, 0.29, 0.28, 0.26,
+    ];
+    let scaled = EFF.map(|value| (value / 5.622).sqrt());
+    if frequency_ghz <= FREQ[0] {
+        return scaled[0];
+    }
+    for index in 1..FREQ.len() {
+        if frequency_ghz <= FREQ[index] {
+            let fraction = (frequency_ghz - FREQ[index - 1]) / (FREQ[index] - FREQ[index - 1]);
+            return scaled[index - 1] + (scaled[index] - scaled[index - 1]) * fraction;
+        }
+    }
+    scaled[scaled.len() - 1]
+}
+
+fn first_observation_time(ms: &MeasurementSet) -> Result<f64, GencalError> {
+    let table = ms
+        .subtable(SubtableId::Observation)
+        .ok_or_else(|| GencalError::InvalidRequest("missing OBSERVATION subtable".to_string()))?;
+    match table
+        .cell_accessor(0, COL_TIME_RANGE)
+        .and_then(|cell| cell.array())
+        .map_err(|error| GencalError::UnsupportedTableValue(error.to_string()))?
+    {
+        ArrayValue::Float64(values) => values.iter().next().copied().ok_or_else(|| {
+            GencalError::UnsupportedTableValue("OBSERVATION.TIME_RANGE is empty".to_string())
+        }),
+        other => Err(GencalError::UnsupportedTableValue(format!(
+            "OBSERVATION.TIME_RANGE has shape {:?}, expected Float64 array",
+            other.shape()
+        ))),
+    }
+}
+
+fn first_main_time(ms: &MeasurementSet) -> Result<f64, GencalError> {
+    if ms.main_table().row_count() == 0 {
+        return Ok(0.0);
+    }
+    get_f64(ms.main_table(), 0, COL_TIME)
+}
+
+fn get_string(table: &Table, row: usize, column: &str) -> Result<String, GencalError> {
+    match table
+        .cell_accessor(row, column)
+        .and_then(|cell| cell.scalar())
+        .map_err(|error| GencalError::UnsupportedTableValue(error.to_string()))?
+    {
+        ScalarValue::String(value) => Ok(value.clone()),
+        other => Err(GencalError::UnsupportedTableValue(format!(
+            "{column} row {row} is {other:?}, expected string"
+        ))),
+    }
+}
+
+fn get_f64(table: &Table, row: usize, column: &str) -> Result<f64, GencalError> {
+    match table
+        .cell_accessor(row, column)
+        .and_then(|cell| cell.scalar())
+        .map_err(|error| GencalError::UnsupportedTableValue(error.to_string()))?
+    {
+        ScalarValue::Float64(value) => Ok(*value),
+        ScalarValue::Float32(value) => Ok(f64::from(*value)),
+        other => Err(GencalError::UnsupportedTableValue(format!(
+            "{column} row {row} is {other:?}, expected float"
+        ))),
+    }
+}
+
+fn get_f32_array_fortran(table: &Table, row: usize, column: &str) -> Result<Vec<f32>, GencalError> {
+    match table
+        .cell_accessor(row, column)
+        .and_then(|cell| cell.array())
+        .map_err(|error| GencalError::UnsupportedTableValue(error.to_string()))?
+    {
+        ArrayValue::Float32(values) => {
+            let shape = values.shape();
+            if shape.len() != 2 {
+                return Ok(values.iter().copied().collect());
+            }
+            let mut out = Vec::with_capacity(shape[0] * shape[1]);
+            for j in 0..shape[1] {
+                for i in 0..shape[0] {
+                    out.push(values[[i, j]]);
+                }
+            }
+            Ok(out)
+        }
+        other => Err(GencalError::UnsupportedTableValue(format!(
+            "{column} row {row} has shape {:?}, expected Float32 array",
+            other.shape()
+        ))),
+    }
+}
+
+fn f32_column(values: &[f32]) -> ArrayValue {
+    ArrayValue::Float32(
+        ArrayD::from_shape_vec(IxDyn(&[values.len(), 1]).f(), values.to_vec())
+            .expect("float gencal vector should reshape to receptor x channel"),
+    )
+}
+
+fn bool_column(values: &[bool]) -> ArrayValue {
+    ArrayValue::Bool(
+        ArrayD::from_shape_vec(IxDyn(&[values.len(), 1]).f(), values.to_vec())
+            .expect("flag gencal vector should reshape to receptor x channel"),
+    )
+}
+
+fn prepare_output_root(path: &Path) -> Result<(), GencalError> {
+    if path.exists() {
+        fs::remove_dir_all(path)
+            .or_else(|_| fs::remove_file(path))
+            .map_err(|error| GencalError::PrepareOutput {
+                path: path.display().to_string(),
+                reason: error.to_string(),
+            })?;
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| GencalError::PrepareOutput {
+            path: path.display().to_string(),
+            reason: error.to_string(),
+        })?;
+    }
+    Ok(())
+}
+
+fn copy_standard_subtables(ms: &MeasurementSet, output_root: &Path) -> Result<(), GencalError> {
+    for (id, name) in [
+        (SubtableId::Observation, "OBSERVATION"),
+        (SubtableId::Antenna, "ANTENNA"),
+        (SubtableId::Field, "FIELD"),
+        (SubtableId::SpectralWindow, "SPECTRAL_WINDOW"),
+        (SubtableId::History, "HISTORY"),
+    ] {
+        if let Some(table) = ms.subtable(id) {
+            table
+                .save(TableOptions::new(output_root.join(name)))
+                .map_err(|source| GencalError::CopySubtable {
+                    subtable: name.to_string(),
+                    path: output_root.display().to_string(),
+                    source: Box::new(source),
+                })?;
+        }
+    }
+    Ok(())
+}
+
+fn default_vla_gaincurve_table() -> Option<PathBuf> {
+    if let Ok(path) = env::var("CASA_RS_VLA_GAINCURVES") {
+        return Some(PathBuf::from(path));
+    }
+    if let Ok(path) = env::var("CASA_RS_MEASURESPATH") {
+        return Some(PathBuf::from(path).join("nrao/VLA/GainCurves"));
+    }
+    env::var_os("HOME").map(|home| PathBuf::from(home).join(".casa/data/nrao/VLA/GainCurves"))
+}

--- a/crates/casa-calibration/src/gencal.rs
+++ b/crates/casa-calibration/src/gencal.rs
@@ -629,12 +629,18 @@ fn spw_center_frequency_hz(
             "failed to read SPECTRAL_WINDOW row {row}: {source}"
         ))
     })?;
+    casa_middle_channel_frequency_hz(&freqs, row)
+}
+
+fn casa_middle_channel_frequency_hz(freqs: &[f64], row: usize) -> Result<f64, GencalError> {
     if freqs.is_empty() {
         return Err(GencalError::InvalidRequest(format!(
             "SPECTRAL_WINDOW row {row} has no channel frequencies"
         )));
     }
-    Ok(freqs.iter().sum::<f64>() / freqs.len() as f64)
+    // CASA EGainCurve uses chanfreqs(chanfreqs.nelements()/2), not the
+    // arithmetic center, for the VLA efficiency lookup.
+    Ok(freqs[freqs.len() / 2])
 }
 
 fn vla_spw_band(
@@ -875,4 +881,21 @@ fn default_vla_gaincurve_table() -> Option<PathBuf> {
         return Some(PathBuf::from(path).join("nrao/VLA/GainCurves"));
     }
     env::var_os("HOME").map(|home| PathBuf::from(home).join(".casa/data/nrao/VLA/GainCurves"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn casa_middle_channel_frequency_uses_upper_middle_for_even_spw() {
+        let freqs = [100.0, 125.0, 150.0, 175.0];
+        assert_eq!(casa_middle_channel_frequency_hz(&freqs, 0).unwrap(), 150.0);
+    }
+
+    #[test]
+    fn casa_middle_channel_frequency_rejects_empty_spw() {
+        let err = casa_middle_channel_frequency_hz(&[], 7).unwrap_err();
+        assert!(err.to_string().contains("SPECTRAL_WINDOW row 7"));
+    }
 }

--- a/crates/casa-calibration/src/lib.rs
+++ b/crates/casa-calibration/src/lib.rs
@@ -28,6 +28,7 @@ mod continuum_subtract;
 mod corrected_export;
 mod execute;
 mod fluxscale;
+mod gencal;
 mod least_squares;
 mod managed_output;
 mod model;
@@ -60,6 +61,7 @@ pub use fluxscale::{
     FluxScaleError, FluxScaleFieldResult, FluxScaleReport, FluxScaleRequest, FluxScaleSpwResult,
     fluxscale,
 };
+pub use gencal::{GencalError, GencalReport, GencalRequest, GencalType, gencal};
 pub use managed_output::{CalibrationTaskResult, ManagedCalibrationOutput};
 pub use model::{
     CalibrationColumnSummary, CalibrationIssueSeverity, CalibrationKeywordSummary,
@@ -88,6 +90,7 @@ pub use summary::{CalibrationTableError, summarize_table, summarize_tables};
 pub use task_contract::{
     CALIBRATION_TASK_PROTOCOL_NAME, CALIBRATION_TASK_PROTOCOL_VERSION, CalibrationProtocolInfo,
     CalibrationTaskRequest, CalibrationTaskSchemaBundle, ContinuumSubtractionTaskRequest,
-    ExecuteApplyTaskRequest, ExportCorrectedDataTaskRequest, PlanApplyTaskRequest,
-    SolveBandpassTaskRequest, SolveGainTaskRequest, StatsTaskRequest, SummaryTaskRequest,
+    ExecuteApplyTaskRequest, ExportCorrectedDataTaskRequest, GencalTaskRequest,
+    PlanApplyTaskRequest, SolveBandpassTaskRequest, SolveGainTaskRequest, StatsTaskRequest,
+    SummaryTaskRequest,
 };

--- a/crates/casa-calibration/src/managed_output.rs
+++ b/crates/casa-calibration/src/managed_output.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     ApplyExecutionReport, ApplyPlan, BandpassSolveReport, CalibrationStatsReport,
     CalibrationTableSummary, ContinuumSubtractionReport, ExportCorrectedDataReport,
-    FluxScaleReport, GainSolveReport,
+    FluxScaleReport, GainSolveReport, GencalReport,
 };
 
 /// Canonical structured result for one calibration task execution.
@@ -32,6 +32,8 @@ pub enum CalibrationTaskResult {
     SolveBandpass(BandpassSolveReport),
     /// `calibrate fluxscale`
     FluxScale(FluxScaleReport),
+    /// `calibrate gencal`
+    Gencal(GencalReport),
 }
 
 /// Backward-compatible alias for the launcher-managed calibration output type.

--- a/crates/casa-calibration/src/model.rs
+++ b/crates/casa-calibration/src/model.rs
@@ -141,7 +141,8 @@ impl CalibrationTableSummary {
     /// apply surface:
     ///
     /// - complex `CPARAM` antenna-based tables, or
-    /// - narrow float `FPARAM` support for `K Jones`
+    /// - float `FPARAM` support for `K Jones` and the VLA prior families
+    ///   `KAntPos Jones`, `EGainCurve`, and `TOpac`
     /// - legacy `BPOLY` bandpass tables
     ///
     /// and carries no error-level validation issues.
@@ -151,6 +152,9 @@ impl CalibrationTableSummary {
                 (&self.parameter_family, self.table_subtype.as_str()),
                 (CalibrationParameterFamily::Complex, _)
                     | (CalibrationParameterFamily::Float, "K Jones")
+                    | (CalibrationParameterFamily::Float, "KAntPos Jones")
+                    | (CalibrationParameterFamily::Float, "EGainCurve")
+                    | (CalibrationParameterFamily::Float, "TOpac")
             ) || self.table_subtype == "BPOLY")
             && self
                 .issues

--- a/crates/casa-calibration/src/plan.rs
+++ b/crates/casa-calibration/src/plan.rs
@@ -500,20 +500,21 @@ fn build_selected_rows(
         .data_description()
         .map_err(|source| ApplyPlanError::Selection { source })?;
     let table = ms.main_table();
-    let data_desc_ids = load_i32_column(table, "DATA_DESC_ID")?;
-    let field_ids = load_i32_column(table, "FIELD_ID")?;
-    let observation_ids = load_i32_column(table, "OBSERVATION_ID")?;
-    let antenna1s = load_i32_column(table, "ANTENNA1")?;
-    let antenna2s = load_i32_column(table, "ANTENNA2")?;
-    let feed1s = load_i32_column(table, "FEED1")?;
-    let feed2s = load_i32_column(table, "FEED2")?;
-    let times = load_f64_column(table, "TIME")?;
-    let intervals = load_f64_column(table, "INTERVAL")?;
+    let data_desc_ids = load_i32_column_rows(table, "DATA_DESC_ID", row_indices)?;
+    let field_ids = load_i32_column_rows(table, "FIELD_ID", row_indices)?;
+    let observation_ids = load_i32_column_rows(table, "OBSERVATION_ID", row_indices)?;
+    let antenna1s = load_i32_column_rows(table, "ANTENNA1", row_indices)?;
+    let antenna2s = load_i32_column_rows(table, "ANTENNA2", row_indices)?;
+    let feed1s = load_i32_column_rows(table, "FEED1", row_indices)?;
+    let feed2s = load_i32_column_rows(table, "FEED2", row_indices)?;
+    let times = load_f64_column_rows(table, "TIME", row_indices)?;
+    let intervals = load_f64_column_rows(table, "INTERVAL", row_indices)?;
 
     row_indices
         .iter()
-        .map(|&row_index| {
-            let data_desc_id = value_at_i32(&data_desc_ids, row_index, "DATA_DESC_ID")?;
+        .enumerate()
+        .map(|(selected_idx, &row_index)| {
+            let data_desc_id = value_at_i32(&data_desc_ids, selected_idx, "DATA_DESC_ID")?;
             let ddid_index = usize::try_from(data_desc_id).map_err(|_| {
                 ApplyPlanError::MissingDataDescription {
                     row_index,
@@ -529,8 +530,8 @@ fn build_selected_rows(
 
             Ok(ApplyRowPlan {
                 row_index,
-                field_id: value_at_i32(&field_ids, row_index, "FIELD_ID")?,
-                observation_id: value_at_i32(&observation_ids, row_index, "OBSERVATION_ID")?,
+                field_id: value_at_i32(&field_ids, selected_idx, "FIELD_ID")?,
+                observation_id: value_at_i32(&observation_ids, selected_idx, "OBSERVATION_ID")?,
                 data_desc_id,
                 data_spw_id: dd
                     .spectral_window_id(ddid_index)
@@ -538,30 +539,34 @@ fn build_selected_rows(
                 polarization_id: dd
                     .polarization_id(ddid_index)
                     .map_err(|source| ApplyPlanError::Selection { source })?,
-                antenna1: value_at_i32(&antenna1s, row_index, "ANTENNA1")?,
-                antenna2: value_at_i32(&antenna2s, row_index, "ANTENNA2")?,
-                feed1: value_at_i32(&feed1s, row_index, "FEED1")?,
-                feed2: value_at_i32(&feed2s, row_index, "FEED2")?,
-                time_seconds: value_at_f64(&times, row_index, "TIME")?,
-                interval_seconds: value_at_f64(&intervals, row_index, "INTERVAL")?,
+                antenna1: value_at_i32(&antenna1s, selected_idx, "ANTENNA1")?,
+                antenna2: value_at_i32(&antenna2s, selected_idx, "ANTENNA2")?,
+                feed1: value_at_i32(&feed1s, selected_idx, "FEED1")?,
+                feed2: value_at_i32(&feed2s, selected_idx, "FEED2")?,
+                time_seconds: value_at_f64(&times, selected_idx, "TIME")?,
+                interval_seconds: value_at_f64(&intervals, selected_idx, "INTERVAL")?,
             })
         })
         .collect()
 }
 
-fn load_i32_column(table: &Table, column: &str) -> Result<Vec<Option<i32>>, ApplyPlanError> {
+fn load_i32_column_rows(
+    table: &Table,
+    column: &str,
+    row_indices: &[usize],
+) -> Result<Vec<Option<i32>>, ApplyPlanError> {
     table
         .column_accessor(column)
-        .and_then(|column| column.scalar_cells_owned())
+        .and_then(|column| column.scalar_cells_owned_for_rows(row_indices))
         .map_err(|source| ApplyPlanError::Selection {
             source: MsError::from(source),
         })?
         .into_iter()
         .enumerate()
-        .map(|(row_index, value)| match value {
+        .map(|(selected_idx, value)| match value {
             Some(casa_types::ScalarValue::Int32(v)) => Ok(Some(v)),
             Some(other) => Err(ApplyPlanError::ScalarTypeMismatch {
-                context: format!("{column} row {row_index}"),
+                context: format!("{column} selected row {selected_idx}"),
                 expected: "Int32",
                 found: scalar_kind(&other),
             }),
@@ -570,19 +575,23 @@ fn load_i32_column(table: &Table, column: &str) -> Result<Vec<Option<i32>>, Appl
         .collect()
 }
 
-fn load_f64_column(table: &Table, column: &str) -> Result<Vec<Option<f64>>, ApplyPlanError> {
+fn load_f64_column_rows(
+    table: &Table,
+    column: &str,
+    row_indices: &[usize],
+) -> Result<Vec<Option<f64>>, ApplyPlanError> {
     table
         .column_accessor(column)
-        .and_then(|column| column.scalar_cells_owned())
+        .and_then(|column| column.scalar_cells_owned_for_rows(row_indices))
         .map_err(|source| ApplyPlanError::Selection {
             source: MsError::from(source),
         })?
         .into_iter()
         .enumerate()
-        .map(|(row_index, value)| match value {
+        .map(|(selected_idx, value)| match value {
             Some(casa_types::ScalarValue::Float64(v)) => Ok(Some(v)),
             Some(other) => Err(ApplyPlanError::ScalarTypeMismatch {
-                context: format!("{column} row {row_index}"),
+                context: format!("{column} selected row {selected_idx}"),
                 expected: "Float64",
                 found: scalar_kind(&other),
             }),
@@ -685,8 +694,16 @@ fn build_table_plan(
     } else {
         summary.spectral_window_ids.clone()
     };
+    let effective_spec;
+    let spec_for_spw_mapping = if summary.table_subtype == "KAntPos Jones" && spec.spwmap.is_empty()
+    {
+        effective_spec = k_antpos_default_spwmap_spec(spec, &applicable_data_spw_ids);
+        &effective_spec
+    } else {
+        spec
+    };
     let spw_mapping = resolve_spw_mapping(
-        spec,
+        spec_for_spw_mapping,
         &available_calibration_spw_ids,
         &applicable_data_spw_ids,
     )?;
@@ -709,6 +726,21 @@ fn build_table_plan(
         interp: spec.interp,
         calwt: spec.calwt,
     })
+}
+
+fn k_antpos_default_spwmap_spec(
+    spec: &ApplyCalibrationTableSpec,
+    applicable_data_spw_ids: &[i32],
+) -> ApplyCalibrationTableSpec {
+    let mut spec = spec.clone();
+    let len = applicable_data_spw_ids
+        .iter()
+        .filter_map(|spw| usize::try_from(*spw).ok())
+        .max()
+        .map(|spw| spw + 1)
+        .unwrap_or_default();
+    spec.spwmap = vec![0; len];
+    spec
 }
 
 fn resolve_gainfield(

--- a/crates/casa-calibration/src/solve.rs
+++ b/crates/casa-calibration/src/solve.rs
@@ -16,7 +16,7 @@
 pub(crate) mod grouping;
 pub(crate) mod kernel;
 mod trace;
-mod writer;
+pub(crate) mod writer;
 
 use std::path::{Path, PathBuf};
 

--- a/crates/casa-calibration/src/summary.rs
+++ b/crates/casa-calibration/src/summary.rs
@@ -360,11 +360,15 @@ fn validate_shape(
 
     match parameter_family {
         CalibrationParameterFamily::Complex => {}
-        CalibrationParameterFamily::Float if keywords.vis_cal.as_deref() == Some("K Jones") => {}
+        CalibrationParameterFamily::Float
+            if matches!(
+                keywords.vis_cal.as_deref(),
+                Some("K Jones" | "KAntPos Jones" | "EGainCurve" | "TOpac")
+            ) => {}
         CalibrationParameterFamily::Float => issues.push(issue(
             "unsupported-float-family",
             CalibrationIssueSeverity::Error,
-            "float-parameter calibration tables are only supported for K Jones in the current apply surface"
+            "float-parameter calibration tables are only supported for K Jones and VLA prior tables in the current apply surface"
                 .to_string(),
         )),
         CalibrationParameterFamily::Unknown => issues.push(issue(

--- a/crates/casa-calibration/src/task_contract.rs
+++ b/crates/casa-calibration/src/task_contract.rs
@@ -19,8 +19,8 @@ use crate::{
     BandpassSolveRequest, BandpassType, CalibrationStatsAxis, CalibrationStatsRequest,
     ContinuumSubtractionDataColumn, ContinuumSubtractionRequest, FluxScaleRequest,
     GainSolveCombine, GainSolveInterval, GainSolveMode, GainSolveModelSource, GainSolveRequest,
-    GainType, RefAntSelector, calibration_stats, command_schema, continuum_subtract,
-    execute_apply_from_path, export_corrected_data, fluxscale, plan_apply_from_path,
+    GainType, GencalRequest, RefAntSelector, calibration_stats, command_schema, continuum_subtract,
+    execute_apply_from_path, export_corrected_data, fluxscale, gencal, plan_apply_from_path,
     solve_bandpass_from_path, solve_gain_from_path, summarize_tables,
 };
 
@@ -166,6 +166,11 @@ fn calibration_task_operations() -> Vec<TaskOperationDescriptor> {
             request_kind: "flux_scale".to_string(),
             result_kind: Some("flux_scale".to_string()),
         },
+        TaskOperationDescriptor {
+            name: "gencal".to_string(),
+            request_kind: "gencal".to_string(),
+            result_kind: Some("gencal".to_string()),
+        },
     ]
 }
 
@@ -188,6 +193,9 @@ pub struct StatsTaskRequest {
     /// Whether flagged values should be included.
     pub use_flags: bool,
 }
+
+/// Request for generating one externally specified calibration table.
+pub type GencalTaskRequest = GencalRequest;
 
 /// Request for planning an `applycal`-class operation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -356,6 +364,8 @@ pub enum CalibrationTaskRequest {
     SolveBandpass(SolveBandpassTaskRequest),
     /// Bootstrap flux density scaling.
     FluxScale(FluxScaleRequest),
+    /// Generate a prior calibration table.
+    Gencal(GencalTaskRequest),
 }
 
 impl CalibrationTaskRequest {
@@ -467,6 +477,9 @@ impl CalibrationTaskRequest {
             .map_err(|error| error.to_string()),
             Self::FluxScale(request) => fluxscale(request)
                 .map(CalibrationTaskResult::FluxScale)
+                .map_err(|error| error.to_string()),
+            Self::Gencal(request) => gencal(request)
+                .map(CalibrationTaskResult::Gencal)
                 .map_err(|error| error.to_string()),
         }
     }
@@ -683,7 +696,7 @@ mod tests {
             CALIBRATION_TASK_PROTOCOL_VERSION
         );
         assert_eq!(bundle.protocol.surface_kind, ProviderSurfaceKind::Task);
-        assert_eq!(bundle.semantic.operations.len(), 9);
+        assert_eq!(bundle.semantic.operations.len(), 10);
         assert!(
             bundle
                 .semantic
@@ -697,6 +710,13 @@ mod tests {
                 .operations
                 .iter()
                 .any(|operation| operation.request_kind == "flux_scale")
+        );
+        assert!(
+            bundle
+                .semantic
+                .operations
+                .iter()
+                .any(|operation| operation.request_kind == "gencal")
         );
         assert!(bundle.components.contains_key("SummaryTaskRequest"));
         assert!(bundle.projections.ui_schema.is_some());

--- a/crates/casa-calibration/tests/apply_execute.rs
+++ b/crates/casa-calibration/tests/apply_execute.rs
@@ -189,11 +189,17 @@ fn export_corrected_data_writes_imaging_ready_data_column() {
     let output_data = output
         .data_column(VisibilityDataColumn::Data)
         .expect("output data column");
+    let input_data = input
+        .data_column(VisibilityDataColumn::Data)
+        .expect("input data column");
     for row in 0..input.row_count() {
-        assert_eq!(
-            input_corrected.get(row).expect("input corrected row"),
-            output_data.get(row).expect("output data row")
-        );
+        let corrected = input_corrected.get(row).expect("input corrected row");
+        let expected = if !corrected.is_empty() {
+            corrected
+        } else {
+            input_data.get(row).expect("input data row")
+        };
+        assert_eq!(expected, output_data.get(row).expect("output data row"));
     }
 }
 

--- a/crates/casa-images/src/analysis.rs
+++ b/crates/casa-images/src/analysis.rs
@@ -1577,12 +1577,18 @@ where
     } else {
         None
     };
+    let input = image.get_slice(&start, &shape)?;
     let mut output_shape = shape.clone();
     output_shape[0] = path.len();
     output_shape[1] = 1;
+    if let Some((axis, indices)) = &channel_indices {
+        output_shape[*axis] = indices.len();
+    }
     let mut output_data = ArrayD::<f32>::zeros(IxDyn(&output_shape).f());
     let other_shape = output_shape[2..].to_vec();
     let offsets = perpendicular_offsets(x0, y0, x1, y1, request.width.max(1));
+    let mut input_index = vec![0; input.ndim()];
+    let mut output_index = vec![0; output_shape.len()];
     for sample_index in all_indices_for_shape(&other_shape) {
         for (path_index, &(x, y)) in path.iter().enumerate() {
             let mut sum = 0.0;
@@ -1597,21 +1603,19 @@ where
                 {
                     continue;
                 }
-                let mut input_index = start.clone();
                 input_index[0] = sx as usize;
                 input_index[1] = sy as usize;
                 for (offset_axis, value) in sample_index.iter().copied().enumerate() {
-                    input_index[offset_axis + 2] += value;
+                    input_index[offset_axis + 2] = value;
                 }
                 if let Some((axis, indices)) = &channel_indices {
                     let local = sample_index[*axis - 2];
-                    input_index[*axis] = indices[local];
+                    input_index[*axis] = indices[local] - start[*axis];
                 }
-                sum += image.get_at(&input_index)?.into();
+                sum += input[IxDyn(&input_index)].into();
                 count += 1;
             }
             if count > 0 {
-                let mut output_index = vec![0; output_shape.len()];
                 output_index[0] = path_index;
                 output_index[1] = 0;
                 for (offset_axis, value) in sample_index.iter().copied().enumerate() {

--- a/crates/casa-images/src/analysis.rs
+++ b/crates/casa-images/src/analysis.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 //! Tutorial-scoped image-analysis operations matching CASA image task semantics.
 
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -108,6 +109,11 @@ impl ImageAnalysisTaskSchemaBundle {
                         result_kind: Some("immoments".to_string()),
                     },
                     TaskOperationDescriptor {
+                        name: "impv".to_string(),
+                        request_kind: "impv".to_string(),
+                        result_kind: Some("impv".to_string()),
+                    },
+                    TaskOperationDescriptor {
                         name: "exportfits".to_string(),
                         request_kind: "exportfits".to_string(),
                         result_kind: Some("exportfits".to_string()),
@@ -134,7 +140,7 @@ impl ImageAnalysisTaskSchemaBundle {
                 ui_schema: None,
                 python: Some(serde_json::json!({
                     "module": "casars.tasks.image_analysis",
-                    "functions": ["imhead", "imstat", "immoments", "exportfits", "importfits"],
+                    "functions": ["imhead", "imstat", "immoments", "impv", "exportfits", "importfits"],
                 })),
             },
             request_schema,
@@ -211,6 +217,91 @@ pub fn image_analysis_ui_schema_json(binary: &str) -> Result<String, ImageError>
                     id: "overwrite",
                     label: "Overwrite",
                     order: 5,
+                    parser: toggle(["--overwrite"], []),
+                    value_kind: "bool",
+                    required: false,
+                    default: serde_json::json!("false"),
+                    help: "Replace existing output image",
+                    group: "Output",
+                })
+            ]),
+        ),
+        "impv" => (
+            "impv",
+            "Position-Velocity Slice",
+            "Extract a CASA-style position-velocity image",
+            "impv <imagename> --outfile <path> --start x,y --end x,y [--width pixels] [--chans 4~12] [--overwrite]",
+            serde_json::json!([
+                arg(UiArgument {
+                    id: "imagename",
+                    label: "Image",
+                    order: 0,
+                    parser: positional("imagename"),
+                    value_kind: "path",
+                    required: true,
+                    default: JsonValue::Null,
+                    help: "Input CASA image path",
+                    group: "Input",
+                }),
+                arg(UiArgument {
+                    id: "outfile",
+                    label: "Output",
+                    order: 1,
+                    parser: option(["--outfile"], "path", []),
+                    value_kind: "path",
+                    required: true,
+                    default: JsonValue::Null,
+                    help: "Output CASA image path",
+                    group: "Output",
+                }),
+                arg(UiArgument {
+                    id: "start",
+                    label: "Start",
+                    order: 2,
+                    parser: option(["--start"], "x,y", []),
+                    value_kind: "string",
+                    required: true,
+                    default: JsonValue::Null,
+                    help: "Start pixel coordinate",
+                    group: "Slice",
+                }),
+                arg(UiArgument {
+                    id: "end",
+                    label: "End",
+                    order: 3,
+                    parser: option(["--end"], "x,y", []),
+                    value_kind: "string",
+                    required: true,
+                    default: JsonValue::Null,
+                    help: "End pixel coordinate",
+                    group: "Slice",
+                }),
+                arg(UiArgument {
+                    id: "width",
+                    label: "Width",
+                    order: 4,
+                    parser: option(["--width"], "pixels", []),
+                    value_kind: "number",
+                    required: false,
+                    default: serde_json::json!("1"),
+                    help: "Averaging width in pixels",
+                    group: "Slice",
+                }),
+                arg(UiArgument {
+                    id: "chans",
+                    label: "Channels",
+                    order: 5,
+                    parser: option(["--chans"], "range", []),
+                    value_kind: "string",
+                    required: false,
+                    default: JsonValue::Null,
+                    help: "CASA channel range, for example 4~12",
+                    group: "Selection",
+                }),
+                arg(UiArgument {
+                    id: "overwrite",
+                    label: "Overwrite",
+                    order: 6,
                     parser: toggle(["--overwrite"], []),
                     value_kind: "bool",
                     required: false,
@@ -402,6 +493,8 @@ pub enum ImageAnalysisTaskRequest {
     Imstat(ImstatRequest),
     /// CASA `immoments` style moment map generation.
     Immoments(ImmomentsRequest),
+    /// CASA `impv` style position-velocity extraction.
+    Impv(ImpvRequest),
     /// CASA `exportfits` style FITS image export.
     Exportfits(ExportFitsRequest),
     /// CASA `importfits` style FITS image import.
@@ -418,6 +511,8 @@ pub enum ImageAnalysisTaskResult {
     Imstat(ImageStatisticsSummary),
     /// Result for [`ImageAnalysisTaskRequest::Immoments`].
     Immoments(MomentMapSummary),
+    /// Result for [`ImageAnalysisTaskRequest::Impv`].
+    Impv(PvImageSummary),
     /// Result for [`ImageAnalysisTaskRequest::Exportfits`].
     Exportfits(FitsExportSummary),
     /// Result for [`ImageAnalysisTaskRequest::Importfits`].
@@ -465,6 +560,56 @@ pub struct ImmomentsRequest {
     /// Replace an existing output image.
     #[serde(default)]
     pub overwrite: bool,
+}
+
+/// CASA `impv` request for a tutorial-scoped position-velocity image.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct ImpvRequest {
+    /// Input CASA image path.
+    pub imagename: PathBuf,
+    /// Output CASA image path.
+    pub outfile: PathBuf,
+    /// CASA mode. This implementation supports `coords`.
+    #[serde(default = "default_impv_mode")]
+    pub mode: String,
+    /// Start pixel coordinate as `x,y`.
+    pub start: String,
+    /// End pixel coordinate as `x,y`.
+    pub end: String,
+    /// Slice width in pixels, averaged perpendicular to the path.
+    #[serde(default = "default_impv_width")]
+    pub width: usize,
+    /// CASA channel expression, supporting tutorial forms like `4~12`.
+    #[serde(default)]
+    pub chans: Option<String>,
+    /// Replace an existing output image.
+    #[serde(default)]
+    pub overwrite: bool,
+}
+
+fn default_impv_mode() -> String {
+    "coords".to_string()
+}
+
+fn default_impv_width() -> usize {
+    1
+}
+
+/// Summary returned after writing a PV image.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct PvImageSummary {
+    /// Input CASA image path.
+    pub imagename: String,
+    /// Output CASA image path.
+    pub outfile: String,
+    /// Output image shape.
+    pub shape: Vec<usize>,
+    /// Number of samples along the PV path.
+    pub path_pixels: usize,
+    /// Width in pixels averaged perpendicular to the path.
+    pub width: usize,
+    /// Pixel units copied from the input image.
+    pub units: String,
 }
 
 /// CASA `exportfits` request.
@@ -656,6 +801,9 @@ pub fn run_image_analysis_task(
         ImageAnalysisTaskRequest::Immoments(request) => {
             Ok(ImageAnalysisTaskResult::Immoments(immoments(&request)?))
         }
+        ImageAnalysisTaskRequest::Impv(request) => {
+            Ok(ImageAnalysisTaskResult::Impv(impv(&request)?))
+        }
         ImageAnalysisTaskRequest::Exportfits(request) => {
             Ok(ImageAnalysisTaskResult::Exportfits(export_fits(
                 &request.imagename,
@@ -752,6 +900,18 @@ pub fn immoments(request: &ImmomentsRequest) -> Result<MomentMapSummary, ImageEr
                 "immoments currently supports real-valued images".to_string(),
             ))
         }
+    }
+}
+
+/// Extract a CASA `impv`-style position-velocity image for pixel-coordinate slices.
+pub fn impv(request: &ImpvRequest) -> Result<PvImageSummary, ImageError> {
+    let image = AnyPagedImage::open(&request.imagename)?;
+    match &image {
+        AnyPagedImage::Float32(image) => impv_typed(image, request),
+        AnyPagedImage::Float64(image) => impv_typed(image, request),
+        AnyPagedImage::Complex32(_) | AnyPagedImage::Complex64(_) => Err(
+            ImageError::InvalidMetadata("impv currently supports real-valued images".to_string()),
+        ),
     }
 }
 
@@ -1294,6 +1454,14 @@ fn direction_pixel_area(coords: &CoordinateSystem) -> Option<f64> {
     None
 }
 
+fn collapsed_image_info<T: ImagePixel>(image: &PagedImage<T>) -> Result<ImageInfo, ImageError> {
+    let mut info = image.image_info()?;
+    if info.beam_set.is_multi() {
+        info.beam_set = ImageBeamSet::new(info.beam_set.common_beam()?);
+    }
+    Ok(info)
+}
+
 fn immoments_typed<T>(
     image: &PagedImage<T>,
     request: &ImmomentsRequest,
@@ -1339,11 +1507,13 @@ where
     let out_shape = output_data.shape().to_vec();
     let mut output = TempImage::<f32>::new(out_shape.clone(), image.coordinates().clone())?;
     output.set_units(moment_units(image.units(), request.moments))?;
-    output.set_image_info(&image.image_info()?)?;
+    output.set_image_info(&collapsed_image_info(image)?)?;
     output.set_misc_info(image.misc_info())?;
     output.put_slice(&output_data, &vec![0; output.ndim()])?;
-    output.put_mask("mask0", &output_mask)?;
-    output.set_default_mask("mask0")?;
+    if output_mask.iter().any(|valid| !*valid) {
+        output.put_mask("mask0", &output_mask)?;
+        output.set_default_mask("mask0")?;
+    }
     output.save_as(&request.outfile)?;
     let valid_profiles = output_mask.iter().filter(|value| **value).count();
     Ok(MomentMapSummary {
@@ -1354,6 +1524,207 @@ where
         units: output.units().to_string(),
         valid_profiles,
     })
+}
+
+fn impv_typed<T>(image: &PagedImage<T>, request: &ImpvRequest) -> Result<PvImageSummary, ImageError>
+where
+    T: ImagePixel + Into<f64> + Copy,
+{
+    if !request.mode.eq_ignore_ascii_case("coords") {
+        return Err(ImageError::InvalidMetadata(format!(
+            "impv mode {:?} is not supported by the tutorial path; use mode='coords'",
+            request.mode
+        )));
+    }
+    if image.ndim() < 2 {
+        return Err(ImageError::InvalidMetadata(
+            "impv requires at least two image axes".to_string(),
+        ));
+    }
+    if request.outfile.exists() {
+        if request.overwrite {
+            fs::remove_dir_all(&request.outfile)
+                .map_err(|error| ImageError::Io(error.to_string()))?;
+        } else {
+            return Err(ImageError::Io(format!(
+                "PV output already exists: {}",
+                request.outfile.display()
+            )));
+        }
+    }
+    let [x0, y0] = parse_pixel_pair(&request.start)?;
+    let [x1, y1] = parse_pixel_pair(&request.end)?;
+    let path = bresenham_line(x0, y0, x1, y1);
+    if path.is_empty() {
+        return Err(ImageError::InvalidMetadata(
+            "impv path contains no pixels".to_string(),
+        ));
+    }
+    let mut start = vec![0; image.ndim()];
+    let mut shape = image.shape().to_vec();
+    let spectral_axis = image.find_axis(CoordinateType::Spectral);
+    let channel_indices = if let (Some(axis), Some(chans)) = (
+        spectral_axis,
+        request
+            .chans
+            .as_deref()
+            .filter(|text| !text.trim().is_empty()),
+    ) {
+        let indices = parse_indices(chans, image.shape()[axis])?;
+        start[axis] = indices[0];
+        shape[axis] = indices[indices.len() - 1] - indices[0] + 1;
+        Some((axis, indices))
+    } else {
+        None
+    };
+    let mut output_shape = shape.clone();
+    output_shape[0] = path.len();
+    output_shape[1] = 1;
+    let mut output_data = ArrayD::<f32>::zeros(IxDyn(&output_shape).f());
+    let other_shape = output_shape[2..].to_vec();
+    let offsets = perpendicular_offsets(x0, y0, x1, y1, request.width.max(1));
+    for sample_index in all_indices_for_shape(&other_shape) {
+        for (path_index, &(x, y)) in path.iter().enumerate() {
+            let mut sum = 0.0;
+            let mut count = 0usize;
+            for &(dx, dy) in &offsets {
+                let sx = x + dx;
+                let sy = y + dy;
+                if sx < 0
+                    || sy < 0
+                    || sx as usize >= image.shape()[0]
+                    || sy as usize >= image.shape()[1]
+                {
+                    continue;
+                }
+                let mut input_index = start.clone();
+                input_index[0] = sx as usize;
+                input_index[1] = sy as usize;
+                for (offset_axis, value) in sample_index.iter().copied().enumerate() {
+                    input_index[offset_axis + 2] += value;
+                }
+                if let Some((axis, indices)) = &channel_indices {
+                    let local = sample_index[*axis - 2];
+                    input_index[*axis] = indices[local];
+                }
+                sum += image.get_at(&input_index)?.into();
+                count += 1;
+            }
+            if count > 0 {
+                let mut output_index = vec![0; output_shape.len()];
+                output_index[0] = path_index;
+                output_index[1] = 0;
+                for (offset_axis, value) in sample_index.iter().copied().enumerate() {
+                    output_index[offset_axis + 2] = value;
+                }
+                output_data[IxDyn(&output_index)] = (sum / count as f64) as f32;
+            }
+        }
+    }
+    let mut output = TempImage::<f32>::new(output_shape.clone(), image.coordinates().clone())?;
+    output.set_units(image.units())?;
+    output.set_image_info(&collapsed_image_info(image)?)?;
+    output.set_misc_info(image.misc_info())?;
+    output.put_slice(&output_data, &vec![0; output.ndim()])?;
+    output.save_as(&request.outfile)?;
+    Ok(PvImageSummary {
+        imagename: request.imagename.display().to_string(),
+        outfile: request.outfile.display().to_string(),
+        shape: output_shape,
+        path_pixels: path.len(),
+        width: request.width.max(1),
+        units: output.units().to_string(),
+    })
+}
+
+fn parse_pixel_pair(text: &str) -> Result<[isize; 2], ImageError> {
+    let values = text
+        .split(',')
+        .map(|part| {
+            part.trim().parse::<isize>().map_err(|error| {
+                ImageError::InvalidMetadata(format!("invalid pixel coordinate {text:?}: {error}"))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if values.len() != 2 {
+        return Err(ImageError::InvalidMetadata(format!(
+            "pixel coordinate must be x,y, got {text:?}"
+        )));
+    }
+    Ok([values[0], values[1]])
+}
+
+fn bresenham_line(x0: isize, y0: isize, x1: isize, y1: isize) -> Vec<(isize, isize)> {
+    let mut points = Vec::new();
+    let mut x = x0;
+    let mut y = y0;
+    let dx = (x1 - x0).abs();
+    let sx = if x0 < x1 { 1 } else { -1 };
+    let dy = -(y1 - y0).abs();
+    let sy = if y0 < y1 { 1 } else { -1 };
+    let mut err = dx + dy;
+    loop {
+        points.push((x, y));
+        if x == x1 && y == y1 {
+            break;
+        }
+        let e2 = 2 * err;
+        if e2 >= dy {
+            err += dy;
+            x += sx;
+        }
+        if e2 <= dx {
+            err += dx;
+            y += sy;
+        }
+    }
+    points
+}
+
+fn perpendicular_offsets(
+    x0: isize,
+    y0: isize,
+    x1: isize,
+    y1: isize,
+    width: usize,
+) -> Vec<(isize, isize)> {
+    let dx = (x1 - x0) as f64;
+    let dy = (y1 - y0) as f64;
+    let length = (dx * dx + dy * dy).sqrt();
+    let (px, py) = if length > 0.0 {
+        (-dy / length, dx / length)
+    } else {
+        (0.0, 1.0)
+    };
+    let center = (width as isize - 1) as f64 / 2.0;
+    (0..width)
+        .map(|index| {
+            let offset = index as f64 - center;
+            (
+                (px * offset).round() as isize,
+                (py * offset).round() as isize,
+            )
+        })
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn all_indices_for_shape(shape: &[usize]) -> Vec<Vec<usize>> {
+    fn push(shape: &[usize], axis: usize, current: &mut Vec<usize>, out: &mut Vec<Vec<usize>>) {
+        if axis == shape.len() {
+            out.push(current.clone());
+            return;
+        }
+        for value in 0..shape[axis] {
+            current.push(value);
+            push(shape, axis + 1, current, out);
+            current.pop();
+        }
+    }
+    let mut out = Vec::new();
+    push(shape, 0, &mut Vec::new(), &mut out);
+    out
 }
 
 fn collapse_moment<T>(
@@ -1865,7 +2236,7 @@ mod tests {
             bundle.protocol.protocol_name,
             IMAGE_ANALYSIS_TASK_PROTOCOL_NAME
         );
-        assert_eq!(bundle.semantic.operations.len(), 5);
+        assert_eq!(bundle.semantic.operations.len(), 6);
         assert_eq!(
             bundle
                 .projections
@@ -1884,6 +2255,7 @@ mod tests {
 
         for (binary, expected_args) in [
             ("immoments", ["imagename", "outfile", "moments"].as_slice()),
+            ("impv", ["imagename", "outfile", "start", "end"].as_slice()),
             (
                 "exportfits",
                 ["imagename", "fitsimage", "velocity"].as_slice(),
@@ -1972,7 +2344,27 @@ mod tests {
         assert_eq!(moment.units, "Jy/beam.km/s");
         assert_eq!(moment.valid_profiles, 4);
         let moment_image = PagedImage::<f32>::open(&moment_path).unwrap();
-        assert_eq!(moment_image.default_mask_name().as_deref(), Some("mask0"));
+        assert_eq!(moment_image.default_mask_name(), None);
+
+        let pv_path = temp.path().join("pv.image");
+        let pv_result = run_image_analysis_task(ImageAnalysisTaskRequest::Impv(ImpvRequest {
+            imagename: source_path.clone(),
+            outfile: pv_path.clone(),
+            mode: "coords".to_string(),
+            start: "0,0".to_string(),
+            end: "1,1".to_string(),
+            width: 1,
+            chans: Some("1~2".to_string()),
+            overwrite: false,
+        }))
+        .unwrap();
+        let ImageAnalysisTaskResult::Impv(pv) = pv_result else {
+            panic!("expected impv result");
+        };
+        assert_eq!(pv.shape, vec![2, 1, 2]);
+        assert_eq!(pv.path_pixels, 2);
+        let pv_image = PagedImage::<f32>::open(&pv_path).unwrap();
+        assert_eq!(pv_image.shape(), &[2, 1, 2]);
 
         run_image_analysis_task(ImageAnalysisTaskRequest::Exportfits(ExportFitsRequest {
             imagename: source_path.clone(),

--- a/crates/casa-images/src/bin/imexplore.rs
+++ b/crates/casa-images/src/bin/imexplore.rs
@@ -6,7 +6,10 @@ use std::io::{self, BufRead, Write};
 use std::path::PathBuf;
 use std::process;
 
-use casa_images::{ImageBrowserSession, imexplore_ui_schema_json, imhead, imstat};
+use casa_images::{
+    ImageBrowserSession, ImmomentsRequest, ImpvRequest, imexplore_ui_schema_json, imhead,
+    immoments, impv, imstat,
+};
 use casars_imagebrowser_protocol::{
     ImageBrowserCommand, ImageBrowserProtocolInfo, ImageBrowserRequestEnvelope,
     ImageBrowserResponseEnvelope, ImageBrowserViewport, PROTOCOL_VERSION, schema_bundle_json,
@@ -120,6 +123,44 @@ fn run() -> Result<(), String> {
         }
         return Ok(());
     }
+    if args.peek().is_some_and(|arg| arg == "immoments") {
+        args.next();
+        let moment_args = parse_immoments_args(args)?;
+        let summary = immoments(&moment_args.request).map_err(|error| error.to_string())?;
+        if moment_args.json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&summary)
+                    .map_err(|error| format!("serialize immoments summary: {error}"))?
+            );
+        } else {
+            println!("outfile: {}", summary.outfile);
+            println!("moment: {}", summary.moment);
+            println!("shape: {:?}", summary.shape);
+            println!("valid_profiles: {}", summary.valid_profiles);
+            println!("units: {}", summary.units);
+        }
+        return Ok(());
+    }
+    if args.peek().is_some_and(|arg| arg == "impv") {
+        args.next();
+        let pv_args = parse_impv_args(args)?;
+        let summary = impv(&pv_args.request).map_err(|error| error.to_string())?;
+        if pv_args.json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&summary)
+                    .map_err(|error| format!("serialize impv summary: {error}"))?
+            );
+        } else {
+            println!("outfile: {}", summary.outfile);
+            println!("shape: {:?}", summary.shape);
+            println!("path_pixels: {}", summary.path_pixels);
+            println!("width: {}", summary.width);
+            println!("units: {}", summary.units);
+        }
+        return Ok(());
+    }
 
     let image_path = parse_path(args)?;
     run_snapshot(&image_path)
@@ -150,6 +191,16 @@ struct ImstatArgs {
     path: PathBuf,
     box_pixels: Option<String>,
     chans: Option<String>,
+    json: bool,
+}
+
+struct ImmomentsArgs {
+    request: ImmomentsRequest,
+    json: bool,
+}
+
+struct ImpvArgs {
+    request: ImpvRequest,
     json: bool,
 }
 
@@ -193,11 +244,157 @@ fn imstat_usage() -> String {
     "usage: imexplore imstat <image-path> [--box x0,y0,x1,y1] [--chans 0~4] [--json]".to_string()
 }
 
+fn parse_immoments_args(args: impl IntoIterator<Item = String>) -> Result<ImmomentsArgs, String> {
+    let args = args.into_iter().collect::<Vec<_>>();
+    let mut path = None;
+    let mut outfile = None;
+    let mut moments = 0;
+    let mut chans = None;
+    let mut includepix = None;
+    let mut overwrite = false;
+    let mut json = false;
+    let mut idx = 0;
+    while idx < args.len() {
+        match args[idx].as_str() {
+            "--outfile" => {
+                idx += 1;
+                outfile = Some(PathBuf::from(args.get(idx).ok_or_else(immoments_usage)?));
+            }
+            "--moments" => {
+                idx += 1;
+                moments = args
+                    .get(idx)
+                    .ok_or_else(immoments_usage)?
+                    .parse::<i32>()
+                    .map_err(|error| format!("invalid --moments: {error}"))?;
+            }
+            "--chans" => {
+                idx += 1;
+                chans = Some(args.get(idx).ok_or_else(immoments_usage)?.clone());
+            }
+            "--includepix" => {
+                idx += 1;
+                includepix = Some(parse_range(args.get(idx).ok_or_else(immoments_usage)?)?);
+            }
+            "--overwrite" => overwrite = true,
+            "--json" => json = true,
+            _ if path.is_none() => path = Some(PathBuf::from(&args[idx])),
+            other => {
+                return Err(format!(
+                    "unknown immoments argument {other:?}\n{}",
+                    immoments_usage()
+                ));
+            }
+        }
+        idx += 1;
+    }
+
+    Ok(ImmomentsArgs {
+        request: ImmomentsRequest {
+            imagename: path.ok_or_else(immoments_usage)?,
+            outfile: outfile.ok_or_else(immoments_usage)?,
+            moments,
+            chans,
+            includepix,
+            overwrite,
+        },
+        json,
+    })
+}
+
+fn immoments_usage() -> String {
+    "usage: imexplore immoments <image-path> --outfile <path> [--moments 0|1] [--chans 4~12] [--includepix min,max] [--overwrite] [--json]".to_string()
+}
+
+fn parse_impv_args(args: impl IntoIterator<Item = String>) -> Result<ImpvArgs, String> {
+    let args = args.into_iter().collect::<Vec<_>>();
+    let mut path = None;
+    let mut outfile = None;
+    let mut mode = "coords".to_string();
+    let mut start = None;
+    let mut end = None;
+    let mut width = 1usize;
+    let mut chans = None;
+    let mut overwrite = false;
+    let mut json = false;
+    let mut idx = 0;
+    while idx < args.len() {
+        match args[idx].as_str() {
+            "--outfile" => {
+                idx += 1;
+                outfile = Some(PathBuf::from(args.get(idx).ok_or_else(impv_usage)?));
+            }
+            "--mode" => {
+                idx += 1;
+                mode = args.get(idx).ok_or_else(impv_usage)?.clone();
+            }
+            "--start" => {
+                idx += 1;
+                start = Some(args.get(idx).ok_or_else(impv_usage)?.clone());
+            }
+            "--end" => {
+                idx += 1;
+                end = Some(args.get(idx).ok_or_else(impv_usage)?.clone());
+            }
+            "--width" => {
+                idx += 1;
+                width = args
+                    .get(idx)
+                    .ok_or_else(impv_usage)?
+                    .parse::<usize>()
+                    .map_err(|error| format!("invalid --width: {error}"))?;
+            }
+            "--chans" => {
+                idx += 1;
+                chans = Some(args.get(idx).ok_or_else(impv_usage)?.clone());
+            }
+            "--overwrite" => overwrite = true,
+            "--json" => json = true,
+            _ if path.is_none() => path = Some(PathBuf::from(&args[idx])),
+            other => return Err(format!("unknown impv argument {other:?}\n{}", impv_usage())),
+        }
+        idx += 1;
+    }
+
+    Ok(ImpvArgs {
+        request: ImpvRequest {
+            imagename: path.ok_or_else(impv_usage)?,
+            outfile: outfile.ok_or_else(impv_usage)?,
+            mode,
+            start: start.ok_or_else(impv_usage)?,
+            end: end.ok_or_else(impv_usage)?,
+            width,
+            chans,
+            overwrite,
+        },
+        json,
+    })
+}
+
+fn impv_usage() -> String {
+    "usage: imexplore impv <image-path> --outfile <path> --start x,y --end x,y [--mode coords] [--width pixels] [--chans 4~12] [--overwrite] [--json]".to_string()
+}
+
+fn parse_range(text: &str) -> Result<[f64; 2], String> {
+    let values = text
+        .split(',')
+        .map(|part| {
+            part.trim()
+                .parse::<f64>()
+                .map_err(|error| format!("invalid range {text:?}: {error}"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if values.len() != 2 {
+        return Err(format!("range must be min,max, got {text:?}"));
+    }
+    Ok([values[0], values[1]])
+}
+
 fn parse_path(args: impl IntoIterator<Item = String>) -> Result<PathBuf, String> {
     let args = args.into_iter().collect::<Vec<_>>();
     if args.len() != 1 {
         return Err(
-            "usage: imexplore <image-path> | imexplore imhead <image-path> [--json] | imexplore imstat <image-path> [--box x0,y0,x1,y1] [--chans 0~4] [--json] | imexplore --session | imexplore --json-schema | imexplore --protocol-info | imexplore --ui-schema".into(),
+            "usage: imexplore <image-path> | imexplore imhead <image-path> [--json] | imexplore imstat <image-path> [--box x0,y0,x1,y1] [--chans 0~4] [--json] | imexplore immoments <image-path> --outfile <path> [--json] | imexplore impv <image-path> --outfile <path> --start x,y --end x,y [--json] | imexplore --session | imexplore --json-schema | imexplore --protocol-info | imexplore --ui-schema".into(),
         );
     }
     Ok(PathBuf::from(&args[0]))

--- a/crates/casa-images/src/bin/impv.rs
+++ b/crates/casa-images/src/bin/impv.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//! `impv` - CASA-style position-velocity extraction.
+
+use std::env;
+use std::path::PathBuf;
+use std::process;
+
+use casa_images::{
+    ImageAnalysisProtocolInfo, ImageAnalysisTaskResult, ImageAnalysisTaskSchemaBundle, ImpvRequest,
+    image_analysis_ui_schema_json, impv, read_image_analysis_request_source,
+    run_image_analysis_task,
+};
+
+fn main() {
+    match run() {
+        Ok(()) => {}
+        Err(error) => {
+            eprintln!("Error: {error}");
+            process::exit(1);
+        }
+    }
+}
+
+fn run() -> Result<(), String> {
+    let args = env::args().skip(1).collect::<Vec<_>>();
+    if args.first().is_some_and(|arg| arg == "--protocol-info") {
+        print_json(&ImageAnalysisProtocolInfo::current())?;
+        return Ok(());
+    }
+    if args.first().is_some_and(|arg| arg == "--json-schema") {
+        print_json(&ImageAnalysisTaskSchemaBundle::current("impv"))?;
+        return Ok(());
+    }
+    if args.first().is_some_and(|arg| arg == "--ui-schema") {
+        print!(
+            "{}",
+            image_analysis_ui_schema_json("impv").map_err(|error| error.to_string())?
+        );
+        return Ok(());
+    }
+    if args.first().is_some_and(|arg| arg == "--json-run") {
+        let source = args
+            .get(1)
+            .ok_or_else(|| "--json-run requires <SOURCE> or -".to_string())?;
+        let request =
+            read_image_analysis_request_source(source).map_err(|error| error.to_string())?;
+        let result = run_image_analysis_task(request).map_err(|error| error.to_string())?;
+        print_json(&result)?;
+        return Ok(());
+    }
+    let request = parse_request(&args)?;
+    let result = impv(&request).map_err(|error| error.to_string())?;
+    print_json(&ImageAnalysisTaskResult::Impv(result))
+}
+
+fn parse_request(args: &[String]) -> Result<ImpvRequest, String> {
+    let imagename = args.first().ok_or_else(usage)?.as_str().to_string();
+    let mut outfile = None;
+    let mut mode = "coords".to_string();
+    let mut start = None;
+    let mut end = None;
+    let mut width = 1usize;
+    let mut chans = None;
+    let mut overwrite = false;
+    let mut idx = 1;
+    while idx < args.len() {
+        match args[idx].as_str() {
+            "--outfile" => {
+                idx += 1;
+                outfile = Some(PathBuf::from(args.get(idx).ok_or_else(usage)?));
+            }
+            "--mode" => {
+                idx += 1;
+                mode = args.get(idx).ok_or_else(usage)?.clone();
+            }
+            "--start" => {
+                idx += 1;
+                start = Some(args.get(idx).ok_or_else(usage)?.clone());
+            }
+            "--end" => {
+                idx += 1;
+                end = Some(args.get(idx).ok_or_else(usage)?.clone());
+            }
+            "--width" => {
+                idx += 1;
+                width = args
+                    .get(idx)
+                    .ok_or_else(usage)?
+                    .parse::<usize>()
+                    .map_err(|error| format!("invalid --width: {error}"))?;
+            }
+            "--chans" => {
+                idx += 1;
+                chans = Some(args.get(idx).ok_or_else(usage)?.clone());
+            }
+            "--overwrite" => overwrite = true,
+            other => return Err(format!("unknown argument {other:?}\n{}", usage())),
+        }
+        idx += 1;
+    }
+    Ok(ImpvRequest {
+        imagename: PathBuf::from(imagename),
+        outfile: outfile.ok_or_else(usage)?,
+        mode,
+        start: start.ok_or_else(usage)?,
+        end: end.ok_or_else(usage)?,
+        width,
+        chans,
+        overwrite,
+    })
+}
+
+fn print_json<T: serde::Serialize>(value: &T) -> Result<(), String> {
+    println!(
+        "{}",
+        serde_json::to_string_pretty(value).map_err(|error| error.to_string())?
+    );
+    Ok(())
+}
+
+fn usage() -> String {
+    "usage: impv <imagename> --outfile <path> --start x,y --end x,y [--width pixels] [--chans 4~12] [--overwrite] | impv --json-run <SOURCE>".to_string()
+}

--- a/crates/casa-images/src/lib.rs
+++ b/crates/casa-images/src/lib.rs
@@ -82,8 +82,9 @@ pub use analysis::{
     ExportFitsRequest, FitsExportSummary, FitsImportSummary, ImageAnalysisProtocolInfo,
     ImageAnalysisTaskRequest, ImageAnalysisTaskResult, ImageAnalysisTaskSchemaBundle,
     ImageHeaderSummary, ImageStatisticsSummary, ImheadRequest, ImmomentsRequest, ImportFitsRequest,
-    ImstatRequest, MomentMapSummary, export_fits, image_analysis_ui_schema_json, imhead, immoments,
-    import_fits, imstat, read_image_analysis_request_source, run_image_analysis_task,
+    ImpvRequest, ImstatRequest, MomentMapSummary, PvImageSummary, export_fits,
+    image_analysis_ui_schema_json, imhead, immoments, import_fits, impv, imstat,
+    read_image_analysis_request_source, run_image_analysis_task,
 };
 pub use beam::{GaussianBeam, ImageBeamSet};
 pub use browser_render::{

--- a/crates/casa-imaging/src/types.rs
+++ b/crates/casa-imaging/src/types.rs
@@ -387,7 +387,7 @@ pub struct CubeChannelRequest {
 }
 
 impl CubeChannelRequest {
-    pub(crate) fn validate(&self) -> Result<(), ImagingError> {
+    pub(crate) fn validate(&self, require_model_interpolation: bool) -> Result<(), ImagingError> {
         if !(self.channel_frequency_hz.is_finite() && self.channel_frequency_hz > 0.0) {
             return Err(ImagingError::InvalidRequest(
                 "cube channel frequencies must be finite positive Hz".to_string(),
@@ -400,6 +400,12 @@ impl CubeChannelRequest {
         }
         for batch in &self.density_batches {
             batch.validate()?;
+        }
+        for batch in &self.visibility_batches {
+            batch.validate()?;
+        }
+        if self.model_interpolation_batches.is_empty() && !require_model_interpolation {
+            return Ok(());
         }
         if self.model_interpolation_batches.len() != self.visibility_batches.len() {
             return Err(ImagingError::InvalidRequest(format!(
@@ -414,7 +420,6 @@ impl CubeChannelRequest {
             .zip(self.model_interpolation_batches.iter())
             .enumerate()
         {
-            batch.validate()?;
             if interpolation.sample_contributions.len() != batch.len() {
                 return Err(ImagingError::InvalidRequest(format!(
                     "cube model interpolation batch {batch_index} length {} does not match visibility batch length {}",
@@ -1047,8 +1052,9 @@ impl CubeImagingRequest {
                 "cube imaging requires at least one spectral plane".to_string(),
             ));
         }
+        let require_model_interpolation = self.clean.niter > 0;
         for channel in &self.channels {
-            channel.validate()?;
+            channel.validate(require_model_interpolation)?;
         }
         Ok(())
     }

--- a/crates/casa-ms/Cargo.toml
+++ b/crates/casa-ms/Cargo.toml
@@ -37,6 +37,10 @@ tempfile = "3"
 name = "msexplore"
 path = "src/bin/msexplore.rs"
 
+[[bin]]
+name = "mstransform"
+path = "src/bin/mstransform.rs"
+
 [lints]
 workspace = true
 

--- a/crates/casa-ms/src/bin/mstransform.rs
+++ b/crates/casa-ms/src/bin/mstransform.rs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//! `mstransform` - tutorial-scoped MeasurementSet transform.
+
+use std::env;
+use std::path::PathBuf;
+use std::process;
+
+use casa_ms::selection::MsSelection;
+use casa_ms::{MsTransformRequest, TransformDataColumn, mstransform, parse_numeric_id_selector};
+
+fn main() {
+    match run() {
+        Ok(()) => {}
+        Err(error) => {
+            eprintln!("Error: {error}");
+            process::exit(1);
+        }
+    }
+}
+
+fn run() -> Result<(), String> {
+    let args = env::args().skip(1).collect::<Vec<_>>();
+    let request = parse_request(&args)?;
+    let report = mstransform(&request).map_err(|error| error.to_string())?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&report).map_err(|error| error.to_string())?
+    );
+    Ok(())
+}
+
+fn parse_request(args: &[String]) -> Result<MsTransformRequest, String> {
+    let mut input_ms = None;
+    let mut output_ms = None;
+    let mut spw = None;
+    let mut data_column = TransformDataColumn::default();
+    let mut selection = MsSelection::default();
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--ms" | "--vis" => {
+                index += 1;
+                input_ms = Some(PathBuf::from(args.get(index).ok_or_else(usage)?));
+            }
+            "--out" | "--outputvis" => {
+                index += 1;
+                output_ms = Some(PathBuf::from(args.get(index).ok_or_else(usage)?));
+            }
+            "--spw" => {
+                index += 1;
+                spw = Some(args.get(index).ok_or_else(usage)?.clone());
+            }
+            "--datacolumn" => {
+                index += 1;
+                data_column = parse_data_column(args.get(index).ok_or_else(usage)?)?;
+            }
+            "--field" => {
+                index += 1;
+                selection = selection.field(
+                    &parse_numeric_id_selector(args.get(index).ok_or_else(usage)?, "field")
+                        .map_err(|error| error.to_string())?,
+                );
+            }
+            "--scan" => {
+                index += 1;
+                selection = selection.scan(
+                    &parse_numeric_id_selector(args.get(index).ok_or_else(usage)?, "scan")
+                        .map_err(|error| error.to_string())?,
+                );
+            }
+            "--antenna" => {
+                index += 1;
+                selection = selection.antenna(
+                    &parse_numeric_id_selector(args.get(index).ok_or_else(usage)?, "antenna")
+                        .map_err(|error| error.to_string())?,
+                );
+            }
+            "--timerange" => {
+                index += 1;
+                let value = args.get(index).ok_or_else(usage)?;
+                let (start, end) = parse_time_range(value)?;
+                selection = selection.time_range(start, end);
+            }
+            "--msselect" => {
+                index += 1;
+                selection = selection.taql(args.get(index).ok_or_else(usage)?);
+            }
+            "--selectdata" => {}
+            "--no-selectdata" => {}
+            other => return Err(format!("unknown argument {other:?}\n{}", usage())),
+        }
+        index += 1;
+    }
+    Ok(MsTransformRequest {
+        input_ms: input_ms.ok_or_else(usage)?,
+        output_ms: output_ms.ok_or_else(usage)?,
+        spw: spw.ok_or_else(usage)?,
+        data_column,
+        selection,
+    })
+}
+
+fn parse_data_column(value: &str) -> Result<TransformDataColumn, String> {
+    match value.trim().to_ascii_uppercase().as_str() {
+        "DATA" => Ok(TransformDataColumn::Data),
+        "CORRECTED" | "CORRECTED_DATA" => Ok(TransformDataColumn::CorrectedData),
+        other => Err(format!(
+            "unsupported --datacolumn {other:?}; expected DATA or CORRECTED_DATA"
+        )),
+    }
+}
+
+fn parse_time_range(value: &str) -> Result<(f64, f64), String> {
+    let (start, end) = value
+        .split_once('~')
+        .ok_or_else(|| format!("--timerange must be start~end MJD seconds, got {value:?}"))?;
+    let start = start
+        .trim()
+        .parse::<f64>()
+        .map_err(|error| format!("invalid timerange start {start:?}: {error}"))?;
+    let end = end
+        .trim()
+        .parse::<f64>()
+        .map_err(|error| format!("invalid timerange end {end:?}: {error}"))?;
+    Ok((start, end))
+}
+
+fn usage() -> String {
+    "usage: mstransform --ms <input.ms> --out <output.ms> --spw <spw[:channels]> [--field <ids>] [--datacolumn DATA|CORRECTED_DATA]".to_string()
+}

--- a/crates/casa-ms/src/derived/engine.rs
+++ b/crates/casa-ms/src/derived/engine.rs
@@ -382,6 +382,27 @@ impl MsCalEngine {
         Ok([u, v, w])
     }
 
+    /// Project an ITRF antenna-position offset into source-frame UVW meters.
+    ///
+    /// This mirrors CASA `KAntPosJones`: build the frame at antenna 0, convert
+    /// the earth-frame antenna offset to the field direction's sky frame, then
+    /// use its W projection as the per-antenna delay.
+    pub fn project_itrf_offset_to_uvw(
+        &self,
+        time_mjd_sec: f64,
+        field_id: usize,
+        _antenna_id: usize,
+        offset_m: [f64; 3],
+    ) -> MsResult<[f64; 3]> {
+        let frame = self.make_frame(time_mjd_sec, 0)?;
+        let dir = self.field_dir(field_id)?;
+        let source_itrf = dir.convert_to(DirectionRef::ITRF, &frame)?.cosines();
+        let w = offset_m[0] * source_itrf[0]
+            + offset_m[1] * source_itrf[1]
+            + offset_m[2] * source_itrf[2];
+        Ok([0.0, 0.0, w])
+    }
+
     /// Reproject raw MS UVW coordinates from one field phase center to another.
     ///
     /// The input UVW is assumed to be stored in native MeasurementSet

--- a/crates/casa-ms/src/lib.rs
+++ b/crates/casa-ms/src/lib.rs
@@ -59,6 +59,7 @@ pub mod selection_helpers;
 pub mod selection_syntax;
 pub mod spectral_selection;
 pub mod subtables;
+pub mod transform;
 pub mod ui_schema;
 pub mod validate;
 
@@ -125,4 +126,7 @@ pub use subtables::{
     MsPolarization, MsPolarizationMut, MsProcessor, MsProcessorMut, MsSource, MsSourceMut,
     MsSpectralWindow, MsSpectralWindowMut, MsState, MsStateMut, MsSysCal, MsSysCalMut, MsWeather,
     MsWeatherMut, SubTable,
+};
+pub use transform::{
+    MsTransformError, MsTransformReport, MsTransformRequest, TransformDataColumn, mstransform,
 };

--- a/crates/casa-ms/src/ms.rs
+++ b/crates/casa-ms/src/ms.rs
@@ -801,7 +801,7 @@ fn apply_column_metadata(table: &mut Table, defs: &[ColumnDef]) {
     }
 }
 
-fn measurement_set_table_options(path: &Path) -> TableOptions {
+pub(crate) fn measurement_set_table_options(path: &Path) -> TableOptions {
     TableOptions::new(path).with_data_manager(DataManagerKind::StandardStMan)
 }
 
@@ -843,7 +843,7 @@ fn save_main_table_with_policy(main: &Table, path: &Path, assume_valid: bool) ->
     Ok(())
 }
 
-fn measurement_set_main_table_bindings(main: &Table) -> HashMap<String, ColumnBinding> {
+pub(crate) fn measurement_set_main_table_bindings(main: &Table) -> HashMap<String, ColumnBinding> {
     let column_names: HashSet<_> = main
         .schema()
         .map(|schema| {

--- a/crates/casa-ms/src/msexplore/cli.rs
+++ b/crates/casa-ms/src/msexplore/cli.rs
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 //! Schema-backed CLI support for `msexplore`.
 
+use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::fs;
 use std::path::PathBuf;
 
+use casa_types::{ArrayValue, ScalarValue, Value};
 use serde::Deserialize;
 
 use super::task_contract::{
@@ -12,10 +14,10 @@ use super::task_contract::{
 };
 use super::{
     DEFAULT_MAX_PLOT_POINTS, MsAxis, MsColorAxis, MsDataColumn, MsExploreSpec, MsExportFormat,
-    MsFlagAction, MsFlagEditSpec, MsFlagRegion, MsIterationAxis, MsLegendPosition,
-    MsPageExportRange, MsPageHeaderItem, MsPlotPreset, MsPlotSpec, MsPlotStyleSpec,
-    MsSelectionSpec, apply_msexplore_flag_edit_for_request, build_msexplore_payload,
-    export_msexplore_plot, preview_msexplore_flag_edit_for_request,
+    MsFlagAction, MsFlagEditPreview, MsFlagEditSpec, MsFlagRegion, MsFlagRowEdit, MsFlagSampleEdit,
+    MsIterationAxis, MsLegendPosition, MsPageExportRange, MsPageHeaderItem, MsPlotPreset,
+    MsPlotSpec, MsPlotStyleSpec, MsSelectionSpec, apply_msexplore_flag_edit_for_request,
+    build_msexplore_payload, export_msexplore_plot, preview_msexplore_flag_edit_for_request,
 };
 use crate::MeasurementSet;
 pub use crate::ui_schema::{
@@ -91,6 +93,7 @@ struct CliOptions {
     flag_panel: Option<String>,
     flag_extcorr: bool,
     flag_extchannel: bool,
+    flag_selected: bool,
     flag_apply: bool,
     flag_output: Option<PathBuf>,
     plot_output: Option<PathBuf>,
@@ -1216,9 +1219,23 @@ pub fn command_schema(program_name: &str) -> UiCommandSchema {
                 },
             ),
             toggle_argument(
+                "flag_selected",
+                "Flag Selected Rows",
+                64,
+                "Apply the flag action to every FLAG sample in the selected MAIN rows",
+                ToggleArgumentConfig {
+                    true_flags: &["--flag-selected"],
+                    false_flags: &[],
+                    default: false,
+                    group: "Flag Editing",
+                    advanced: true,
+                    hidden_in_tui: false,
+                },
+            ),
+            toggle_argument(
                 "flag_apply",
                 "Apply Flag Edit",
-                64,
+                65,
                 "Apply the staged flag edit to MAIN FLAG / FLAG_ROW; omit for preview-only",
                 ToggleArgumentConfig {
                     true_flags: &["--flag-apply"],
@@ -1232,7 +1249,7 @@ pub fn command_schema(program_name: &str) -> UiCommandSchema {
             option_argument(
                 "flag_output",
                 "Flag Preview Output",
-                65,
+                66,
                 &["--flag-output"],
                 "PATH",
                 UiValueKind::Path,
@@ -1243,8 +1260,8 @@ pub fn command_schema(program_name: &str) -> UiCommandSchema {
                 true,
                 false,
             ),
-            action_argument(66, "ui_schema", &["--ui-schema"], UiActionKind::UiSchema),
-            action_argument(67, "help", &["-h", "--help"], UiActionKind::Help),
+            action_argument(67, "ui_schema", &["--ui-schema"], UiActionKind::UiSchema),
+            action_argument(68, "help", &["-h", "--help"], UiActionKind::Help),
         ],
         managed_output: Some(UiManagedOutputSchema {
             renderer: "measurementset-summary-v1".to_string(),
@@ -1290,29 +1307,36 @@ fn run(options: CliOptions) -> Result<(), String> {
         None
     };
 
-    if let Some(explore_spec) = &explore_spec {
-        if let Some(flag_edit) = &flag_edit {
+    if let Some(action) = options.flag_action {
+        if options.flag_selected {
+            let preview = if options.flag_apply && options.flag_output.is_none() {
+                apply_selection_flag_edit_direct(&mut ms, &options.selection, action)?
+            } else {
+                let preview = preview_selection_flag_edit(&ms, &options.selection, action)?;
+                if options.flag_apply {
+                    apply_selection_flag_edit_preview(&mut ms, &preview)?;
+                }
+                preview
+            };
+            if options.flag_apply {
+                ms.save_main_table_only_assuming_valid()
+                    .map_err(|error| error.to_string())?;
+            }
+            write_or_log_flag_preview(&options, &preview)?;
+        } else if let Some(explore_spec) = &explore_spec {
+            let flag_edit = flag_edit
+                .as_ref()
+                .ok_or_else(|| "msexplore lost its prepared flag edit".to_string())?;
             let preview = if options.flag_apply {
                 let preview =
                     apply_msexplore_flag_edit_for_request(&mut ms, explore_spec, flag_edit)?;
-                ms.save().map_err(|error| error.to_string())?;
+                ms.save_main_table_only_assuming_valid()
+                    .map_err(|error| error.to_string())?;
                 preview
             } else {
                 preview_msexplore_flag_edit_for_request(&ms, explore_spec, flag_edit)?
             };
-            if let Some(path) = options.flag_output.as_deref() {
-                let json = serde_json::to_string_pretty(&preview)
-                    .map_err(|error| format!("serialize flag preview: {error}"))?;
-                write_output(Some(path), options.overwrite, &json)?;
-            } else {
-                eprintln!(
-                    "Flag edit preview: matched_points={} affected_rows={} affected_samples={} apply={}",
-                    preview.matched_points,
-                    preview.affected_rows,
-                    preview.affected_samples,
-                    options.flag_apply
-                );
-            }
+            write_or_log_flag_preview(&options, &preview)?;
         }
     }
 
@@ -1469,6 +1493,9 @@ fn build_flag_edit_spec(options: &CliOptions) -> Result<Option<MsFlagEditSpec>, 
     let Some(action) = options.flag_action else {
         return Ok(None);
     };
+    if options.flag_selected {
+        return Ok(None);
+    }
     let x_min = options
         .flag_xmin
         .ok_or_else(|| "--flag-action requires --flag-xmin".to_string())?;
@@ -1494,6 +1521,200 @@ fn build_flag_edit_spec(options: &CliOptions) -> Result<Option<MsFlagEditSpec>, 
         extcorr: options.flag_extcorr,
         extchannel: options.flag_extchannel,
     }))
+}
+
+fn write_or_log_flag_preview(
+    options: &CliOptions,
+    preview: &MsFlagEditPreview,
+) -> Result<(), String> {
+    if let Some(path) = options.flag_output.as_deref() {
+        let json = serde_json::to_string_pretty(preview)
+            .map_err(|error| format!("serialize flag preview: {error}"))?;
+        write_output(Some(path), options.overwrite, &json)?;
+    } else {
+        eprintln!(
+            "Flag edit preview: matched_points={} affected_rows={} affected_samples={} apply={}",
+            preview.matched_points,
+            preview.affected_rows,
+            preview.affected_samples,
+            options.flag_apply
+        );
+    }
+    Ok(())
+}
+
+fn preview_selection_flag_edit(
+    ms: &MeasurementSet,
+    selection: &MsSelectionSpec,
+    action: MsFlagAction,
+) -> Result<MsFlagEditPreview, String> {
+    let listobs_options = selection.to_summary_options();
+    let row_numbers = super::resolve_selected_rows_with_msselect(ms, selection, &listobs_options)?;
+    let mut sample_edits = Vec::new();
+    let mut row_edits = Vec::new();
+
+    for row in row_numbers {
+        let old_flag_row = ms
+            .flag_row_column()
+            .get(row)
+            .map_err(|error| error.to_string())?;
+        let old_matrix = super::clone_flag_matrix(ms, row)?;
+        let mut new_matrix = old_matrix.clone();
+        let (corr_count, chan_count) = old_matrix.dim();
+        let mut changed_samples = 0usize;
+        for corr in 0..corr_count {
+            for chan in 0..chan_count {
+                let old_flag = old_matrix[(corr, chan)];
+                let new_flag = match action {
+                    MsFlagAction::Flag => true,
+                    MsFlagAction::Unflag => false,
+                };
+                if old_flag != new_flag {
+                    new_matrix[(corr, chan)] = new_flag;
+                    sample_edits.push(MsFlagSampleEdit {
+                        row,
+                        corr,
+                        chan,
+                        old_flag,
+                        new_flag,
+                    });
+                    changed_samples += 1;
+                }
+            }
+        }
+        let new_flag_row = new_matrix.iter().all(|value| *value);
+        if changed_samples > 0 || old_flag_row != new_flag_row {
+            row_edits.push(MsFlagRowEdit {
+                row,
+                old_flag_row,
+                new_flag_row,
+                changed_samples,
+            });
+        }
+    }
+
+    Ok(MsFlagEditPreview {
+        plot_title: "selection flag edit".to_string(),
+        plot_index: None,
+        panel_key: None,
+        panel_label: None,
+        x_axis: MsAxis::Time,
+        y_axis: MsAxis::Flag,
+        region: MsFlagRegion {
+            x_min: 0.0,
+            x_max: 0.0,
+            y_min: 0.0,
+            y_max: 0.0,
+        },
+        action,
+        extcorr: true,
+        extchannel: true,
+        matched_points: sample_edits.len(),
+        affected_rows: row_edits.len(),
+        affected_samples: sample_edits.len(),
+        sample_edits,
+        row_edits,
+    })
+}
+
+fn apply_selection_flag_edit_preview(
+    ms: &mut MeasurementSet,
+    preview: &MsFlagEditPreview,
+) -> Result<(), String> {
+    let mut row_updates = BTreeMap::<usize, (ndarray::Array2<bool>, bool)>::new();
+    for row_edit in &preview.row_edits {
+        row_updates.insert(
+            row_edit.row,
+            (
+                super::clone_flag_matrix(ms, row_edit.row)?,
+                row_edit.new_flag_row,
+            ),
+        );
+    }
+    for sample in &preview.sample_edits {
+        let (matrix, _) = row_updates
+            .get_mut(&sample.row)
+            .ok_or_else(|| format!("flag edit lost planned row {}", sample.row))?;
+        matrix[(sample.corr, sample.chan)] = sample.new_flag;
+    }
+    for (row, (matrix, flag_row)) in row_updates {
+        ms.main_table_mut()
+            .cell_accessor_mut(row, "FLAG")
+            .map_err(|error| error.to_string())?
+            .set(Value::Array(ArrayValue::Bool(matrix.into_dyn())))
+            .map_err(|error| error.to_string())?;
+        ms.main_table_mut()
+            .cell_accessor_mut(row, "FLAG_ROW")
+            .map_err(|error| error.to_string())?
+            .set(Value::Scalar(ScalarValue::Bool(flag_row)))
+            .map_err(|error| error.to_string())?;
+    }
+    Ok(())
+}
+
+fn apply_selection_flag_edit_direct(
+    ms: &mut MeasurementSet,
+    selection: &MsSelectionSpec,
+    action: MsFlagAction,
+) -> Result<MsFlagEditPreview, String> {
+    let listobs_options = selection.to_summary_options();
+    let row_numbers = super::resolve_selected_rows_with_msselect(ms, selection, &listobs_options)?;
+    let mut affected_rows = 0usize;
+    let mut affected_samples = 0usize;
+
+    for row in row_numbers {
+        let mut matrix = super::clone_flag_matrix(ms, row)?;
+        let mut changed_samples = 0usize;
+        let new_flag = match action {
+            MsFlagAction::Flag => true,
+            MsFlagAction::Unflag => false,
+        };
+        for value in &mut matrix {
+            if *value != new_flag {
+                *value = new_flag;
+                changed_samples += 1;
+            }
+        }
+        if changed_samples == 0 {
+            continue;
+        }
+        let new_flag_row = matrix.iter().all(|value| *value);
+        ms.main_table_mut()
+            .cell_accessor_mut(row, "FLAG")
+            .map_err(|error| error.to_string())?
+            .set(Value::Array(ArrayValue::Bool(matrix.into_dyn())))
+            .map_err(|error| error.to_string())?;
+        ms.main_table_mut()
+            .cell_accessor_mut(row, "FLAG_ROW")
+            .map_err(|error| error.to_string())?
+            .set(Value::Scalar(ScalarValue::Bool(new_flag_row)))
+            .map_err(|error| error.to_string())?;
+        affected_rows += 1;
+        affected_samples += changed_samples;
+    }
+
+    Ok(MsFlagEditPreview {
+        plot_title: "selection flag edit".to_string(),
+        plot_index: None,
+        panel_key: None,
+        panel_label: None,
+        x_axis: MsAxis::Time,
+        y_axis: MsAxis::Flag,
+        region: MsFlagRegion {
+            x_min: 0.0,
+            x_max: 0.0,
+            y_min: 0.0,
+            y_max: 0.0,
+        },
+        action,
+        extcorr: true,
+        extchannel: true,
+        matched_points: affected_samples,
+        affected_rows,
+        affected_samples,
+        sample_edits: Vec::new(),
+        row_edits: Vec::new(),
+    })
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1729,6 +1950,7 @@ fn parse_args(args: impl IntoIterator<Item = OsString>) -> Result<CliAction, Str
     let mut flag_panel = None;
     let mut flag_extcorr = false;
     let mut flag_extchannel = false;
+    let mut flag_selected = false;
     let mut flag_apply = false;
     let mut flag_output = None;
     let mut plot_output = None;
@@ -1993,6 +2215,7 @@ fn parse_args(args: impl IntoIterator<Item = OsString>) -> Result<CliAction, Str
             "--flag-panel" => flag_panel = Some(take_value(&mut index, &args, "--flag-panel")?),
             "--flag-extcorr" => flag_extcorr = true,
             "--flag-extchannel" => flag_extchannel = true,
+            "--flag-selected" => flag_selected = true,
             "--flag-apply" => flag_apply = true,
             "--flag-output" => {
                 flag_output = Some(PathBuf::from(take_value(
@@ -2058,6 +2281,7 @@ fn parse_args(args: impl IntoIterator<Item = OsString>) -> Result<CliAction, Str
         );
     }
     if flag_action.is_some()
+        && !flag_selected
         && page_spec.is_none()
         && preset.is_none()
         && (x_axis.is_none() || y_axis.is_none())
@@ -2071,6 +2295,21 @@ fn parse_args(args: impl IntoIterator<Item = OsString>) -> Result<CliAction, Str
             "msexplore staged flag editing accepts either --flag-plotindex or --flag-panel, not both".to_string(),
         );
     }
+    if flag_selected
+        && (flag_xmin.is_some()
+            || flag_xmax.is_some()
+            || flag_ymin.is_some()
+            || flag_ymax.is_some()
+            || flag_plotindex.is_some()
+            || flag_panel.is_some()
+            || flag_extcorr
+            || flag_extchannel)
+    {
+        return Err(
+            "msexplore --flag-selected cannot be combined with plot-region flag-edit controls"
+                .to_string(),
+        );
+    }
     if flag_action.is_none()
         && (flag_xmin.is_some()
             || flag_xmax.is_some()
@@ -2080,6 +2319,7 @@ fn parse_args(args: impl IntoIterator<Item = OsString>) -> Result<CliAction, Str
             || flag_panel.is_some()
             || flag_extcorr
             || flag_extchannel
+            || flag_selected
             || flag_apply
             || flag_output.is_some())
     {
@@ -2138,6 +2378,7 @@ fn parse_args(args: impl IntoIterator<Item = OsString>) -> Result<CliAction, Str
         flag_panel,
         flag_extcorr,
         flag_extchannel,
+        flag_selected,
         flag_apply,
         flag_output,
         plot_output,

--- a/crates/casa-ms/src/transform.rs
+++ b/crates/casa-ms/src/transform.rs
@@ -265,9 +265,37 @@ pub fn mstransform(request: &MsTransformRequest) -> Result<MsTransformReport, Ms
         });
     }
     let stage_started_at = Instant::now();
-    let selected_ddids = filtered_ddids;
+    let selected_times = input
+        .main_table()
+        .column_accessor("TIME")
+        .and_then(|column| column.scalar_cells_owned_for_rows(&selected_rows))
+        .map_err(|source| MsTransformError::MutateMeasurementSet {
+            path: request.input_ms.display().to_string(),
+            source: Box::new(source),
+        })?;
+    let mut row_order = selected_rows
+        .into_iter()
+        .zip(filtered_ddids)
+        .zip(selected_times)
+        .enumerate()
+        .map(|(original_index, ((row_index, ddid), time))| {
+            scalar_f64(time.as_ref(), "TIME", row_index)
+                .map(|time| (time, original_index, row_index, ddid))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    row_order.sort_by(|left, right| {
+        left.0
+            .total_cmp(&right.0)
+            .then_with(|| left.1.cmp(&right.1))
+    });
+    let mut selected_rows = Vec::with_capacity(row_order.len());
+    let mut selected_ddids = Vec::with_capacity(row_order.len());
+    for (_time, _original_index, row_index, ddid) in row_order {
+        selected_rows.push(row_index);
+        selected_ddids.push(ddid);
+    }
     maybe_log_transform_progress(
-        "preserve_input_row_order",
+        "sort_rows_by_time",
         stage_started_at.elapsed(),
         started_at.elapsed(),
     );
@@ -997,6 +1025,24 @@ fn scalar_i32(
 ) -> Result<i32, MsTransformError> {
     match value {
         Some(ScalarValue::Int32(value)) => Ok(*value),
+        _ => Err(MsTransformError::MutateMeasurementSet {
+            path: "<measurement-set>".to_string(),
+            source: Box::new(TableError::ColumnNotFound {
+                row_index,
+                column: column.to_string(),
+            }),
+        }),
+    }
+}
+
+fn scalar_f64(
+    value: Option<&ScalarValue>,
+    column: &str,
+    row_index: usize,
+) -> Result<f64, MsTransformError> {
+    match value {
+        Some(ScalarValue::Float64(value)) => Ok(*value),
+        Some(ScalarValue::Float32(value)) => Ok(f64::from(*value)),
         _ => Err(MsTransformError::MutateMeasurementSet {
             path: "<measurement-set>".to_string(),
             source: Box::new(TableError::ColumnNotFound {

--- a/crates/casa-ms/src/transform.rs
+++ b/crates/casa-ms/src/transform.rs
@@ -1,0 +1,842 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//! Tutorial-scoped `mstransform`-style MeasurementSet materialization.
+//!
+//! CASA routes `mstransform` through the `mstransformer` tool and a chain of
+//! TVI layers. This module implements the IRC+10216 tutorial subset needed by
+//! downstream line-imaging workflows: row selection plus per-SPW channel
+//! selection into a new on-disk MeasurementSet while preserving the standard
+//! subtables and updating spectral-window channel metadata.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use casa_tables::{Table, TableError, TableOptions};
+use casa_types::{ArrayValue, ScalarValue, Value};
+use ndarray::Axis;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::MsError;
+use crate::ms::MeasurementSet;
+use crate::schema::SubtableId;
+use crate::schema::main_table::VisibilityDataColumn;
+use crate::selection::MsSelection;
+use crate::selection_syntax::{ChannelSelection, parse_spw_selector};
+
+/// Input visibility column to materialize as output `DATA`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum TransformDataColumn {
+    /// MAIN.DATA.
+    Data,
+    /// MAIN.CORRECTED_DATA.
+    #[default]
+    CorrectedData,
+}
+
+impl TransformDataColumn {
+    fn source_name(self) -> &'static str {
+        match self {
+            Self::Data => VisibilityDataColumn::Data.name(),
+            Self::CorrectedData => VisibilityDataColumn::CorrectedData.name(),
+        }
+    }
+}
+
+/// Request for a native tutorial-scoped MeasurementSet transform.
+#[derive(Debug, Clone)]
+pub struct MsTransformRequest {
+    /// Input MeasurementSet root path.
+    pub input_ms: PathBuf,
+    /// Output MeasurementSet root path.
+    pub output_ms: PathBuf,
+    /// CASA-style SPW/channel selector such as `0:7~58`.
+    pub spw: String,
+    /// Source visibility data column to copy into output `DATA`.
+    pub data_column: TransformDataColumn,
+    /// Structured row selection.
+    pub selection: MsSelection,
+}
+
+/// Report returned after materializing a transformed MeasurementSet.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct MsTransformReport {
+    /// Input MeasurementSet root path.
+    pub input_ms: PathBuf,
+    /// Output MeasurementSet root path.
+    pub output_ms: PathBuf,
+    /// Number of MAIN rows in the output.
+    pub row_count: usize,
+    /// Source column read from the input MS.
+    pub source_column: String,
+    /// Output visibility data column populated.
+    pub output_column: String,
+    /// CASA-style SPW/channel selector used for the transform.
+    pub spw: String,
+    /// Spectral windows represented in the output.
+    pub spectral_window_ids: Vec<i32>,
+    /// Output channel counts by spectral window.
+    pub output_channels_by_spw: BTreeMap<i32, usize>,
+    /// End-to-end runtime in nanoseconds.
+    pub elapsed_ns: u64,
+}
+
+/// Errors returned by [`mstransform`].
+#[derive(Debug, Error)]
+pub enum MsTransformError {
+    /// Opening an MS failed.
+    #[error("failed to open MeasurementSet {path}: {source}")]
+    OpenMeasurementSet {
+        /// Path being opened.
+        path: String,
+        /// Underlying MS error.
+        #[source]
+        source: MsError,
+    },
+
+    /// Input and output paths are identical.
+    #[error("input and output MeasurementSet paths must differ: {path}")]
+    SameInputOutput {
+        /// Duplicated path.
+        path: String,
+    },
+
+    /// The requested source column is absent.
+    #[error("MeasurementSet {path} does not contain {column}")]
+    MissingDataColumn {
+        /// Input MS path.
+        path: String,
+        /// Missing column.
+        column: String,
+    },
+
+    /// The row selection failed.
+    #[error("failed to select rows from MeasurementSet {path}: {source}")]
+    SelectRows {
+        /// Input MS path.
+        path: String,
+        /// Underlying MS error.
+        #[source]
+        source: MsError,
+    },
+
+    /// The row selection was empty.
+    #[error("mstransform selection produced no rows for {path}")]
+    EmptySelection {
+        /// Input MS path.
+        path: String,
+    },
+
+    /// Parsing or resolving `spw` failed.
+    #[error("invalid spectral-window selection {selector:?}: {reason}")]
+    InvalidSpw {
+        /// CASA-style selector.
+        selector: String,
+        /// Human-readable reason.
+        reason: String,
+    },
+
+    /// Required spectral metadata is missing or inconsistent.
+    #[error("missing or invalid spectral metadata in {path}: {reason}")]
+    SpectralMetadata {
+        /// Input MS path.
+        path: String,
+        /// Human-readable reason.
+        reason: String,
+    },
+
+    /// MAIN or subtable mutation failed.
+    #[error("failed to transform MeasurementSet data for {path}: {source}")]
+    MutateMeasurementSet {
+        /// MS path.
+        path: String,
+        /// Underlying table error.
+        #[source]
+        source: Box<TableError>,
+    },
+
+    /// Output filesystem preparation failed.
+    #[error("failed to prepare output MeasurementSet {path}: {reason}")]
+    PrepareOutput {
+        /// Output path.
+        path: String,
+        /// Error context.
+        reason: String,
+    },
+
+    /// Saving the output MS failed.
+    #[error("failed to save MeasurementSet {path}: {source}")]
+    SaveMeasurementSet {
+        /// Output path.
+        path: String,
+        /// Underlying MS error.
+        #[source]
+        source: MsError,
+    },
+}
+
+/// Materialize a selected/channel-subset MeasurementSet.
+pub fn mstransform(request: &MsTransformRequest) -> Result<MsTransformReport, MsTransformError> {
+    let started_at = Instant::now();
+    if request.input_ms == request.output_ms {
+        return Err(MsTransformError::SameInputOutput {
+            path: request.input_ms.display().to_string(),
+        });
+    }
+
+    let input = MeasurementSet::open(&request.input_ms).map_err(|source| {
+        MsTransformError::OpenMeasurementSet {
+            path: request.input_ms.display().to_string(),
+            source,
+        }
+    })?;
+    let source_column = request.data_column.source_name();
+    if !input
+        .main_table()
+        .schema()
+        .is_some_and(|schema| schema.contains_column(source_column))
+    {
+        return Err(MsTransformError::MissingDataColumn {
+            path: request.input_ms.display().to_string(),
+            column: source_column.to_string(),
+        });
+    }
+    let mut selected_rows =
+        request
+            .selection
+            .apply(&input)
+            .map_err(|source| MsTransformError::SelectRows {
+                path: request.input_ms.display().to_string(),
+                source,
+            })?;
+    if selected_rows.is_empty() {
+        return Err(MsTransformError::EmptySelection {
+            path: request.input_ms.display().to_string(),
+        });
+    }
+    let channel_selection = resolve_transform_channels(&input, &request.spw)?;
+    let ddid_to_spw = data_description_spw_map(&input)?;
+    let all_input_ddids = input
+        .main_table()
+        .column_accessor("DATA_DESC_ID")
+        .and_then(|column| column.scalar_cells_owned())
+        .map_err(|source| MsTransformError::MutateMeasurementSet {
+            path: request.input_ms.display().to_string(),
+            source: Box::new(source),
+        })?;
+    selected_rows = selected_rows
+        .into_iter()
+        .filter_map(|row_index| {
+            let ddid = all_input_ddids.get(row_index)?;
+            let ddid = scalar_i32(ddid.as_ref(), "DATA_DESC_ID", row_index).ok()?;
+            let spw = ddid_to_spw.get(&ddid)?;
+            channel_selection.contains_key(spw).then_some(row_index)
+        })
+        .collect();
+    if selected_rows.is_empty() {
+        return Err(MsTransformError::EmptySelection {
+            path: request.input_ms.display().to_string(),
+        });
+    }
+    let all_input_times = input
+        .main_table()
+        .column_accessor("TIME")
+        .and_then(|column| column.scalar_cells_owned())
+        .map_err(|source| MsTransformError::MutateMeasurementSet {
+            path: request.input_ms.display().to_string(),
+            source: Box::new(source),
+        })?;
+    selected_rows.sort_by(|left, right| {
+        let left_time = all_input_times
+            .get(*left)
+            .and_then(Option::as_ref)
+            .and_then(scalar_f64_value)
+            .unwrap_or(f64::NAN);
+        let right_time = all_input_times
+            .get(*right)
+            .and_then(Option::as_ref)
+            .and_then(scalar_f64_value)
+            .unwrap_or(f64::NAN);
+        left_time
+            .total_cmp(&right_time)
+            .then_with(|| left.cmp(right))
+    });
+    prepare_output_root(&request.output_ms)?;
+    materialize_selected_main_table(&input, &selected_rows, &request.output_ms)?;
+    copy_subtables(&request.input_ms, &request.output_ms)?;
+
+    let row_indices = (0..selected_rows.len()).collect::<Vec<_>>();
+    let source_values = input
+        .main_table()
+        .column_accessor(source_column)
+        .and_then(|column| column.array_cells_owned(&selected_rows))
+        .map_err(|source| MsTransformError::MutateMeasurementSet {
+            path: request.output_ms.display().to_string(),
+            source: Box::new(source),
+        })?;
+    let flag_values = input
+        .main_table()
+        .column_accessor("FLAG")
+        .and_then(|column| column.array_cells_owned(&selected_rows))
+        .map_err(|source| MsTransformError::MutateMeasurementSet {
+            path: request.output_ms.display().to_string(),
+            source: Box::new(source),
+        })?;
+    let uvw_values = input
+        .main_table()
+        .column_accessor("UVW")
+        .and_then(|column| column.array_cells_owned(&selected_rows))
+        .map_err(|source| MsTransformError::MutateMeasurementSet {
+            path: request.output_ms.display().to_string(),
+            source: Box::new(source),
+        })?;
+    let data_desc_ids = input
+        .main_table()
+        .column_accessor("DATA_DESC_ID")
+        .and_then(|column| column.scalar_cells_owned_for_rows(&selected_rows))
+        .map_err(|source| MsTransformError::MutateMeasurementSet {
+            path: request.output_ms.display().to_string(),
+            source: Box::new(source),
+        })?;
+    let weight_spectrum_values = if input
+        .main_table()
+        .schema()
+        .is_some_and(|schema| schema.contains_column("WEIGHT_SPECTRUM"))
+    {
+        Some(
+            input
+                .main_table()
+                .column_accessor("WEIGHT_SPECTRUM")
+                .and_then(|column| column.array_cells_owned(&selected_rows))
+                .map_err(|source| MsTransformError::MutateMeasurementSet {
+                    path: request.output_ms.display().to_string(),
+                    source: Box::new(source),
+                })?,
+        )
+    } else {
+        None
+    };
+
+    let mut touched_spws = BTreeSet::new();
+    let mut transformed_data = Vec::with_capacity(row_indices.len());
+    let mut transformed_flags = Vec::with_capacity(row_indices.len());
+    let mut transformed_weight_spectrum = weight_spectrum_values
+        .as_ref()
+        .map(|_| Vec::with_capacity(row_indices.len()));
+    let mut weight_spectrum_values = weight_spectrum_values.map(Vec::into_iter);
+    for (((row_index, data), flags), ddid) in row_indices
+        .iter()
+        .copied()
+        .zip(source_values)
+        .zip(flag_values)
+        .zip(data_desc_ids)
+    {
+        let data =
+            data.ok_or_else(|| missing_column_error(&request.output_ms, row_index, source_column))?;
+        let flags =
+            flags.ok_or_else(|| missing_column_error(&request.output_ms, row_index, "FLAG"))?;
+        let ddid = scalar_i32(ddid.as_ref(), "DATA_DESC_ID", row_index)?;
+        let spw_id = ddid_to_spw.get(&ddid).copied().ok_or_else(|| {
+            MsTransformError::SpectralMetadata {
+                path: request.output_ms.display().to_string(),
+                reason: format!("MAIN row {row_index} references DATA_DESC_ID {ddid}, which has no DATA_DESCRIPTION row"),
+            }
+        })?;
+        let channels = channel_selection.get(&spw_id).ok_or_else(|| MsTransformError::InvalidSpw {
+            selector: request.spw.clone(),
+            reason: format!("selected row {row_index} maps to spectral window {spw_id}, but --spw does not include that SPW"),
+        })?;
+        transformed_data.push(Value::Array(select_channels(data, channels).map_err(
+            |source| MsTransformError::MutateMeasurementSet {
+                path: request.output_ms.display().to_string(),
+                source: Box::new(source),
+            },
+        )?));
+        transformed_flags.push(Value::Array(select_channels(flags, channels).map_err(
+            |source| MsTransformError::MutateMeasurementSet {
+                path: request.output_ms.display().to_string(),
+                source: Box::new(source),
+            },
+        )?));
+        if let Some(values) = weight_spectrum_values.as_mut() {
+            let weight_spectrum = values.next().flatten().ok_or_else(|| {
+                missing_column_error(&request.output_ms, row_index, "WEIGHT_SPECTRUM")
+            })?;
+            if let Some(transformed) = transformed_weight_spectrum.as_mut() {
+                transformed.push(Value::Array(
+                    select_channels(weight_spectrum, channels).map_err(|source| {
+                        MsTransformError::MutateMeasurementSet {
+                            path: request.output_ms.display().to_string(),
+                            source: Box::new(source),
+                        }
+                    })?,
+                ));
+            }
+        }
+        touched_spws.insert(spw_id);
+    }
+
+    let mut output = MeasurementSet::open(&request.output_ms).map_err(|source| {
+        MsTransformError::OpenMeasurementSet {
+            path: request.output_ms.display().to_string(),
+            source,
+        }
+    })?;
+    output
+        .main_table_mut()
+        .column_accessor_mut(VisibilityDataColumn::Data.name())
+        .and_then(|mut column| column.put(transformed_data))
+        .map_err(|source| MsTransformError::MutateMeasurementSet {
+            path: request.output_ms.display().to_string(),
+            source: Box::new(source),
+        })?;
+    output
+        .main_table_mut()
+        .column_accessor_mut("FLAG")
+        .and_then(|mut column| column.put(transformed_flags))
+        .map_err(|source| MsTransformError::MutateMeasurementSet {
+            path: request.output_ms.display().to_string(),
+            source: Box::new(source),
+        })?;
+    output
+        .main_table_mut()
+        .column_accessor_mut("UVW")
+        .and_then(|mut column| {
+            column.put(
+                uvw_values
+                    .into_iter()
+                    .enumerate()
+                    .map(|(row_index, value)| {
+                        value
+                            .map(Value::Array)
+                            .ok_or_else(|| TableError::ColumnNotFound {
+                                row_index,
+                                column: "UVW".to_string(),
+                            })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?,
+            )
+        })
+        .map_err(|source| MsTransformError::MutateMeasurementSet {
+            path: request.output_ms.display().to_string(),
+            source: Box::new(source),
+        })?;
+    if let Some(transformed) = transformed_weight_spectrum {
+        output
+            .main_table_mut()
+            .column_accessor_mut("WEIGHT_SPECTRUM")
+            .and_then(|mut column| column.put(transformed))
+            .map_err(|source| MsTransformError::MutateMeasurementSet {
+                path: request.output_ms.display().to_string(),
+                source: Box::new(source),
+            })?;
+    }
+
+    update_spectral_window_metadata(&mut output, &channel_selection, &request.output_ms)?;
+    output
+        .save_as_assuming_valid(&request.output_ms)
+        .map_err(|source| MsTransformError::SaveMeasurementSet {
+            path: request.output_ms.display().to_string(),
+            source,
+        })?;
+
+    Ok(MsTransformReport {
+        input_ms: request.input_ms.clone(),
+        output_ms: request.output_ms.clone(),
+        row_count: row_indices.len(),
+        source_column: source_column.to_string(),
+        output_column: VisibilityDataColumn::Data.name().to_string(),
+        spw: request.spw.clone(),
+        spectral_window_ids: touched_spws.into_iter().collect(),
+        output_channels_by_spw: channel_selection
+            .iter()
+            .map(|(spw, channels)| (*spw, channels.len()))
+            .collect(),
+        elapsed_ns: started_at.elapsed().as_nanos() as u64,
+    })
+}
+
+fn materialize_selected_main_table(
+    input: &MeasurementSet,
+    selected_rows: &[usize],
+    output_path: &Path,
+) -> Result<(), MsTransformError> {
+    input
+        .main_table()
+        .shallow_copy(TableOptions::new(output_path))
+        .map_err(|source| MsTransformError::MutateMeasurementSet {
+            path: output_path.display().to_string(),
+            source: Box::new(source),
+        })?;
+    let mut main = Table::open(TableOptions::new(output_path)).map_err(|source| {
+        MsTransformError::MutateMeasurementSet {
+            path: output_path.display().to_string(),
+            source: Box::new(source),
+        }
+    })?;
+    for &row_index in selected_rows {
+        let row = input
+            .main_table()
+            .row_accessor()
+            .row(row_index)
+            .map_err(|source| MsTransformError::MutateMeasurementSet {
+                path: output_path.display().to_string(),
+                source: Box::new(source),
+            })?
+            .clone();
+        main.add_row_assuming_valid(row).map_err(|source| {
+            MsTransformError::MutateMeasurementSet {
+                path: output_path.display().to_string(),
+                source: Box::new(source),
+            }
+        })?;
+    }
+    main.save_assuming_valid(TableOptions::new(output_path))
+        .map_err(|source| MsTransformError::MutateMeasurementSet {
+            path: output_path.display().to_string(),
+            source: Box::new(source),
+        })?;
+    Ok(())
+}
+
+fn copy_subtables(input_path: &Path, output_path: &Path) -> Result<(), MsTransformError> {
+    for id in SubtableId::ALL_REQUIRED
+        .iter()
+        .chain(SubtableId::ALL_OPTIONAL.iter())
+    {
+        let source = input_path.join(id.name());
+        if !source.exists() {
+            continue;
+        }
+        let destination = output_path.join(id.name());
+        copy_dir_recursive(&source, &destination).map_err(|source| {
+            MsTransformError::PrepareOutput {
+                path: output_path.display().to_string(),
+                reason: source.to_string(),
+            }
+        })?;
+    }
+    Ok(())
+}
+
+fn copy_dir_recursive(source: &Path, destination: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(destination)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            copy_dir_recursive(&source_path, &destination_path)?;
+        } else if file_type.is_file() {
+            fs::copy(&source_path, &destination_path)?;
+        } else if file_type.is_symlink() {
+            let target = fs::read_link(&source_path)?;
+            #[cfg(unix)]
+            std::os::unix::fs::symlink(target, &destination_path)?;
+        }
+    }
+    Ok(())
+}
+
+fn resolve_transform_channels(
+    ms: &MeasurementSet,
+    spw: &str,
+) -> Result<BTreeMap<i32, Vec<usize>>, MsTransformError> {
+    let selectors = parse_spw_selector(spw).map_err(|source| MsTransformError::InvalidSpw {
+        selector: spw.to_string(),
+        reason: source.to_string(),
+    })?;
+    let spectral_window =
+        ms.spectral_window()
+            .map_err(|source| MsTransformError::SpectralMetadata {
+                path: "<measurement-set/SPECTRAL_WINDOW>".to_string(),
+                reason: source.to_string(),
+            })?;
+    let mut by_spw = BTreeMap::new();
+    for selector in selectors {
+        if selector.spw_id < 0 {
+            return Err(MsTransformError::InvalidSpw {
+                selector: spw.to_string(),
+                reason: format!("negative spectral-window id {}", selector.spw_id),
+            });
+        }
+        let row = selector.spw_id as usize;
+        if row >= spectral_window.row_count() {
+            return Err(MsTransformError::InvalidSpw {
+                selector: spw.to_string(),
+                reason: format!(
+                    "spectral-window id {} is outside SPECTRAL_WINDOW with {} rows",
+                    selector.spw_id,
+                    spectral_window.row_count()
+                ),
+            });
+        }
+        let num_chan =
+            spectral_window
+                .num_chan(row)
+                .map_err(|source| MsTransformError::SpectralMetadata {
+                    path: "<measurement-set/SPECTRAL_WINDOW>".to_string(),
+                    reason: source.to_string(),
+                })?;
+        if num_chan < 0 {
+            return Err(MsTransformError::SpectralMetadata {
+                path: "<measurement-set/SPECTRAL_WINDOW>".to_string(),
+                reason: format!(
+                    "spectral-window {} has negative NUM_CHAN {num_chan}",
+                    selector.spw_id
+                ),
+            });
+        }
+        let num_chan = num_chan as usize;
+        let indices = match selector.channels {
+            Some(ChannelSelection { segments }) => ChannelSelection { segments }
+                .indices(num_chan)
+                .map_err(|source| MsTransformError::InvalidSpw {
+                    selector: spw.to_string(),
+                    reason: source.to_string(),
+                })?,
+            None => (0..num_chan).collect(),
+        };
+        if indices.is_empty() {
+            return Err(MsTransformError::InvalidSpw {
+                selector: spw.to_string(),
+                reason: format!(
+                    "spectral-window {} selection produced no channels",
+                    selector.spw_id
+                ),
+            });
+        }
+        by_spw.insert(selector.spw_id, indices);
+    }
+    Ok(by_spw)
+}
+
+fn data_description_spw_map(ms: &MeasurementSet) -> Result<BTreeMap<i32, i32>, MsTransformError> {
+    let data_description =
+        ms.data_description()
+            .map_err(|source| MsTransformError::SpectralMetadata {
+                path: "<measurement-set/DATA_DESCRIPTION>".to_string(),
+                reason: source.to_string(),
+            })?;
+    let mut map = BTreeMap::new();
+    for row in 0..data_description.row_count() {
+        let spw = data_description.spectral_window_id(row).map_err(|source| {
+            MsTransformError::SpectralMetadata {
+                path: "<measurement-set/DATA_DESCRIPTION>".to_string(),
+                reason: source.to_string(),
+            }
+        })?;
+        map.insert(row as i32, spw);
+    }
+    Ok(map)
+}
+
+fn select_channels(value: ArrayValue, channels: &[usize]) -> Result<ArrayValue, TableError> {
+    match value {
+        ArrayValue::Complex32(values) => {
+            if values.ndim() != 2 {
+                return Err(TableError::Schema(
+                    "visibility DATA arrays must be rank-2 [corr, chan]".to_string(),
+                ));
+            }
+            if values.shape()[1] == 0 {
+                return Ok(ArrayValue::Complex32(values));
+            }
+            Ok(ArrayValue::Complex32(values.select(Axis(1), channels)))
+        }
+        ArrayValue::Bool(values) => {
+            if values.ndim() != 2 {
+                return Err(TableError::Schema(
+                    "FLAG arrays must be rank-2 [corr, chan]".to_string(),
+                ));
+            }
+            if values.shape()[1] == 0 {
+                return Ok(ArrayValue::Bool(values));
+            }
+            Ok(ArrayValue::Bool(values.select(Axis(1), channels)))
+        }
+        ArrayValue::Float32(values) => {
+            if values.ndim() != 2 {
+                return Err(TableError::Schema(
+                    "WEIGHT_SPECTRUM arrays must be rank-2 [corr, chan]".to_string(),
+                ));
+            }
+            if values.shape()[1] == 0 {
+                return Ok(ArrayValue::Float32(values));
+            }
+            Ok(ArrayValue::Float32(values.select(Axis(1), channels)))
+        }
+        other => Err(TableError::Schema(format!(
+            "unsupported rank-2 channel selection for {:?}",
+            other.primitive_type()
+        ))),
+    }
+}
+
+fn update_spectral_window_metadata(
+    ms: &mut MeasurementSet,
+    channel_selection: &BTreeMap<i32, Vec<usize>>,
+    output_ms: &Path,
+) -> Result<(), MsTransformError> {
+    let spw_path = output_ms.join(SubtableId::SpectralWindow.name());
+    let mut spectral_window =
+        ms.spectral_window_mut()
+            .map_err(|source| MsTransformError::SpectralMetadata {
+                path: spw_path.display().to_string(),
+                reason: source.to_string(),
+            })?;
+    for (&spw_id, channels) in channel_selection {
+        let row = spw_id as usize;
+        update_f64_vector_column(&mut spectral_window, row, "CHAN_FREQ", channels, &spw_path)?;
+        update_f64_vector_column(&mut spectral_window, row, "CHAN_WIDTH", channels, &spw_path)?;
+        update_f64_vector_column(
+            &mut spectral_window,
+            row,
+            "EFFECTIVE_BW",
+            channels,
+            &spw_path,
+        )?;
+        update_f64_vector_column(&mut spectral_window, row, "RESOLUTION", channels, &spw_path)?;
+        spectral_window
+            .set_i32(row, "NUM_CHAN", channels.len() as i32)
+            .map_err(|source| MsTransformError::SpectralMetadata {
+                path: spw_path.display().to_string(),
+                reason: source.to_string(),
+            })?;
+        let chan_freq = spectral_window.as_ref().chan_freq(row).map_err(|source| {
+            MsTransformError::SpectralMetadata {
+                path: spw_path.display().to_string(),
+                reason: source.to_string(),
+            }
+        })?;
+        if let (Some(first), Some(last)) = (chan_freq.first(), chan_freq.last()) {
+            spectral_window
+                .set_f64(row, "REF_FREQUENCY", *first)
+                .map_err(|source| MsTransformError::SpectralMetadata {
+                    path: spw_path.display().to_string(),
+                    reason: source.to_string(),
+                })?;
+            let total_bw = if chan_freq.len() > 1 {
+                (last - first).abs()
+                    + spectral_window
+                        .as_ref()
+                        .chan_width(row)
+                        .ok()
+                        .and_then(|widths| widths.first().copied())
+                        .unwrap_or(0.0)
+                        .abs()
+            } else {
+                spectral_window
+                    .as_ref()
+                    .chan_width(row)
+                    .ok()
+                    .and_then(|widths| widths.first().copied())
+                    .unwrap_or(0.0)
+                    .abs()
+            };
+            spectral_window
+                .set_f64(row, "TOTAL_BANDWIDTH", total_bw)
+                .map_err(|source| MsTransformError::SpectralMetadata {
+                    path: spw_path.display().to_string(),
+                    reason: source.to_string(),
+                })?;
+        }
+    }
+    Ok(())
+}
+
+fn update_f64_vector_column(
+    spectral_window: &mut crate::subtables::MsSpectralWindowMut<'_>,
+    row: usize,
+    column: &str,
+    channels: &[usize],
+    spw_path: &Path,
+) -> Result<(), MsTransformError> {
+    let values = spectral_window
+        .table_mut()
+        .cell_accessor(row, column)
+        .and_then(|cell| cell.array().cloned())
+        .map_err(|source| MsTransformError::MutateMeasurementSet {
+            path: spw_path.display().to_string(),
+            source: Box::new(source),
+        })?;
+    let ArrayValue::Float64(values) = values else {
+        return Err(MsTransformError::SpectralMetadata {
+            path: spw_path.display().to_string(),
+            reason: format!("{column} must be a Float64 vector"),
+        });
+    };
+    if values.ndim() != 1 {
+        return Err(MsTransformError::SpectralMetadata {
+            path: spw_path.display().to_string(),
+            reason: format!("{column} must be rank-1"),
+        });
+    }
+    spectral_window
+        .set_array(
+            row,
+            column,
+            ArrayValue::Float64(values.select(Axis(0), channels)),
+        )
+        .map_err(|source| MsTransformError::SpectralMetadata {
+            path: spw_path.display().to_string(),
+            reason: source.to_string(),
+        })
+}
+
+fn scalar_i32(
+    value: Option<&ScalarValue>,
+    column: &str,
+    row_index: usize,
+) -> Result<i32, MsTransformError> {
+    match value {
+        Some(ScalarValue::Int32(value)) => Ok(*value),
+        _ => Err(MsTransformError::MutateMeasurementSet {
+            path: "<measurement-set>".to_string(),
+            source: Box::new(TableError::ColumnNotFound {
+                row_index,
+                column: column.to_string(),
+            }),
+        }),
+    }
+}
+
+fn scalar_f64_value(value: &ScalarValue) -> Option<f64> {
+    match value {
+        ScalarValue::Float64(value) => Some(*value),
+        ScalarValue::Float32(value) => Some(f64::from(*value)),
+        _ => None,
+    }
+}
+
+fn missing_column_error(path: &Path, row_index: usize, column: &str) -> MsTransformError {
+    MsTransformError::MutateMeasurementSet {
+        path: path.display().to_string(),
+        source: Box::new(TableError::ColumnNotFound {
+            row_index,
+            column: column.to_string(),
+        }),
+    }
+}
+
+fn prepare_output_root(path: &Path) -> Result<(), MsTransformError> {
+    if path.exists() {
+        fs::remove_dir_all(path)
+            .or_else(|_| fs::remove_file(path))
+            .map_err(|error| MsTransformError::PrepareOutput {
+                path: path.display().to_string(),
+                reason: error.to_string(),
+            })?;
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| MsTransformError::PrepareOutput {
+            path: path.display().to_string(),
+            reason: error.to_string(),
+        })?;
+    }
+    Ok(())
+}

--- a/crates/casa-ms/src/transform.rs
+++ b/crates/casa-ms/src/transform.rs
@@ -12,15 +12,16 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
-use casa_tables::{Table, TableError, TableOptions};
-use casa_types::{ArrayValue, ScalarValue, Value};
-use ndarray::Axis;
+use casa_tables::{ColumnType, Table, TableError, TableOptions};
+use casa_types::{ArrayValue, RecordField, RecordValue, ScalarValue, Value};
+use ndarray::{Axis, Slice};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::MsError;
 use crate::ms::MeasurementSet;
+use crate::ms::{measurement_set_main_table_bindings, measurement_set_table_options};
 use crate::schema::SubtableId;
 use crate::schema::main_table::VisibilityDataColumn;
 use crate::selection::MsSelection;
@@ -219,53 +220,70 @@ pub fn mstransform(request: &MsTransformRequest) -> Result<MsTransformReport, Ms
     }
     let channel_selection = resolve_transform_channels(&input, &request.spw)?;
     let ddid_to_spw = data_description_spw_map(&input)?;
-    let all_input_ddids = input
+    let selected_ddids = input
         .main_table()
         .column_accessor("DATA_DESC_ID")
-        .and_then(|column| column.scalar_cells_owned())
+        .and_then(|column| column.scalar_cells_owned_for_rows(&selected_rows))
         .map_err(|source| MsTransformError::MutateMeasurementSet {
             path: request.input_ms.display().to_string(),
             source: Box::new(source),
         })?;
-    selected_rows = selected_rows
-        .into_iter()
-        .filter_map(|row_index| {
-            let ddid = all_input_ddids.get(row_index)?;
-            let ddid = scalar_i32(ddid.as_ref(), "DATA_DESC_ID", row_index).ok()?;
-            let spw = ddid_to_spw.get(&ddid)?;
-            channel_selection.contains_key(spw).then_some(row_index)
-        })
-        .collect();
+    let mut filtered_rows = Vec::with_capacity(selected_rows.len());
+    let mut filtered_ddids = Vec::with_capacity(selected_rows.len());
+    for (row_index, ddid) in selected_rows.into_iter().zip(selected_ddids) {
+        let ddid = scalar_i32(ddid.as_ref(), "DATA_DESC_ID", row_index)?;
+        let Some(spw) = ddid_to_spw.get(&ddid) else {
+            continue;
+        };
+        if channel_selection.contains_key(spw) {
+            filtered_rows.push(row_index);
+            filtered_ddids.push(ddid);
+        }
+    }
+    selected_rows = filtered_rows;
     if selected_rows.is_empty() {
         return Err(MsTransformError::EmptySelection {
             path: request.input_ms.display().to_string(),
         });
     }
-    let all_input_times = input
+    let selected_times = input
         .main_table()
         .column_accessor("TIME")
-        .and_then(|column| column.scalar_cells_owned())
+        .and_then(|column| column.scalar_cells_owned_for_rows(&selected_rows))
         .map_err(|source| MsTransformError::MutateMeasurementSet {
             path: request.input_ms.display().to_string(),
             source: Box::new(source),
         })?;
-    selected_rows.sort_by(|left, right| {
-        let left_time = all_input_times
-            .get(*left)
+    let mut order = (0..selected_rows.len()).collect::<Vec<_>>();
+    order.sort_by(|&left, &right| {
+        let left_time = selected_times
+            .get(left)
             .and_then(Option::as_ref)
             .and_then(scalar_f64_value)
             .unwrap_or(f64::NAN);
-        let right_time = all_input_times
-            .get(*right)
+        let right_time = selected_times
+            .get(right)
             .and_then(Option::as_ref)
             .and_then(scalar_f64_value)
             .unwrap_or(f64::NAN);
-        left_time
-            .total_cmp(&right_time)
-            .then_with(|| left.cmp(right))
+        left_time.total_cmp(&right_time).then_with(|| {
+            selected_rows[left]
+                .cmp(&selected_rows[right])
+                .then_with(|| left.cmp(&right))
+        })
     });
+    selected_rows = order.iter().map(|&index| selected_rows[index]).collect();
+    let selected_ddids = order
+        .iter()
+        .map(|&index| filtered_ddids[index])
+        .collect::<Vec<_>>();
     prepare_output_root(&request.output_ms)?;
-    materialize_selected_main_table(&input, &selected_rows, &request.output_ms)?;
+    let mut output_main = materialize_selected_main_table(
+        &request.input_ms,
+        &input,
+        &selected_rows,
+        &request.output_ms,
+    )?;
     copy_subtables(&request.input_ms, &request.output_ms)?;
 
     let row_indices = (0..selected_rows.len()).collect::<Vec<_>>();
@@ -281,22 +299,6 @@ pub fn mstransform(request: &MsTransformRequest) -> Result<MsTransformReport, Ms
         .main_table()
         .column_accessor("FLAG")
         .and_then(|column| column.array_cells_owned(&selected_rows))
-        .map_err(|source| MsTransformError::MutateMeasurementSet {
-            path: request.output_ms.display().to_string(),
-            source: Box::new(source),
-        })?;
-    let uvw_values = input
-        .main_table()
-        .column_accessor("UVW")
-        .and_then(|column| column.array_cells_owned(&selected_rows))
-        .map_err(|source| MsTransformError::MutateMeasurementSet {
-            path: request.output_ms.display().to_string(),
-            source: Box::new(source),
-        })?;
-    let data_desc_ids = input
-        .main_table()
-        .column_accessor("DATA_DESC_ID")
-        .and_then(|column| column.scalar_cells_owned_for_rows(&selected_rows))
         .map_err(|source| MsTransformError::MutateMeasurementSet {
             path: request.output_ms.display().to_string(),
             source: Box::new(source),
@@ -332,13 +334,12 @@ pub fn mstransform(request: &MsTransformRequest) -> Result<MsTransformReport, Ms
         .copied()
         .zip(source_values)
         .zip(flag_values)
-        .zip(data_desc_ids)
+        .zip(selected_ddids)
     {
         let data =
             data.ok_or_else(|| missing_column_error(&request.output_ms, row_index, source_column))?;
         let flags =
             flags.ok_or_else(|| missing_column_error(&request.output_ms, row_index, "FLAG"))?;
-        let ddid = scalar_i32(ddid.as_ref(), "DATA_DESC_ID", row_index)?;
         let spw_id = ddid_to_spw.get(&ddid).copied().ok_or_else(|| {
             MsTransformError::SpectralMetadata {
                 path: request.output_ms.display().to_string(),
@@ -379,54 +380,22 @@ pub fn mstransform(request: &MsTransformRequest) -> Result<MsTransformReport, Ms
         touched_spws.insert(spw_id);
     }
 
-    let mut output = MeasurementSet::open(&request.output_ms).map_err(|source| {
-        MsTransformError::OpenMeasurementSet {
-            path: request.output_ms.display().to_string(),
-            source,
-        }
-    })?;
-    output
-        .main_table_mut()
+    output_main
         .column_accessor_mut(VisibilityDataColumn::Data.name())
         .and_then(|mut column| column.put(transformed_data))
         .map_err(|source| MsTransformError::MutateMeasurementSet {
             path: request.output_ms.display().to_string(),
             source: Box::new(source),
         })?;
-    output
-        .main_table_mut()
+    output_main
         .column_accessor_mut("FLAG")
         .and_then(|mut column| column.put(transformed_flags))
         .map_err(|source| MsTransformError::MutateMeasurementSet {
             path: request.output_ms.display().to_string(),
             source: Box::new(source),
         })?;
-    output
-        .main_table_mut()
-        .column_accessor_mut("UVW")
-        .and_then(|mut column| {
-            column.put(
-                uvw_values
-                    .into_iter()
-                    .enumerate()
-                    .map(|(row_index, value)| {
-                        value
-                            .map(Value::Array)
-                            .ok_or_else(|| TableError::ColumnNotFound {
-                                row_index,
-                                column: "UVW".to_string(),
-                            })
-                    })
-                    .collect::<Result<Vec<_>, _>>()?,
-            )
-        })
-        .map_err(|source| MsTransformError::MutateMeasurementSet {
-            path: request.output_ms.display().to_string(),
-            source: Box::new(source),
-        })?;
     if let Some(transformed) = transformed_weight_spectrum {
-        output
-            .main_table_mut()
+        output_main
             .column_accessor_mut("WEIGHT_SPECTRUM")
             .and_then(|mut column| column.put(transformed))
             .map_err(|source| MsTransformError::MutateMeasurementSet {
@@ -435,13 +404,16 @@ pub fn mstransform(request: &MsTransformRequest) -> Result<MsTransformReport, Ms
             })?;
     }
 
-    update_spectral_window_metadata(&mut output, &channel_selection, &request.output_ms)?;
-    output
-        .save_as_assuming_valid(&request.output_ms)
-        .map_err(|source| MsTransformError::SaveMeasurementSet {
+    output_main
+        .save_with_bindings_assuming_valid(
+            measurement_set_table_options(&request.output_ms),
+            &measurement_set_main_table_bindings(&output_main),
+        )
+        .map_err(|source| MsTransformError::MutateMeasurementSet {
             path: request.output_ms.display().to_string(),
-            source,
+            source: Box::new(source),
         })?;
+    update_spectral_window_metadata(&channel_selection, &request.output_ms)?;
 
     Ok(MsTransformReport {
         input_ms: request.input_ms.clone(),
@@ -460,13 +432,19 @@ pub fn mstransform(request: &MsTransformRequest) -> Result<MsTransformReport, Ms
 }
 
 fn materialize_selected_main_table(
+    input_path: &Path,
     input: &MeasurementSet,
     selected_rows: &[usize],
     output_path: &Path,
-) -> Result<(), MsTransformError> {
-    input
-        .main_table()
-        .shallow_copy(TableOptions::new(output_path))
+) -> Result<Table, MsTransformError> {
+    let metadata = Table::open_metadata_only(TableOptions::new(input_path)).map_err(|source| {
+        MsTransformError::MutateMeasurementSet {
+            path: input_path.display().to_string(),
+            source: Box::new(source),
+        }
+    })?;
+    metadata
+        .save_assuming_valid(TableOptions::new(output_path))
         .map_err(|source| MsTransformError::MutateMeasurementSet {
             path: output_path.display().to_string(),
             source: Box::new(source),
@@ -477,29 +455,94 @@ fn materialize_selected_main_table(
             source: Box::new(source),
         }
     })?;
-    for &row_index in selected_rows {
-        let row = input
-            .main_table()
-            .row_accessor()
-            .row(row_index)
-            .map_err(|source| MsTransformError::MutateMeasurementSet {
-                path: output_path.display().to_string(),
-                source: Box::new(source),
-            })?
-            .clone();
-        main.add_row_assuming_valid(row).map_err(|source| {
-            MsTransformError::MutateMeasurementSet {
-                path: output_path.display().to_string(),
-                source: Box::new(source),
-            }
-        })?;
-    }
-    main.save_assuming_valid(TableOptions::new(output_path))
-        .map_err(|source| MsTransformError::MutateMeasurementSet {
+    let rows = gather_selected_rows_column_wise(input.main_table(), selected_rows, output_path)?;
+    main.add_rows_assuming_valid(rows).map_err(|source| {
+        MsTransformError::MutateMeasurementSet {
             path: output_path.display().to_string(),
             source: Box::new(source),
+        }
+    })?;
+    Ok(main)
+}
+
+fn gather_selected_rows_column_wise(
+    table: &Table,
+    selected_rows: &[usize],
+    output_path: &Path,
+) -> Result<Vec<RecordValue>, MsTransformError> {
+    let schema = table
+        .schema()
+        .ok_or_else(|| MsTransformError::MutateMeasurementSet {
+            path: output_path.display().to_string(),
+            source: Box::new(TableError::Schema(
+                "MAIN table is missing schema metadata".to_string(),
+            )),
         })?;
-    Ok(())
+    let mut rows = vec![RecordValue::default(); selected_rows.len()];
+    for column in schema.columns() {
+        let name = column.name();
+        if is_deferred_visibility_column(name) {
+            continue;
+        }
+        match column.column_type() {
+            ColumnType::Scalar => {
+                let values = table
+                    .column_accessor(name)
+                    .and_then(|column| column.scalar_cells_owned_for_rows(selected_rows))
+                    .map_err(|source| MsTransformError::MutateMeasurementSet {
+                        path: output_path.display().to_string(),
+                        source: Box::new(source),
+                    })?;
+                for (row, value) in rows.iter_mut().zip(values) {
+                    if let Some(value) = value {
+                        row.push(RecordField::new(name, Value::Scalar(value)));
+                    }
+                }
+            }
+            ColumnType::Array(_) => {
+                let values = table
+                    .column_accessor(name)
+                    .and_then(|column| column.array_cells_owned(selected_rows))
+                    .map_err(|source| MsTransformError::MutateMeasurementSet {
+                        path: output_path.display().to_string(),
+                        source: Box::new(source),
+                    })?;
+                for (row, value) in rows.iter_mut().zip(values) {
+                    if let Some(value) = value {
+                        row.push(RecordField::new(name, Value::Array(value)));
+                    }
+                }
+            }
+            ColumnType::Record => {
+                for (row, &input_row) in rows.iter_mut().zip(selected_rows) {
+                    let value = table
+                        .column_accessor(name)
+                        .and_then(|column| column.record_cell(input_row))
+                        .map_err(|source| MsTransformError::MutateMeasurementSet {
+                            path: output_path.display().to_string(),
+                            source: Box::new(source),
+                        })?;
+                    row.push(RecordField::new(name, Value::Record(value)));
+                }
+            }
+        }
+    }
+    Ok(rows)
+}
+
+fn is_deferred_visibility_column(column: &str) -> bool {
+    [
+        "DATA",
+        "CORRECTED_DATA",
+        "MODEL_DATA",
+        "FLOAT_DATA",
+        "LAG_DATA",
+        "FLAG",
+        "WEIGHT_SPECTRUM",
+        "SIGMA_SPECTRUM",
+        "CORRECTED_WEIGHT_SPECTRUM",
+    ]
+    .contains(&column)
 }
 
 fn copy_subtables(input_path: &Path, output_path: &Path) -> Result<(), MsTransformError> {
@@ -643,8 +686,16 @@ fn select_channels(value: ArrayValue, channels: &[usize]) -> Result<ArrayValue, 
                     "visibility DATA arrays must be rank-2 [corr, chan]".to_string(),
                 ));
             }
-            if values.shape()[1] == 0 {
+            let channel_count = values.shape()[1];
+            if channel_count == 0 || all_channels_selected(channels, channel_count) {
                 return Ok(ArrayValue::Complex32(values));
+            }
+            if let Some((start, end)) = contiguous_channel_range(channels) {
+                return Ok(ArrayValue::Complex32(
+                    values
+                        .slice_axis(Axis(1), Slice::from(start..end))
+                        .to_owned(),
+                ));
             }
             Ok(ArrayValue::Complex32(values.select(Axis(1), channels)))
         }
@@ -654,8 +705,16 @@ fn select_channels(value: ArrayValue, channels: &[usize]) -> Result<ArrayValue, 
                     "FLAG arrays must be rank-2 [corr, chan]".to_string(),
                 ));
             }
-            if values.shape()[1] == 0 {
+            let channel_count = values.shape()[1];
+            if channel_count == 0 || all_channels_selected(channels, channel_count) {
                 return Ok(ArrayValue::Bool(values));
+            }
+            if let Some((start, end)) = contiguous_channel_range(channels) {
+                return Ok(ArrayValue::Bool(
+                    values
+                        .slice_axis(Axis(1), Slice::from(start..end))
+                        .to_owned(),
+                ));
             }
             Ok(ArrayValue::Bool(values.select(Axis(1), channels)))
         }
@@ -665,8 +724,16 @@ fn select_channels(value: ArrayValue, channels: &[usize]) -> Result<ArrayValue, 
                     "WEIGHT_SPECTRUM arrays must be rank-2 [corr, chan]".to_string(),
                 ));
             }
-            if values.shape()[1] == 0 {
+            let channel_count = values.shape()[1];
+            if channel_count == 0 || all_channels_selected(channels, channel_count) {
                 return Ok(ArrayValue::Float32(values));
+            }
+            if let Some((start, end)) = contiguous_channel_range(channels) {
+                return Ok(ArrayValue::Float32(
+                    values
+                        .slice_axis(Axis(1), Slice::from(start..end))
+                        .to_owned(),
+                ));
             }
             Ok(ArrayValue::Float32(values.select(Axis(1), channels)))
         }
@@ -677,18 +744,31 @@ fn select_channels(value: ArrayValue, channels: &[usize]) -> Result<ArrayValue, 
     }
 }
 
+fn contiguous_channel_range(channels: &[usize]) -> Option<(usize, usize)> {
+    let (&start, rest) = channels.split_first()?;
+    for (offset, &channel) in rest.iter().enumerate() {
+        if channel != start + offset + 1 {
+            return None;
+        }
+    }
+    Some((start, start + channels.len()))
+}
+
+fn all_channels_selected(channels: &[usize], channel_count: usize) -> bool {
+    channels.len() == channel_count && channels.iter().copied().enumerate().all(|(i, ch)| ch == i)
+}
+
 fn update_spectral_window_metadata(
-    ms: &mut MeasurementSet,
     channel_selection: &BTreeMap<i32, Vec<usize>>,
     output_ms: &Path,
 ) -> Result<(), MsTransformError> {
     let spw_path = output_ms.join(SubtableId::SpectralWindow.name());
-    let mut spectral_window =
-        ms.spectral_window_mut()
-            .map_err(|source| MsTransformError::SpectralMetadata {
-                path: spw_path.display().to_string(),
-                reason: source.to_string(),
-            })?;
+    let mut spectral_window = Table::open(TableOptions::new(&spw_path)).map_err(|source| {
+        MsTransformError::MutateMeasurementSet {
+            path: spw_path.display().to_string(),
+            source: Box::new(source),
+        }
+    })?;
     for (&spw_id, channels) in channel_selection {
         let row = spw_id as usize;
         update_f64_vector_column(&mut spectral_window, row, "CHAN_FREQ", channels, &spw_path)?;
@@ -702,62 +782,67 @@ fn update_spectral_window_metadata(
         )?;
         update_f64_vector_column(&mut spectral_window, row, "RESOLUTION", channels, &spw_path)?;
         spectral_window
-            .set_i32(row, "NUM_CHAN", channels.len() as i32)
+            .column_accessor_mut("NUM_CHAN")
+            .and_then(|mut column| {
+                column.set_scalar_assuming_valid(row, ScalarValue::Int32(channels.len() as i32))
+            })
             .map_err(|source| MsTransformError::SpectralMetadata {
                 path: spw_path.display().to_string(),
                 reason: source.to_string(),
             })?;
-        let chan_freq = spectral_window.as_ref().chan_freq(row).map_err(|source| {
-            MsTransformError::SpectralMetadata {
-                path: spw_path.display().to_string(),
-                reason: source.to_string(),
-            }
-        })?;
+        let chan_freq = f64_vector_cell(&spectral_window, row, "CHAN_FREQ", &spw_path)?;
         if let (Some(first), Some(last)) = (chan_freq.first(), chan_freq.last()) {
             spectral_window
-                .set_f64(row, "REF_FREQUENCY", *first)
+                .column_accessor_mut("REF_FREQUENCY")
+                .and_then(|mut column| {
+                    column.set_scalar_assuming_valid(row, ScalarValue::Float64(*first))
+                })
                 .map_err(|source| MsTransformError::SpectralMetadata {
                     path: spw_path.display().to_string(),
                     reason: source.to_string(),
                 })?;
             let total_bw = if chan_freq.len() > 1 {
                 (last - first).abs()
-                    + spectral_window
-                        .as_ref()
-                        .chan_width(row)
+                    + f64_vector_cell(&spectral_window, row, "CHAN_WIDTH", &spw_path)
                         .ok()
                         .and_then(|widths| widths.first().copied())
                         .unwrap_or(0.0)
                         .abs()
             } else {
-                spectral_window
-                    .as_ref()
-                    .chan_width(row)
+                f64_vector_cell(&spectral_window, row, "CHAN_WIDTH", &spw_path)
                     .ok()
                     .and_then(|widths| widths.first().copied())
                     .unwrap_or(0.0)
                     .abs()
             };
             spectral_window
-                .set_f64(row, "TOTAL_BANDWIDTH", total_bw)
+                .column_accessor_mut("TOTAL_BANDWIDTH")
+                .and_then(|mut column| {
+                    column.set_scalar_assuming_valid(row, ScalarValue::Float64(total_bw))
+                })
                 .map_err(|source| MsTransformError::SpectralMetadata {
                     path: spw_path.display().to_string(),
                     reason: source.to_string(),
                 })?;
         }
     }
+    spectral_window
+        .save_assuming_valid(TableOptions::new(&spw_path))
+        .map_err(|source| MsTransformError::MutateMeasurementSet {
+            path: spw_path.display().to_string(),
+            source: Box::new(source),
+        })?;
     Ok(())
 }
 
 fn update_f64_vector_column(
-    spectral_window: &mut crate::subtables::MsSpectralWindowMut<'_>,
+    spectral_window: &mut Table,
     row: usize,
     column: &str,
     channels: &[usize],
     spw_path: &Path,
 ) -> Result<(), MsTransformError> {
     let values = spectral_window
-        .table_mut()
         .cell_accessor(row, column)
         .and_then(|cell| cell.array().cloned())
         .map_err(|source| MsTransformError::MutateMeasurementSet {
@@ -777,15 +862,45 @@ fn update_f64_vector_column(
         });
     }
     spectral_window
-        .set_array(
-            row,
-            column,
-            ArrayValue::Float64(values.select(Axis(0), channels)),
-        )
+        .column_accessor_mut(column)
+        .and_then(|mut column| {
+            column.set_array_assuming_valid(
+                row,
+                ArrayValue::Float64(values.select(Axis(0), channels)),
+            )
+        })
         .map_err(|source| MsTransformError::SpectralMetadata {
             path: spw_path.display().to_string(),
             reason: source.to_string(),
         })
+}
+
+fn f64_vector_cell(
+    table: &Table,
+    row: usize,
+    column: &str,
+    path: &Path,
+) -> Result<Vec<f64>, MsTransformError> {
+    let value = table
+        .cell_accessor(row, column)
+        .and_then(|cell| cell.array().cloned())
+        .map_err(|source| MsTransformError::MutateMeasurementSet {
+            path: path.display().to_string(),
+            source: Box::new(source),
+        })?;
+    let ArrayValue::Float64(values) = value else {
+        return Err(MsTransformError::SpectralMetadata {
+            path: path.display().to_string(),
+            reason: format!("{column} must be a Float64 vector"),
+        });
+    };
+    if values.ndim() != 1 {
+        return Err(MsTransformError::SpectralMetadata {
+            path: path.display().to_string(),
+            reason: format!("{column} must be rank-1"),
+        });
+    }
+    Ok(values.iter().copied().collect())
 }
 
 fn scalar_i32(

--- a/crates/casa-ms/src/transform.rs
+++ b/crates/casa-ms/src/transform.rs
@@ -518,21 +518,9 @@ fn materialize_selected_main_table(
     selected_rows: &[usize],
     output_path: &Path,
 ) -> Result<Table, MsTransformError> {
-    let metadata = Table::open_metadata_only(TableOptions::new(input_path)).map_err(|source| {
+    let mut main = Table::open_metadata_only(TableOptions::new(input_path)).map_err(|source| {
         MsTransformError::MutateMeasurementSet {
             path: input_path.display().to_string(),
-            source: Box::new(source),
-        }
-    })?;
-    metadata
-        .save_assuming_valid(TableOptions::new(output_path))
-        .map_err(|source| MsTransformError::MutateMeasurementSet {
-            path: output_path.display().to_string(),
-            source: Box::new(source),
-        })?;
-    let mut main = Table::open(TableOptions::new(output_path)).map_err(|source| {
-        MsTransformError::MutateMeasurementSet {
-            path: output_path.display().to_string(),
             source: Box::new(source),
         }
     })?;

--- a/crates/casa-ms/src/transform.rs
+++ b/crates/casa-ms/src/transform.rs
@@ -10,7 +10,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use casa_tables::{ColumnType, Table, TableError, TableOptions};
 use casa_types::{ArrayValue, RecordField, RecordValue, ScalarValue, Value};
@@ -188,12 +188,18 @@ pub fn mstransform(request: &MsTransformRequest) -> Result<MsTransformReport, Ms
         });
     }
 
+    let stage_started_at = Instant::now();
     let input = MeasurementSet::open(&request.input_ms).map_err(|source| {
         MsTransformError::OpenMeasurementSet {
             path: request.input_ms.display().to_string(),
             source,
         }
     })?;
+    maybe_log_transform_progress(
+        "open_measurement_set",
+        stage_started_at.elapsed(),
+        started_at.elapsed(),
+    );
     let source_column = request.data_column.source_name();
     if !input
         .main_table()
@@ -205,6 +211,7 @@ pub fn mstransform(request: &MsTransformRequest) -> Result<MsTransformReport, Ms
             column: source_column.to_string(),
         });
     }
+    let stage_started_at = Instant::now();
     let mut selected_rows =
         request
             .selection
@@ -213,11 +220,17 @@ pub fn mstransform(request: &MsTransformRequest) -> Result<MsTransformReport, Ms
                 path: request.input_ms.display().to_string(),
                 source,
             })?;
+    maybe_log_transform_progress(
+        "select_rows",
+        stage_started_at.elapsed(),
+        started_at.elapsed(),
+    );
     if selected_rows.is_empty() {
         return Err(MsTransformError::EmptySelection {
             path: request.input_ms.display().to_string(),
         });
     }
+    let stage_started_at = Instant::now();
     let channel_selection = resolve_transform_channels(&input, &request.spw)?;
     let ddid_to_spw = data_description_spw_map(&input)?;
     let selected_ddids = input
@@ -241,11 +254,17 @@ pub fn mstransform(request: &MsTransformRequest) -> Result<MsTransformReport, Ms
         }
     }
     selected_rows = filtered_rows;
+    maybe_log_transform_progress(
+        "filter_rows_by_spw",
+        stage_started_at.elapsed(),
+        started_at.elapsed(),
+    );
     if selected_rows.is_empty() {
         return Err(MsTransformError::EmptySelection {
             path: request.input_ms.display().to_string(),
         });
     }
+    let stage_started_at = Instant::now();
     let selected_times = input
         .main_table()
         .column_accessor("TIME")
@@ -277,6 +296,12 @@ pub fn mstransform(request: &MsTransformRequest) -> Result<MsTransformReport, Ms
         .iter()
         .map(|&index| filtered_ddids[index])
         .collect::<Vec<_>>();
+    maybe_log_transform_progress(
+        "sort_selected_rows",
+        stage_started_at.elapsed(),
+        started_at.elapsed(),
+    );
+    let stage_started_at = Instant::now();
     prepare_output_root(&request.output_ms)?;
     let mut output_main = materialize_selected_main_table(
         &request.input_ms,
@@ -284,9 +309,21 @@ pub fn mstransform(request: &MsTransformRequest) -> Result<MsTransformReport, Ms
         &selected_rows,
         &request.output_ms,
     )?;
+    maybe_log_transform_progress(
+        "materialize_selected_main",
+        stage_started_at.elapsed(),
+        started_at.elapsed(),
+    );
+    let stage_started_at = Instant::now();
     copy_subtables(&request.input_ms, &request.output_ms)?;
+    maybe_log_transform_progress(
+        "copy_subtables",
+        stage_started_at.elapsed(),
+        started_at.elapsed(),
+    );
 
     let row_indices = (0..selected_rows.len()).collect::<Vec<_>>();
+    let stage_started_at = Instant::now();
     let source_values = input
         .main_table()
         .column_accessor(source_column)
@@ -321,7 +358,13 @@ pub fn mstransform(request: &MsTransformRequest) -> Result<MsTransformReport, Ms
     } else {
         None
     };
+    maybe_log_transform_progress(
+        "load_visibility_columns",
+        stage_started_at.elapsed(),
+        started_at.elapsed(),
+    );
 
+    let stage_started_at = Instant::now();
     let mut touched_spws = BTreeSet::new();
     let mut transformed_data = Vec::with_capacity(row_indices.len());
     let mut transformed_flags = Vec::with_capacity(row_indices.len());
@@ -379,7 +422,13 @@ pub fn mstransform(request: &MsTransformRequest) -> Result<MsTransformReport, Ms
         }
         touched_spws.insert(spw_id);
     }
+    maybe_log_transform_progress(
+        "select_channels",
+        stage_started_at.elapsed(),
+        started_at.elapsed(),
+    );
 
+    let stage_started_at = Instant::now();
     output_main
         .column_accessor_mut(VisibilityDataColumn::Data.name())
         .and_then(|mut column| column.put(transformed_data))
@@ -403,7 +452,13 @@ pub fn mstransform(request: &MsTransformRequest) -> Result<MsTransformReport, Ms
                 source: Box::new(source),
             })?;
     }
+    maybe_log_transform_progress(
+        "put_output_columns",
+        stage_started_at.elapsed(),
+        started_at.elapsed(),
+    );
 
+    let stage_started_at = Instant::now();
     output_main
         .save_with_bindings_assuming_valid(
             measurement_set_table_options(&request.output_ms),
@@ -413,7 +468,18 @@ pub fn mstransform(request: &MsTransformRequest) -> Result<MsTransformReport, Ms
             path: request.output_ms.display().to_string(),
             source: Box::new(source),
         })?;
+    maybe_log_transform_progress(
+        "save_output_main",
+        stage_started_at.elapsed(),
+        started_at.elapsed(),
+    );
+    let stage_started_at = Instant::now();
     update_spectral_window_metadata(&channel_selection, &request.output_ms)?;
+    maybe_log_transform_progress(
+        "update_spectral_window",
+        stage_started_at.elapsed(),
+        started_at.elapsed(),
+    );
 
     Ok(MsTransformReport {
         input_ms: request.input_ms.clone(),
@@ -429,6 +495,21 @@ pub fn mstransform(request: &MsTransformRequest) -> Result<MsTransformReport, Ms
             .collect(),
         elapsed_ns: started_at.elapsed().as_nanos() as u64,
     })
+}
+
+fn transform_progress_enabled() -> bool {
+    std::env::var_os("CASA_RS_MSTRANSFORM_PROGRESS").is_some()
+}
+
+fn maybe_log_transform_progress(stage: &str, stage_elapsed: Duration, total_elapsed: Duration) {
+    if transform_progress_enabled() {
+        eprintln!(
+            "mstransform stage={} stage_elapsed_s={:.3} total_elapsed_s={:.3}",
+            stage,
+            stage_elapsed.as_secs_f64(),
+            total_elapsed.as_secs_f64(),
+        );
+    }
 }
 
 fn materialize_selected_main_table(
@@ -478,8 +559,16 @@ fn gather_selected_rows_column_wise(
                 "MAIN table is missing schema metadata".to_string(),
             )),
         })?;
-    let mut rows = vec![RecordValue::default(); selected_rows.len()];
+    let copied_column_count = schema
+        .columns()
+        .iter()
+        .filter(|column| !is_deferred_visibility_column(column.name()))
+        .count();
+    let mut rows = (0..selected_rows.len())
+        .map(|_| RecordValue::new(Vec::with_capacity(copied_column_count)))
+        .collect::<Vec<_>>();
     for column in schema.columns() {
+        let column_started_at = Instant::now();
         let name = column.name();
         if is_deferred_visibility_column(name) {
             continue;
@@ -526,6 +615,11 @@ fn gather_selected_rows_column_wise(
                 }
             }
         }
+        maybe_log_transform_progress(
+            &format!("materialize_selected_main/column/{name}"),
+            column_started_at.elapsed(),
+            column_started_at.elapsed(),
+        );
     }
     Ok(rows)
 }

--- a/crates/casa-ms/src/transform.rs
+++ b/crates/casa-ms/src/transform.rs
@@ -7,14 +7,14 @@
 //! selection into a new on-disk MeasurementSet while preserving the standard
 //! subtables and updating spectral-window channel metadata.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use casa_tables::{ColumnType, Table, TableError, TableOptions};
-use casa_types::{ArrayValue, RecordField, RecordValue, ScalarValue, Value};
-use ndarray::{Axis, Slice};
+use casa_types::{ArrayValue, RecordValue, ScalarValue, Value};
+use ndarray::{ArrayD, Axis, IxDyn, ShapeBuilder, Slice};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -265,50 +265,16 @@ pub fn mstransform(request: &MsTransformRequest) -> Result<MsTransformReport, Ms
         });
     }
     let stage_started_at = Instant::now();
-    let selected_times = input
-        .main_table()
-        .column_accessor("TIME")
-        .and_then(|column| column.scalar_cells_owned_for_rows(&selected_rows))
-        .map_err(|source| MsTransformError::MutateMeasurementSet {
-            path: request.input_ms.display().to_string(),
-            source: Box::new(source),
-        })?;
-    let mut order = (0..selected_rows.len()).collect::<Vec<_>>();
-    order.sort_by(|&left, &right| {
-        let left_time = selected_times
-            .get(left)
-            .and_then(Option::as_ref)
-            .and_then(scalar_f64_value)
-            .unwrap_or(f64::NAN);
-        let right_time = selected_times
-            .get(right)
-            .and_then(Option::as_ref)
-            .and_then(scalar_f64_value)
-            .unwrap_or(f64::NAN);
-        left_time.total_cmp(&right_time).then_with(|| {
-            selected_rows[left]
-                .cmp(&selected_rows[right])
-                .then_with(|| left.cmp(&right))
-        })
-    });
-    selected_rows = order.iter().map(|&index| selected_rows[index]).collect();
-    let selected_ddids = order
-        .iter()
-        .map(|&index| filtered_ddids[index])
-        .collect::<Vec<_>>();
+    let selected_ddids = filtered_ddids;
     maybe_log_transform_progress(
-        "sort_selected_rows",
+        "preserve_input_row_order",
         stage_started_at.elapsed(),
         started_at.elapsed(),
     );
     let stage_started_at = Instant::now();
     prepare_output_root(&request.output_ms)?;
-    let mut output_main = materialize_selected_main_table(
-        &request.input_ms,
-        &input,
-        &selected_rows,
-        &request.output_ms,
-    )?;
+    let output_main =
+        materialize_empty_main_table(&request.input_ms, selected_rows.len(), &request.output_ms)?;
     maybe_log_transform_progress(
         "materialize_selected_main",
         stage_started_at.elapsed(),
@@ -323,6 +289,17 @@ pub fn mstransform(request: &MsTransformRequest) -> Result<MsTransformReport, Ms
     );
 
     let row_indices = (0..selected_rows.len()).collect::<Vec<_>>();
+    let stage_started_at = Instant::now();
+    let mut output_column_overrides = gather_selected_main_column_overrides(
+        input.main_table(),
+        &selected_rows,
+        &request.output_ms,
+    )?;
+    maybe_log_transform_progress(
+        "load_main_column_overrides",
+        stage_started_at.elapsed(),
+        started_at.elapsed(),
+    );
     let stage_started_at = Instant::now();
     let source_values = input
         .main_table()
@@ -393,31 +370,31 @@ pub fn mstransform(request: &MsTransformRequest) -> Result<MsTransformReport, Ms
             selector: request.spw.clone(),
             reason: format!("selected row {row_index} maps to spectral window {spw_id}, but --spw does not include that SPW"),
         })?;
-        transformed_data.push(Value::Array(select_channels(data, channels).map_err(
-            |source| MsTransformError::MutateMeasurementSet {
+        transformed_data.push(select_channels(data, channels).map_err(|source| {
+            MsTransformError::MutateMeasurementSet {
                 path: request.output_ms.display().to_string(),
                 source: Box::new(source),
-            },
-        )?));
-        transformed_flags.push(Value::Array(select_channels(flags, channels).map_err(
-            |source| MsTransformError::MutateMeasurementSet {
+            }
+        })?);
+        transformed_flags.push(select_channels(flags, channels).map_err(|source| {
+            MsTransformError::MutateMeasurementSet {
                 path: request.output_ms.display().to_string(),
                 source: Box::new(source),
-            },
-        )?));
+            }
+        })?);
         if let Some(values) = weight_spectrum_values.as_mut() {
             let weight_spectrum = values.next().flatten().ok_or_else(|| {
                 missing_column_error(&request.output_ms, row_index, "WEIGHT_SPECTRUM")
             })?;
             if let Some(transformed) = transformed_weight_spectrum.as_mut() {
-                transformed.push(Value::Array(
+                transformed.push(
                     select_channels(weight_spectrum, channels).map_err(|source| {
                         MsTransformError::MutateMeasurementSet {
                             path: request.output_ms.display().to_string(),
                             source: Box::new(source),
                         }
                     })?,
-                ));
+                );
             }
         }
         touched_spws.insert(spw_id);
@@ -429,40 +406,34 @@ pub fn mstransform(request: &MsTransformRequest) -> Result<MsTransformReport, Ms
     );
 
     let stage_started_at = Instant::now();
-    output_main
-        .column_accessor_mut(VisibilityDataColumn::Data.name())
-        .and_then(|mut column| column.put(transformed_data))
-        .map_err(|source| MsTransformError::MutateMeasurementSet {
-            path: request.output_ms.display().to_string(),
-            source: Box::new(source),
-        })?;
-    output_main
-        .column_accessor_mut("FLAG")
-        .and_then(|mut column| column.put(transformed_flags))
-        .map_err(|source| MsTransformError::MutateMeasurementSet {
-            path: request.output_ms.display().to_string(),
-            source: Box::new(source),
-        })?;
-    if let Some(transformed) = transformed_weight_spectrum {
-        output_main
-            .column_accessor_mut("WEIGHT_SPECTRUM")
-            .and_then(|mut column| column.put(transformed))
-            .map_err(|source| MsTransformError::MutateMeasurementSet {
-                path: request.output_ms.display().to_string(),
-                source: Box::new(source),
-            })?;
-    }
-    maybe_log_transform_progress(
-        "put_output_columns",
-        stage_started_at.elapsed(),
-        started_at.elapsed(),
+    output_column_overrides.insert(
+        VisibilityDataColumn::Data.name().to_string(),
+        transformed_data
+            .into_iter()
+            .map(|value| Some(Value::Array(value)))
+            .collect(),
     );
-
-    let stage_started_at = Instant::now();
+    output_column_overrides.insert(
+        "FLAG".to_string(),
+        transformed_flags
+            .into_iter()
+            .map(|value| Some(Value::Array(value)))
+            .collect(),
+    );
+    if let Some(transformed_weight_spectrum) = transformed_weight_spectrum {
+        output_column_overrides.insert(
+            "WEIGHT_SPECTRUM".to_string(),
+            transformed_weight_spectrum
+                .into_iter()
+                .map(|value| Some(Value::Array(value)))
+                .collect(),
+        );
+    }
     output_main
-        .save_with_bindings_assuming_valid(
+        .save_with_bindings_and_column_overrides_assuming_valid(
             measurement_set_table_options(&request.output_ms),
             &measurement_set_main_table_bindings(&output_main),
+            &output_column_overrides,
         )
         .map_err(|source| MsTransformError::MutateMeasurementSet {
             path: request.output_ms.display().to_string(),
@@ -512,10 +483,9 @@ fn maybe_log_transform_progress(stage: &str, stage_elapsed: Duration, total_elap
     }
 }
 
-fn materialize_selected_main_table(
+fn materialize_empty_main_table(
     input_path: &Path,
-    input: &MeasurementSet,
-    selected_rows: &[usize],
+    row_count: usize,
     output_path: &Path,
 ) -> Result<Table, MsTransformError> {
     let mut main = Table::open_metadata_only(TableOptions::new(input_path)).map_err(|source| {
@@ -524,21 +494,19 @@ fn materialize_selected_main_table(
             source: Box::new(source),
         }
     })?;
-    let rows = gather_selected_rows_column_wise(input.main_table(), selected_rows, output_path)?;
-    main.add_rows_assuming_valid(rows).map_err(|source| {
-        MsTransformError::MutateMeasurementSet {
+    main.add_rows_assuming_valid((0..row_count).map(|_| RecordValue::default()))
+        .map_err(|source| MsTransformError::MutateMeasurementSet {
             path: output_path.display().to_string(),
             source: Box::new(source),
-        }
-    })?;
+        })?;
     Ok(main)
 }
 
-fn gather_selected_rows_column_wise(
+fn gather_selected_main_column_overrides(
     table: &Table,
     selected_rows: &[usize],
     output_path: &Path,
-) -> Result<Vec<RecordValue>, MsTransformError> {
+) -> Result<HashMap<String, Vec<Option<Value>>>, MsTransformError> {
     let schema = table
         .schema()
         .ok_or_else(|| MsTransformError::MutateMeasurementSet {
@@ -547,14 +515,7 @@ fn gather_selected_rows_column_wise(
                 "MAIN table is missing schema metadata".to_string(),
             )),
         })?;
-    let copied_column_count = schema
-        .columns()
-        .iter()
-        .filter(|column| !is_deferred_visibility_column(column.name()))
-        .count();
-    let mut rows = (0..selected_rows.len())
-        .map(|_| RecordValue::new(Vec::with_capacity(copied_column_count)))
-        .collect::<Vec<_>>();
+    let mut columns = HashMap::new();
     for column in schema.columns() {
         let column_started_at = Instant::now();
         let name = column.name();
@@ -570,11 +531,13 @@ fn gather_selected_rows_column_wise(
                         path: output_path.display().to_string(),
                         source: Box::new(source),
                     })?;
-                for (row, value) in rows.iter_mut().zip(values) {
-                    if let Some(value) = value {
-                        row.push(RecordField::new(name, Value::Scalar(value)));
-                    }
-                }
+                columns.insert(
+                    name.to_string(),
+                    values
+                        .into_iter()
+                        .map(|value| value.map(Value::Scalar))
+                        .collect(),
+                );
             }
             ColumnType::Array(_) => {
                 let values = table
@@ -584,32 +547,39 @@ fn gather_selected_rows_column_wise(
                         path: output_path.display().to_string(),
                         source: Box::new(source),
                     })?;
-                for (row, value) in rows.iter_mut().zip(values) {
-                    if let Some(value) = value {
-                        row.push(RecordField::new(name, Value::Array(value)));
-                    }
-                }
+                columns.insert(
+                    name.to_string(),
+                    values
+                        .into_iter()
+                        .map(|value| value.map(Value::Array))
+                        .collect(),
+                );
             }
             ColumnType::Record => {
-                for (row, &input_row) in rows.iter_mut().zip(selected_rows) {
-                    let value = table
-                        .column_accessor(name)
-                        .and_then(|column| column.record_cell(input_row))
-                        .map_err(|source| MsTransformError::MutateMeasurementSet {
-                            path: output_path.display().to_string(),
-                            source: Box::new(source),
-                        })?;
-                    row.push(RecordField::new(name, Value::Record(value)));
-                }
+                let values = selected_rows
+                    .iter()
+                    .copied()
+                    .map(|input_row| {
+                        table
+                            .column_accessor(name)
+                            .and_then(|column| column.record_cell(input_row))
+                            .map(|value| Some(Value::Record(value)))
+                            .map_err(|source| MsTransformError::MutateMeasurementSet {
+                                path: output_path.display().to_string(),
+                                source: Box::new(source),
+                            })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                columns.insert(name.to_string(), values);
             }
         }
         maybe_log_transform_progress(
-            &format!("materialize_selected_main/column/{name}"),
+            &format!("load_main_column_overrides/column/{name}"),
             column_started_at.elapsed(),
             column_started_at.elapsed(),
         );
     }
-    Ok(rows)
+    Ok(columns)
 }
 
 fn is_deferred_visibility_column(column: &str) -> bool {
@@ -773,6 +743,9 @@ fn select_channels(value: ArrayValue, channels: &[usize]) -> Result<ArrayValue, 
                 return Ok(ArrayValue::Complex32(values));
             }
             if let Some((start, end)) = contiguous_channel_range(channels) {
+                if let Some(values) = select_fortran_contiguous_axis1(values.view(), start, end)? {
+                    return Ok(ArrayValue::Complex32(values));
+                }
                 return Ok(ArrayValue::Complex32(
                     values
                         .slice_axis(Axis(1), Slice::from(start..end))
@@ -792,6 +765,9 @@ fn select_channels(value: ArrayValue, channels: &[usize]) -> Result<ArrayValue, 
                 return Ok(ArrayValue::Bool(values));
             }
             if let Some((start, end)) = contiguous_channel_range(channels) {
+                if let Some(values) = select_fortran_contiguous_axis1(values.view(), start, end)? {
+                    return Ok(ArrayValue::Bool(values));
+                }
                 return Ok(ArrayValue::Bool(
                     values
                         .slice_axis(Axis(1), Slice::from(start..end))
@@ -811,6 +787,9 @@ fn select_channels(value: ArrayValue, channels: &[usize]) -> Result<ArrayValue, 
                 return Ok(ArrayValue::Float32(values));
             }
             if let Some((start, end)) = contiguous_channel_range(channels) {
+                if let Some(values) = select_fortran_contiguous_axis1(values.view(), start, end)? {
+                    return Ok(ArrayValue::Float32(values));
+                }
                 return Ok(ArrayValue::Float32(
                     values
                         .slice_axis(Axis(1), Slice::from(start..end))
@@ -824,6 +803,32 @@ fn select_channels(value: ArrayValue, channels: &[usize]) -> Result<ArrayValue, 
             other.primitive_type()
         ))),
     }
+}
+
+fn select_fortran_contiguous_axis1<T: Clone>(
+    values: ndarray::ArrayViewD<'_, T>,
+    start: usize,
+    end: usize,
+) -> Result<Option<ArrayD<T>>, TableError> {
+    let shape = values.shape();
+    if shape.len() != 2 || start > end || end > shape[1] {
+        return Err(TableError::Schema(format!(
+            "channel range {start}..{end} is outside array shape {shape:?}"
+        )));
+    }
+    let Some(input) = values.as_slice_memory_order() else {
+        return Ok(None);
+    };
+    let corr_count = shape[0];
+    let output_shape = [corr_count, end - start];
+    let start_offset = start * corr_count;
+    let end_offset = end * corr_count;
+    ArrayD::from_shape_vec(
+        IxDyn(&output_shape).f(),
+        input[start_offset..end_offset].to_vec(),
+    )
+    .map(Some)
+    .map_err(|error| TableError::Schema(format!("channel slice shape mismatch: {error}")))
 }
 
 fn contiguous_channel_range(channels: &[usize]) -> Option<(usize, usize)> {
@@ -999,14 +1004,6 @@ fn scalar_i32(
                 column: column.to_string(),
             }),
         }),
-    }
-}
-
-fn scalar_f64_value(value: &ScalarValue) -> Option<f64> {
-    match value {
-        ScalarValue::Float64(value) => Some(*value),
-        ScalarValue::Float32(value) => Some(f64::from(*value)),
-        _ => None,
     }
 }
 

--- a/crates/casa-ms/tests/msexplore_cli.rs
+++ b/crates/casa-ms/tests/msexplore_cli.rs
@@ -75,6 +75,7 @@ fn msexplore_help_mentions_plot_controls() {
     assert!(stdout.contains("--flag-panel <KEY>"));
     assert!(stdout.contains("--flag-extcorr"));
     assert!(stdout.contains("--flag-extchannel"));
+    assert!(stdout.contains("--flag-selected"));
     assert!(stdout.contains("--flag-apply"));
     assert!(stdout.contains("--flag-output <PATH>"));
     assert!(stdout.contains("--plot-output <PATH>"));
@@ -2020,6 +2021,58 @@ fn cli_flag_preview_is_non_mutating_and_cli_apply_persists_changes() {
 
     let ms_after_apply = MeasurementSet::open(&ms_path).expect("reopen after apply");
     assert!(row_flag_matrix(&ms_after_apply, 0)[(0, 0)]);
+}
+
+#[test]
+fn cli_flag_selected_applies_to_selected_rows_without_plot_region() {
+    let temp = tempdir().expect("tempdir");
+    let ms_path = create_msexplore_fixture_ms(temp.path());
+    let preview_path = temp.path().join("selected-flag-preview.json");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_msexplore"))
+        .args([
+            "--format",
+            "json",
+            "--overwrite",
+            "--scan",
+            "2",
+            "--flag-action",
+            "flag",
+            "--flag-selected",
+            "--flag-apply",
+            "--flag-output",
+        ])
+        .arg(&preview_path)
+        .arg(&ms_path)
+        .output()
+        .expect("run selected flag apply");
+    assert!(output.status.success(), "{output:?}");
+
+    let preview_json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&preview_path).expect("read preview json"))
+            .expect("parse preview json");
+    assert_eq!(preview_json["affected_rows"], 1);
+    assert_eq!(
+        preview_json["affected_samples"],
+        common::NUM_CORR * common::NUM_CHAN
+    );
+
+    let ms_after_apply = MeasurementSet::open(&ms_path).expect("reopen after apply");
+    assert!(
+        row_flag_matrix(&ms_after_apply, 0)
+            .iter()
+            .all(|value| !*value)
+    );
+    assert!(
+        row_flag_matrix(&ms_after_apply, 1)
+            .iter()
+            .all(|value| *value)
+    );
+    assert!(
+        row_flag_matrix(&ms_after_apply, 3)
+            .iter()
+            .all(|value| !*value)
+    );
 }
 
 #[test]

--- a/crates/casa-tables/src/storage/incremental_stman.rs
+++ b/crates/casa-tables/src/storage/incremental_stman.rs
@@ -1070,6 +1070,64 @@ pub(crate) fn read_ism_scalar_column_rows(
     Ok(Some(values))
 }
 
+pub(crate) fn read_ism_scalar_column(
+    file_path: &Path,
+    dm_blob: &[u8],
+    col_descs: &[&ColumnDescContents],
+    target_col_idx: usize,
+    nrrow: usize,
+) -> Result<Option<Vec<Option<ScalarValue>>>, StorageError> {
+    if target_col_idx >= col_descs.len() {
+        return Err(StorageError::FormatMismatch(format!(
+            "ISM scalar column index {target_col_idx} is out of range"
+        )));
+    }
+    let target_col_desc = col_descs[target_col_idx];
+    if target_col_desc.is_array || target_col_desc.is_record() {
+        return Ok(None);
+    }
+
+    let _dm_name = parse_ism_dm_blob(dm_blob)?;
+    let mut file = File::open(file_path)?;
+    let header = parse_ism_header(&mut file)?;
+    let index = parse_ism_index(&mut file, &header)?;
+    let big_endian = header.big_endian;
+    let scalar_dt =
+        CasacoreDataType::from_primitive_type(target_col_desc.require_primitive_type()?, false);
+
+    let mut values = Vec::with_capacity(nrrow);
+    let mut last_bucket_nr = None;
+    let mut cached_bucket = None;
+    for interval in 0..index.bucket_nrs.len() {
+        let bucket_start = index.rows[interval] as usize;
+        let bucket_end = index.rows[interval + 1] as usize;
+        let rows_in_bucket = bucket_end.saturating_sub(bucket_start);
+        let bucket_nr = index.bucket_nrs[interval];
+        if last_bucket_nr != Some(bucket_nr) {
+            let raw_bucket = read_ism_bucket(&mut file, &header, bucket_nr)?;
+            cached_bucket = Some(parse_ism_bucket(&raw_bucket, col_descs.len(), big_endian)?);
+            last_bucket_nr = Some(bucket_nr);
+        }
+        let bucket = cached_bucket
+            .as_ref()
+            .expect("ISM bucket loaded before scalar column extraction");
+        values.extend(load_scalar_bucket_column_values(
+            bucket,
+            target_col_desc,
+            target_col_idx,
+            scalar_dt,
+            rows_in_bucket,
+            big_endian,
+        )?);
+    }
+
+    values.truncate(nrrow);
+    if values.len() < nrrow {
+        values.resize(nrrow, None);
+    }
+    Ok(Some(values))
+}
+
 fn ism_selected_scalar_rows_cache_key(
     file_path: &Path,
     col_descs: &[&ColumnDescContents],
@@ -1718,6 +1776,158 @@ fn encode_value_bytes(
     buf
 }
 
+fn encode_scalar_column_value_bytes(
+    value: Option<&casa_types::ScalarValue>,
+    dt: CasacoreDataType,
+    nrelem: usize,
+    big_endian: bool,
+) -> Vec<u8> {
+    use casa_types::ScalarValue;
+
+    if nrelem != 1 {
+        let value = value.cloned().map(casa_types::Value::Scalar);
+        return encode_value_bytes(value.as_ref(), dt, nrelem, big_endian);
+    }
+
+    if dt == CasacoreDataType::TpString {
+        let string = match value {
+            Some(ScalarValue::String(value)) => value.as_str(),
+            _ => "",
+        };
+        let total_length = (4 + string.len()) as u32;
+        let mut buf = Vec::with_capacity(total_length as usize);
+        if big_endian {
+            buf.extend_from_slice(&total_length.to_be_bytes());
+        } else {
+            buf.extend_from_slice(&total_length.to_le_bytes());
+        }
+        buf.extend_from_slice(string.as_bytes());
+        return buf;
+    }
+
+    if dt == CasacoreDataType::TpBool {
+        return vec![match value {
+            Some(ScalarValue::Bool(true)) => 1,
+            _ => 0,
+        }];
+    }
+
+    let elem_size = ism_element_size(dt);
+    let mut buf = vec![0u8; elem_size];
+    match dt {
+        CasacoreDataType::TpUChar => {
+            if let Some(ScalarValue::UInt8(value)) = value {
+                buf[0] = *value;
+            }
+        }
+        CasacoreDataType::TpShort => {
+            let value = match value {
+                Some(ScalarValue::Int16(value)) => *value,
+                _ => 0,
+            };
+            if big_endian {
+                write_i16_be(&mut buf, value);
+            } else {
+                write_i16_le(&mut buf, value);
+            }
+        }
+        CasacoreDataType::TpUShort => {
+            let value = match value {
+                Some(ScalarValue::UInt16(value)) => *value,
+                _ => 0,
+            };
+            if big_endian {
+                write_u16_be(&mut buf, value);
+            } else {
+                write_u16_le(&mut buf, value);
+            }
+        }
+        CasacoreDataType::TpInt => {
+            let value = match value {
+                Some(ScalarValue::Int32(value)) => *value,
+                _ => 0,
+            };
+            if big_endian {
+                write_i32_be(&mut buf, value);
+            } else {
+                write_i32_le(&mut buf, value);
+            }
+        }
+        CasacoreDataType::TpUInt => {
+            let value = match value {
+                Some(ScalarValue::UInt32(value)) => *value,
+                _ => 0,
+            };
+            if big_endian {
+                write_u32_be(&mut buf, value);
+            } else {
+                write_u32_le(&mut buf, value);
+            }
+        }
+        CasacoreDataType::TpFloat => {
+            let value = match value {
+                Some(ScalarValue::Float32(value)) => *value,
+                _ => 0.0,
+            };
+            if big_endian {
+                write_f32_be(&mut buf, value);
+            } else {
+                write_f32_le(&mut buf, value);
+            }
+        }
+        CasacoreDataType::TpDouble => {
+            let value = match value {
+                Some(ScalarValue::Float64(value)) => *value,
+                _ => 0.0,
+            };
+            if big_endian {
+                write_f64_be(&mut buf, value);
+            } else {
+                write_f64_le(&mut buf, value);
+            }
+        }
+        CasacoreDataType::TpInt64 => {
+            let value = match value {
+                Some(ScalarValue::Int64(value)) => *value,
+                _ => 0,
+            };
+            if big_endian {
+                write_i64_be(&mut buf, value);
+            } else {
+                write_i64_le(&mut buf, value);
+            }
+        }
+        CasacoreDataType::TpComplex => {
+            let (re, im) = match value {
+                Some(ScalarValue::Complex32(value)) => (value.re, value.im),
+                _ => (0.0, 0.0),
+            };
+            if big_endian {
+                write_f32_be(&mut buf, re);
+                write_f32_be(&mut buf[4..], im);
+            } else {
+                write_f32_le(&mut buf, re);
+                write_f32_le(&mut buf[4..], im);
+            }
+        }
+        CasacoreDataType::TpDComplex => {
+            let (re, im) = match value {
+                Some(ScalarValue::Complex64(value)) => (value.re, value.im),
+                _ => (0.0, 0.0),
+            };
+            if big_endian {
+                write_f64_be(&mut buf, re);
+                write_f64_be(&mut buf[8..], im);
+            } else {
+                write_f64_le(&mut buf, re);
+                write_f64_le(&mut buf[8..], im);
+            }
+        }
+        _ => {}
+    }
+    buf
+}
+
 /// Encode string value(s) in ISM format (C++ `ISMColumn::fromString`):
 ///
 /// Scalar (nrelem == 1): `[u32: total_length] [string_bytes]`
@@ -1877,15 +2087,20 @@ pub(crate) fn write_ism_file_scalar_columns(
             let rel_row = (row_idx - *bucket_start_rows.last().unwrap()) as u32;
 
             let mut new_data_estimate = 0usize;
+            let mut row_encoded_values = Vec::with_capacity(ncol);
             for col_idx in 0..ncol {
                 let (dt, nrelem) = col_info[col_idx];
-                let temp_value = scalar_columns[col_idx][row_idx]
-                    .as_ref()
-                    .cloned()
-                    .map(casa_types::Value::Scalar);
-                let encoded = encode_value_bytes(temp_value.as_ref(), dt, nrelem, big_endian);
+                let encoded = encode_scalar_column_value_bytes(
+                    scalar_columns[col_idx][row_idx].as_ref(),
+                    dt,
+                    nrelem,
+                    big_endian,
+                );
                 if rel_row == 0 || encoded != last_values[col_idx] {
                     new_data_estimate += encoded.len();
+                    row_encoded_values.push(Some(encoded));
+                } else {
+                    row_encoded_values.push(None);
                 }
             }
 
@@ -1922,11 +2137,14 @@ pub(crate) fn write_ism_file_scalar_columns(
                 }
                 for col_idx in 0..ncol {
                     let (dt, nrelem) = col_info[col_idx];
-                    let temp_value = scalar_columns[col_idx][row_idx]
-                        .as_ref()
-                        .cloned()
-                        .map(casa_types::Value::Scalar);
-                    let encoded = encode_value_bytes(temp_value.as_ref(), dt, nrelem, big_endian);
+                    let encoded = row_encoded_values[col_idx].take().unwrap_or_else(|| {
+                        encode_scalar_column_value_bytes(
+                            scalar_columns[col_idx][row_idx].as_ref(),
+                            dt,
+                            nrelem,
+                            big_endian,
+                        )
+                    });
                     if encoded != last_values[col_idx] {
                         let offset = current.data.len() as u32;
                         current.data.extend_from_slice(&encoded);
@@ -1940,14 +2158,7 @@ pub(crate) fn write_ism_file_scalar_columns(
             }
 
             for col_idx in 0..ncol {
-                let (dt, nrelem) = col_info[col_idx];
-                let temp_value = scalar_columns[col_idx][row_idx]
-                    .as_ref()
-                    .cloned()
-                    .map(casa_types::Value::Scalar);
-                let encoded = encode_value_bytes(temp_value.as_ref(), dt, nrelem, big_endian);
-
-                if rel_row == 0 || encoded != last_values[col_idx] {
+                if let Some(encoded) = row_encoded_values[col_idx].take() {
                     let offset = current.data.len() as u32;
                     current.data.extend_from_slice(&encoded);
                     current.col_indices[col_idx].0.push(rel_row);
@@ -2634,6 +2845,66 @@ fn load_scalar_bucket_values(
             }
         }
         values.push(column);
+    }
+    Ok(values)
+}
+
+fn load_scalar_bucket_column_values(
+    bucket: &IsmBucket,
+    col_desc: &ColumnDescContents,
+    col_idx: usize,
+    dt: CasacoreDataType,
+    rows_in_bucket: usize,
+    big_endian: bool,
+) -> Result<Vec<Option<ScalarValue>>, StorageError> {
+    if col_idx >= bucket.col_indices.len() {
+        let value = default_value(dt, false, col_desc);
+        let scalar = match value {
+            casa_types::Value::Scalar(scalar) => scalar,
+            other => {
+                return Err(StorageError::FormatMismatch(format!(
+                    "ISM default value for column '{}' is not scalar: {other:?}",
+                    col_desc.col_name
+                )));
+            }
+        };
+        let value = if (col_desc.option & 2) != 0
+            && scalar_value_is_default(
+                &casa_types::Value::Scalar(scalar.clone()),
+                col_desc.require_primitive_type()?,
+            ) {
+            None
+        } else {
+            Some(scalar)
+        };
+        return Ok(vec![value; rows_in_bucket]);
+    }
+
+    let col_index = &bucket.col_indices[col_idx];
+    let mut values = Vec::with_capacity(rows_in_bucket);
+    for rel_row in 0..rows_in_bucket {
+        let interval = get_interval(col_index, rel_row as u32);
+        let data_offset = col_index.offsets[interval] as usize;
+        let value = read_scalar_at(&bucket.data, data_offset, dt, big_endian)?;
+        let scalar = match value {
+            casa_types::Value::Scalar(scalar) => scalar,
+            other => {
+                return Err(StorageError::FormatMismatch(format!(
+                    "ISM sparse bucket value for column '{}' is not scalar: {other:?}",
+                    col_desc.col_name
+                )));
+            }
+        };
+        if (col_desc.option & 2) != 0
+            && scalar_value_is_default(
+                &casa_types::Value::Scalar(scalar.clone()),
+                col_desc.require_primitive_type()?,
+            )
+        {
+            values.push(None);
+        } else {
+            values.push(Some(scalar));
+        }
     }
     Ok(values)
 }

--- a/crates/casa-tables/src/storage/incremental_stman.rs
+++ b/crates/casa-tables/src/storage/incremental_stman.rs
@@ -15,10 +15,12 @@
 //! C++ equivalent: `casacore/tables/DataMan/ISMBase`, `ISMBucket`, `ISMIndex`,
 //! `ISMColumn`.
 
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 use casa_aipsio::{AipsIo, ByteOrder};
 use casa_types::ScalarValue;
@@ -41,6 +43,26 @@ const ISM_HEADER_SIZE: u64 = 512;
 const AIPSIO_MAGIC: u32 = 0xbebebebe;
 
 type SparseScalarRowValues = Vec<(usize, Option<casa_types::ScalarValue>)>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IsmSelectedScalarRowsCacheKey {
+    file_path: PathBuf,
+    file_len: u64,
+    file_modified: Option<SystemTime>,
+    selected_rows: Vec<usize>,
+    column_names: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct IsmSelectedScalarRowsCache {
+    key: IsmSelectedScalarRowsCacheKey,
+    values_by_column: Vec<Vec<Option<ScalarValue>>>,
+}
+
+thread_local! {
+    static ISM_SELECTED_SCALAR_ROWS_CACHE: RefCell<Option<IsmSelectedScalarRowsCache>> =
+        const { RefCell::new(None) };
+}
 
 // ---------------------------------------------------------------------------
 // In-memory AipsIO helpers
@@ -1016,12 +1038,6 @@ pub(crate) fn read_ism_scalar_column_rows(
         return Ok(Some(Vec::new()));
     }
 
-    let _dm_name = parse_ism_dm_blob(dm_blob)?;
-    let mut file = File::open(file_path)?;
-    let header = parse_ism_header(&mut file)?;
-    let index = parse_ism_index(&mut file, &header)?;
-    let big_endian = header.big_endian;
-
     if target_col_idx >= col_descs.len() {
         return Err(StorageError::FormatMismatch(format!(
             "ISM scalar column index {target_col_idx} is out of range"
@@ -1032,11 +1048,97 @@ pub(crate) fn read_ism_scalar_column_rows(
         return Ok(None);
     }
 
+    let cache_key = ism_selected_scalar_rows_cache_key(file_path, col_descs, selected_rows)?;
+    if let Some(values) =
+        cached_ism_selected_scalar_column(&cache_key, target_col_idx, selected_rows.len())
+    {
+        return Ok(Some(values));
+    }
+
+    let values_by_column =
+        read_ism_scalar_columns_rows_uncached(file_path, dm_blob, col_descs, selected_rows)?;
+    let values = values_by_column
+        .get(target_col_idx)
+        .cloned()
+        .ok_or_else(|| {
+            StorageError::FormatMismatch(format!(
+                "ISM scalar column '{}' missing from selected-row cache",
+                target_col_desc.col_name
+            ))
+        })?;
+    store_ism_selected_scalar_rows_cache(cache_key, values_by_column);
+    Ok(Some(values))
+}
+
+fn ism_selected_scalar_rows_cache_key(
+    file_path: &Path,
+    col_descs: &[&ColumnDescContents],
+    selected_rows: &[usize],
+) -> Result<IsmSelectedScalarRowsCacheKey, StorageError> {
+    let metadata = std::fs::metadata(file_path)?;
+    Ok(IsmSelectedScalarRowsCacheKey {
+        file_path: file_path.to_path_buf(),
+        file_len: metadata.len(),
+        file_modified: metadata.modified().ok(),
+        selected_rows: selected_rows.to_vec(),
+        column_names: col_descs
+            .iter()
+            .map(|col_desc| col_desc.col_name.clone())
+            .collect(),
+    })
+}
+
+fn cached_ism_selected_scalar_column(
+    key: &IsmSelectedScalarRowsCacheKey,
+    target_col_idx: usize,
+    expected_len: usize,
+) -> Option<Vec<Option<ScalarValue>>> {
+    ISM_SELECTED_SCALAR_ROWS_CACHE.with(|cache| {
+        let cache = cache.borrow();
+        let entry = cache.as_ref()?;
+        if &entry.key != key {
+            return None;
+        }
+        let values = entry.values_by_column.get(target_col_idx)?;
+        (values.len() == expected_len).then(|| values.clone())
+    })
+}
+
+fn store_ism_selected_scalar_rows_cache(
+    key: IsmSelectedScalarRowsCacheKey,
+    values_by_column: Vec<Vec<Option<ScalarValue>>>,
+) {
+    ISM_SELECTED_SCALAR_ROWS_CACHE.with(|cache| {
+        *cache.borrow_mut() = Some(IsmSelectedScalarRowsCache {
+            key,
+            values_by_column,
+        });
+    });
+}
+
+fn read_ism_scalar_columns_rows_uncached(
+    file_path: &Path,
+    dm_blob: &[u8],
+    col_descs: &[&ColumnDescContents],
+    selected_rows: &[usize],
+) -> Result<Vec<Vec<Option<ScalarValue>>>, StorageError> {
+    let _dm_name = parse_ism_dm_blob(dm_blob)?;
+    let mut file = File::open(file_path)?;
+    let header = parse_ism_header(&mut file)?;
+    let index = parse_ism_index(&mut file, &header)?;
+    let big_endian = header.big_endian;
+
     let owned_col_descs: Vec<ColumnDescContents> =
         col_descs.iter().map(|col| (*col).clone()).collect();
     let col_info: Vec<(CasacoreDataType, usize)> = owned_col_descs
         .iter()
         .map(|col_desc| {
+            if col_desc.is_array || col_desc.is_record() {
+                return Err(StorageError::FormatMismatch(format!(
+                    "ISM selected scalar reader only supports scalar columns, found '{}'",
+                    col_desc.col_name
+                )));
+            }
             let scalar_dt =
                 CasacoreDataType::from_primitive_type(col_desc.require_primitive_type()?, false);
             let nrelem = if col_desc.is_array && !col_desc.shape.is_empty() {
@@ -1056,10 +1158,12 @@ pub(crate) fn read_ism_scalar_column_rows(
         .collect();
     requests.sort_unstable_by_key(|&(row_index, _)| row_index);
 
-    let mut values = vec![None; selected_rows.len()];
     let mut cached_interval = None;
     let mut cached_bucket_start = 0usize;
-    let mut cached_bucket_values: Vec<Option<ScalarValue>> = Vec::new();
+    let mut cached_bucket_values: Vec<Vec<Option<ScalarValue>>> = Vec::new();
+    let mut values_by_column = (0..col_descs.len())
+        .map(|_| vec![None; selected_rows.len()])
+        .collect::<Vec<_>>();
 
     for (row_index, out_idx) in requests {
         let interval = index
@@ -1090,21 +1194,21 @@ pub(crate) fn read_ism_scalar_column_rows(
                 bucket_end.saturating_sub(cached_bucket_start),
                 big_endian,
             )?;
-            cached_bucket_values = bucket_rows.get(target_col_idx).cloned().ok_or_else(|| {
-                StorageError::FormatMismatch(format!(
-                    "ISM scalar column '{}' missing from parsed bucket",
-                    target_col_desc.col_name
-                ))
-            })?;
+            cached_bucket_values = bucket_rows;
         }
 
-        values[out_idx] = cached_bucket_values
-            .get(row_index.saturating_sub(cached_bucket_start))
-            .cloned()
-            .unwrap_or(None);
+        let bucket_row = row_index.saturating_sub(cached_bucket_start);
+        for (column_values, bucket_column_values) in
+            values_by_column.iter_mut().zip(cached_bucket_values.iter())
+        {
+            column_values[out_idx] = bucket_column_values
+                .get(bucket_row)
+                .cloned()
+                .unwrap_or(None);
+        }
     }
 
-    Ok(Some(values))
+    Ok(values_by_column)
 }
 
 fn default_value(

--- a/crates/casa-tables/src/storage/mod.rs
+++ b/crates/casa-tables/src/storage/mod.rs
@@ -33,12 +33,12 @@ use crate::schema::{SchemaError, TableSchema};
 
 use self::data_type::CasacoreDataType;
 use self::incremental_stman::{
-    IsmColumnResult, read_ism_file, read_ism_scalar_column_rows, write_ism_file,
-    write_ism_file_indexed,
+    IsmColumnResult, read_ism_file, read_ism_scalar_column, read_ism_scalar_column_rows,
+    write_ism_file, write_ism_file_indexed, write_ism_file_scalar_columns,
 };
 use self::standard_stman::{
     read_ssm_array_column_rows, read_ssm_file, read_ssm_scalar_column_rows, write_ssm_file,
-    write_ssm_file_indexed,
+    write_ssm_file_indexed, write_ssm_file_scalar_columns,
 };
 use self::stman_aipsio::scalar_value_is_default;
 use self::stman_aipsio::{
@@ -290,21 +290,29 @@ fn project_rows_for_group(
     rows: &[RecordValue],
     group_col_descs: &[table_control::ColumnDescContents],
     group_col_indices: Option<&[usize]>,
+    column_overrides: &HashMap<String, Vec<Option<Value>>>,
 ) -> Vec<RecordValue> {
     rows.iter()
-        .map(|row| {
+        .enumerate()
+        .map(|(row_idx, row)| {
             let fields = group_col_descs
                 .iter()
                 .enumerate()
                 .filter_map(|(col_idx, desc)| {
-                    let value = group_col_indices
-                        .and_then(|indices| {
-                            row.fields()
-                                .get(indices[col_idx])
-                                .filter(|field| field.name == desc.col_name)
-                                .map(|field| field.value.clone())
-                        })
-                        .or_else(|| row.get(&desc.col_name).cloned());
+                    let value = column_overrides
+                        .get(&desc.col_name)
+                        .and_then(|values| values.get(row_idx))
+                        .and_then(|value| value.clone())
+                        .or_else(|| {
+                            group_col_indices
+                                .and_then(|indices| {
+                                    row.fields()
+                                        .get(indices[col_idx])
+                                        .filter(|field| field.name == desc.col_name)
+                                        .map(|field| field.value.clone())
+                                })
+                                .or_else(|| row.get(&desc.col_name).cloned())
+                        });
                     value.map(|value| RecordField::new(desc.col_name.clone(), value))
                 })
                 .collect();
@@ -328,6 +336,37 @@ fn project_column_values_for_group<'a>(
             row.get(col_name)
         })
         .collect()
+}
+
+fn scalar_override_columns_for_group(
+    group_col_descs: &[table_control::ColumnDescContents],
+    column_overrides: &HashMap<String, Vec<Option<Value>>>,
+) -> Result<Option<Vec<Vec<Option<ScalarValue>>>>, StorageError> {
+    let mut columns = Vec::with_capacity(group_col_descs.len());
+    for desc in group_col_descs {
+        if desc.is_array || desc.is_record() {
+            return Ok(None);
+        }
+        let Some(values) = column_overrides.get(&desc.col_name) else {
+            return Ok(None);
+        };
+        let mut scalar_values = Vec::with_capacity(values.len());
+        for value in values {
+            match value {
+                Some(Value::Scalar(value)) => scalar_values.push(Some(value.clone())),
+                Some(other) => {
+                    return Err(StorageError::FormatMismatch(format!(
+                        "column override {} expected scalar values, found {:?}",
+                        desc.col_name,
+                        other.kind()
+                    )));
+                }
+                None => scalar_values.push(None),
+            }
+        }
+        columns.push(scalar_values);
+    }
+    Ok(Some(columns))
 }
 
 /// Composite storage manager that dispatches per data manager type.
@@ -1469,26 +1508,30 @@ impl CompositeStorage {
                 ))
             })?;
         let data_path = table_path.join(format!("{}{}", TABLE_DATA_FILE_PREFIX, dm.seq_nr));
+        let nrrow = table_dat
+            .nrrow
+            .max(table_dat.column_set.nrrow)
+            .max(row_hint.unwrap_or(0)) as usize;
+        let bound_cols: Vec<(usize, &_)> = table_dat
+            .column_set
+            .columns
+            .iter()
+            .enumerate()
+            .filter(|(_, pc)| pc.dm_seq_nr == dm.seq_nr)
+            .collect();
+        let target_col_idx = bound_cols
+            .iter()
+            .position(|(candidate_desc_idx, _)| *candidate_desc_idx == desc_idx)
+            .ok_or_else(|| {
+                StorageError::FormatMismatch(format!(
+                    "scalar column '{column}' missing data-manager binding index"
+                ))
+            })?;
 
         if dm.type_name == "StManAipsIO" {
             if !data_path.is_file() {
                 return Err(StorageError::MissingDataFile(data_path));
             }
-            let bound_cols: Vec<(usize, &_)> = table_dat
-                .column_set
-                .columns
-                .iter()
-                .enumerate()
-                .filter(|(_, pc)| pc.dm_seq_nr == dm.seq_nr)
-                .collect();
-            let target_col_idx = bound_cols
-                .iter()
-                .position(|(candidate_desc_idx, _)| *candidate_desc_idx == desc_idx)
-                .ok_or_else(|| {
-                    StorageError::FormatMismatch(format!(
-                        "scalar column '{column}' missing StManAipsIO binding index"
-                    ))
-                })?;
             let dm_columns: Vec<_> = bound_cols
                 .iter()
                 .map(|(candidate_desc_idx, _)| {
@@ -1500,6 +1543,24 @@ impl CompositeStorage {
                 &dm_columns,
                 target_col_idx,
                 ByteOrder::BigEndian,
+            )? {
+                return Ok(values);
+            }
+        }
+        if dm.type_name == "IncrementalStMan" {
+            if !data_path.is_file() {
+                return Err(StorageError::MissingDataFile(data_path));
+            }
+            let group_col_descs: Vec<_> = bound_cols
+                .iter()
+                .map(|(bound_desc_idx, _)| &table_dat.table_desc.columns[*bound_desc_idx])
+                .collect();
+            if let Some(values) = read_ism_scalar_column(
+                &data_path,
+                &dm.data,
+                &group_col_descs,
+                target_col_idx,
+                nrrow,
             )? {
                 return Ok(values);
             }
@@ -2262,6 +2323,43 @@ impl CompositeStorage {
         default_tile_shape: Option<&[usize]>,
         bindings: &std::collections::HashMap<String, crate::table::ColumnBinding>,
     ) -> Result<(), StorageError> {
+        let column_overrides = HashMap::new();
+        self.save_with_bindings_and_column_overrides_borrowed(
+            table_path,
+            rows,
+            undefined_cells,
+            keywords,
+            column_keywords,
+            schema,
+            table_info,
+            virtual_columns,
+            virtual_bindings,
+            default_dm,
+            big_endian,
+            default_tile_shape,
+            bindings,
+            &column_overrides,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn save_with_bindings_and_column_overrides_borrowed(
+        &self,
+        table_path: &Path,
+        rows: &[RecordValue],
+        undefined_cells: &[HashSet<String>],
+        keywords: &RecordValue,
+        column_keywords: &HashMap<String, RecordValue>,
+        schema: Option<&TableSchema>,
+        table_info: &TableInfo,
+        virtual_columns: &HashSet<String>,
+        virtual_bindings: &[virtual_engine::VirtualColumnBinding],
+        default_dm: crate::table::DataManagerKind,
+        big_endian: bool,
+        default_tile_shape: Option<&[usize]>,
+        bindings: &std::collections::HashMap<String, crate::table::ColumnBinding>,
+        column_overrides: &HashMap<String, Vec<Option<Value>>>,
+    ) -> Result<(), StorageError> {
         use crate::table::DataManagerKind;
 
         let mut profiler = StorageProfiler::start(format!(
@@ -2525,25 +2623,52 @@ impl CompositeStorage {
                     | DataManagerKind::TiledCellStMan
                     | DataManagerKind::TiledDataStMan
             ) && group_col_descs.len() == 1;
+            let override_columns: Vec<_> = group_col_descs
+                .iter()
+                .filter_map(|desc| {
+                    column_overrides
+                        .contains_key(&desc.col_name)
+                        .then_some(desc.col_name.as_str())
+                })
+                .collect();
             let use_direct_indexed_rows = matches!(
                 group.dm_kind,
                 DataManagerKind::StandardStMan | DataManagerKind::IncrementalStMan
-            ) && group_col_indices.is_some();
+            ) && group_col_indices.is_some()
+                && override_columns.is_empty();
             let group_col_index = group_col_indices
                 .as_ref()
                 .and_then(|indices| (indices.len() == 1).then_some(indices[0]));
-            let group_values = use_borrowed_tiled_values.then(|| {
-                project_column_values_for_group(
-                    filtered_rows,
-                    &group_col_descs[0].col_name,
-                    group_col_index,
-                )
-            });
-            let group_rows = if group_values.is_none() && !use_direct_indexed_rows {
+            let group_values = if use_borrowed_tiled_values {
+                if let Some(override_values) = column_overrides.get(&group_col_descs[0].col_name) {
+                    Some(override_values.iter().map(|value| value.as_ref()).collect())
+                } else {
+                    Some(project_column_values_for_group(
+                        filtered_rows,
+                        &group_col_descs[0].col_name,
+                        group_col_index,
+                    ))
+                }
+            } else {
+                None
+            };
+            let scalar_override_columns = if matches!(
+                group.dm_kind,
+                DataManagerKind::StandardStMan | DataManagerKind::IncrementalStMan
+            ) {
+                scalar_override_columns_for_group(&group_col_descs, column_overrides)?
+            } else {
+                None
+            };
+            let group_rows = if group_values.is_none()
+                && !use_direct_indexed_rows
+                && scalar_override_columns.is_none()
+            {
                 Some(project_rows_for_group(
                     filtered_rows,
                     &group_col_descs,
                     group_col_indices.as_deref(),
+                    column_overrides,
                 ))
             } else {
                 None
@@ -2562,6 +2687,8 @@ impl CompositeStorage {
                             "borrowed_values"
                         } else if use_direct_indexed_rows {
                             "direct_rows"
+                        } else if scalar_override_columns.is_some() {
+                            "scalar_override_columns"
                         } else {
                             "projected_rows"
                         }
@@ -2579,24 +2706,34 @@ impl CompositeStorage {
                     )?;
                 }
                 DataManagerKind::StandardStMan => {
-                    let dm_data = if let Some(group_col_indices) = group_col_indices.as_ref() {
-                        write_ssm_file_indexed(
-                            &data_path,
-                            &group_col_descs,
-                            filtered_rows,
-                            group_col_indices,
-                            big_endian,
-                        )?
-                    } else {
-                        write_ssm_file(
-                            &data_path,
-                            &group_col_descs,
-                            group_rows
-                                .as_ref()
-                                .expect("row projection for StandardStMan"),
-                            big_endian,
-                        )?
-                    };
+                    let dm_data =
+                        if let Some(scalar_override_columns) = scalar_override_columns.as_ref() {
+                            let scalar_refs: Vec<_> =
+                                scalar_override_columns.iter().map(Vec::as_slice).collect();
+                            write_ssm_file_scalar_columns(
+                                &data_path,
+                                &group_col_descs,
+                                &scalar_refs,
+                                big_endian,
+                            )?
+                        } else if let Some(group_col_indices) = group_col_indices.as_ref() {
+                            write_ssm_file_indexed(
+                                &data_path,
+                                &group_col_descs,
+                                filtered_rows,
+                                group_col_indices,
+                                big_endian,
+                            )?
+                        } else {
+                            write_ssm_file(
+                                &data_path,
+                                &group_col_descs,
+                                group_rows
+                                    .as_ref()
+                                    .expect("row projection for StandardStMan"),
+                                big_endian,
+                            )?
+                        };
                     // Update the DM blob in the table_dat.
                     if let Some(entry) = table_dat
                         .column_set
@@ -2608,24 +2745,34 @@ impl CompositeStorage {
                     }
                 }
                 DataManagerKind::IncrementalStMan => {
-                    let dm_data = if let Some(group_col_indices) = group_col_indices.as_ref() {
-                        write_ism_file_indexed(
-                            &data_path,
-                            &group_col_descs,
-                            filtered_rows,
-                            group_col_indices,
-                            big_endian,
-                        )?
-                    } else {
-                        write_ism_file(
-                            &data_path,
-                            &group_col_descs,
-                            group_rows
-                                .as_ref()
-                                .expect("row projection for IncrementalStMan"),
-                            big_endian,
-                        )?
-                    };
+                    let dm_data =
+                        if let Some(scalar_override_columns) = scalar_override_columns.as_ref() {
+                            let scalar_refs: Vec<_> =
+                                scalar_override_columns.iter().map(Vec::as_slice).collect();
+                            write_ism_file_scalar_columns(
+                                &data_path,
+                                &group_col_descs,
+                                &scalar_refs,
+                                big_endian,
+                            )?
+                        } else if let Some(group_col_indices) = group_col_indices.as_ref() {
+                            write_ism_file_indexed(
+                                &data_path,
+                                &group_col_descs,
+                                filtered_rows,
+                                group_col_indices,
+                                big_endian,
+                            )?
+                        } else {
+                            write_ism_file(
+                                &data_path,
+                                &group_col_descs,
+                                group_rows
+                                    .as_ref()
+                                    .expect("row projection for IncrementalStMan"),
+                                big_endian,
+                            )?
+                        };
                     if let Some(entry) = table_dat
                         .column_set
                         .data_managers

--- a/crates/casa-tables/src/storage/mod.rs
+++ b/crates/casa-tables/src/storage/mod.rs
@@ -37,7 +37,8 @@ use self::incremental_stman::{
     write_ism_file_indexed,
 };
 use self::standard_stman::{
-    read_ssm_file, read_ssm_scalar_column_rows, write_ssm_file, write_ssm_file_indexed,
+    read_ssm_array_column_rows, read_ssm_file, read_ssm_scalar_column_rows, write_ssm_file,
+    write_ssm_file_indexed,
 };
 use self::stman_aipsio::scalar_value_is_default;
 use self::stman_aipsio::{
@@ -1954,6 +1955,14 @@ impl CompositeStorage {
             .enumerate()
             .filter(|(_, pc)| pc.dm_seq_nr == dm.seq_nr)
             .collect();
+        let target_col_idx = bound_cols
+            .iter()
+            .position(|(bound_desc_idx, _)| *bound_desc_idx == desc_idx)
+            .ok_or_else(|| {
+                StorageError::FormatMismatch(format!(
+                    "array column '{column}' missing data-manager column binding"
+                ))
+            })?;
 
         match dm.type_name.as_str() {
             "StManAipsIO" => {
@@ -1963,14 +1972,6 @@ impl CompositeStorage {
                         table_dat.table_desc.columns[*bound_desc_idx].clone()
                     })
                     .collect();
-                let Some(target_col_idx) = bound_cols
-                    .iter()
-                    .position(|(bound_desc_idx, _)| *bound_desc_idx == desc_idx)
-                else {
-                    return Err(StorageError::FormatMismatch(format!(
-                        "array column '{column}' missing StManAipsIO column binding"
-                    )));
-                };
                 if let Some(values) = read_stman_array_column_rows(
                     &data_path,
                     &group_col_descs,
@@ -1993,6 +1994,24 @@ impl CompositeStorage {
                     desc_idx,
                     selected_rows,
                 )
+            }
+            "StandardStMan" => {
+                let group_col_descs: Vec<_> = bound_cols
+                    .iter()
+                    .map(|(bound_desc_idx, _)| &table_dat.table_desc.columns[*bound_desc_idx])
+                    .collect();
+                if let Some(values) = read_ssm_array_column_rows(
+                    &data_path,
+                    &dm.data,
+                    &group_col_descs,
+                    target_col_idx,
+                    selected_rows,
+                )? {
+                    return Ok(values);
+                }
+                let values =
+                    self.load_plain_array_column(table_path, table_dat, column, row_hint)?;
+                Ok(select_array_rows(&values, selected_rows))
             }
             _ => {
                 let values =

--- a/crates/casa-tables/src/storage/standard_stman.rs
+++ b/crates/casa-tables/src/storage/standard_stman.rs
@@ -1652,7 +1652,7 @@ pub(crate) fn write_ssm_file(
     rows: &[casa_types::RecordValue],
     big_endian: bool,
 ) -> Result<Vec<u8>, StorageError> {
-    write_ssm_file_impl(file_path, col_descs, rows, None, big_endian)
+    write_ssm_file_impl(file_path, col_descs, rows, None, None, big_endian)
 }
 
 pub(crate) fn write_ssm_file_indexed(
@@ -1662,23 +1662,53 @@ pub(crate) fn write_ssm_file_indexed(
     field_indices: &[usize],
     big_endian: bool,
 ) -> Result<Vec<u8>, StorageError> {
-    write_ssm_file_impl(file_path, col_descs, rows, Some(field_indices), big_endian)
+    write_ssm_file_impl(
+        file_path,
+        col_descs,
+        rows,
+        Some(field_indices),
+        None,
+        big_endian,
+    )
 }
 
-fn row_value_at_index<'a>(
-    row: &'a casa_types::RecordValue,
-    field_index: usize,
-    field_name: &str,
-) -> Option<&'a casa_types::Value> {
-    if let Some(field) = row.fields().get(field_index) {
-        if field.name == field_name {
-            return Some(&field.value);
+pub(crate) fn write_ssm_file_scalar_columns(
+    file_path: &Path,
+    col_descs: &[ColumnDescContents],
+    scalar_columns: &[&[Option<ScalarValue>]],
+    big_endian: bool,
+) -> Result<Vec<u8>, StorageError> {
+    let nrrow = scalar_columns.first().map_or(0, |values| values.len());
+    if scalar_columns.len() != col_descs.len() {
+        return Err(StorageError::FormatMismatch(format!(
+            "SSM scalar column count mismatch: expected {}, got {}",
+            col_descs.len(),
+            scalar_columns.len()
+        )));
+    }
+    for values in scalar_columns.iter().skip(1) {
+        if values.len() != nrrow {
+            return Err(StorageError::FormatMismatch(
+                "SSM scalar columns have inconsistent row counts".to_string(),
+            ));
         }
     }
-    row.fields()
+    if col_descs
         .iter()
-        .find(|field| field.name == field_name)
-        .map(|field| &field.value)
+        .any(|col_desc| col_desc.is_array || col_desc.is_record())
+    {
+        return Err(StorageError::FormatMismatch(
+            "SSM scalar column writer only supports scalar non-record columns".to_string(),
+        ));
+    }
+    write_ssm_file_impl(
+        file_path,
+        col_descs,
+        &[],
+        None,
+        Some(scalar_columns),
+        big_endian,
+    )
 }
 
 fn write_ssm_file_impl(
@@ -1686,9 +1716,12 @@ fn write_ssm_file_impl(
     col_descs: &[ColumnDescContents],
     rows: &[casa_types::RecordValue],
     field_indices: Option<&[usize]>,
+    scalar_columns: Option<&[&[Option<ScalarValue>]]>,
     big_endian: bool,
 ) -> Result<Vec<u8>, StorageError> {
-    let nrrow = rows.len();
+    let nrrow = scalar_columns
+        .and_then(|columns| columns.first().map(|values| values.len()))
+        .unwrap_or(rows.len());
     let ncol = col_descs.len();
 
     // Check if any array columns are stored indirectly.
@@ -1809,20 +1842,35 @@ fn write_ssm_file_impl(
                 )
             })?;
 
-            for (row, row_record) in rows.iter().enumerate() {
+            for row in 0..nrrow {
                 let bucket_idx = row / rows_per_bucket as usize;
                 let row_in_bucket = row % rows_per_bucket as usize;
                 let bucket = &mut buckets[bucket_idx];
                 let byte_off = col_off + row_in_bucket * 8;
 
-                let value = if let Some(indices) = field_indices {
-                    row_value_at_index(row_record, indices[col_idx], &col_desc.col_name)
+                let scalar_value;
+                let value = if let Some(columns) = scalar_columns {
+                    scalar_value = columns[col_idx][row].as_ref().cloned().map(Value::Scalar);
+                    scalar_value.as_ref()
                 } else {
+                    let row_record = &rows[row];
                     row_record
                         .fields()
-                        .iter()
-                        .find(|f| f.name == col_desc.col_name)
-                        .map(|f| &f.value)
+                        .get(
+                            field_indices
+                                .and_then(|indices| indices.get(col_idx))
+                                .copied()
+                                .unwrap_or(usize::MAX),
+                        )
+                        .filter(|field| field.name == col_desc.col_name)
+                        .map(|field| &field.value)
+                        .or_else(|| {
+                            row_record
+                                .fields()
+                                .iter()
+                                .find(|f| f.name == col_desc.col_name)
+                                .map(|f| &f.value)
+                        })
                 };
 
                 let offset: i64 =
@@ -1859,19 +1907,34 @@ fn write_ssm_file_impl(
                 }
             }
         } else {
-            for (row, row_record) in rows.iter().enumerate() {
+            for row in 0..nrrow {
                 let bucket_idx = row / rows_per_bucket as usize;
                 let row_in_bucket = row % rows_per_bucket as usize;
                 let bucket = &mut buckets[bucket_idx];
 
-                let value = if let Some(indices) = field_indices {
-                    row_value_at_index(row_record, indices[col_idx], &col_desc.col_name)
+                let scalar_value;
+                let value = if let Some(columns) = scalar_columns {
+                    scalar_value = columns[col_idx][row].as_ref().cloned().map(Value::Scalar);
+                    scalar_value.as_ref()
                 } else {
+                    let row_record = &rows[row];
                     row_record
                         .fields()
-                        .iter()
-                        .find(|f| f.name == col_desc.col_name)
-                        .map(|f| &f.value)
+                        .get(
+                            field_indices
+                                .and_then(|indices| indices.get(col_idx))
+                                .copied()
+                                .unwrap_or(usize::MAX),
+                        )
+                        .filter(|field| field.name == col_desc.col_name)
+                        .map(|field| &field.value)
+                        .or_else(|| {
+                            row_record
+                                .fields()
+                                .iter()
+                                .find(|f| f.name == col_desc.col_name)
+                                .map(|f| &f.value)
+                        })
                 };
 
                 write_cell_to_bucket(

--- a/crates/casa-tables/src/storage/standard_stman.rs
+++ b/crates/casa-tables/src/storage/standard_stman.rs
@@ -34,7 +34,7 @@ use super::canonical::{
     write_u16_be, write_u16_le, write_u32_be, write_u32_le,
 };
 use super::data_type::CasacoreDataType;
-use super::stman_aipsio::ColumnRawData;
+use super::stman_aipsio::{ColumnRawData, extract_row_value};
 use super::stman_array_file::{StManArrayFileReader, StManArrayFileWriter};
 use super::table_control::ColumnDescContents;
 
@@ -1128,6 +1128,153 @@ pub(crate) fn read_ssm_scalar_column_rows(
         });
     }
 
+    Ok(Some(values))
+}
+
+pub(crate) fn read_ssm_array_column_rows(
+    file_path: &Path,
+    dm_blob: &[u8],
+    col_descs: &[&ColumnDescContents],
+    target_col_idx: usize,
+    selected_rows: &[usize],
+) -> Result<Option<Vec<Option<ArrayValue>>>, StorageError> {
+    if selected_rows.is_empty() {
+        return Ok(Some(Vec::new()));
+    }
+
+    let mut file = File::open(file_path)?;
+    let header = parse_ssm_header(&mut file)?;
+    let dm_info = parse_ssm_dm_blob(dm_blob)?;
+    let indices = parse_ssm_indices(&mut file, &header)?;
+
+    if target_col_idx >= col_descs.len() {
+        return Err(StorageError::FormatMismatch(format!(
+            "SSM array column index {target_col_idx} is out of range"
+        )));
+    }
+    if target_col_idx >= dm_info.column_offsets.len()
+        || target_col_idx >= dm_info.col_index_map.len()
+    {
+        return Err(StorageError::FormatMismatch(format!(
+            "SSM array column index {target_col_idx} missing dm blob metadata"
+        )));
+    }
+
+    let col_desc = col_descs[target_col_idx];
+    if !col_desc.is_array || col_desc.is_record() || is_ssm_variable_string(col_desc) {
+        return Ok(None);
+    }
+
+    let column_offset = dm_info.column_offsets[target_col_idx] as usize;
+    let index_nr = dm_info.col_index_map[target_col_idx] as usize;
+    if index_nr >= indices.len() {
+        return Err(StorageError::FormatMismatch(format!(
+            "SSM column '{}' references index {index_nr} but only {} indices exist",
+            col_desc.col_name,
+            indices.len()
+        )));
+    }
+    let index = &indices[index_nr];
+    let rows_to_read = selected_rows
+        .iter()
+        .copied()
+        .max()
+        .map(|row| row + 1)
+        .unwrap_or(0);
+
+    if is_ssm_array_file_indirect(col_desc) {
+        let offsets = read_column_from_buckets(
+            &mut file,
+            &header,
+            index,
+            column_offset,
+            CasacoreDataType::TpInt64,
+            1,
+            rows_to_read,
+        )?;
+        let offset_values = match offsets {
+            ColumnRawData::Int64(values) => values,
+            _ => {
+                return Err(StorageError::FormatMismatch(
+                    "SSM indirect array: expected Int64 offsets".to_string(),
+                ));
+            }
+        };
+
+        let dt = CasacoreDataType::from_primitive_type(col_desc.require_primitive_type()?, false);
+        let mut array_path = file_path.as_os_str().to_os_string();
+        array_path.push("i");
+        let array_path = std::path::PathBuf::from(array_path);
+        if !array_path.exists() {
+            if selected_rows
+                .iter()
+                .all(|&row| offset_values.get(row).copied().unwrap_or(0) == 0)
+            {
+                return Ok(Some(vec![None; selected_rows.len()]));
+            }
+            return Err(StorageError::FormatMismatch(
+                "SSM indirect array column but no array file found".to_string(),
+            ));
+        }
+
+        let mut reader = StManArrayFileReader::open(&array_path, header.big_endian)?;
+        let mut values = Vec::with_capacity(selected_rows.len());
+        for &row in selected_rows {
+            let offset = *offset_values.get(row).ok_or_else(|| {
+                StorageError::FormatMismatch(format!(
+                    "SSM indirect array column '{}' missing offset for row {row}",
+                    col_desc.col_name
+                ))
+            })?;
+            let value = reader.read_array_at(offset, dt).map_err(|err| {
+                StorageError::FormatMismatch(format!(
+                    "SSM indirect array column '{}' row {row} offset {offset} type {:?}: {err}",
+                    col_desc.col_name, dt
+                ))
+            })?;
+            values.push(match value {
+                Some(Value::Array(array)) => Some(array),
+                Some(other) => {
+                    return Err(StorageError::FormatMismatch(format!(
+                        "SSM indirect array column '{}' row {row} expected array value, found {:?}",
+                        col_desc.col_name,
+                        other.kind()
+                    )));
+                }
+                None => None,
+            });
+        }
+        return Ok(Some(values));
+    }
+
+    let nrelem = if col_desc.nrdim > 0 && !col_desc.shape.is_empty() {
+        col_desc.shape.iter().map(|&s| s as usize).product()
+    } else {
+        return Ok(None);
+    };
+    let raw = read_column_from_buckets(
+        &mut file,
+        &header,
+        index,
+        column_offset,
+        col_desc.data_type,
+        nrelem,
+        rows_to_read,
+    )?;
+    let mut values = Vec::with_capacity(selected_rows.len());
+    for &row in selected_rows {
+        let value = extract_row_value(&raw, col_desc, row, rows_to_read)?;
+        values.push(match value {
+            Value::Array(array) => Some(array),
+            other => {
+                return Err(StorageError::FormatMismatch(format!(
+                    "SSM direct array column '{}' row {row} expected array value, found {:?}",
+                    col_desc.col_name,
+                    other.kind()
+                )));
+            }
+        });
+    }
     Ok(Some(values))
 }
 

--- a/crates/casa-tables/src/storage/stman_aipsio.rs
+++ b/crates/casa-tables/src/storage/stman_aipsio.rs
@@ -691,23 +691,18 @@ pub(crate) fn read_stman_array_column_rows(
         return Ok(Some(Vec::new()));
     }
     let layouts = parse_sparse_column_layouts(path, columns, byte_order)?;
-    let Some(SparseColumnLayout::IndirectArrayOffsetsU32 { data_type, extents }) = layouts
+    let Some(layout) = layouts
         .get(target_col_idx)
         .and_then(|layout| layout.as_ref())
     else {
         return Ok(None);
     };
+    let column = columns.get(target_col_idx).ok_or_else(|| {
+        StorageError::FormatMismatch(format!(
+            "target StManAipsIO array column index {target_col_idx} is out of range"
+        ))
+    })?;
 
-    let array_file_path = indirect_array_file_path(path);
-    if std::fs::metadata(&array_file_path)
-        .map(|meta| meta.len())
-        .unwrap_or(0)
-        >= LARGE_OFFSET_MARKER as u64
-    {
-        return Ok(None);
-    }
-
-    let mut main_file = std::fs::File::open(path)?;
     let mut requests: Vec<(usize, usize)> = selected_rows
         .iter()
         .copied()
@@ -715,32 +710,75 @@ pub(crate) fn read_stman_array_column_rows(
         .map(|(out_idx, row_index)| (row_index, out_idx))
         .collect();
     requests.sort_unstable_by_key(|&(row_index, _)| row_index);
+    let mut main_file = std::fs::File::open(path)?;
 
-    let mut offsets = vec![0u32; selected_rows.len()];
-    for (row_index, out_idx) in requests {
-        let slot = locate_extent_slot(extents, row_index)?;
-        main_file.seek(SeekFrom::Start(slot))?;
-        offsets[out_idx] = read_be_u32(&mut main_file)?;
+    match layout {
+        SparseColumnLayout::IndirectArrayOffsetsU32 { data_type, extents } => {
+            let array_file_path = indirect_array_file_path(path);
+            if std::fs::metadata(&array_file_path)
+                .map(|meta| meta.len())
+                .unwrap_or(0)
+                >= LARGE_OFFSET_MARKER as u64
+            {
+                return Ok(None);
+            }
+
+            let mut offsets = vec![0u32; selected_rows.len()];
+            for (row_index, out_idx) in requests {
+                let slot = locate_extent_slot(extents, row_index)?;
+                main_file.seek(SeekFrom::Start(slot))?;
+                offsets[out_idx] = read_be_u32(&mut main_file)?;
+            }
+
+            let mut reader =
+                StManArrayFileReader::open(&array_file_path, byte_order == ByteOrder::BigEndian)?;
+            let mut values = Vec::with_capacity(offsets.len());
+            for offset in offsets {
+                let value = reader
+                    .read_array_at(offset as i64, *data_type)?
+                    .map(|value| match value {
+                        Value::Array(array) => Ok(array),
+                        other => Err(StorageError::FormatMismatch(format!(
+                            "expected array value in indirect StManAipsIO column, found {:?}",
+                            other.kind()
+                        ))),
+                    })
+                    .transpose()?;
+                values.push(value);
+            }
+            Ok(Some(values))
+        }
+        SparseColumnLayout::DirectArrayFixed { data_type, extents } => {
+            let shape: Vec<usize> = column.shape.iter().map(|&dim| dim as usize).collect();
+            if shape.is_empty() {
+                return Ok(None);
+            }
+            let row_width = extents
+                .first()
+                .map(|extent| extent.row_width_bytes)
+                .ok_or_else(|| {
+                    StorageError::FormatMismatch(format!(
+                        "direct StManAipsIO array column '{}' has no extents",
+                        column.col_name
+                    ))
+                })?;
+            let mut row_bytes = vec![0u8; row_width];
+            let mut values = vec![None; selected_rows.len()];
+            for (row_index, out_idx) in requests {
+                let slot = locate_extent_slot(extents, row_index)?;
+                main_file.seek(SeekFrom::Start(slot))?;
+                main_file.read_exact(&mut row_bytes)?;
+                values[out_idx] = Some(decode_fixed_array_value(
+                    *data_type,
+                    &shape,
+                    &row_bytes,
+                    &column.col_name,
+                )?);
+            }
+            Ok(Some(values))
+        }
+        _ => Ok(None),
     }
-
-    let mut reader =
-        StManArrayFileReader::open(&array_file_path, byte_order == ByteOrder::BigEndian)?;
-    let mut values = Vec::with_capacity(offsets.len());
-    for offset in offsets {
-        let value = reader
-            .read_array_at(offset as i64, *data_type)?
-            .map(|value| match value {
-                Value::Array(array) => Ok(array),
-                other => Err(StorageError::FormatMismatch(format!(
-                    "expected array value in indirect StManAipsIO column, found {:?}",
-                    other.kind()
-                ))),
-            })
-            .transpose()?;
-        values.push(value);
-    }
-
-    Ok(Some(values))
 }
 
 pub(crate) fn read_stman_scalar_column_rows(
@@ -1259,6 +1297,118 @@ fn decode_fixed_scalar_value(
         }
     };
     Ok(scalar)
+}
+
+fn decode_fixed_array_value(
+    data_type: CasacoreDataType,
+    shape: &[usize],
+    bytes: &[u8],
+    column_name: &str,
+) -> Result<ArrayValue, StorageError> {
+    let elem_width = scalar_fixed_width_bytes(data_type).ok_or_else(|| {
+        StorageError::FormatMismatch(format!(
+            "unsupported direct StManAipsIO array type {data_type:?}"
+        ))
+    })?;
+    let elements_per_row: usize = shape.iter().product();
+    if bytes.len() != elements_per_row * elem_width {
+        return Err(StorageError::FormatMismatch(format!(
+            "direct StManAipsIO array column '{column_name}' row width {} does not match shape {:?} and type {:?}",
+            bytes.len(),
+            shape,
+            data_type
+        )));
+    }
+
+    match data_type {
+        CasacoreDataType::TpBool => {
+            let values = bytes.iter().map(|byte| *byte != 0).collect();
+            Ok(ArrayValue::Bool(array_from_fixed_row(shape, values)?))
+        }
+        CasacoreDataType::TpUChar | CasacoreDataType::TpChar => Ok(ArrayValue::UInt8(
+            array_from_fixed_row(shape, bytes.to_vec())?,
+        )),
+        CasacoreDataType::TpShort => {
+            let mut values = Vec::with_capacity(elements_per_row);
+            for chunk in bytes.chunks_exact(elem_width) {
+                values.push(i16::from_be_bytes(chunk.try_into().expect("chunk width")));
+            }
+            Ok(ArrayValue::Int16(array_from_fixed_row(shape, values)?))
+        }
+        CasacoreDataType::TpUShort => {
+            let mut values = Vec::with_capacity(elements_per_row);
+            for chunk in bytes.chunks_exact(elem_width) {
+                values.push(u16::from_be_bytes(chunk.try_into().expect("chunk width")));
+            }
+            Ok(ArrayValue::UInt16(array_from_fixed_row(shape, values)?))
+        }
+        CasacoreDataType::TpInt => {
+            let mut values = Vec::with_capacity(elements_per_row);
+            for chunk in bytes.chunks_exact(elem_width) {
+                values.push(i32::from_be_bytes(chunk.try_into().expect("chunk width")));
+            }
+            Ok(ArrayValue::Int32(array_from_fixed_row(shape, values)?))
+        }
+        CasacoreDataType::TpUInt => {
+            let mut values = Vec::with_capacity(elements_per_row);
+            for chunk in bytes.chunks_exact(elem_width) {
+                values.push(u32::from_be_bytes(chunk.try_into().expect("chunk width")));
+            }
+            Ok(ArrayValue::UInt32(array_from_fixed_row(shape, values)?))
+        }
+        CasacoreDataType::TpInt64 => {
+            let mut values = Vec::with_capacity(elements_per_row);
+            for chunk in bytes.chunks_exact(elem_width) {
+                values.push(i64::from_be_bytes(chunk.try_into().expect("chunk width")));
+            }
+            Ok(ArrayValue::Int64(array_from_fixed_row(shape, values)?))
+        }
+        CasacoreDataType::TpFloat => {
+            let mut values = Vec::with_capacity(elements_per_row);
+            for chunk in bytes.chunks_exact(elem_width) {
+                values.push(f32::from_be_bytes(chunk.try_into().expect("chunk width")));
+            }
+            Ok(ArrayValue::Float32(array_from_fixed_row(shape, values)?))
+        }
+        CasacoreDataType::TpDouble => {
+            let mut values = Vec::with_capacity(elements_per_row);
+            for chunk in bytes.chunks_exact(elem_width) {
+                values.push(f64::from_be_bytes(chunk.try_into().expect("chunk width")));
+            }
+            Ok(ArrayValue::Float64(array_from_fixed_row(shape, values)?))
+        }
+        CasacoreDataType::TpComplex => {
+            let mut values = Vec::with_capacity(elements_per_row);
+            for chunk in bytes.chunks_exact(elem_width) {
+                values.push(casa_types::Complex32 {
+                    re: f32::from_be_bytes(chunk[0..4].try_into().expect("chunk width")),
+                    im: f32::from_be_bytes(chunk[4..8].try_into().expect("chunk width")),
+                });
+            }
+            Ok(ArrayValue::Complex32(array_from_fixed_row(shape, values)?))
+        }
+        CasacoreDataType::TpDComplex => {
+            let mut values = Vec::with_capacity(elements_per_row);
+            for chunk in bytes.chunks_exact(elem_width) {
+                values.push(casa_types::Complex64 {
+                    re: f64::from_be_bytes(chunk[0..8].try_into().expect("chunk width")),
+                    im: f64::from_be_bytes(chunk[8..16].try_into().expect("chunk width")),
+                });
+            }
+            Ok(ArrayValue::Complex64(array_from_fixed_row(shape, values)?))
+        }
+        other => Err(StorageError::FormatMismatch(format!(
+            "unsupported direct StManAipsIO array decode for {other:?}"
+        ))),
+    }
+}
+
+fn array_from_fixed_row<T: Clone>(
+    shape: &[usize],
+    values: Vec<T>,
+) -> Result<ArrayD<T>, StorageError> {
+    ArrayD::from_shape_vec(IxDyn(shape).f(), values)
+        .map_err(|err| StorageError::FormatMismatch(format!("array shape: {err}")))
 }
 
 fn encode_fixed_scalar_value(

--- a/crates/casa-tables/src/storage/table_control.rs
+++ b/crates/casa-tables/src/storage/table_control.rs
@@ -2114,7 +2114,7 @@ impl ColumnDescContents {
         }
     }
 
-    fn from_column_schema(col: &ColumnSchema) -> Self {
+    pub(crate) fn from_column_schema(col: &ColumnSchema) -> Self {
         use crate::schema::{ArrayShapeContract, ColumnType};
 
         // Record columns have no primitive type; use TpRecord directly.

--- a/crates/casa-tables/src/storage/tiled_stman.rs
+++ b/crates/casa-tables/src/storage/tiled_stman.rs
@@ -180,6 +180,17 @@ pub(crate) fn shared_tile_cache_entry_count() -> usize {
         .len()
 }
 
+#[cfg(test)]
+fn shared_tile_cache_entry_count_for_table(table_path: &Path) -> usize {
+    SHARED_TILE_CACHE
+        .lock()
+        .expect("shared tile cache lock poisoned")
+        .entries
+        .keys()
+        .filter(|key| key.table_path == table_path)
+        .count()
+}
+
 pub(crate) fn invalidate_shared_tile_cache_for_table(table_path: &Path) {
     let mut cache = SHARED_TILE_CACHE
         .lock()
@@ -6349,11 +6360,11 @@ mod tests {
             .expect("save tiled-shape table");
 
         let reopened = Table::open(TableOptions::new(&root)).expect("open lazy table");
-        assert_eq!(shared_tile_cache_entry_count(), 0);
+        assert_eq!(shared_tile_cache_entry_count_for_table(&root), 0);
         reopened
             .get_array_cells_owned("data", &[0, 1, 4, 5])
             .expect("first tiled selected-row read");
-        let cache_entries_after_first_read = shared_tile_cache_entry_count();
+        let cache_entries_after_first_read = shared_tile_cache_entry_count_for_table(&root);
         assert!(
             cache_entries_after_first_read > 0,
             "first tiled selected-row read should populate the shared tile cache"
@@ -6363,7 +6374,7 @@ mod tests {
             .get_array_cells_owned("data", &[0, 1, 4, 5])
             .expect("second tiled selected-row read");
         assert_eq!(
-            shared_tile_cache_entry_count(),
+            shared_tile_cache_entry_count_for_table(&root),
             cache_entries_after_first_read,
             "repeated tiled selected-row reads should reuse the shared tile cache"
         );

--- a/crates/casa-tables/src/storage/tiled_stman.rs
+++ b/crates/casa-tables/src/storage/tiled_stman.rs
@@ -1628,6 +1628,9 @@ fn load_tiled_shape_stman(
             }
 
             let diff = row_map[interval] as usize - row_idx;
+            if diff > pos_map[interval] as usize {
+                continue;
+            }
             let Some(pos_in_cube) = (pos_map[interval] as usize).checked_sub(diff) else {
                 return Err(StorageError::FormatMismatch(format!(
                     "invalid TiledShapeStMan row map for row {row_idx}: interval {interval} has pos {} < diff {diff}",
@@ -1715,6 +1718,9 @@ fn load_tiled_column_rows_shape_variant(
             continue;
         }
         let diff = mapping.row_map[interval] as usize - row_idx;
+        if diff > mapping.pos_map[interval] as usize {
+            continue;
+        }
         let Some(pos_in_cube) = (mapping.pos_map[interval] as usize).checked_sub(diff) else {
             return Err(StorageError::FormatMismatch(format!(
                 "invalid TiledShapeStMan row map for row {row_idx}: interval {interval} has pos {} < diff {diff}",
@@ -3291,7 +3297,10 @@ fn save_single_column_tiled_shape_stman(
 
     let mut shape_groups: Vec<(Vec<usize>, Vec<usize>)> = Vec::new();
     for (row_idx, value) in values.iter().enumerate() {
-        let shape = if let Some(Value::Array(av)) = value {
+        let Some(value) = *value else {
+            continue;
+        };
+        let shape = if let Value::Array(av) = value {
             array_shape(av)
         } else {
             vec![]

--- a/crates/casa-tables/src/storage/tiled_stman.rs
+++ b/crates/casa-tables/src/storage/tiled_stman.rs
@@ -15,6 +15,7 @@
 //! `TiledColumnStMan`, `TiledShapeStMan`, `TiledCellStMan`, `TiledStMan`,
 //! `TSMCube`, `TSMFile`.
 
+use std::borrow::Cow;
 use std::collections::HashSet;
 use std::fs::OpenOptions;
 use std::io::{Read as IoRead, Seek, SeekFrom, Write as IoWrite};
@@ -1071,26 +1072,21 @@ fn encode_array_value(
         }
     };
 
-    // IMPORTANT: Tile data is stored in Fortran (column-major) order.
-    // For arrays already in Fortran layout, `as_slice_memory_order()` provides
-    // a zero-copy fast path. For C-order arrays, `t().as_standard_layout()`
-    // creates a contiguous Fortran-order copy (avoids cache-unfriendly strided
-    // iteration that causes ~100× slowdowns on large arrays).
+    // Tile data is stored in Fortran (column-major) order. Most arrays read
+    // from casacore tables already have that memory order, so use the raw
+    // memory-order slice before falling back to a transposed contiguous copy.
     match arr {
         ArrayValue::Bool(a) => {
-            let f = a.t().as_standard_layout().into_owned();
-            let slice = f.as_slice().expect("contiguous after as_standard_layout");
+            let slice = array_memory_order_values(a);
             let data: Vec<u8> = slice.iter().map(|&b| if b { 1u8 } else { 0u8 }).collect();
             Ok((data, CasacoreDataType::TpBool))
         }
         ArrayValue::UInt8(a) => {
-            let f = a.t().as_standard_layout().into_owned();
-            let data = f.as_slice().expect("contiguous").to_vec();
+            let data = array_memory_order_values(a).as_ref().to_vec();
             Ok((data, CasacoreDataType::TpUChar))
         }
         ArrayValue::Int16(a) => {
-            let f = a.t().as_standard_layout().into_owned();
-            let slice = f.as_slice().expect("contiguous");
+            let slice = array_memory_order_values(a);
             let mut data = vec![0u8; slice.len() * 2];
             for (i, &v) in slice.iter().enumerate() {
                 if big_endian {
@@ -1102,8 +1098,7 @@ fn encode_array_value(
             Ok((data, CasacoreDataType::TpShort))
         }
         ArrayValue::UInt16(a) => {
-            let f = a.t().as_standard_layout().into_owned();
-            let slice = f.as_slice().expect("contiguous");
+            let slice = array_memory_order_values(a);
             let mut data = vec![0u8; slice.len() * 2];
             for (i, &v) in slice.iter().enumerate() {
                 if big_endian {
@@ -1115,8 +1110,7 @@ fn encode_array_value(
             Ok((data, CasacoreDataType::TpUShort))
         }
         ArrayValue::Int32(a) => {
-            let f = a.t().as_standard_layout().into_owned();
-            let slice = f.as_slice().expect("contiguous");
+            let slice = array_memory_order_values(a);
             let mut data = vec![0u8; slice.len() * 4];
             for (i, &v) in slice.iter().enumerate() {
                 if big_endian {
@@ -1128,8 +1122,7 @@ fn encode_array_value(
             Ok((data, CasacoreDataType::TpInt))
         }
         ArrayValue::UInt32(a) => {
-            let f = a.t().as_standard_layout().into_owned();
-            let slice = f.as_slice().expect("contiguous");
+            let slice = array_memory_order_values(a);
             let mut data = vec![0u8; slice.len() * 4];
             for (i, &v) in slice.iter().enumerate() {
                 if big_endian {
@@ -1141,8 +1134,7 @@ fn encode_array_value(
             Ok((data, CasacoreDataType::TpUInt))
         }
         ArrayValue::Float32(a) => {
-            let f = a.t().as_standard_layout().into_owned();
-            let slice = f.as_slice().expect("contiguous");
+            let slice = array_memory_order_values(a);
             let mut data = vec![0u8; slice.len() * 4];
             for (i, &v) in slice.iter().enumerate() {
                 if big_endian {
@@ -1154,8 +1146,7 @@ fn encode_array_value(
             Ok((data, CasacoreDataType::TpFloat))
         }
         ArrayValue::Float64(a) => {
-            let f = a.t().as_standard_layout().into_owned();
-            let slice = f.as_slice().expect("contiguous");
+            let slice = array_memory_order_values(a);
             let mut data = vec![0u8; slice.len() * 8];
             for (i, &v) in slice.iter().enumerate() {
                 if big_endian {
@@ -1167,8 +1158,7 @@ fn encode_array_value(
             Ok((data, CasacoreDataType::TpDouble))
         }
         ArrayValue::Int64(a) => {
-            let f = a.t().as_standard_layout().into_owned();
-            let slice = f.as_slice().expect("contiguous");
+            let slice = array_memory_order_values(a);
             let mut data = vec![0u8; slice.len() * 8];
             for (i, &v) in slice.iter().enumerate() {
                 if big_endian {
@@ -1180,8 +1170,7 @@ fn encode_array_value(
             Ok((data, CasacoreDataType::TpInt64))
         }
         ArrayValue::Complex32(a) => {
-            let f = a.t().as_standard_layout().into_owned();
-            let slice = f.as_slice().expect("contiguous");
+            let slice = array_memory_order_values(a);
             let mut data = vec![0u8; slice.len() * 8];
             for (i, &v) in slice.iter().enumerate() {
                 if big_endian {
@@ -1195,8 +1184,7 @@ fn encode_array_value(
             Ok((data, CasacoreDataType::TpComplex))
         }
         ArrayValue::Complex64(a) => {
-            let f = a.t().as_standard_layout().into_owned();
-            let slice = f.as_slice().expect("contiguous");
+            let slice = array_memory_order_values(a);
             let mut data = vec![0u8; slice.len() * 16];
             for (i, &v) in slice.iter().enumerate() {
                 if big_endian {
@@ -1213,6 +1201,33 @@ fn encode_array_value(
             "string arrays not supported in tiled storage".to_string(),
         )),
     }
+}
+
+fn array_memory_order_values<T: Clone>(array: &ArrayD<T>) -> Cow<'_, [T]> {
+    if is_fortran_contiguous(array.shape(), array.strides())
+        && let Some(slice) = array.as_slice_memory_order()
+    {
+        Cow::Borrowed(slice)
+    } else {
+        let fortran_ordered = array.t().as_standard_layout().into_owned();
+        Cow::Owned(
+            fortran_ordered
+                .as_slice()
+                .expect("contiguous after as_standard_layout")
+                .to_vec(),
+        )
+    }
+}
+
+fn is_fortran_contiguous(shape: &[usize], strides: &[isize]) -> bool {
+    let mut expected = 1isize;
+    for (&dim, &stride) in shape.iter().zip(strides.iter()) {
+        if dim > 1 && stride != expected {
+            return false;
+        }
+        expected = expected.saturating_mul(dim.max(1) as isize);
+    }
+    true
 }
 
 // ---------------------------------------------------------------------------
@@ -3098,6 +3113,73 @@ fn encode_column_cube_values(
     Ok(cube_bytes)
 }
 
+#[allow(clippy::too_many_arguments)]
+fn encode_single_column_shape_cube_direct(
+    values: &[Option<&Value>],
+    cell_shape: &[usize],
+    tile_shape: &[usize],
+    cell_nelem: usize,
+    elem_size: usize,
+    nr_tiles: usize,
+    bucket_size: usize,
+    col_offset: usize,
+    col_data_type: CasacoreDataType,
+    big_endian: bool,
+) -> Result<Option<Vec<u8>>, StorageError> {
+    if tile_shape.len() != cell_shape.len() + 1 {
+        return Ok(None);
+    }
+    if tile_shape[..cell_shape.len()] != *cell_shape {
+        return Ok(None);
+    }
+    let rows_per_tile = tile_shape[cell_shape.len()];
+    if rows_per_tile == 0 {
+        return Ok(None);
+    }
+
+    let row_bytes = cell_nelem * elem_size;
+    let tile_nelem: usize = tile_shape.iter().product();
+    let tile_storage_len = tile_storage_bytes(col_data_type, tile_nelem);
+    let mut tsm_data = vec![0u8; nr_tiles * bucket_size];
+    for (pos_in_cube, value) in values.iter().enumerate() {
+        let Some(value) = value else {
+            continue;
+        };
+        let (encoded, encoded_type) = encode_array_value(value, big_endian)?;
+        if encoded_type != col_data_type {
+            return Ok(None);
+        }
+        let tile_idx = pos_in_cube / rows_per_tile;
+        let row_in_tile = pos_in_cube % rows_per_tile;
+        let tile_start = tile_idx * bucket_size + col_offset;
+        if col_data_type == CasacoreDataType::TpBool {
+            if encoded.len() != cell_nelem {
+                return Ok(None);
+            }
+            let tile_end = tile_start + tile_storage_len;
+            if tile_end > tsm_data.len() {
+                return Ok(None);
+            }
+            write_bool_bits_from_bytes(
+                &mut tsm_data[tile_start..tile_end],
+                row_in_tile * cell_nelem,
+                &encoded,
+            );
+        } else {
+            if encoded.len() != row_bytes {
+                return Ok(None);
+            }
+            let dst_start = tile_start + row_in_tile * row_bytes;
+            let dst_end = dst_start + row_bytes;
+            if dst_end > tsm_data.len() {
+                return Ok(None);
+            }
+            tsm_data[dst_start..dst_end].copy_from_slice(&encoded);
+        }
+    }
+    Ok(Some(tsm_data))
+}
+
 fn save_single_column_tiled_column_stman(
     table_path: &Path,
     dm_seq_nr: u32,
@@ -3384,48 +3466,65 @@ fn save_single_column_tiled_shape_stman(
 
         let group_values: Vec<Option<&Value>> =
             group_rows.iter().map(|&row_idx| values[row_idx]).collect();
-        let cube_bytes = encode_column_cube_values(
+        let tsm_data = if let Some(tsm_data) = encode_single_column_shape_cube_direct(
             &group_values,
-            &cube_shape,
+            cell_shape,
+            &tile_shape,
             cell_nelem,
             elem_size,
+            nr_tiles,
+            bucket_size,
+            col_offsets[0],
+            col_data_type,
             big_endian,
-        )?;
-
-        let mut tsm_data = vec![0u8; nr_tiles * bucket_size];
-        for tile_idx in 0..nr_tiles {
-            let tile_pos = linear_to_nd(tile_idx, &tiles_per_dim);
-            let cube_start: Vec<usize> = cube_shape
-                .iter()
-                .zip(tile_pos.iter())
-                .zip(tile_shape.iter())
-                .map(|((_, &tp), &ts)| tp * ts)
-                .collect();
-            let actual_extent: Vec<usize> = cube_shape
-                .iter()
-                .zip(cube_start.iter())
-                .zip(tile_shape.iter())
-                .map(|((&cs, &st), &ts)| std::cmp::min(ts, cs - st))
-                .collect();
-
-            let mut tile_col = vec![0u8; nrpixels * elem_size];
-            copy_cube_to_tile(
-                &cube_bytes,
+        )? {
+            tsm_data
+        } else {
+            let cube_bytes = encode_column_cube_values(
+                &group_values,
                 &cube_shape,
-                &mut tile_col,
-                &tile_shape,
-                &cube_start,
-                &actual_extent,
+                cell_nelem,
                 elem_size,
-            );
-            let dst_start = tile_idx * bucket_size + col_offsets[0];
-            write_tile_storage(
-                &mut tsm_data[dst_start..dst_start + tile_storage_bytes(col_data_type, nrpixels)],
-                col_data_type,
-                &tile_col,
-                nrpixels,
-            );
-        }
+                big_endian,
+            )?;
+
+            let mut tsm_data = vec![0u8; nr_tiles * bucket_size];
+            for tile_idx in 0..nr_tiles {
+                let tile_pos = linear_to_nd(tile_idx, &tiles_per_dim);
+                let cube_start: Vec<usize> = cube_shape
+                    .iter()
+                    .zip(tile_pos.iter())
+                    .zip(tile_shape.iter())
+                    .map(|((_, &tp), &ts)| tp * ts)
+                    .collect();
+                let actual_extent: Vec<usize> = cube_shape
+                    .iter()
+                    .zip(cube_start.iter())
+                    .zip(tile_shape.iter())
+                    .map(|((&cs, &st), &ts)| std::cmp::min(ts, cs - st))
+                    .collect();
+
+                let mut tile_col = vec![0u8; nrpixels * elem_size];
+                copy_cube_to_tile(
+                    &cube_bytes,
+                    &cube_shape,
+                    &mut tile_col,
+                    &tile_shape,
+                    &cube_start,
+                    &actual_extent,
+                    elem_size,
+                );
+                let dst_start = tile_idx * bucket_size + col_offsets[0];
+                write_tile_storage(
+                    &mut tsm_data
+                        [dst_start..dst_start + tile_storage_bytes(col_data_type, nrpixels)],
+                    col_data_type,
+                    &tile_col,
+                    nrpixels,
+                );
+            }
+            tsm_data
+        };
 
         let tsm_path = tsm_data_path(table_path, dm_seq_nr, file_seq_nr);
         std::fs::write(&tsm_path, &tsm_data)?;
@@ -4667,6 +4766,40 @@ fn decode_selected_cube_row_from_shared_tiles(
         .collect();
     let tile_grid_strides = fortran_order_strides(&tiles_per_dim);
     let (bucket_size, col_offsets) = compute_tile_layout(&header.col_data_types, &cube.tile_shape);
+
+    if cell_tile_shape == cell_shape.as_slice() {
+        let tile_index = row_tile * tile_grid_strides[cell_ndim];
+        let tile = load_shared_column_tile(
+            table_path,
+            dm_seq_nr,
+            header,
+            cube_idx,
+            cube,
+            target_col_idx,
+            bucket_size,
+            col_offsets[target_col_idx],
+            dt,
+            tile_index,
+            session,
+        )?;
+        let src_start = row_in_tile * row_tile_nelem * elem_size;
+        let src_end = src_start + row_tile_nelem * elem_size;
+        let value = decode_array_value(
+            &tile[src_start..src_end],
+            &cell_shape,
+            dt,
+            header.big_endian,
+        )?;
+        return match value {
+            Value::Array(array) => Ok(Some(array)),
+            other => Err(StorageError::FormatMismatch(format!(
+                "tiled array column {} decoded as non-array value {:?}",
+                col_desc.col_name,
+                other.kind()
+            ))),
+        };
+    }
+
     let mut raw = vec![0u8; cell_nelem * elem_size];
 
     for cell_tile_linear in 0..cell_tiles_per_dim.iter().product::<usize>() {

--- a/crates/casa-tables/src/table/columns.rs
+++ b/crates/casa-tables/src/table/columns.rs
@@ -316,6 +316,36 @@ impl Table {
         self.finish_write_operation(auto_unlock, result)
     }
 
+    /// Appends rows without re-validating them against the attached schema.
+    ///
+    /// This is the bulk counterpart to [`add_row_assuming_valid`](Table::add_row_assuming_valid)
+    /// for writers that already have schema-compatible records and need to
+    /// avoid per-row write-operation overhead.
+    pub fn add_rows_assuming_valid<I>(&mut self, rows: I) -> Result<usize, TableError>
+    where
+        I: IntoIterator<Item = RecordValue>,
+    {
+        let auto_unlock = self.begin_write_operation("add_rows_assuming_valid")?;
+        let result = (|| {
+            let schema = self.schema().cloned();
+            let mut count = 0usize;
+            for row in rows {
+                let undefined = schema
+                    .as_ref()
+                    .map(|schema| undefined_columns_for_row(&row, schema));
+                self.inner.add_row(row)?;
+                if let Some(undefined) = undefined
+                    && let Some(set) = self.inner.undefined_for_row_mut(self.row_count() - 1)?
+                {
+                    *set = undefined;
+                }
+                count += 1;
+            }
+            Ok(count)
+        })();
+        self.finish_write_operation(auto_unlock, result)
+    }
+
     /// Returns a shared reference to the row at `row_index`.
     ///
     /// Compatibility note: new row-oriented code should prefer

--- a/crates/casa-tables/src/table/columns.rs
+++ b/crates/casa-tables/src/table/columns.rs
@@ -857,6 +857,41 @@ impl Table {
             .collect()
     }
 
+    pub(crate) fn get_scalar_cells_owned_for_rows(
+        &self,
+        column: &str,
+        row_indices: &[usize],
+    ) -> Result<Vec<Option<ScalarValue>>, TableError> {
+        self.require_column(column)?;
+        for &row_index in row_indices {
+            if row_index >= self.row_count() {
+                return Err(TableError::RowOutOfBounds {
+                    row_index,
+                    row_count: self.row_count(),
+                });
+            }
+        }
+        if let Some(values) = self
+            .inner
+            .scalar_cells_owned_for_rows(row_indices, column)?
+        {
+            return Ok(values);
+        }
+        row_indices
+            .iter()
+            .map(|&row_index| match self.cell(row_index, column)? {
+                Some(Value::Scalar(scalar)) => Ok(Some(scalar.clone())),
+                Some(value) => Err(TableError::ColumnTypeMismatch {
+                    row_index,
+                    column: column.to_string(),
+                    expected: "scalar",
+                    found: value.kind(),
+                }),
+                None => Ok(None),
+            })
+            .collect()
+    }
+
     /// Returns a reference to the scalar value in a cell without cloning.
     ///
     /// Compatibility note: new cell-oriented code should prefer
@@ -1503,6 +1538,18 @@ impl<'a> TableColumn<'a> {
     /// Returns owned scalar values for the column.
     pub fn scalar_cells_owned(&self) -> Result<Vec<Option<ScalarValue>>, TableError> {
         self.table.get_scalar_cells_owned(&self.column)
+    }
+
+    /// Returns owned scalar values for selected rows in this column.
+    ///
+    /// The output preserves the order of `row_indices`. Missing cells are
+    /// returned as `None`.
+    pub fn scalar_cells_owned_for_rows(
+        &self,
+        row_indices: &[usize],
+    ) -> Result<Vec<Option<ScalarValue>>, TableError> {
+        self.table
+            .get_scalar_cells_owned_for_rows(&self.column, row_indices)
     }
 
     /// Returns owned array values for the selected rows.

--- a/crates/casa-tables/src/table/io.rs
+++ b/crates/casa-tables/src/table/io.rs
@@ -1211,13 +1211,14 @@ fn collect_sparse_array_group_values_from_current_cells(
         let Some(pending_values) = table.inner.pending_array_cells(&col_desc.col_name) else {
             return Ok(None);
         };
+        let pending_by_row: std::collections::HashMap<usize, &ArrayValue> = pending_values
+            .iter()
+            .map(|(row_index, value)| (*row_index, value))
+            .collect();
         let mut values = Vec::with_capacity(row_indices.len());
         for &row_index in row_indices {
-            if let Some((_, value)) = pending_values
-                .iter()
-                .find(|(pending_row, _)| *pending_row == row_index)
-            {
-                values.push((row_index, Some(value.clone())));
+            if let Some(value) = pending_by_row.get(&row_index) {
+                values.push((row_index, Some((*value).clone())));
             }
         }
         columns.push(Some(values));

--- a/crates/casa-tables/src/table/io.rs
+++ b/crates/casa-tables/src/table/io.rs
@@ -665,6 +665,150 @@ impl Table {
         Ok(())
     }
 
+    /// Persists a newly-added variable-shape array column as a standalone
+    /// `TiledShapeStMan` data manager without rewriting existing managers.
+    ///
+    /// The column must already exist in the in-memory schema and must not
+    /// exist in the on-disk `table.dat` descriptor. Defined cells are written
+    /// to the tiled row map; undefined or absent cells are left undefined.
+    ///
+    /// C++ equivalent: `Table::addColumn(desc, TiledShapeStMan(...))` followed
+    /// by cell writes.
+    pub fn save_added_tiled_shape_column_in_place_assuming_valid(
+        &mut self,
+        column: &str,
+        changed_rows: &[usize],
+        tile_shape: Option<&[usize]>,
+    ) -> Result<(), TableError> {
+        if self.kind != TableKind::Plain {
+            return Err(TableError::Storage(
+                "adding a tiled column in place requires a plain disk-backed table".to_string(),
+            ));
+        }
+        if !self.virtual_columns.is_empty() || !self.virtual_bindings.is_empty() {
+            return Err(TableError::Storage(
+                "adding a tiled column in place does not support virtual columns".to_string(),
+            ));
+        }
+
+        let source_path = self
+            .source_path
+            .as_ref()
+            .ok_or_else(|| TableError::Storage("table has no source path".to_string()))?
+            .clone();
+        let schema_column = self
+            .inner
+            .schema()
+            .and_then(|schema| schema.column(column))
+            .cloned()
+            .ok_or_else(|| TableError::SchemaColumnUnknown {
+                column: column.to_string(),
+            })?;
+
+        let auto_unlock = self.begin_write_operation("save_added_tiled_shape_column")?;
+        let result = (|| {
+            let control_path = source_path.join(crate::storage::TABLE_CONTROL_FILE);
+            let mut table_dat =
+                match crate::storage::table_control::read_table_dat_dispatch(&control_path)? {
+                    crate::storage::table_control::TableDatResult::Plain(table_dat) => table_dat,
+                    _ => {
+                        return Err(TableError::Storage(
+                            "adding a tiled column in place only supports plain tables".to_string(),
+                        ));
+                    }
+                };
+
+            if table_dat
+                .table_desc
+                .columns
+                .iter()
+                .any(|desc| desc.col_name == column)
+            {
+                return Err(TableError::Storage(format!(
+                    "column \"{column}\" already exists on disk"
+                )));
+            }
+
+            let mut desc = crate::storage::table_control::ColumnDescContents::from_column_schema(
+                &schema_column,
+            );
+            desc.data_manager_type = "TiledShapeStMan".to_string();
+            desc.data_manager_group = column.to_string();
+            if let Some(keywords) = self.inner.column_keywords(column) {
+                desc.keywords = keywords.clone();
+            }
+
+            let seq_nr = table_dat
+                .column_set
+                .data_managers
+                .iter()
+                .map(|dm| dm.seq_nr)
+                .max()
+                .map_or(0, |seq| seq + 1);
+            let mut value_storage = vec![None; self.row_count()];
+            if let Some(pending_values) = self.inner.pending_array_cells(column) {
+                for (row_idx, value) in pending_values {
+                    if *row_idx < value_storage.len() {
+                        value_storage[*row_idx] = Some(Value::Array(value.clone()));
+                    }
+                }
+            }
+            for &row_idx in changed_rows {
+                if row_idx >= value_storage.len() || value_storage[row_idx].is_some() {
+                    continue;
+                }
+                value_storage[row_idx] = current_value_for_column(self, row_idx, &desc)?;
+            }
+            let values: Vec<Option<&Value>> = value_storage.iter().map(Option::as_ref).collect();
+
+            crate::storage::tiled_stman::save_tiled_single_column_values(
+                &source_path,
+                seq_nr,
+                &desc,
+                &values,
+                crate::storage::tiled_stman::SingleColumnTiledSaveOptions {
+                    dm_type_name: "TiledShapeStMan",
+                    big_endian: table_dat.big_endian,
+                    default_tile_shape: tile_shape,
+                    dm_name: column,
+                },
+            )?;
+
+            table_dat.table_desc.columns.push(desc);
+            table_dat
+                .column_set
+                .columns
+                .push(crate::storage::table_control::PlainColumnEntry {
+                    original_name: column.to_string(),
+                    dm_seq_nr: seq_nr,
+                    is_array: true,
+                });
+            table_dat.column_set.data_managers.push(
+                crate::storage::table_control::DataManagerEntry {
+                    type_name: "TiledShapeStMan".to_string(),
+                    seq_nr,
+                    data: Vec::new(),
+                },
+            );
+            table_dat.column_set.seq_count = table_dat
+                .column_set
+                .data_managers
+                .iter()
+                .map(|dm| dm.seq_nr + 1)
+                .max()
+                .unwrap_or(1);
+            crate::storage::table_control::write_table_dat(&control_path, &table_dat)?;
+            crate::storage::tiled_stman::invalidate_shared_tile_cache_for_table(&source_path);
+            self.dm_info.push(crate::storage::DataManagerInfo {
+                dm_type: "TiledShapeStMan".to_string(),
+                seq_nr,
+                columns: vec![column.to_string()],
+            });
+            Ok(())
+        })();
+        self.finish_write_operation(auto_unlock, result)
+    }
+
     /// Returns the filesystem path this table was opened from or saved to,
     /// if any. In-memory tables that have never been persisted return `None`.
     pub fn path(&self) -> Option<&Path> {

--- a/crates/casa-tables/src/table/io.rs
+++ b/crates/casa-tables/src/table/io.rs
@@ -272,6 +272,83 @@ impl Table {
         Ok(())
     }
 
+    /// Save the table with per-column bindings and complete column-value overrides.
+    ///
+    /// This advanced writer is for high-volume materialization paths that
+    /// build some large array columns column-wise while the rest of the table
+    /// is still represented as rows. Each override must contain exactly one
+    /// value slot per table row. Overrides can be written directly for
+    /// single-column tiled data-manager groups, matching MeasurementSet
+    /// visibility columns such as `DATA` and `FLAG`, and for scalar
+    /// IncrementalStMan groups when the whole scalar group is overridden.
+    ///
+    /// The caller is responsible for ensuring that override values satisfy the
+    /// table schema; this method intentionally shares the same "assuming
+    /// valid" contract as [`save_with_bindings_assuming_valid`](Self::save_with_bindings_assuming_valid).
+    pub fn save_with_bindings_and_column_overrides_assuming_valid(
+        &self,
+        options: TableOptions,
+        bindings: &std::collections::HashMap<String, ColumnBinding>,
+        column_overrides: &std::collections::HashMap<String, Vec<Option<Value>>>,
+    ) -> Result<(), TableError> {
+        let row_count = self.inner.row_count();
+        if let Some(schema) = self.inner.schema() {
+            for column in column_overrides.keys() {
+                if !schema.contains_column(column) {
+                    return Err(TableError::SchemaColumnUnknown {
+                        column: column.clone(),
+                    });
+                }
+            }
+        }
+        for (column, values) in column_overrides {
+            if values.len() != row_count {
+                return Err(TableError::Storage(format!(
+                    "column override {column} has {} values for {row_count} rows",
+                    values.len()
+                )));
+            }
+        }
+
+        let mut profiler = StorageProfiler::start(format!(
+            "Table::save_with_bindings_and_column_overrides path={}",
+            options.path.display()
+        ));
+        if let Some(profiler) = profiler.as_mut() {
+            profiler.mark_with_detail(
+                "validate",
+                Some(format!(
+                    "rows={} bindings={} overrides={} skipped=true",
+                    row_count,
+                    bindings.len(),
+                    column_overrides.len()
+                )),
+            );
+        }
+        let storage = CompositeStorage;
+        storage.save_with_bindings_and_column_overrides_borrowed(
+            &options.path,
+            self.inner.rows()?,
+            self.inner.undefined_cells()?,
+            self.inner.keywords(),
+            self.inner.all_column_keywords(),
+            self.inner.schema(),
+            &self.table_info,
+            &self.virtual_columns,
+            &self.virtual_bindings,
+            options.data_manager,
+            options.endian_format.is_big_endian(),
+            options.tile_shape.as_deref(),
+            bindings,
+            column_overrides,
+        )?;
+        if let Some(profiler) = profiler.as_mut() {
+            profiler.mark("storage_save");
+        }
+        crate::storage::tiled_stman::invalidate_shared_tile_cache_for_table(&options.path);
+        Ok(())
+    }
+
     /// Rewrites only the existing data-manager groups that contain `changed_columns`.
     ///
     /// This is a narrow in-place optimization for schema-stable disk-backed

--- a/crates/casa-tables/src/table/tests.rs
+++ b/crates/casa-tables/src/table/tests.rs
@@ -3490,6 +3490,69 @@ fn add_column_none_default_with_undefined() {
 }
 
 #[test]
+fn add_variable_shape_tiled_column_in_place_persists_defined_rows_only() {
+    let root = unique_test_dir("add_sparse_tiled_shape_col");
+    std::fs::create_dir_all(&root).expect("mkdir");
+    build_mutation_test_table()
+        .save(TableOptions::new(&root).with_data_manager(DataManagerKind::StandardStMan))
+        .expect("save base table");
+
+    let mut table = Table::open(TableOptions::new(&root)).expect("open base table");
+    let column = ColumnSchema::array_variable("vis", PrimitiveType::Float32, Some(2));
+    table.add_column(column, None).expect("add column");
+    table_set_cell(
+        &mut table,
+        1,
+        "vis",
+        Value::Array(ArrayValue::Float32(
+            ArrayD::from_shape_vec(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]).unwrap(),
+        )),
+    )
+    .expect("set row 1");
+    table_set_cell(
+        &mut table,
+        2,
+        "vis",
+        Value::Array(ArrayValue::Float32(
+            ArrayD::from_shape_vec(vec![1, 3], vec![5.0, 6.0, 7.0]).unwrap(),
+        )),
+    )
+    .expect("set row 2");
+    table
+        .save_added_tiled_shape_column_in_place_assuming_valid("vis", &[1, 2], Some(&[2, 2, 8]))
+        .expect("save added tiled column");
+
+    let reopened = Table::open(TableOptions::new(&root)).expect("reopen table");
+    match table_cell(&reopened, 0, "vis") {
+        Ok(None) => {}
+        Ok(Some(Value::Array(ArrayValue::Float32(array)))) => {
+            assert_eq!(array.shape(), &[0, 0]);
+        }
+        other => panic!("unexpected row 0 value: {other:?}"),
+    }
+    assert_eq!(
+        table_array(&reopened, 1, "vis"),
+        Ok(&ArrayValue::Float32(
+            ArrayD::from_shape_vec(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]).unwrap()
+        ))
+    );
+    assert_eq!(
+        table_array(&reopened, 2, "vis"),
+        Ok(&ArrayValue::Float32(
+            ArrayD::from_shape_vec(vec![1, 3], vec![5.0, 6.0, 7.0]).unwrap()
+        ))
+    );
+    assert!(
+        reopened
+            .data_manager_info()
+            .iter()
+            .any(|dm| dm.dm_type == "TiledShapeStMan" && dm.columns == ["vis"])
+    );
+
+    std::fs::remove_dir_all(&root).expect("cleanup");
+}
+
+#[test]
 fn from_rows_with_schema_persists_missing_undefined_scalar_cells() {
     use crate::schema::ColumnOptions;
 

--- a/crates/casa-tables/src/table/tests.rs
+++ b/crates/casa-tables/src/table/tests.rs
@@ -3236,6 +3236,71 @@ fn save_with_bindings_keeps_different_tiled_array_dims_in_separate_groups() {
     std::fs::remove_dir_all(&root).expect("cleanup");
 }
 
+#[test]
+fn save_with_bindings_column_overrides_write_single_tiled_array_column() {
+    let schema = TableSchema::new(vec![
+        ColumnSchema::scalar("ROW_ID", PrimitiveType::Int32),
+        ColumnSchema::array_variable("DATA", PrimitiveType::Int32, Some(2)),
+    ])
+    .expect("schema");
+    let mut table = Table::with_schema(schema);
+    for row_id in 0..3 {
+        table
+            .add_row(RecordValue::new(vec![RecordField::new(
+                "ROW_ID",
+                Value::Scalar(ScalarValue::Int32(row_id)),
+            )]))
+            .expect("add scalar-only row");
+    }
+
+    let root = unique_test_dir("save_with_bindings_column_overrides");
+    std::fs::create_dir_all(&root).expect("mkdir");
+
+    let bindings = HashMap::from([(
+        "DATA".to_string(),
+        ColumnBinding {
+            data_manager: DataManagerKind::TiledShapeStMan,
+            tile_shape: None,
+        },
+    )]);
+    let overrides = HashMap::from([(
+        "DATA".to_string(),
+        vec![
+            Some(Value::Array(ArrayValue::Int32(
+                ArrayD::from_shape_vec(vec![2, 2], vec![1, 2, 3, 4]).expect("row 0 shape"),
+            ))),
+            Some(Value::Array(ArrayValue::Int32(
+                ArrayD::from_shape_vec(vec![2, 2], vec![5, 6, 7, 8]).expect("row 1 shape"),
+            ))),
+            Some(Value::Array(ArrayValue::Int32(
+                ArrayD::from_shape_vec(vec![2, 2], vec![9, 10, 11, 12]).expect("row 2 shape"),
+            ))),
+        ],
+    )]);
+
+    table
+        .save_with_bindings_and_column_overrides_assuming_valid(
+            TableOptions::new(&root).with_data_manager(DataManagerKind::StandardStMan),
+            &bindings,
+            &overrides,
+        )
+        .expect("save with column overrides");
+
+    let reopened = Table::open(TableOptions::new(&root)).expect("reopen table");
+    assert_eq!(
+        table_scalar(&reopened, 1, "ROW_ID").expect("row id"),
+        &ScalarValue::Int32(1)
+    );
+    assert_eq!(
+        table_array(&reopened, 2, "DATA").expect("data row 2"),
+        &ArrayValue::Int32(
+            ArrayD::from_shape_vec(vec![2, 2], vec![9, 10, 11, 12]).expect("expected shape")
+        )
+    );
+
+    std::fs::remove_dir_all(&root).expect("cleanup");
+}
+
 fn assert_save_with_bindings_preserves_scalar_values_when_row_field_order_varies(
     dm_kind: DataManagerKind,
     label: &str,

--- a/crates/casa-tables/src/table/tests.rs
+++ b/crates/casa-tables/src/table/tests.rs
@@ -2123,6 +2123,72 @@ fn lazy_disk_open_reads_selected_array_cells_without_loading_full_tiled_column()
 }
 
 #[test]
+fn lazy_disk_open_reads_selected_fixed_array_cells_without_loading_full_column() {
+    let schema = TableSchema::new(vec![ColumnSchema::array_fixed(
+        "uvw",
+        PrimitiveType::Float64,
+        vec![3],
+    )])
+    .expect("schema");
+
+    for dm in [DataManagerKind::StManAipsIO, DataManagerKind::StandardStMan] {
+        let mut table = Table::with_schema(schema.clone());
+        for row_idx in 0..6 {
+            table
+                .add_row(RecordValue::new(vec![RecordField::new(
+                    "uvw",
+                    Value::Array(ArrayValue::Float64(
+                        ArrayD::from_shape_vec(
+                            vec![3],
+                            vec![row_idx as f64, row_idx as f64 + 10.0, row_idx as f64 + 20.0],
+                        )
+                        .expect("shape uvw"),
+                    )),
+                )]))
+                .expect("push row");
+        }
+
+        let root = unique_test_dir(&format!("lazy_selected_fixed_array_rows_{dm:?}"));
+        std::fs::create_dir_all(&root).expect("create test dir");
+        table
+            .save(TableOptions::new(&root).with_data_manager(dm))
+            .expect("save table");
+
+        let reopened = Table::open(TableOptions::new(&root)).expect("open lazy table");
+        assert!(!reopened.inner.has_loaded_rows());
+        assert!(!reopened.inner.has_loaded_array_column("uvw"));
+
+        let selected =
+            table_array_cells_owned(&reopened, "uvw", &[5, 2, 4]).expect("read selected uvw rows");
+        assert_eq!(
+            selected,
+            vec![
+                Some(ArrayValue::Float64(
+                    ArrayD::from_shape_vec(vec![3], vec![5.0, 15.0, 25.0]).unwrap()
+                )),
+                Some(ArrayValue::Float64(
+                    ArrayD::from_shape_vec(vec![3], vec![2.0, 12.0, 22.0]).unwrap()
+                )),
+                Some(ArrayValue::Float64(
+                    ArrayD::from_shape_vec(vec![3], vec![4.0, 14.0, 24.0]).unwrap()
+                )),
+            ],
+            "dm={dm:?}"
+        );
+        assert!(
+            !reopened.inner.has_loaded_rows(),
+            "selected fixed-array reads should not force row materialization for {dm:?}"
+        );
+        assert!(
+            !reopened.inner.has_loaded_array_column("uvw"),
+            "selected fixed-array reads should not populate the full array-column cache for {dm:?}"
+        );
+
+        std::fs::remove_dir_all(&root).expect("cleanup test dir");
+    }
+}
+
+#[test]
 fn lazy_disk_open_reads_array_cells_without_loading_full_tiled_column() {
     let schema = TableSchema::new(vec![ColumnSchema::array_fixed(
         "data",

--- a/crates/casa-tables/src/table_impl.rs
+++ b/crates/casa-tables/src/table_impl.rs
@@ -424,6 +424,43 @@ impl TableImpl {
         Ok(values)
     }
 
+    fn load_scalar_column_rows_now(
+        source: &LazyRowsSource,
+        column: &str,
+        row_indices: &[usize],
+    ) -> Result<Vec<Option<ScalarValue>>, TableError> {
+        let mut profiler = StorageProfiler::start(format!(
+            "table_impl::load_scalar_column_rows_now path={} column={column}",
+            source.path.display()
+        ));
+        let storage = CompositeStorage;
+        let values = storage
+            .load_scalar_column_rows_with_row_hint(
+                &source.path,
+                column,
+                row_indices,
+                Some(source.row_count_hint as u64),
+            )
+            .map_err(|err| {
+                TableError::Storage(format!(
+                    "failed to load selected rows for scalar column '{column}' from table {}: {err}",
+                    source.path.display()
+                ))
+            })?;
+        if let Some(profiler) = profiler.as_mut() {
+            profiler.mark_with_detail(
+                "storage_load_complete",
+                Some(format!(
+                    "row_count_hint={} requested_rows={} values={}",
+                    source.row_count_hint,
+                    row_indices.len(),
+                    values.len()
+                )),
+            );
+        }
+        Ok(values)
+    }
+
     fn ensure_loaded(&self) -> Result<&LoadedRows, TableError> {
         if let Some(loaded) = self.loaded_rows.get() {
             return Ok(loaded);
@@ -680,6 +717,54 @@ impl TableImpl {
         if let Some(overrides) = self.pending_scalar_cells.by_column.get(column) {
             for (&row_index, value) in overrides {
                 if let Some(cell) = values.get_mut(row_index) {
+                    *cell = Some(value.clone());
+                }
+            }
+        }
+        Ok(Some(values))
+    }
+
+    pub(crate) fn scalar_cells_owned_for_rows(
+        &self,
+        row_indices: &[usize],
+        column: &str,
+    ) -> Result<Option<Vec<Option<ScalarValue>>>, TableError> {
+        if let Some(loaded) = self.loaded_rows.get() {
+            let values = row_indices
+                .iter()
+                .map(|&row_index| {
+                    loaded
+                        .rows
+                        .get(row_index)
+                        .and_then(|row| match row.get(column) {
+                            Some(Value::Scalar(scalar)) => Some(scalar.clone()),
+                            _ => None,
+                        })
+                })
+                .collect();
+            return Ok(Some(values));
+        }
+
+        if let Some(cached_column) = self.loaded_scalar_columns.get(column)
+            && let Some(values) = cached_column.get()
+        {
+            let selected = row_indices
+                .iter()
+                .map(|&row_index| values.get(row_index).cloned().unwrap_or(None))
+                .collect();
+            return Ok(Some(selected));
+        }
+
+        let Some(source) = &self.lazy_rows else {
+            return Ok(None);
+        };
+
+        let mut values = Self::load_scalar_column_rows_now(source, column, row_indices)?;
+        if let Some(overrides) = self.pending_scalar_cells.by_column.get(column) {
+            for (out_idx, &row_index) in row_indices.iter().enumerate() {
+                if let Some(value) = overrides.get(&row_index)
+                    && let Some(cell) = values.get_mut(out_idx)
+                {
                     *cell = Some(value.clone());
                 }
             }

--- a/crates/casars-imager/src/lib.rs
+++ b/crates/casars-imager/src/lib.rs
@@ -33,6 +33,7 @@ use casa_imaging::{
     trace_w_project_plan,
 };
 use casa_ms::MeasurementSet;
+#[cfg(test)]
 use casa_ms::columns::time_columns::TimeColumn;
 use casa_ms::columns::weight_columns::WeightSpectrumColumn;
 use casa_ms::derived::engine::{MsCalEngine, resolve_field_phase_direction_j2000};
@@ -2595,7 +2596,11 @@ fn select_main_rows(
         select_started_at.elapsed(),
     );
     let allowed_ddids = allowed_ddids(config, ddid_info)?;
-    let time_column = TimeColumn::new(ms.main_table());
+    let time_values = if needs_row_times {
+        Some(load_f64_main_column_owned(ms, "TIME")?)
+    } else {
+        None
+    };
     let allowed_field_ids = config
         .field_ids
         .as_ref()
@@ -2628,9 +2633,10 @@ fn select_main_rows(
         let field_id_usize = usize::try_from(field_id)
             .map_err(|_| format!("FIELD_ID row {row} must be non-negative, found {field_id}"))?;
         let row_time_mjd_sec = if needs_row_times {
-            let row_time_mjd_sec = time_column
-                .get_mjd_seconds(row)
-                .map_err(|error| format!("read TIME row {row}: {error}"))?;
+            let row_time_mjd_sec = *time_values
+                .as_ref()
+                .and_then(|values| values.get(row))
+                .ok_or_else(|| format!("TIME row {row} is missing"))?;
             reference_row_time_mjd_sec.get_or_insert(row_time_mjd_sec);
             if config.spectral_mode.is_cube_like() {
                 match &mut time_bounds_mjd_sec {
@@ -2727,6 +2733,37 @@ fn load_i32_main_column_owned(
             Some(ScalarValue::Int32(value)) => Ok(value),
             Some(other) => Err(format!(
                 "{column_name} row {row} must be Int32, found {:?}",
+                other.primitive_type()
+            )),
+            None => Err(format!("{column_name} row {row} is missing")),
+        })
+        .collect()
+}
+
+fn load_f64_main_column_owned(
+    ms: &MeasurementSet,
+    column_name: &'static str,
+) -> Result<Vec<f64>, String> {
+    let values = ms
+        .main_table()
+        .column_accessor(column_name)
+        .and_then(|column| column.scalar_cells_owned())
+        .map_err(|error| format!("load {column_name} column: {error}"))?;
+    if values.len() != ms.main_table().row_count() {
+        return Err(format!(
+            "{column_name} length {} does not match MAIN row count {}",
+            values.len(),
+            ms.main_table().row_count()
+        ));
+    }
+    values
+        .into_iter()
+        .enumerate()
+        .map(|(row, value)| match value {
+            Some(ScalarValue::Float64(value)) => Ok(value),
+            Some(ScalarValue::Float32(value)) => Ok(value as f64),
+            Some(other) => Err(format!(
+                "{column_name} row {row} must be Float64, found {:?}",
                 other.primitive_type()
             )),
             None => Err(format!("{column_name} row {row} is missing")),
@@ -3155,6 +3192,8 @@ fn prepare_plane_input_inner(
     };
     let fast_standard_mfs =
         !force_trace && can_prepare_standard_mfs_without_trace(config, &selection);
+    let build_trace =
+        force_trace || (matches!(config.spectral_mode, SpectralMode::Mfs) && !fast_standard_mfs);
     let mut prepared = PreparedSelection::new(
         config,
         selection.selected_ddid,
@@ -3163,7 +3202,7 @@ fn prepare_plane_input_inner(
         &polarization,
         selection.phase_center.clone(),
         cube_context,
-        !fast_standard_mfs,
+        build_trace,
     );
     if let Some(init_error) = prepared.initialization_error.take() {
         return Err(init_error);
@@ -3197,6 +3236,16 @@ fn prepare_plane_input_inner(
         let prepared_input = prepared.finish_standard_mfs_without_trace()?;
         maybe_log_frontend_progress(
             "prepare_plane_input/finish_standard_mfs_without_trace",
+            stage_started_at.elapsed(),
+            prepare_started_at.elapsed(),
+        );
+        return Ok((prepared_input, None));
+    }
+    if !force_trace && config.spectral_mode.is_cube_like() {
+        let stage_started_at = Instant::now();
+        let prepared_input = prepared.finish_cube_without_trace()?;
+        maybe_log_frontend_progress(
+            "prepare_plane_input/finish_cube_without_trace",
             stage_started_at.elapsed(),
             prepare_started_at.elapsed(),
         );
@@ -4837,42 +4886,44 @@ impl PreparedSelection {
                             source_model_contributions,
                         ),
                     );
-                    channel_samples[output_channel].push(PendingPairedSampleTrace {
-                        common: TraceSampleCommon {
-                            row_index: selected_row.row_index,
-                            input_field_id: selected_row.field_id,
-                            phase_center_field_id: self.phase_center.field_id,
-                            ddid: selected_row.ddid,
-                            spw_id: selected_row.spw_id,
-                            polarization_id: selected_row.polarization_id,
-                            antenna1_id,
-                            antenna2_id,
-                            is_cross,
-                            raw_uvw_m,
-                            imaging_uvw_m: uvw_m,
-                            phase_shift_m: transform.phase_shift_m,
-                            output_channel_index: Some(output_channel),
-                            output_frequency_hz,
-                            field_phase_center_direction_rad: geometry_row
-                                .field_phase_center_direction_rad,
-                            pointing_direction_rad: baseline_pointing_direction_rad,
-                            source_contributions: build_source_contribution_traces(
-                                &self.source_channel_indices,
-                                &self.source_channel_frequencies_hz,
-                                contributions,
-                            ),
-                            gridable: is_cross,
-                        },
-                        correlation_indices: [pair.0, pair.1],
-                        first_visibility: sample.first_visibility,
-                        second_visibility: sample.second_visibility,
-                        first_weight: sample.first_weight,
-                        second_weight: sample.second_weight,
-                        first_weight_source: sample.first_weight_source,
-                        second_weight_source: sample.second_weight_source,
-                        first_flagged: false,
-                        second_flagged: false,
-                    });
+                    if trace_enabled {
+                        channel_samples[output_channel].push(PendingPairedSampleTrace {
+                            common: TraceSampleCommon {
+                                row_index: selected_row.row_index,
+                                input_field_id: selected_row.field_id,
+                                phase_center_field_id: self.phase_center.field_id,
+                                ddid: selected_row.ddid,
+                                spw_id: selected_row.spw_id,
+                                polarization_id: selected_row.polarization_id,
+                                antenna1_id,
+                                antenna2_id,
+                                is_cross,
+                                raw_uvw_m,
+                                imaging_uvw_m: uvw_m,
+                                phase_shift_m: transform.phase_shift_m,
+                                output_channel_index: Some(output_channel),
+                                output_frequency_hz,
+                                field_phase_center_direction_rad: geometry_row
+                                    .field_phase_center_direction_rad,
+                                pointing_direction_rad: baseline_pointing_direction_rad,
+                                source_contributions: build_source_contribution_traces(
+                                    &self.source_channel_indices,
+                                    &self.source_channel_frequencies_hz,
+                                    contributions,
+                                ),
+                                gridable: is_cross,
+                            },
+                            correlation_indices: [pair.0, pair.1],
+                            first_visibility: sample.first_visibility,
+                            second_visibility: sample.second_visibility,
+                            first_weight: sample.first_weight,
+                            second_weight: sample.second_weight,
+                            first_weight_source: sample.first_weight_source,
+                            second_weight_source: sample.second_weight_source,
+                            first_flagged: false,
+                            second_flagged: false,
+                        });
+                    }
                 }
             }
             _ => {
@@ -4952,6 +5003,123 @@ impl PreparedSelection {
                 gridder_mode: GridderMode::Standard,
             })),
             _ => Err("internal error: fast trace-free prepare requires MFS state".to_string()),
+        }
+    }
+
+    fn finish_cube_without_trace(self) -> Result<PreparedInput, String> {
+        let PreparedSelection {
+            initialization_error: _,
+            source_channel_indices: _,
+            source_channel_frequencies_hz,
+            source_channel_widths_hz: _,
+            selected_frequency_range_hz: _,
+            reffreq_hz: _,
+            freq_ref,
+            cube_spectral_setup,
+            cube_row_spectral_cache: _,
+            casa_cube_grid_interpolation: _,
+            phase_center,
+            state,
+            trace_state: _,
+            trace_enabled: _,
+        } = self;
+        let output_channel_frequencies_hz = cube_spectral_setup
+            .as_ref()
+            .map(|setup| setup.output_channel_frequencies_hz.clone())
+            .unwrap_or(source_channel_frequencies_hz);
+        match state {
+            PreparedState::ExplicitCube {
+                plane_stokes,
+                channel_batches,
+                channel_density_batches,
+                channel_model_interpolation_samples,
+                ..
+            } => {
+                let channels = output_channel_frequencies_hz
+                    .iter()
+                    .copied()
+                    .zip(channel_batches)
+                    .zip(channel_density_batches)
+                    .zip(channel_model_interpolation_samples)
+                    .map(
+                        |(
+                            ((channel_frequency_hz, batch), density_batch),
+                            model_interpolation_samples,
+                        )| CubeChannelRequest {
+                            channel_frequency_hz,
+                            visibility_batches: chunk_visibility_batch(batch, DEFAULT_BATCH_SIZE),
+                            density_batches: chunk_visibility_batch(
+                                density_batch,
+                                DEFAULT_BATCH_SIZE,
+                            ),
+                            model_interpolation_batches: chunk_model_interpolation_batches(
+                                model_interpolation_samples,
+                                DEFAULT_BATCH_SIZE,
+                            ),
+                        },
+                    )
+                    .collect();
+                Ok(PreparedInput::Cube(CubePlaneInput {
+                    phase_center,
+                    freq_ref,
+                    plane_stokes,
+                    channels,
+                }))
+            }
+            PreparedState::PairedCube {
+                plane_stokes,
+                transform,
+                channel_batches,
+                channel_density_batches,
+                channel_model_interpolation_samples,
+                ..
+            } => {
+                let channels = output_channel_frequencies_hz
+                    .iter()
+                    .copied()
+                    .zip(channel_batches)
+                    .zip(channel_density_batches)
+                    .zip(channel_model_interpolation_samples)
+                    .map(
+                        |(
+                            ((channel_frequency_hz, batch), density_batch),
+                            model_interpolation_samples,
+                        )| {
+                            let collapsed =
+                                collapse_paired_visibility_batch(&batch, transform, plane_stokes)
+                                    .map_err(|error| error.to_string())?;
+                            let collapsed_model_interpolation_samples =
+                                collapse_paired_model_interpolation_samples_from_batch(
+                                    &batch,
+                                    model_interpolation_samples,
+                                    transform,
+                                )?;
+                            Ok(CubeChannelRequest {
+                                channel_frequency_hz,
+                                visibility_batches: chunk_visibility_batch(
+                                    collapsed,
+                                    DEFAULT_BATCH_SIZE,
+                                ),
+                                density_batches: chunk_visibility_batch(
+                                    density_batch,
+                                    DEFAULT_BATCH_SIZE,
+                                ),
+                                model_interpolation_batches: chunk_model_interpolation_batches(
+                                    collapsed_model_interpolation_samples,
+                                    DEFAULT_BATCH_SIZE,
+                                ),
+                            })
+                        },
+                    )
+                    .collect::<Result<Vec<_>, String>>()?;
+                Ok(PreparedInput::Cube(CubePlaneInput {
+                    phase_center,
+                    freq_ref,
+                    plane_stokes,
+                    channels,
+                }))
+            }
+            _ => Err("internal error: trace-free cube prepare requires cube state".to_string()),
         }
     }
 
@@ -6855,6 +7023,48 @@ fn collapse_pending_pair_model_interpolation_samples(
                 CollapsedPairTrace::Accepted(_)
             )
             .then_some(model_contributions)
+        })
+        .collect())
+}
+
+fn collapse_paired_model_interpolation_samples_from_batch(
+    paired: &ParallelHandBatch,
+    model_interpolation_samples: Vec<Vec<CubeModelChannelContribution>>,
+    transform: PairCollapseTransform,
+) -> Result<Vec<Vec<CubeModelChannelContribution>>, String> {
+    if paired.len() != model_interpolation_samples.len() {
+        return Err(format!(
+            "paired cube model interpolation sample count {} does not match paired batch count {}",
+            model_interpolation_samples.len(),
+            paired.len()
+        ));
+    }
+    Ok(model_interpolation_samples
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, model_contributions)| {
+            if paired.first_flagged[index] || paired.second_flagged[index] {
+                return None;
+            }
+            let first_weight = paired.first_weight[index];
+            let second_weight = paired.second_weight[index];
+            if !(first_weight.is_finite()
+                && first_weight > 0.0
+                && second_weight.is_finite()
+                && second_weight > 0.0)
+            {
+                return None;
+            }
+            let visibility = collapse_paired_visibility(
+                paired.first_visibility[index],
+                paired.second_visibility[index],
+                transform,
+            );
+            if !(visibility.re.is_finite() && visibility.im.is_finite()) {
+                return None;
+            }
+            let combined_weight = 0.5 * (first_weight + second_weight);
+            (combined_weight.is_finite() && combined_weight > 0.0).then_some(model_contributions)
         })
         .collect())
 }

--- a/crates/casars-imager/src/lib.rs
+++ b/crates/casars-imager/src/lib.rs
@@ -1309,6 +1309,13 @@ fn maybe_log_frontend_progress(stage: &str, stage_elapsed: Duration, total_elaps
     }
 }
 
+fn config_for_cube_residual_trace_preparation(config: &CliConfig) -> CliConfig {
+    let mut trace_config = config.clone();
+    trace_config.dirty_only = false;
+    trace_config.niter = trace_config.niter.max(1);
+    trace_config
+}
+
 /// Trace the standard residual-refresh seam for a single prepared cube channel.
 ///
 /// This reuses the same MeasurementSet preparation path as `run_from_config()`,
@@ -1332,7 +1339,8 @@ pub fn trace_cube_channel_residual_refresh_from_config(
     let mut model_planes = Vec::new();
     let ms = MeasurementSet::open(&config.ms).map_err(|error| format!("open MS: {error}"))?;
     let data_column = resolve_data_column(&ms, config.datacolumn.as_deref())?;
-    let prepared = prepare_plane_input(&ms, config, data_column)?;
+    let trace_config = config_for_cube_residual_trace_preparation(config);
+    let prepared = prepare_plane_input(&ms, &trace_config, data_column)?;
     let PreparedInput::Cube(cube) = prepared else {
         return Err("trace_cube_channel_residual_refresh_from_config requires cube input".into());
     };
@@ -1403,7 +1411,8 @@ pub fn trace_cube_channel_residual_refresh_from_config_with_model_cube(
 ) -> Result<ResidualRefreshDiagnostics, String> {
     let ms = MeasurementSet::open(&config.ms).map_err(|error| format!("open MS: {error}"))?;
     let data_column = resolve_data_column(&ms, config.datacolumn.as_deref())?;
-    let prepared = prepare_plane_input(&ms, config, data_column)?;
+    let trace_config = config_for_cube_residual_trace_preparation(config);
+    let prepared = prepare_plane_input(&ms, &trace_config, data_column)?;
     let PreparedInput::Cube(cube) = prepared else {
         return Err("trace_cube_channel_residual_refresh_from_config requires cube input".into());
     };
@@ -1466,7 +1475,8 @@ pub fn trace_cube_channel_residual_refresh_from_config_with_model_cube_model_cha
 ) -> Result<ResidualRefreshDiagnostics, String> {
     let ms = MeasurementSet::open(&config.ms).map_err(|error| format!("open MS: {error}"))?;
     let data_column = resolve_data_column(&ms, config.datacolumn.as_deref())?;
-    let prepared = prepare_plane_input(&ms, config, data_column)?;
+    let trace_config = config_for_cube_residual_trace_preparation(config);
+    let prepared = prepare_plane_input(&ms, &trace_config, data_column)?;
     let PreparedInput::Cube(cube) = prepared else {
         return Err("trace_cube_channel_residual_refresh_from_config requires cube input".into());
     };
@@ -3646,6 +3656,8 @@ struct PreparedSelection {
     cube_spectral_setup: Option<CubeSpectralSetup>,
     cube_row_spectral_cache: HashMap<(u64, usize), Rc<CubeRowSpectralContributions>>,
     casa_cube_grid_interpolation: bool,
+    use_density_batches: bool,
+    use_model_interpolation_batches: bool,
     phase_center: PhaseCenter,
     state: PreparedState,
     trace_state: PreparedTraceState,
@@ -3739,6 +3751,14 @@ enum PreparedState {
         channel_density_batches: Vec<VisibilityBatch>,
         channel_model_interpolation_samples: Vec<Vec<Vec<CubeModelChannelContribution>>>,
         pair: (usize, usize),
+    },
+    CollapsedCube {
+        plane_stokes: PlaneStokes,
+        transform: PairCollapseTransform,
+        pair: (usize, usize),
+        channel_batches: Vec<VisibilityBatch>,
+        channel_density_batches: Vec<VisibilityBatch>,
+        channel_model_interpolation_samples: Vec<Vec<Vec<CubeModelChannelContribution>>>,
     },
 }
 
@@ -3971,6 +3991,8 @@ impl PreparedSelection {
                 .as_ref()
                 .map(|setup| setup.output_freq_ref)
                 .unwrap_or(freq_ref);
+            let use_density_batches = config.weighting != WeightingMode::Natural;
+            let use_model_interpolation_batches = !(config.dirty_only || config.niter == 0);
             let selected_frequency_range_hz = [
                 *output_channel_frequencies_hz
                     .first()
@@ -4043,23 +4065,44 @@ impl PreparedSelection {
                             pair,
                             batch: empty_visibility_batch(max_samples),
                         },
-                        SpectralMode::Cube | SpectralMode::Cubedata => PreparedState::PairedCube {
-                            plane_stokes,
-                            transform,
-                            pair,
-                            channel_batches: output_channel_frequencies_hz
-                                .iter()
-                                .map(|_| empty_parallel_hand_batch(16))
-                                .collect(),
-                            channel_density_batches: output_channel_frequencies_hz
-                                .iter()
-                                .map(|_| empty_visibility_batch(16))
-                                .collect(),
-                            channel_model_interpolation_samples: output_channel_frequencies_hz
-                                .iter()
-                                .map(|_| Vec::new())
-                                .collect(),
-                        },
+                        SpectralMode::Cube | SpectralMode::Cubedata if trace_enabled => {
+                            PreparedState::PairedCube {
+                                plane_stokes,
+                                transform,
+                                pair,
+                                channel_batches: output_channel_frequencies_hz
+                                    .iter()
+                                    .map(|_| empty_parallel_hand_batch(16))
+                                    .collect(),
+                                channel_density_batches: output_channel_frequencies_hz
+                                    .iter()
+                                    .map(|_| empty_visibility_batch(16))
+                                    .collect(),
+                                channel_model_interpolation_samples: output_channel_frequencies_hz
+                                    .iter()
+                                    .map(|_| Vec::new())
+                                    .collect(),
+                            }
+                        }
+                        SpectralMode::Cube | SpectralMode::Cubedata => {
+                            PreparedState::CollapsedCube {
+                                plane_stokes,
+                                transform,
+                                pair,
+                                channel_batches: output_channel_frequencies_hz
+                                    .iter()
+                                    .map(|_| empty_visibility_batch(16))
+                                    .collect(),
+                                channel_density_batches: output_channel_frequencies_hz
+                                    .iter()
+                                    .map(|_| empty_visibility_batch(16))
+                                    .collect(),
+                                channel_model_interpolation_samples: output_channel_frequencies_hz
+                                    .iter()
+                                    .map(|_| Vec::new())
+                                    .collect(),
+                            }
+                        }
                     }
                 }
             } else {
@@ -4077,13 +4120,32 @@ impl PreparedSelection {
                         pair,
                         batch: empty_visibility_batch(max_samples),
                     },
-                    SpectralMode::Cube | SpectralMode::Cubedata => PreparedState::PairedCube {
+                    SpectralMode::Cube | SpectralMode::Cubedata if trace_enabled => {
+                        PreparedState::PairedCube {
+                            plane_stokes: PlaneStokes::I,
+                            transform,
+                            pair,
+                            channel_batches: output_channel_frequencies_hz
+                                .iter()
+                                .map(|_| empty_parallel_hand_batch(16))
+                                .collect(),
+                            channel_density_batches: output_channel_frequencies_hz
+                                .iter()
+                                .map(|_| empty_visibility_batch(16))
+                                .collect(),
+                            channel_model_interpolation_samples: output_channel_frequencies_hz
+                                .iter()
+                                .map(|_| Vec::new())
+                                .collect(),
+                        }
+                    }
+                    SpectralMode::Cube | SpectralMode::Cubedata => PreparedState::CollapsedCube {
                         plane_stokes: PlaneStokes::I,
                         transform,
                         pair,
                         channel_batches: output_channel_frequencies_hz
                             .iter()
-                            .map(|_| empty_parallel_hand_batch(16))
+                            .map(|_| empty_visibility_batch(16))
                             .collect(),
                         channel_density_batches: output_channel_frequencies_hz
                             .iter()
@@ -4138,6 +4200,8 @@ impl PreparedSelection {
                         config.weighting,
                         WeightingMode::Briggs { .. } | WeightingMode::BriggsBwTaper { .. }
                     ),
+                use_density_batches,
+                use_model_interpolation_batches,
                 phase_center,
                 state,
                 trace_state,
@@ -4157,6 +4221,8 @@ impl PreparedSelection {
                 cube_spectral_setup: None,
                 cube_row_spectral_cache: HashMap::new(),
                 casa_cube_grid_interpolation: false,
+                use_density_batches: false,
+                use_model_interpolation_batches: false,
                 phase_center: PhaseCenter {
                     field_id: Some(0),
                     angles_rad: [0.0, 0.0],
@@ -4242,7 +4308,9 @@ impl PreparedSelection {
             .map(|setup| setup.output_channel_frequencies_hz.clone());
         let cube_row_spectral_contributions = if matches!(
             &self.state,
-            PreparedState::ExplicitCube { .. } | PreparedState::PairedCube { .. }
+            PreparedState::ExplicitCube { .. }
+                | PreparedState::PairedCube { .. }
+                | PreparedState::CollapsedCube { .. }
         ) {
             let cube_setup = self
                 .cube_spectral_setup
@@ -4297,6 +4365,8 @@ impl PreparedSelection {
         };
         let trace_enabled = self.trace_enabled;
         let use_casa_cube_grid_interpolation = self.casa_cube_grid_interpolation;
+        let use_density_batches = self.use_density_batches;
+        let use_model_interpolation_batches = self.use_model_interpolation_batches;
         let mfs_freq_ref = self.freq_ref;
         let mfs_frequency_scale = if matches!(
             &self.state,
@@ -4437,34 +4507,36 @@ impl PreparedSelection {
                     .len()
                     .saturating_sub(channel_density_batches.len()))
                     / 2;
-                for (output_channel, density_batch) in
-                    channel_density_batches.iter_mut().enumerate()
-                {
-                    let source_slot = if use_casa_cube_grid_interpolation {
-                        output_channel + density_slot_offset
-                    } else {
-                        match row_spectral_contributions
-                            .source_channel_output_map
-                            .iter()
-                            .position(|mapped| *mapped == Some(output_channel))
-                        {
-                            Some(source_slot) => source_slot,
-                            None => continue,
+                if use_density_batches {
+                    for (output_channel, density_batch) in
+                        channel_density_batches.iter_mut().enumerate()
+                    {
+                        let source_slot = if use_casa_cube_grid_interpolation {
+                            output_channel + density_slot_offset
+                        } else {
+                            match row_spectral_contributions
+                                .source_channel_output_map
+                                .iter()
+                                .position(|mapped| *mapped == Some(output_channel))
+                            {
+                                Some(source_slot) => source_slot,
+                                None => continue,
+                            }
+                        };
+                        if source_slot >= self.source_channel_indices.len() {
+                            continue;
                         }
-                    };
-                    if source_slot >= self.source_channel_indices.len() {
-                        continue;
+                        push_explicit_cube_density_sample(
+                            density_batch,
+                            &flags_2d,
+                            &weights,
+                            *corr_index,
+                            self.source_channel_indices[source_slot],
+                            self.source_channel_frequencies_hz[source_slot],
+                            uvw_m,
+                            is_cross,
+                        )?;
                     }
-                    push_explicit_cube_density_sample(
-                        density_batch,
-                        &flags_2d,
-                        &weights,
-                        *corr_index,
-                        self.source_channel_indices[source_slot],
-                        self.source_channel_frequencies_hz[source_slot],
-                        uvw_m,
-                        is_cross,
-                    )?;
                 }
                 let grid_assignments;
                 let assignment_iter: Box<
@@ -4529,12 +4601,14 @@ impl PreparedSelection {
                     batch.sumwt_factor.push(sample.sumwt_factor);
                     batch.gridable.push(is_cross);
                     batch.visibility.push(sample.visibility);
-                    channel_model_interpolation_samples[output_channel].push(
-                        combine_model_channel_contributions(
-                            contributions,
-                            source_model_contributions,
-                        ),
-                    );
+                    if use_model_interpolation_batches {
+                        channel_model_interpolation_samples[output_channel].push(
+                            combine_model_channel_contributions(
+                                contributions,
+                                source_model_contributions,
+                            ),
+                        );
+                    }
                     channel_samples[output_channel].push(PreparedVisibilitySampleTrace {
                         row_index: selected_row.row_index,
                         input_field_id: selected_row.field_id,
@@ -4765,6 +4839,145 @@ impl PreparedSelection {
                 }
             }
             (
+                PreparedState::CollapsedCube {
+                    plane_stokes,
+                    transform: pair_transform,
+                    channel_batches,
+                    channel_density_batches,
+                    channel_model_interpolation_samples,
+                    pair,
+                },
+                PreparedTraceState::PairedCube { .. },
+            ) => {
+                let row_spectral_contributions = cube_row_spectral_contributions
+                    .as_ref()
+                    .expect("cube spectral contributions prepared for cube state");
+                let source_model_contributions =
+                    &row_spectral_contributions.source_channel_model_contributions;
+                let assignments = &row_spectral_contributions.output_channel_contributions;
+                let density_slot_offset = (self
+                    .source_channel_indices
+                    .len()
+                    .saturating_sub(channel_density_batches.len()))
+                    / 2;
+                if use_density_batches {
+                    for (output_channel, density_batch) in
+                        channel_density_batches.iter_mut().enumerate()
+                    {
+                        let source_slot = if use_casa_cube_grid_interpolation {
+                            output_channel + density_slot_offset
+                        } else {
+                            match row_spectral_contributions
+                                .source_channel_output_map
+                                .iter()
+                                .position(|mapped| *mapped == Some(output_channel))
+                            {
+                                Some(source_slot) => source_slot,
+                                None => continue,
+                            }
+                        };
+                        if source_slot >= self.source_channel_indices.len() {
+                            continue;
+                        }
+                        push_paired_cube_density_sample(
+                            density_batch,
+                            &flags_2d,
+                            &weights,
+                            *pair,
+                            self.source_channel_indices[source_slot],
+                            self.source_channel_frequencies_hz[source_slot],
+                            uvw_m,
+                            is_cross,
+                        )?;
+                    }
+                }
+                let grid_assignments;
+                let assignment_iter: Box<
+                    dyn Iterator<Item = (usize, f64, &[CubeChannelContribution])> + '_,
+                > = if use_casa_cube_grid_interpolation {
+                    Box::new(
+                        row_spectral_contributions
+                            .grid_channel_contributions
+                            .iter()
+                            .map(|grid| {
+                                (
+                                    grid.output_channel,
+                                    grid.grid_frequency_hz,
+                                    grid.contributions.as_slice(),
+                                )
+                            }),
+                    )
+                } else {
+                    grid_assignments = assignments
+                        .iter()
+                        .enumerate()
+                        .map(|(output_channel, contributions)| {
+                            (
+                                output_channel,
+                                cube_output_channel_frequencies_hz
+                                    .as_ref()
+                                    .expect("missing cube spectral setup")[output_channel],
+                                contributions.as_slice(),
+                            )
+                        })
+                        .collect::<Vec<_>>();
+                    Box::new(grid_assignments.into_iter())
+                };
+                let sumwt_factor = reported_sumwt_factor_for_paired_plane(*plane_stokes);
+                for (output_channel, output_frequency_hz, contributions) in assignment_iter {
+                    if contributions.is_empty() {
+                        continue;
+                    }
+                    let Some(sample) = interpolate_paired_cube_output_sample(
+                        data,
+                        flags,
+                        row_weights,
+                        weight_spectrum_row,
+                        *pair,
+                        &self.source_channel_indices,
+                        &self.source_channel_frequencies_hz,
+                        transform.phase_shift_m,
+                        contributions,
+                        use_casa_cube_grid_interpolation,
+                    )?
+                    else {
+                        continue;
+                    };
+                    if !(output_frequency_hz.is_finite() && output_frequency_hz > 0.0) {
+                        continue;
+                    }
+                    let visibility = collapse_paired_visibility(
+                        sample.first_visibility,
+                        sample.second_visibility,
+                        *pair_transform,
+                    );
+                    if !(visibility.re.is_finite() && visibility.im.is_finite()) {
+                        continue;
+                    }
+                    let combined_weight = 0.5 * (sample.first_weight + sample.second_weight);
+                    if !(combined_weight.is_finite() && combined_weight > 0.0) {
+                        continue;
+                    }
+                    let lambda_scale = output_frequency_hz / SPEED_OF_LIGHT_M_PER_S;
+                    let batch = &mut channel_batches[output_channel];
+                    batch.u_lambda.push(uvw_m[0] * lambda_scale);
+                    batch.v_lambda.push(uvw_m[1] * lambda_scale);
+                    batch.w_lambda.push(uvw_m[2] * lambda_scale);
+                    batch.weight.push(combined_weight);
+                    batch.sumwt_factor.push(sumwt_factor);
+                    batch.gridable.push(is_cross);
+                    batch.visibility.push(visibility);
+                    if use_model_interpolation_batches {
+                        channel_model_interpolation_samples[output_channel].push(
+                            combine_model_channel_contributions(
+                                contributions,
+                                source_model_contributions,
+                            ),
+                        );
+                    }
+                }
+            }
+            (
                 PreparedState::PairedCube {
                     channel_batches,
                     channel_density_batches,
@@ -4785,34 +4998,36 @@ impl PreparedSelection {
                     .len()
                     .saturating_sub(channel_density_batches.len()))
                     / 2;
-                for (output_channel, density_batch) in
-                    channel_density_batches.iter_mut().enumerate()
-                {
-                    let source_slot = if use_casa_cube_grid_interpolation {
-                        output_channel + density_slot_offset
-                    } else {
-                        match row_spectral_contributions
-                            .source_channel_output_map
-                            .iter()
-                            .position(|mapped| *mapped == Some(output_channel))
-                        {
-                            Some(source_slot) => source_slot,
-                            None => continue,
+                if use_density_batches {
+                    for (output_channel, density_batch) in
+                        channel_density_batches.iter_mut().enumerate()
+                    {
+                        let source_slot = if use_casa_cube_grid_interpolation {
+                            output_channel + density_slot_offset
+                        } else {
+                            match row_spectral_contributions
+                                .source_channel_output_map
+                                .iter()
+                                .position(|mapped| *mapped == Some(output_channel))
+                            {
+                                Some(source_slot) => source_slot,
+                                None => continue,
+                            }
+                        };
+                        if source_slot >= self.source_channel_indices.len() {
+                            continue;
                         }
-                    };
-                    if source_slot >= self.source_channel_indices.len() {
-                        continue;
+                        push_paired_cube_density_sample(
+                            density_batch,
+                            &flags_2d,
+                            &weights,
+                            *pair,
+                            self.source_channel_indices[source_slot],
+                            self.source_channel_frequencies_hz[source_slot],
+                            uvw_m,
+                            is_cross,
+                        )?;
                     }
-                    push_paired_cube_density_sample(
-                        density_batch,
-                        &flags_2d,
-                        &weights,
-                        *pair,
-                        self.source_channel_indices[source_slot],
-                        self.source_channel_frequencies_hz[source_slot],
-                        uvw_m,
-                        is_cross,
-                    )?;
                 }
                 let grid_assignments;
                 let assignment_iter: Box<
@@ -4880,12 +5095,14 @@ impl PreparedSelection {
                     batch.first_flagged.push(false);
                     batch.second_flagged.push(false);
                     batch.gridable.push(is_cross);
-                    channel_model_interpolation_samples[output_channel].push(
-                        combine_model_channel_contributions(
-                            contributions,
-                            source_model_contributions,
-                        ),
-                    );
+                    if use_model_interpolation_batches {
+                        channel_model_interpolation_samples[output_channel].push(
+                            combine_model_channel_contributions(
+                                contributions,
+                                source_model_contributions,
+                            ),
+                        );
+                    }
                     if trace_enabled {
                         channel_samples[output_channel].push(PendingPairedSampleTrace {
                             common: TraceSampleCommon {
@@ -4949,6 +5166,8 @@ impl PreparedSelection {
             cube_spectral_setup: _,
             cube_row_spectral_cache: _,
             casa_cube_grid_interpolation: _,
+            use_density_batches: _,
+            use_model_interpolation_batches: _,
             phase_center,
             state,
             trace_state: _,
@@ -5018,6 +5237,8 @@ impl PreparedSelection {
             cube_spectral_setup,
             cube_row_spectral_cache: _,
             casa_cube_grid_interpolation: _,
+            use_density_batches,
+            use_model_interpolation_batches,
             phase_center,
             state,
             trace_state: _,
@@ -5048,14 +5269,55 @@ impl PreparedSelection {
                         )| CubeChannelRequest {
                             channel_frequency_hz,
                             visibility_batches: chunk_visibility_batch(batch, DEFAULT_BATCH_SIZE),
-                            density_batches: chunk_visibility_batch(
+                            density_batches: chunk_density_batch(
                                 density_batch,
-                                DEFAULT_BATCH_SIZE,
+                                use_density_batches,
                             ),
-                            model_interpolation_batches: chunk_model_interpolation_batches(
-                                model_interpolation_samples,
-                                DEFAULT_BATCH_SIZE,
+                            model_interpolation_batches:
+                                chunk_model_interpolation_batches_if_needed(
+                                    model_interpolation_samples,
+                                    use_model_interpolation_batches,
+                                ),
+                        },
+                    )
+                    .collect();
+                Ok(PreparedInput::Cube(CubePlaneInput {
+                    phase_center,
+                    freq_ref,
+                    plane_stokes,
+                    channels,
+                }))
+            }
+            PreparedState::CollapsedCube {
+                plane_stokes,
+                transform: _,
+                pair: _,
+                channel_batches,
+                channel_density_batches,
+                channel_model_interpolation_samples,
+            } => {
+                let channels = output_channel_frequencies_hz
+                    .iter()
+                    .copied()
+                    .zip(channel_batches)
+                    .zip(channel_density_batches)
+                    .zip(channel_model_interpolation_samples)
+                    .map(
+                        |(
+                            ((channel_frequency_hz, batch), density_batch),
+                            model_interpolation_samples,
+                        )| CubeChannelRequest {
+                            channel_frequency_hz,
+                            visibility_batches: chunk_visibility_batch(batch, DEFAULT_BATCH_SIZE),
+                            density_batches: chunk_density_batch(
+                                density_batch,
+                                use_density_batches,
                             ),
+                            model_interpolation_batches:
+                                chunk_model_interpolation_batches_if_needed(
+                                    model_interpolation_samples,
+                                    use_model_interpolation_batches,
+                                ),
                         },
                     )
                     .collect();
@@ -5089,25 +5351,30 @@ impl PreparedSelection {
                                 collapse_paired_visibility_batch(&batch, transform, plane_stokes)
                                     .map_err(|error| error.to_string())?;
                             let collapsed_model_interpolation_samples =
-                                collapse_paired_model_interpolation_samples_from_batch(
-                                    &batch,
-                                    model_interpolation_samples,
-                                    transform,
-                                )?;
+                                if use_model_interpolation_batches {
+                                    collapse_paired_model_interpolation_samples_from_batch(
+                                        &batch,
+                                        model_interpolation_samples,
+                                        transform,
+                                    )?
+                                } else {
+                                    Vec::new()
+                                };
                             Ok(CubeChannelRequest {
                                 channel_frequency_hz,
                                 visibility_batches: chunk_visibility_batch(
                                     collapsed,
                                     DEFAULT_BATCH_SIZE,
                                 ),
-                                density_batches: chunk_visibility_batch(
+                                density_batches: chunk_density_batch(
                                     density_batch,
-                                    DEFAULT_BATCH_SIZE,
+                                    use_density_batches,
                                 ),
-                                model_interpolation_batches: chunk_model_interpolation_batches(
-                                    collapsed_model_interpolation_samples,
-                                    DEFAULT_BATCH_SIZE,
-                                ),
+                                model_interpolation_batches:
+                                    chunk_model_interpolation_batches_if_needed(
+                                        collapsed_model_interpolation_samples,
+                                        use_model_interpolation_batches,
+                                    ),
                             })
                         },
                     )
@@ -5143,6 +5410,8 @@ impl PreparedSelection {
             cube_spectral_setup,
             cube_row_spectral_cache: _,
             casa_cube_grid_interpolation: _,
+            use_density_batches,
+            use_model_interpolation_batches,
             phase_center: prepared_phase_center,
             state,
             trace_state,
@@ -5255,14 +5524,15 @@ impl PreparedSelection {
                                     batch,
                                     DEFAULT_BATCH_SIZE,
                                 ),
-                                density_batches: chunk_visibility_batch(
+                                density_batches: chunk_density_batch(
                                     density_batch,
-                                    DEFAULT_BATCH_SIZE,
+                                    use_density_batches,
                                 ),
-                                model_interpolation_batches: chunk_model_interpolation_batches(
-                                    model_interpolation_samples,
-                                    DEFAULT_BATCH_SIZE,
-                                ),
+                                model_interpolation_batches:
+                                    chunk_model_interpolation_batches_if_needed(
+                                        model_interpolation_samples,
+                                        use_model_interpolation_batches,
+                                    ),
                             }
                         },
                     )
@@ -5304,25 +5574,30 @@ impl PreparedSelection {
                                 collapse_paired_visibility_batch(&batch, transform, plane_stokes)
                                     .map_err(|error| error.to_string())?;
                             let collapsed_model_interpolation_samples =
-                                collapse_pending_pair_model_interpolation_samples(
-                                    trace_samples,
-                                    model_interpolation_samples,
-                                    transform,
-                                )?;
+                                if use_model_interpolation_batches {
+                                    collapse_pending_pair_model_interpolation_samples(
+                                        trace_samples,
+                                        model_interpolation_samples,
+                                        transform,
+                                    )?
+                                } else {
+                                    Vec::new()
+                                };
                             Ok(CubeChannelRequest {
                                 channel_frequency_hz,
                                 visibility_batches: chunk_visibility_batch(
                                     collapsed,
                                     DEFAULT_BATCH_SIZE,
                                 ),
-                                density_batches: chunk_visibility_batch(
+                                density_batches: chunk_density_batch(
                                     density_batch,
-                                    DEFAULT_BATCH_SIZE,
+                                    use_density_batches,
                                 ),
-                                model_interpolation_batches: chunk_model_interpolation_batches(
-                                    collapsed_model_interpolation_samples,
-                                    DEFAULT_BATCH_SIZE,
-                                ),
+                                model_interpolation_batches:
+                                    chunk_model_interpolation_batches_if_needed(
+                                        collapsed_model_interpolation_samples,
+                                        use_model_interpolation_batches,
+                                    ),
                             })
                         },
                     )
@@ -6332,6 +6607,14 @@ fn chunk_visibility_batch(batch: VisibilityBatch, max_batch_size: usize) -> Vec<
     batches
 }
 
+fn chunk_density_batch(batch: VisibilityBatch, use_density_batches: bool) -> Vec<VisibilityBatch> {
+    if use_density_batches {
+        chunk_visibility_batch(batch, DEFAULT_BATCH_SIZE)
+    } else {
+        Vec::new()
+    }
+}
+
 fn chunk_sample_frequencies_hz_from_samples(
     samples: &[PreparedVisibilitySampleTrace],
     max_batch_size: usize,
@@ -6609,6 +6892,17 @@ fn chunk_model_interpolation_batches(
         start = end;
     }
     batches
+}
+
+fn chunk_model_interpolation_batches_if_needed(
+    sample_contributions: Vec<Vec<CubeModelChannelContribution>>,
+    use_model_interpolation_batches: bool,
+) -> Vec<CubeModelInterpolationBatch> {
+    if use_model_interpolation_batches {
+        chunk_model_interpolation_batches(sample_contributions, DEFAULT_BATCH_SIZE)
+    } else {
+        Vec::new()
+    }
 }
 
 enum ComplexRow2d<'a> {

--- a/crates/casars-python/python/casars/_task_runtime.py
+++ b/crates/casars-python/python/casars/_task_runtime.py
@@ -40,6 +40,8 @@ IMEXPLORE_BINARY_NAME = "imexplore"
 IMEXPLORE_BINARY_ENVVAR = "CASARS_IMEXPLORE_BIN"
 IMMOMENTS_BINARY_NAME = "immoments"
 IMMOMENTS_BINARY_ENVVAR = "CASARS_IMMOMENTS_BIN"
+IMPV_BINARY_NAME = "impv"
+IMPV_BINARY_ENVVAR = "CASARS_IMPV_BIN"
 EXPORTFITS_BINARY_NAME = "exportfits"
 EXPORTFITS_BINARY_ENVVAR = "CASARS_EXPORTFITS_BIN"
 IMPORTFITS_BINARY_NAME = "importfits"
@@ -53,6 +55,7 @@ _configured_msexplore_binary: str | None = None
 _configured_imager_binary: str | None = None
 _configured_imexplore_binary: str | None = None
 _configured_immoments_binary: str | None = None
+_configured_impv_binary: str | None = None
 _configured_exportfits_binary: str | None = None
 _configured_importfits_binary: str | None = None
 
@@ -169,6 +172,13 @@ def configure_immoments_binary(binary: StrPath | None) -> None:
     _configured_immoments_binary = None if binary is None else os.fspath(binary)
 
 
+def configure_impv_binary(binary: StrPath | None) -> None:
+    """Set or clear the module-wide default impv binary override."""
+
+    global _configured_impv_binary
+    _configured_impv_binary = None if binary is None else os.fspath(binary)
+
+
 def configure_exportfits_binary(binary: StrPath | None) -> None:
     """Set or clear the module-wide default exportfits binary override."""
 
@@ -258,6 +268,19 @@ def resolve_immoments_binary(binary: StrPath | None = None) -> str:
         binary_name=IMMOMENTS_BINARY_NAME,
         missing_error_cls=ImageAnalysisBinaryNotFoundError,
         description="immoments",
+    )
+
+
+def resolve_impv_binary(binary: StrPath | None = None) -> str:
+    """Resolve the impv binary using the documented precedence order."""
+
+    return _resolve_task_binary(
+        binary=binary,
+        configured_binary=_configured_impv_binary,
+        envvar=IMPV_BINARY_ENVVAR,
+        binary_name=IMPV_BINARY_NAME,
+        missing_error_cls=ImageAnalysisBinaryNotFoundError,
+        description="impv",
     )
 
 
@@ -352,6 +375,19 @@ def get_immoments_protocol_info(binary: StrPath | None = None) -> ProtocolInfo:
     )
 
 
+def get_impv_protocol_info(binary: StrPath | None = None) -> ProtocolInfo:
+    """Return validated protocol info for the selected impv binary."""
+
+    resolved = resolve_impv_binary(binary)
+    return _validated_protocol_info(
+        resolved,
+        protocol_name=IMAGE_ANALYSIS_PROTOCOL_NAME,
+        protocol_version=IMAGE_ANALYSIS_PROTOCOL_VERSION,
+        mismatch_error_cls=ImageAnalysisProtocolMismatchError,
+        invocation_error_cls=ImageAnalysisInvocationError,
+    )
+
+
 def get_exportfits_protocol_info(binary: StrPath | None = None) -> ProtocolInfo:
     """Return validated protocol info for the selected exportfits binary."""
 
@@ -414,6 +450,14 @@ def fetch_immoments_schema(binary: StrPath | None = None) -> dict[str, Any]:
     """Fetch the JSON schema bundle advertised by the immoments binary."""
 
     resolved = resolve_immoments_binary(binary)
+    stdout = _run_process([resolved, "--json-schema"], error_cls=ImageAnalysisInvocationError)
+    return json.loads(stdout)
+
+
+def fetch_impv_schema(binary: StrPath | None = None) -> dict[str, Any]:
+    """Fetch the JSON schema bundle advertised by the impv binary."""
+
+    resolved = resolve_impv_binary(binary)
     stdout = _run_process([resolved, "--json-schema"], error_cls=ImageAnalysisInvocationError)
     return json.loads(stdout)
 
@@ -550,6 +594,30 @@ def invoke_immoments_task(
         invocation_error_cls=ImageAnalysisInvocationError,
     )
     payload = json.dumps({"kind": "immoments", "request": request}, sort_keys=True)
+    stdout = _run_process(
+        [resolved, "--json-run", "-"],
+        stdin=payload,
+        error_cls=ImageAnalysisInvocationError,
+    )
+    return json.loads(stdout)
+
+
+def invoke_impv_task(
+    *,
+    request: dict[str, Any],
+    binary: StrPath | None = None,
+) -> dict[str, Any]:
+    """Run one impv task request through ``impv --json-run -``."""
+
+    resolved = resolve_impv_binary(binary)
+    _validated_protocol_info(
+        resolved,
+        protocol_name=IMAGE_ANALYSIS_PROTOCOL_NAME,
+        protocol_version=IMAGE_ANALYSIS_PROTOCOL_VERSION,
+        mismatch_error_cls=ImageAnalysisProtocolMismatchError,
+        invocation_error_cls=ImageAnalysisInvocationError,
+    )
+    payload = json.dumps({"kind": "impv", "request": request}, sort_keys=True)
     stdout = _run_process(
         [resolved, "--json-run", "-"],
         stdin=payload,

--- a/crates/casars-python/python/casars/tasks/calibrate.py
+++ b/crates/casars-python/python/casars/tasks/calibrate.py
@@ -26,6 +26,7 @@ GainSolveMode: TypeAlias = Literal["p", "ap"]
 GainSolveModelSource: TypeAlias = Literal["point", "point_source", "model_column"]
 GainSolveInterval: TypeAlias = Literal["inf", "int"] | float
 BandpassType: TypeAlias = Literal["b", "bpoly"]
+GencalType: TypeAlias = Literal["antpos", "gceff", "gc", "opac"]
 GainFieldValue: TypeAlias = int | str | Literal["nearest"]
 ReferenceAntenna: TypeAlias = int | str
 StatsAxis: TypeAlias = Literal["amp", "phase", "real", "imag"] | str
@@ -369,6 +370,36 @@ def fluxscale(
     )
 
 
+def gencal(
+    measurement_set: StrPath,
+    output_table: StrPath,
+    *,
+    caltype: GencalType,
+    antenna: str = "",
+    spw: str = "",
+    parameter: Sequence[float] = (),
+    gaincurve_table: StrPath | None = None,
+    binary: StrPath | None = None,
+) -> TaskResult:
+    """Generate a native CASA-compatible prior calibration table."""
+
+    return invoke_calibration_task(
+        kind="gencal",
+        request={
+            "measurement_set": os.fspath(measurement_set),
+            "output_table": os.fspath(output_table),
+            "caltype": caltype,
+            "antenna": antenna,
+            "spw": spw,
+            "parameter": [float(value) for value in parameter],
+            "gaincurve_table": None
+            if gaincurve_table is None
+            else os.fspath(gaincurve_table),
+        },
+        binary=binary,
+    )
+
+
 def validate_signature_parity(*, binary: StrPath | None = None) -> None:
     """Fail if the Python wrapper metadata drifts from the Rust task schema."""
 
@@ -698,6 +729,35 @@ _WRAPPER_CONTRACTS: dict[str, dict[str, Any]] = {
             "binary": None,
         },
     },
+    "gencal": {
+        "schema": "GencalRequest",
+        "request_fields": [
+            "measurement_set",
+            "output_table",
+            "caltype",
+            "antenna",
+            "spw",
+            "parameter",
+            "gaincurve_table",
+        ],
+        "signature": [
+            "measurement_set",
+            "output_table",
+            "caltype",
+            "antenna",
+            "spw",
+            "parameter",
+            "gaincurve_table",
+            "binary",
+        ],
+        "defaults": {
+            "antenna": "",
+            "spw": "",
+            "parameter": (),
+            "gaincurve_table": None,
+            "binary": None,
+        },
+    },
 }
 
 __all__ = [
@@ -711,6 +771,7 @@ __all__ = [
     "GainSolveMode",
     "GainSolveModelSource",
     "GainType",
+    "GencalType",
     "InterpolationMode",
     "ProtocolInfo",
     "ReferenceAntenna",
@@ -723,6 +784,7 @@ __all__ = [
     "continuum_subtract",
     "export_corrected_data",
     "fluxscale",
+    "gencal",
     "plan_apply",
     "protocol_info",
     "schema",

--- a/crates/casars-python/python/casars/tasks/image_analysis.py
+++ b/crates/casars-python/python/casars/tasks/image_analysis.py
@@ -11,16 +11,20 @@ from .._task_runtime import (
     configure_exportfits_binary,
     configure_imexplore_binary,
     configure_immoments_binary,
+    configure_impv_binary,
     configure_importfits_binary,
     fetch_exportfits_schema,
     fetch_immoments_schema,
+    fetch_impv_schema,
     fetch_importfits_schema,
     get_exportfits_protocol_info,
     get_immoments_protocol_info,
+    get_impv_protocol_info,
     get_importfits_protocol_info,
     invoke_exportfits_task,
     invoke_imexplore_json_subcommand,
     invoke_immoments_task,
+    invoke_impv_task,
     invoke_importfits_task,
 )
 
@@ -32,6 +36,7 @@ def configure(
     *,
     imexplore_binary: StrPath | None = None,
     immoments_binary: StrPath | None = None,
+    impv_binary: StrPath | None = None,
     exportfits_binary: StrPath | None = None,
     importfits_binary: StrPath | None = None,
 ) -> None:
@@ -39,6 +44,7 @@ def configure(
 
     configure_imexplore_binary(imexplore_binary)
     configure_immoments_binary(immoments_binary)
+    configure_impv_binary(impv_binary)
     configure_exportfits_binary(exportfits_binary)
     configure_importfits_binary(importfits_binary)
 
@@ -47,6 +53,12 @@ def immoments_protocol_info(*, binary: StrPath | None = None) -> ProtocolInfo:
     """Return validated protocol information for the selected ``immoments`` binary."""
 
     return get_immoments_protocol_info(binary=binary)
+
+
+def impv_protocol_info(*, binary: StrPath | None = None) -> ProtocolInfo:
+    """Return validated protocol information for the selected ``impv`` binary."""
+
+    return get_impv_protocol_info(binary=binary)
 
 
 def exportfits_protocol_info(*, binary: StrPath | None = None) -> ProtocolInfo:
@@ -65,6 +77,12 @@ def immoments_schema(*, binary: StrPath | None = None) -> dict[str, Any]:
     """Return the Rust-emitted ``immoments`` schema bundle."""
 
     return fetch_immoments_schema(binary=binary)
+
+
+def impv_schema(*, binary: StrPath | None = None) -> dict[str, Any]:
+    """Return the Rust-emitted ``impv`` schema bundle."""
+
+    return fetch_impv_schema(binary=binary)
 
 
 def exportfits_schema(*, binary: StrPath | None = None) -> dict[str, Any]:
@@ -123,6 +141,33 @@ def immoments(
         "overwrite": overwrite,
     }
     return invoke_immoments_task(request=request, binary=binary)
+
+
+def impv(
+    imagename: StrPath,
+    *,
+    outfile: StrPath,
+    start: str,
+    end: str,
+    mode: str = "coords",
+    width: int = 1,
+    chans: str | None = None,
+    overwrite: bool = False,
+    binary: StrPath | None = None,
+) -> TaskResult:
+    """Run CASA-style ``impv`` through the Rust task binary."""
+
+    request = {
+        "imagename": os.fspath(imagename),
+        "outfile": os.fspath(outfile),
+        "mode": mode,
+        "start": start,
+        "end": end,
+        "width": width,
+        "chans": chans,
+        "overwrite": overwrite,
+    }
+    return invoke_impv_task(request=request, binary=binary)
 
 
 def exportfits(

--- a/crates/casars-python/python/tests/test_image_analysis.py
+++ b/crates/casars-python/python/tests/test_image_analysis.py
@@ -15,11 +15,13 @@ def reset_image_analysis_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
     image_analysis.configure(
         imexplore_binary=None,
         immoments_binary=None,
+        impv_binary=None,
         exportfits_binary=None,
         importfits_binary=None,
     )
     monkeypatch.delenv("CASARS_IMEXPLORE_BIN", raising=False)
     monkeypatch.delenv("CASARS_IMMOMENTS_BIN", raising=False)
+    monkeypatch.delenv("CASARS_IMPV_BIN", raising=False)
     monkeypatch.delenv("CASARS_EXPORTFITS_BIN", raising=False)
     monkeypatch.delenv("CASARS_IMPORTFITS_BIN", raising=False)
     monkeypatch.delenv("CASARS_SUITE_ROOT", raising=False)
@@ -88,6 +90,31 @@ def test_exportfits_wrapper_encodes_task_request(tmp_path: Path) -> None:
     assert request["imagename"] == "twhya_n2hp.image"
     assert request["fitsimage"] == "twhya_n2hp.fits"
     assert request["velocity"] is True
+    assert request["overwrite"] is True
+
+
+def test_impv_wrapper_encodes_task_request(tmp_path: Path) -> None:
+    binary = _write_task_stub(tmp_path / "bin" / "impv", version="ok")
+
+    result = image_analysis.impv(
+        "IRC10216_HC3N.cube.image",
+        outfile="IRC10216_HC3N.pv.image",
+        start="120,140",
+        end="180,160",
+        width=3,
+        chans="11~40",
+        overwrite=True,
+        binary=binary,
+    )
+
+    assert result["kind"] == "impv"
+    request = result["result"]["request"]
+    assert request["imagename"] == "IRC10216_HC3N.cube.image"
+    assert request["outfile"] == "IRC10216_HC3N.pv.image"
+    assert request["start"] == "120,140"
+    assert request["end"] == "180,160"
+    assert request["width"] == 3
+    assert request["chans"] == "11~40"
     assert request["overwrite"] is True
 
 

--- a/crates/casars/src/app.rs
+++ b/crates/casars/src/app.rs
@@ -10014,6 +10014,10 @@ impl AppState {
                 self.apply_inspection_defaults_for_path(report.output_table.display().to_string());
                 self.activate_result_tab(ResultTab::Diagnostics);
             }
+            ManagedCalibrationOutput::Gencal(report) => {
+                self.apply_inspection_defaults_for_path(report.output_table.display().to_string());
+                self.activate_result_tab(ResultTab::Diagnostics);
+            }
             ManagedCalibrationOutput::Stats(report) => {
                 self.apply_inspection_defaults_for_path(report.path.display().to_string());
                 self.activate_result_tab(ResultTab::Diagnostics);
@@ -10163,6 +10167,15 @@ impl AppState {
                 vec![
                     format!("output={}", report.output_table.display()),
                     format!("fields={}", report.fields.len()),
+                ],
+            ),
+            ManagedCalibrationOutput::Gencal(report) => (
+                Some(WorkflowStageId::InspectResults),
+                "Generate Prior Cal".to_string(),
+                vec![
+                    format!("output={}", report.output_table.display()),
+                    format!("rows={}", report.row_count),
+                    format!("subtype={}", report.table_subtype),
                 ],
             ),
         };
@@ -12995,6 +13008,7 @@ impl AppState {
             ManagedCalibrationOutput::SolveGain(report) => &report.output_table,
             ManagedCalibrationOutput::SolveBandpass(report) => &report.output_table,
             ManagedCalibrationOutput::FluxScale(report) => &report.output_table,
+            ManagedCalibrationOutput::Gencal(report) => &report.output_table,
             ManagedCalibrationOutput::Apply(_)
             | ManagedCalibrationOutput::ContinuumSubtract(_)
             | ManagedCalibrationOutput::ExportCorrectedData(_)
@@ -13865,6 +13879,19 @@ fn build_calibration_overview_lines(report: &ManagedCalibrationOutput) -> Vec<St
                 "Transfer fields: {}   SPWs: {}",
                 report.fields.len(),
                 report.spw_ids.len()
+            ),
+        ],
+        ManagedCalibrationOutput::Gencal(report) => vec![
+            "Prior Calibration".to_string(),
+            format!("Output: {}", report.output_table.display()),
+            format!(
+                "Type: {:?}   Subtype: {}   Rows: {}",
+                report.caltype, report.table_subtype, report.row_count
+            ),
+            format!(
+                "Antennas: {}   SPWs: {}",
+                report.antenna_ids.len(),
+                report.spectral_window_ids.len()
             ),
         ],
     }

--- a/crates/casars/src/app.rs
+++ b/crates/casars/src/app.rs
@@ -14018,6 +14018,7 @@ fn calibrate_argument_applies_to_mode(field_id: &str, mode: &str) -> bool {
         "out_table" | "refant" => matches!(mode, "solve_gain" | "solve_bandpass"),
         "gain_type" | "solve_mode" | "solint" | "gain_combine" | "gain_model_source"
         | "min_snr" => mode == "solve_gain",
+        "smodel" => matches!(mode, "solve_gain" | "solve_bandpass"),
         "solnorm" => matches!(mode, "solve_gain" | "solve_bandpass"),
         "bandpass_combine" | "bandtype" => mode == "solve_bandpass",
         "fluxscale_input" | "reference_fields" | "transfer_fields" | "refspwmap"

--- a/crates/casars/src/calibration_workflow.rs
+++ b/crates/casars/src/calibration_workflow.rs
@@ -314,6 +314,7 @@ pub(crate) fn workflow_stage_from_report(
         ManagedCalibrationOutput::SolveGain(_) => Some(WorkflowStageId::SolveGain),
         ManagedCalibrationOutput::SolveBandpass(_) => Some(WorkflowStageId::SolveBandpass),
         ManagedCalibrationOutput::FluxScale(_) => Some(WorkflowStageId::FluxScale),
+        ManagedCalibrationOutput::Gencal(_) => Some(WorkflowStageId::InspectResults),
         ManagedCalibrationOutput::PlanApply(_) => None,
     }
 }
@@ -339,6 +340,12 @@ pub(crate) fn workflow_product_metadata_from_report(
             WorkflowStageId::FluxScale,
             "Fluxscale".to_string(),
             "fluxscale output".to_string(),
+        )),
+        ManagedCalibrationOutput::Gencal(report) => Some((
+            report.output_table.clone(),
+            WorkflowStageId::InspectResults,
+            report.table_subtype.clone(),
+            "generated prior calibration table".to_string(),
         )),
         ManagedCalibrationOutput::Apply(report) => {
             report.plan.measurement_set_path.clone().map(|path| {

--- a/crates/casars/src/registry.rs
+++ b/crates/casars/src/registry.rs
@@ -651,6 +651,7 @@ mod tests {
                 "solve_gain",
                 "solve_bandpass",
                 "fluxscale",
+                "gencal",
             ]
         );
         let gaintables = schema

--- a/docs/tutorial-parity/capability-matrix.md
+++ b/docs/tutorial-parity/capability-matrix.md
@@ -52,7 +52,7 @@ Status legend:
 | `bandpass` | partial/available | `casa-calibration` | `calibrate` | VLA tutorial parameter coverage, BPOLY tails | CASA bandpass caltables | calibration benchmark scripts | #122, #128 |
 | `fluxscale` | partial/available | `casa-calibration` | `calibrate` | VLA tutorial models/fields, selection tails | CASA fluxscale tables/results | calibration benchmark scripts | #122 |
 | `setjy` | missing/partial model setup | `casa-calibration`, `casa-ms` | no first-class task stage | calibrator model setup, component/image model writes | CASA model columns/caltable downstream parity | tutorial calibration timings | #122 |
-| `gencal` | missing/partial | `casa-calibration` | none | antenna-position, opacity, gaincurve, prior-cal tutorial subset | CASA generated caltables | tutorial prior-cal timings | #121 |
+| `gencal` | partial/available | `casa-calibration` | `calibrate gencal`, Python calibration wrapper | automatic antenna-position lookup, remaining caltypes beyond antpos/gceff/opac | CASA generated caltables | tutorial prior-cal timings | #121 |
 | `flagdata` | missing/partial | `casa-ms` | no tutorial task surface | manual/list/rflag/tfcrop subsets used by VLA/ALMA breadth | CASA FLAG column deltas | flagging timing on tutorial MS | #121, #128 |
 | `flagmanager` | missing | `casa-ms` | none | save/restore flag versions | CASA flag version products | VLA/ALMA breadth timing | #127, #128 |
 | `statwt` | missing | `casa-ms` | none | weight recomputation for data-combination tutorials | CASA WEIGHT/SIGMA columns | tutorial timing | #127, #128 |

--- a/docs/tutorial-parity/wave-4-issue-121-vla-irc10216-foundation.md
+++ b/docs/tutorial-parity/wave-4-issue-121-vla-irc10216-foundation.md
@@ -1,8 +1,8 @@
 # Wave 4 Issue 121 - VLA IRC+10216 Foundation
 
 Truth class: current descriptive
-Last reality check: 2026-04-29
-Verification: `cargo test -p casa-ms --test msexplore_cli cli_flag_selected_applies_to_selected_rows_without_plot_region`; `scripts/run-vla-irc10216-issue121.sh`
+Last reality check: 2026-04-30
+Verification: `cargo test -p casa-ms --test msexplore_cli cli_flag_selected_applies_to_selected_rows_without_plot_region`; `cargo check -p casa-calibration`; `scripts/run-vla-irc10216-issue121.sh`
 
 Wave issue: #141
 Child issue: #121
@@ -36,8 +36,8 @@ The tutorial inputs are registry artifacts:
 | `listobs(vis="TDRW0001_10s.ms")` | `casa-ms` / `msexplore` | `msexplore --format json ...` emits structured summary JSON for the real tutorial MS. |
 | Initial `plotms` inspection | `casa-ms` / `msexplore` | Side-by-side CASA/casa-rs PNGs cover IRC+10216 scan-6 amplitude vs time and J1229+0203 scan-56 amplitude vs 4-channel bin. |
 | `flagdata(mode="list")` for two low-amplitude ranges | `casa-ms` / `msexplore` | `msexplore --flag-action flag --flag-selected --flag-apply` applies row-selection flag edits and writes selected-summary JSON evidence. |
-| Prior `gencal` tables: `cal.ant`, `cal.gc`, `cal.tau` | future `casa-calibration` work | Not implemented as native table generation in this slice; the exact tutorial impact is confined to the prior-cal corrected MS handoff before #122. |
-| `applycal(... ["cal.ant","cal.gc","cal.tau"])` and `split(datacolumn="corrected")` | `casa-calibration` / `casa-ms` | Existing apply/split coverage does not yet accept these generated prior tables natively; #122 owns the deeper solve/apply parity after this handoff. |
+| Prior `gencal` tables: `cal.ant`, `cal.gc`, `cal.tau` | `casa-calibration` | `calibrate gencal` writes CASA-compatible `KAntPos Jones`, `EGainCurve`, and `TOpac` float caltables for the tutorial prior-cal subset. |
+| `applycal(... ["cal.ant","cal.gc","cal.tau"])` and `split(datacolumn="corrected")` | `casa-calibration` / `casa-ms` | The prior-cal tables are generated natively in #121; #122 owns applying the full prior-cal chain while solving and producing the corrected calibration handoff. |
 
 The real tutorial MS resolves to four fields: `0=J0954+1743`,
 `1=IRC+10216`, `2=J1229+0203`, and `3=1331+305=3C286`, with two spectral
@@ -54,22 +54,28 @@ a fresh evidence run separate from earlier mutated MS copies.
 scripts/run-vla-irc10216-issue121.sh
 ```
 
-Expected visible artifacts:
+Expected visible artifacts and machine-readable evidence:
 
 - `target/wdad-wave4-121/irc10216-target-scan6-amplitude-time-side-by-side.png`
 - `target/wdad-wave4-121/irc10216-bandpass-scan56-amplitude-channel-side-by-side.png`
+- `target/wdad-wave4-121/irc10216-priorcal-fparam-casa-vs-rust.png`
+- `target/wdad-wave4-121/priorcal-comparison.json`
+- `target/wdad-wave4-121/priorcal-casa-cli-timing.json`
+- `target/wdad-wave4-121/priorcal-rust-cli-timing.json`
+- `target/wdad-wave4-121/priorcal-casa-timing.json`
+- `target/wdad-wave4-121/priorcal-rust-timing.json`
 - `target/wdad-wave4-121/flag-j1229-selection-summary.json`
 - `target/wdad-wave4-121/flag-3c286-selection-summary.json`
 
-## Unsupported #121 Surface
+## Implemented Prior-Cal Surface
 
-The unsupported prior-cal surface is deliberately narrow and explicit:
+The native `gencal` surface is deliberately narrow and tutorial-bound:
 
-- native `gencal(caltype="antpos")` for `cal.ant`;
-- native `gencal(caltype="gceff")` for `cal.gc`;
-- native `gencal(caltype="opac")` for `cal.tau`;
-- native apply of that prior-cal table chain into a corrected-data split.
+- `gencal(caltype="antpos")` writes `KAntPos Jones` `FPARAM` triples for explicit antenna offsets;
+- `gencal(caltype="gceff")` reads the CASA VLA `GainCurves` table and writes `EGainCurve` coefficients scaled by the VLA efficiency curve;
+- `gencal(caltype="opac")` writes `TOpac` opacity values for selected SPWs.
 
-Those items require calibration-table generation semantics rather than a new
-top-level app family. They should be implemented in `casa-calibration` before
-declaring the full prior-cal handoff native.
+Automatic VLA antenna-position lookup is not implemented in #121; the script
+passes the tutorial offsets explicitly. Native application of `KAntPos Jones`,
+`EGainCurve`, and `TOpac` into corrected data remains part of the deeper #122
+solve/apply parity work.

--- a/docs/tutorial-parity/wave-4-issue-121-vla-irc10216-foundation.md
+++ b/docs/tutorial-parity/wave-4-issue-121-vla-irc10216-foundation.md
@@ -1,0 +1,75 @@
+# Wave 4 Issue 121 - VLA IRC+10216 Foundation
+
+Truth class: current descriptive
+Last reality check: 2026-04-29
+Verification: `cargo test -p casa-ms --test msexplore_cli cli_flag_selected_applies_to_selected_rows_without_plot_region`; `scripts/run-vla-irc10216-issue121.sh`
+
+Wave issue: #141
+Child issue: #121
+
+This note records the CASA-to-casa-rs mapping for the first VLA IRC+10216
+tutorial segment. It stays inside the existing `casa-ms` / `msexplore` and
+`casa-calibration` surfaces; it does not add a new flagging or calibration app
+family.
+
+## Dataset
+
+The tutorial inputs are registry artifacts:
+
+- key: `vla/irc10216/ms-10s`
+- source artifact: `TDRW0001_10s.ms.tgz`
+- expected SHA-256:
+  `96292e62103b51a456e9a6620ffab54ca00785448935122eaf714aa5b21308cb`
+- local policy:
+  `${CASA_RS_TUTORIAL_DATA_ROOT}/tutorial-parity/vla/irc10216/TDRW0001_10s.ms.tgz`
+- key: `vla/irc10216/fors1-fits`
+- source artifact: `irc_fors1_dec_header.fits`
+- expected SHA-256:
+  `9e476e1f98f63d9d870dfa1d72f6705ca40aed3c006115742a0bb2922cbd8071`
+- local policy:
+  `${CASA_RS_TUTORIAL_DATA_ROOT}/tutorial-parity/vla/irc10216/irc_fors1_dec_header.fits`
+
+## Tutorial Mapping
+
+| CASA tutorial operation | casa-rs owner | Wave 4 #121 mapping |
+|---|---|---|
+| `listobs(vis="TDRW0001_10s.ms")` | `casa-ms` / `msexplore` | `msexplore --format json ...` emits structured summary JSON for the real tutorial MS. |
+| Initial `plotms` inspection | `casa-ms` / `msexplore` | Side-by-side CASA/casa-rs PNGs cover IRC+10216 scan-6 amplitude vs time and J1229+0203 scan-56 amplitude vs 4-channel bin. |
+| `flagdata(mode="list")` for two low-amplitude ranges | `casa-ms` / `msexplore` | `msexplore --flag-action flag --flag-selected --flag-apply` applies row-selection flag edits and writes selected-summary JSON evidence. |
+| Prior `gencal` tables: `cal.ant`, `cal.gc`, `cal.tau` | future `casa-calibration` work | Not implemented as native table generation in this slice; the exact tutorial impact is confined to the prior-cal corrected MS handoff before #122. |
+| `applycal(... ["cal.ant","cal.gc","cal.tau"])` and `split(datacolumn="corrected")` | `casa-calibration` / `casa-ms` | Existing apply/split coverage does not yet accept these generated prior tables natively; #122 owns the deeper solve/apply parity after this handoff. |
+
+The real tutorial MS resolves to four fields: `0=J0954+1743`,
+`1=IRC+10216`, `2=J1229+0203`, and `3=1331+305=3C286`, with two spectral
+windows.
+
+## Executable Evidence
+
+The wave script stages the registry tarball under `target/wdad-wave4-121`
+by default, renders visible CASA-vs-casa-rs plot artifacts, and applies the two
+tutorial flagging ranges. Pass an output directory as the first argument to keep
+a fresh evidence run separate from earlier mutated MS copies.
+
+```bash
+scripts/run-vla-irc10216-issue121.sh
+```
+
+Expected visible artifacts:
+
+- `target/wdad-wave4-121/irc10216-target-scan6-amplitude-time-side-by-side.png`
+- `target/wdad-wave4-121/irc10216-bandpass-scan56-amplitude-channel-side-by-side.png`
+- `target/wdad-wave4-121/flag-j1229-selection-summary.json`
+- `target/wdad-wave4-121/flag-3c286-selection-summary.json`
+
+## Unsupported #121 Surface
+
+The unsupported prior-cal surface is deliberately narrow and explicit:
+
+- native `gencal(caltype="antpos")` for `cal.ant`;
+- native `gencal(caltype="gceff")` for `cal.gc`;
+- native `gencal(caltype="opac")` for `cal.tau`;
+- native apply of that prior-cal table chain into a corrected-data split.
+
+Those items require calibration-table generation semantics rather than a new
+top-level app family. They should be implemented in `casa-calibration` before
+declaring the full prior-cal handoff native.

--- a/scripts/package-suite-bundle.sh
+++ b/scripts/package-suite-bundle.sh
@@ -16,9 +16,11 @@ The suite bundle contains:
   - bin/calibrate
   - bin/casars-importvla
   - bin/msexplore
+  - bin/mstransform
   - bin/casars-imager
   - bin/imexplore
   - bin/immoments
+  - bin/impv
   - bin/exportfits
   - bin/importfits
   - wheels/*.whl
@@ -29,9 +31,11 @@ The binaries bundle contains:
   - bin/calibrate
   - bin/casars-importvla
   - bin/msexplore
+  - bin/mstransform
   - bin/casars-imager
   - bin/imexplore
   - bin/immoments
+  - bin/impv
   - bin/exportfits
   - bin/importfits
 EOF
@@ -94,9 +98,11 @@ binaries=(
   calibrate
   casars-importvla
   msexplore
+  mstransform
   casars-imager
   imexplore
   immoments
+  impv
   exportfits
   importfits
 )
@@ -152,7 +158,7 @@ cat >"$manifest_path" <<EOF
   "version": "$version",
   "platform": "$platform",
   "channel": "$channel",
-  "binaries": ["casars", "calibrate", "casars-importvla", "msexplore", "casars-imager", "imexplore", "immoments", "exportfits", "importfits"],
+  "binaries": ["casars", "calibrate", "casars-importvla", "msexplore", "mstransform", "casars-imager", "imexplore", "immoments", "impv", "exportfits", "importfits"],
   "wheel_files": [${wheel_json}]
 }
 EOF

--- a/scripts/profile-casa-native-issue123.py
+++ b/scripts/profile-casa-native-issue123.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Native CASA profiling harness for Wave 4 issue #123.
+
+The regular issue #123 parity script times CASA tasks from Python, but Python
+profiling cannot see where the C++ extension spends time. This helper runs the
+same applycal -> mstransform slice and attaches macOS `sample` after CASA task
+imports are complete, so the resulting reports mostly reflect native CASA work.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+
+def profile_enabled(value: str | None) -> bool:
+    return value not in {None, "", "0", "false", "False", "FALSE", "off", "Off", "OFF"}
+
+
+def default_casa_python() -> Path:
+    configured = os.environ.get("CASA_RS_CASA_PYTHON")
+    if configured:
+        return Path(configured)
+    return Path.home() / "SoftwareProjects/casa-build/venv/bin/python"
+
+
+def wait_for(path: Path, timeout_seconds: float) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if path.exists():
+            return
+        time.sleep(0.025)
+    raise RuntimeError(f"timed out waiting for {path}")
+
+
+def write_child_script(
+    path: Path,
+    *,
+    label: str,
+    task_body: str,
+) -> None:
+    body = textwrap.dedent(task_body).strip()
+    header = """import json
+import os
+import time
+from pathlib import Path
+
+from casatasks import applycal, mstransform
+
+ready = Path(os.environ["CASA_RS_CHILD_READY"])
+go = Path(os.environ["CASA_RS_CHILD_GO"])
+timing = Path(os.environ["CASA_RS_CHILD_TIMING"])
+ready.write_text("ready\\n")
+while not go.exists():
+    time.sleep(0.01)
+
+started = time.perf_counter()
+"""
+    footer = f"""
+elapsed = time.perf_counter() - started
+timing.write_text(json.dumps({{"label": {label!r}, "elapsed_seconds": elapsed}}, indent=2))
+"""
+    path.write_text(f"{header}{body}\n{footer}")
+
+
+def run_sampled_task(
+    *,
+    casa_python: Path,
+    outdir: Path,
+    label: str,
+    task_body: str,
+    duration_seconds: int,
+    interval_ms: int,
+    extra_env: dict[str, str],
+) -> dict[str, float | str | int]:
+    ready = outdir / f"{label}.ready"
+    go = outdir / f"{label}.go"
+    timing = outdir / f"{label}-timing.json"
+    child_script = outdir / f"{label}.py"
+    sample_file = outdir / f"{label}-native-sample.txt"
+    stdout_file = outdir / f"{label}.stdout"
+    stderr_file = outdir / f"{label}.stderr"
+    for path in [ready, go, timing, sample_file, stdout_file, stderr_file, child_script]:
+        if path.exists():
+            path.unlink()
+
+    write_child_script(child_script, label=label, task_body=task_body)
+    env = os.environ.copy()
+    env.update(extra_env)
+    env.update(
+        {
+            "CASA_RS_CHILD_READY": str(ready),
+            "CASA_RS_CHILD_GO": str(go),
+            "CASA_RS_CHILD_TIMING": str(timing),
+        }
+    )
+    with stdout_file.open("w") as stdout, stderr_file.open("w") as stderr:
+        child = subprocess.Popen(
+            [str(casa_python), str(child_script)],
+            stdout=stdout,
+            stderr=stderr,
+            env=env,
+        )
+    try:
+        wait_for(ready, timeout_seconds=60)
+        sampler = subprocess.Popen(
+            [
+                "sample",
+                str(child.pid),
+                str(duration_seconds),
+                str(interval_ms),
+                "-mayDie",
+                "-fullPaths",
+                "-file",
+                str(sample_file),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        go.write_text("go\n")
+        child_rc = child.wait()
+        sampler_out, _ = sampler.communicate(timeout=duration_seconds + 30)
+    except Exception:
+        child.kill()
+        child.wait()
+        raise
+
+    if child_rc != 0:
+        raise RuntimeError(
+            f"{label} CASA child failed with {child_rc}; see {stderr_file}"
+        )
+    timing_data = json.loads(timing.read_text())
+    return {
+        "label": label,
+        "elapsed_seconds": timing_data["elapsed_seconds"],
+        "child_pid": child.pid,
+        "sample_returncode": sampler.returncode,
+        "sample_report": str(sample_file),
+        "sample_stdout": sampler_out.strip(),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "outdir",
+        nargs="?",
+        default="target/wdad-wave4-123-native-profile",
+        help="output artifact directory",
+    )
+    parser.add_argument(
+        "--issue122-dir",
+        default=os.environ.get(
+            "CASA_RS_ISSUE122_ARTIFACTS", "target/wdad-wave4-122-middlefreq"
+        ),
+        help="issue #122 artifact directory with TDRW0001_10s.ms and casa-priorcal",
+    )
+    parser.add_argument("--sample-interval-ms", type=int, default=1)
+    parser.add_argument("--apply-duration", type=int, default=8)
+    parser.add_argument("--transform-duration", type=int, default=5)
+    args = parser.parse_args()
+
+    casa_python = default_casa_python()
+    if not casa_python.exists():
+        raise SystemExit(f"CASA Python not found: {casa_python}")
+
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+    issue122 = Path(args.issue122_dir).resolve()
+    input_ms = issue122 / "TDRW0001_10s.ms"
+    prior = issue122 / "casa-priorcal"
+    if not input_ms.is_dir() or not prior.is_dir():
+        raise SystemExit(f"missing issue #122 artifacts under {issue122}")
+
+    apply_ms = outdir / "casa-native-apply.ms"
+    transform_ms = outdir / "casa-native-transform.ms"
+    if apply_ms.exists():
+        shutil.rmtree(apply_ms)
+    if transform_ms.exists():
+        shutil.rmtree(transform_ms)
+    shutil.copytree(input_ms, apply_ms)
+
+    common_env = {
+        "CASA_RS_MS_PATH": str(apply_ms),
+        "CASA_RS_PRIOR": str(prior),
+        "CASA_RS_TRANSFORM_OUT": str(transform_ms),
+    }
+    apply_body = """
+    prior = os.environ["CASA_RS_PRIOR"]
+    applycal(
+        vis=os.environ["CASA_RS_MS_PATH"],
+        field="1",
+        gaintable=[f"{prior}/cal.ant", f"{prior}/cal.gc", f"{prior}/cal.tau"],
+        interp=["", "nearest", "nearest"],
+        calwt=False,
+        applymode="calonly",
+    )
+    """
+    transform_body = """
+    mstransform(
+        vis=os.environ["CASA_RS_MS_PATH"],
+        outputvis=os.environ["CASA_RS_TRANSFORM_OUT"],
+        field="1",
+        spw="0:7~58",
+        datacolumn="corrected",
+        reindex=False,
+    )
+    """
+    results = []
+    results.append(
+        run_sampled_task(
+            casa_python=casa_python,
+            outdir=outdir,
+            label="applycal",
+            task_body=apply_body,
+            duration_seconds=args.apply_duration,
+            interval_ms=args.sample_interval_ms,
+            extra_env=common_env,
+        )
+    )
+    results.append(
+        run_sampled_task(
+            casa_python=casa_python,
+            outdir=outdir,
+            label="mstransform",
+            task_body=transform_body,
+            duration_seconds=args.transform_duration,
+            interval_ms=args.sample_interval_ms,
+            extra_env=common_env,
+        )
+    )
+    summary = {
+        "casa_python": str(casa_python),
+        "issue122_dir": str(issue122),
+        "sample_interval_ms": args.sample_interval_ms,
+        "results": results,
+    }
+    (outdir / "casa-native-profile-summary.json").write_text(
+        json.dumps(summary, indent=2)
+    )
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-vla-irc10216-issue121.sh
+++ b/scripts/run-vla-irc10216-issue121.sh
@@ -175,4 +175,177 @@ cargo run -q -p casa-ms --bin msexplore -- \
   --overwrite \
   "$ms_path"
 
+cargo build -q -p casa-calibration --bin calibrate
+
+antpos_antennas="ea01,ea02,ea03,ea05,ea12,ea22,ea23,ea24,ea27"
+antpos_parameters="0.0,0.003,0.0,-0.0008,0.0,0.0,-0.0028,0.0,0.0,0.0,0.0028,0.0,-0.0100,0.0045,-0.0017,-0.0257,0.0027,-0.0190,-0.0014,0.0,0.0,-0.0015,0.0,0.0,0.0,0.0019,-0.0016"
+opac_parameters="0.038307558882357123,0.038092235934944034"
+
+CASA_RS_MS_PATH="$ms_path" \
+CASA_RS_OUTDIR="$outdir" \
+CASA_RS_ANTPOS_ANTENNAS="$antpos_antennas" \
+CASA_RS_ANTPOS_PARAMETERS="$antpos_parameters" \
+CASA_RS_OPAC_PARAMETERS="$opac_parameters" \
+"$CASA_RS_CASA_PYTHON" - <<'PY'
+import json
+import os
+import shutil
+import time
+from pathlib import Path
+from casatasks import gencal
+
+ms = os.environ["CASA_RS_MS_PATH"]
+root = Path(os.environ["CASA_RS_OUTDIR"]) / "casa-priorcal"
+root.mkdir(exist_ok=True)
+for name in ["cal.ant", "cal.gc", "cal.tau"]:
+    path = root / name
+    if path.exists():
+        shutil.rmtree(path)
+antennas = os.environ["CASA_RS_ANTPOS_ANTENNAS"]
+antpos_parameters = [float(value) for value in os.environ["CASA_RS_ANTPOS_PARAMETERS"].split(",")]
+opac_parameters = [float(value) for value in os.environ["CASA_RS_OPAC_PARAMETERS"].split(",")]
+start = time.perf_counter()
+gencal(vis=ms, caltable=str(root / "cal.ant"), caltype="antpos", antenna=antennas, parameter=antpos_parameters)
+gencal(vis=ms, caltable=str(root / "cal.gc"), caltype="gceff")
+gencal(vis=ms, caltable=str(root / "cal.tau"), caltype="opac", spw="0,1", parameter=opac_parameters)
+elapsed = time.perf_counter() - start
+(Path(os.environ["CASA_RS_OUTDIR"]) / "priorcal-casa-timing.json").write_text(
+    json.dumps({"elapsed_seconds": elapsed}, indent=2)
+)
+PY
+
+CASA_RS_CASA_PYTHON="$CASA_RS_CASA_PYTHON" \
+CASA_RS_MS_PATH="$ms_path" \
+CASA_RS_OUTDIR="$outdir" \
+CASA_RS_ANTPOS_ANTENNAS="$antpos_antennas" \
+CASA_RS_ANTPOS_PARAMETERS="$antpos_parameters" \
+CASA_RS_OPAC_PARAMETERS="$opac_parameters" \
+python3 - <<'PY'
+import json
+import os
+import subprocess
+import textwrap
+import time
+from pathlib import Path
+
+outdir = Path(os.environ["CASA_RS_OUTDIR"])
+script = outdir / "run-casa-priorcal-cold.py"
+script.write_text(textwrap.dedent("""
+    import os
+    import shutil
+    from pathlib import Path
+    from casatasks import gencal
+
+    ms = os.environ["CASA_RS_MS_PATH"]
+    root = Path(os.environ["CASA_RS_OUTDIR"]) / "casa-priorcal-cold"
+    root.mkdir(exist_ok=True)
+    for name in ["cal.ant", "cal.gc", "cal.tau"]:
+        path = root / name
+        if path.exists():
+            shutil.rmtree(path)
+    antennas = os.environ["CASA_RS_ANTPOS_ANTENNAS"]
+    antpos_parameters = [float(value) for value in os.environ["CASA_RS_ANTPOS_PARAMETERS"].split(",")]
+    opac_parameters = [float(value) for value in os.environ["CASA_RS_OPAC_PARAMETERS"].split(",")]
+    gencal(vis=ms, caltable=str(root / "cal.ant"), caltype="antpos", antenna=antennas, parameter=antpos_parameters)
+    gencal(vis=ms, caltable=str(root / "cal.gc"), caltype="gceff")
+    gencal(vis=ms, caltable=str(root / "cal.tau"), caltype="opac", spw="0,1", parameter=opac_parameters)
+"""))
+start = time.perf_counter()
+subprocess.run([os.environ["CASA_RS_CASA_PYTHON"], str(script)], check=True)
+elapsed = time.perf_counter() - start
+(outdir / "priorcal-casa-cli-timing.json").write_text(json.dumps({"elapsed_seconds": elapsed}, indent=2))
+PY
+
+CASA_RS_MS_PATH="$ms_path" \
+CASA_RS_OUTDIR="$outdir" \
+CASA_RS_ANTPOS_ANTENNAS="$antpos_antennas" \
+CASA_RS_ANTPOS_PARAMETERS="$antpos_parameters" \
+CASA_RS_OPAC_PARAMETERS="$opac_parameters" \
+python3 - <<'PY'
+import json
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+ms = os.environ["CASA_RS_MS_PATH"]
+root = Path(os.environ["CASA_RS_OUTDIR"]) / "rust-priorcal"
+root.mkdir(exist_ok=True)
+for name in ["cal.ant", "cal.gc", "cal.tau"]:
+    path = root / name
+    if path.exists():
+        shutil.rmtree(path)
+binary = Path("target/debug/calibrate")
+commands = [
+    [
+        str(binary), "gencal", "--ms", ms, "--out", str(root / "cal.ant"),
+        "--caltype", "antpos", "--antenna", os.environ["CASA_RS_ANTPOS_ANTENNAS"],
+        "--parameter", os.environ["CASA_RS_ANTPOS_PARAMETERS"],
+    ],
+    [str(binary), "gencal", "--ms", ms, "--out", str(root / "cal.gc"), "--caltype", "gceff"],
+    [
+        str(binary), "gencal", "--ms", ms, "--out", str(root / "cal.tau"),
+        "--caltype", "opac", "--spw", "0,1", "--parameter", os.environ["CASA_RS_OPAC_PARAMETERS"],
+    ],
+]
+start = time.perf_counter()
+for command in commands:
+    subprocess.run(command, check=True, stdout=subprocess.DEVNULL)
+elapsed = time.perf_counter() - start
+(Path(os.environ["CASA_RS_OUTDIR"]) / "priorcal-rust-timing.json").write_text(
+    json.dumps({"elapsed_seconds": elapsed}, indent=2)
+)
+(Path(os.environ["CASA_RS_OUTDIR"]) / "priorcal-rust-cli-timing.json").write_text(
+    json.dumps({"elapsed_seconds": elapsed}, indent=2)
+)
+PY
+
+CASA_RS_OUTDIR="$outdir" "$CASA_RS_CASA_PYTHON" - <<'PY'
+import json
+import os
+from pathlib import Path
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from casatools import table
+
+outdir = Path(os.environ["CASA_RS_OUTDIR"])
+pairs = [
+    ("cal.ant", "KAntPos Jones"),
+    ("cal.gc", "EGainCurve"),
+    ("cal.tau", "TOpac"),
+]
+tb = table()
+summary = {}
+fig, axes = plt.subplots(len(pairs), 1, figsize=(14, 10), dpi=150, sharex=False)
+for ax, (name, title) in zip(axes, pairs):
+    values = {}
+    for source, root in [("CASA", "casa-priorcal"), ("casa-rs", "rust-priorcal")]:
+        path = outdir / root / name
+        tb.open(str(path))
+        rows = []
+        for row in range(tb.nrows()):
+            rows.extend(np.array(tb.getcell("FPARAM", row)).flatten(order="F").tolist())
+        tb.close()
+        values[source] = np.asarray(rows, dtype=float)
+    diff = values["CASA"] - values["casa-rs"]
+    summary[name] = {
+        "max_abs_fparam_diff": float(np.max(np.abs(diff))) if diff.size else 0.0,
+        "casa_value_count": int(values["CASA"].size),
+        "rust_value_count": int(values["casa-rs"].size),
+    }
+    ax.plot(values["CASA"], ".", markersize=3, label="CASA")
+    ax.plot(values["casa-rs"], "x", markersize=3, label="casa-rs")
+    ax.set_title(title)
+    ax.set_ylabel("FPARAM")
+    ax.grid(True, alpha=0.25)
+axes[-1].set_xlabel("Flattened FPARAM value index")
+axes[0].legend(loc="best")
+fig.tight_layout()
+fig.savefig(outdir / "irc10216-priorcal-fparam-casa-vs-rust.png")
+(outdir / "priorcal-comparison.json").write_text(json.dumps(summary, indent=2))
+PY
+
 echo "IRC+10216 #121 artifacts written under $outdir"

--- a/scripts/run-vla-irc10216-issue121.sh
+++ b/scripts/run-vla-irc10216-issue121.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if [[ -z "${CASA_RS_TUTORIAL_DATA_ROOT:-}" && -d "$HOME/SoftwareProjects/casa-tutorial-data" ]]; then
+  export CASA_RS_TUTORIAL_DATA_ROOT="$HOME/SoftwareProjects/casa-tutorial-data"
+fi
+if [[ -z "${CASA_RS_CASA_PYTHON:-}" && -x "$HOME/SoftwareProjects/casa-build/venv/bin/python" ]]; then
+  export CASA_RS_CASA_PYTHON="$HOME/SoftwareProjects/casa-build/venv/bin/python"
+fi
+
+outdir="${1:-target/wdad-wave4-121}"
+mkdir -p "$outdir"
+outdir="$(cd "$outdir" && pwd)"
+export MPLCONFIGDIR="${MPLCONFIGDIR:-$outdir/matplotlib}"
+mkdir -p "$MPLCONFIGDIR"
+
+ms_archive="${CASA_RS_TUTORIAL_DATA_ROOT:-}/tutorial-parity/vla/irc10216/TDRW0001_10s.ms.tgz"
+fits_path="${CASA_RS_TUTORIAL_DATA_ROOT:-}/tutorial-parity/vla/irc10216/irc_fors1_dec_header.fits"
+ms_path="$outdir/TDRW0001_10s.ms"
+
+if [[ ! -f "$ms_archive" ]]; then
+  echo "missing IRC+10216 MS archive: $ms_archive" >&2
+  exit 2
+fi
+if [[ ! -f "$fits_path" ]]; then
+  echo "missing IRC+10216 FITS input: $fits_path" >&2
+  exit 2
+fi
+if [[ ! -d "$ms_path" ]]; then
+  tar -xzf "$ms_archive" -C "$outdir"
+fi
+
+cargo run -q -p casa-test-support --bin casatestdata-preflight -- \
+  --tier slow-parity \
+  --require-registry-key vla/irc10216/ms-10s
+cargo run -q -p casa-test-support --bin casatestdata-preflight -- \
+  --tier tutorial-parity \
+  --require-registry-key vla/irc10216/fors1-fits
+
+cargo run -q -p casa-ms --bin msexplore -- \
+  --format json \
+  --output "$outdir/irc10216-listobs.json" \
+  --overwrite \
+  "$ms_path"
+
+render_casatools_side_by_side() {
+  local mode="$1"
+  local rust_png="$2"
+  local casa_png="$3"
+  local combined_png="$4"
+  shift 4
+
+  cargo run -q -p casa-ms --bin msexplore -- \
+    --plot-output "$rust_png" \
+    --plot-format png \
+    --plot-width 2400 \
+    --plot-height 1350 \
+    --symbolsize 1 \
+    "$@" \
+    "$ms_path"
+
+  CASA_RS_PLOT_MODE="$mode" \
+  CASA_RS_MS_PATH="$ms_path" \
+  CASA_RS_CASA_PNG="$casa_png" \
+  "$CASA_RS_CASA_PYTHON" - <<'PY'
+import os
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from casatools import table
+
+mode = os.environ["CASA_RS_PLOT_MODE"]
+ms_path = os.environ["CASA_RS_MS_PATH"]
+out = os.environ["CASA_RS_CASA_PNG"]
+
+tb = table()
+tb.open(ms_path)
+query = {
+    "target_time": "FIELD_ID==1 && SCAN_NUMBER==6 && DATA_DESC_ID==0",
+    "bandpass_channel": "FIELD_ID==2 && SCAN_NUMBER==56 && DATA_DESC_ID==0",
+}[mode]
+qt = tb.query(query)
+data = qt.getcol("DATA")
+time = qt.getcol("TIME")
+qt.close()
+tb.close()
+
+fig, ax = plt.subplots(figsize=(16, 9), dpi=150)
+if mode == "target_time":
+    amp_by_chan_row = np.abs(data[0, :, :])
+    amp = amp_by_chan_row.reshape(-1, order="F")
+    x_offset = round(((time.min() + time.max()) / 2.0) / 10.0) * 10.0
+    x = np.repeat(time - x_offset, amp_by_chan_row.shape[0])
+    ax.scatter(x, amp, s=2, alpha=0.65)
+    ax.set_title("CASA casatools IRC+10216 scan 6 RR amplitude vs time")
+    ax.set_xlabel(f"Time (MJD seconds - {x_offset:.0f})")
+    ax.set_ylabel("Amplitude")
+else:
+    amp_by_chan_row = np.abs(data[0, :, :])
+    width = 4
+    trim = (amp_by_chan_row.shape[0] // width) * width
+    binned = amp_by_chan_row[:trim, :].reshape(-1, width, amp_by_chan_row.shape[1]).mean(axis=1)
+    y = binned.reshape(-1, order="C")
+    x = np.repeat(np.arange(binned.shape[0]), binned.shape[1])
+    ax.scatter(x, y, s=14, alpha=0.75)
+    ax.set_title("CASA casatools J1229+0203 scan 56 RR amplitude vs 4-channel bin")
+    ax.set_xlabel("Channel bin")
+    ax.set_ylabel("Amplitude")
+ax.grid(True, alpha=0.25)
+fig.tight_layout()
+fig.savefig(out)
+PY
+
+  python3 - "$rust_png" "$casa_png" "$combined_png" <<'PY'
+import sys
+from pathlib import Path
+from PIL import Image, ImageDraw, ImageFont
+
+rust_path, casa_path, out_path = map(Path, sys.argv[1:4])
+rust = Image.open(rust_path).convert("RGB")
+casa = Image.open(casa_path).convert("RGB").resize(rust.size)
+banner = 42
+canvas = Image.new("RGB", (rust.width + casa.width, rust.height + banner), "white")
+canvas.paste(rust, (0, banner))
+canvas.paste(casa, (rust.width, banner))
+draw = ImageDraw.Draw(canvas)
+font = ImageFont.load_default()
+draw.rectangle((0, 0, rust.width, banner), fill="#f2f6ff")
+draw.rectangle((rust.width, 0, rust.width + casa.width, banner), fill="#fff4e8")
+draw.text((12, 14), "casa-rs msexplore", fill="black", font=font)
+draw.text((rust.width + 12, 14), "CASA casatools", fill="black", font=font)
+canvas.save(out_path)
+PY
+}
+
+render_casatools_side_by_side \
+  target_time \
+  "$outdir/irc10216-target-scan6-amplitude-time.rust.png" \
+  "$outdir/irc10216-target-scan6-amplitude-time.casa.png" \
+  "$outdir/irc10216-target-scan6-amplitude-time-side-by-side.png" \
+  --preset amplitude_vs_time --field 1 --scan 6 --spw 0 --correlation RR
+
+render_casatools_side_by_side \
+  bandpass_channel \
+  "$outdir/irc10216-bandpass-scan56-amplitude-channel.rust.png" \
+  "$outdir/irc10216-bandpass-scan56-amplitude-channel.casa.png" \
+  "$outdir/irc10216-bandpass-scan56-amplitude-channel-side-by-side.png" \
+  --xaxis chan --yaxis amp --field 2 --scan 56 --spw 0 --correlation RR --avgchannel 4
+
+cargo run -q -p casa-ms --bin msexplore -- \
+  --format json \
+  --output "$outdir/flag-j1229-selection-summary.json" \
+  --field 2 \
+  --spw 0 \
+  --timerange "2018/11/07/13:30:27~2018/11/07/13:30:30" \
+  --flag-action flag \
+  --flag-selected \
+  --flag-apply \
+  --overwrite \
+  "$ms_path"
+
+cargo run -q -p casa-ms --bin msexplore -- \
+  --format json \
+  --output "$outdir/flag-3c286-selection-summary.json" \
+  --field 3 \
+  --spw 0 \
+  --timerange "2018/11/07/13:38:54~2018/11/07/13:39:00" \
+  --flag-action flag \
+  --flag-selected \
+  --flag-apply \
+  --overwrite \
+  "$ms_path"
+
+echo "IRC+10216 #121 artifacts written under $outdir"

--- a/scripts/run-vla-irc10216-issue122.sh
+++ b/scripts/run-vla-irc10216-issue122.sh
@@ -111,19 +111,20 @@ from casatools import table
 label = os.environ["CASA_RS_LABEL"]
 outdir = Path(os.environ["CASA_RS_OUTDIR"])
 
-def read_corrected(path):
+def read_visibility(path):
     tb = table()
     tb.open(path)
     qt = tb.query("FIELD_ID==2 && DATA_DESC_ID==0")
+    data = qt.getcol("DATA")
     corrected = qt.getcol("CORRECTED_DATA")
     times = qt.getcol("TIME")
     scans = qt.getcol("SCAN_NUMBER")
     qt.close()
     tb.close()
-    return corrected, times, scans
+    return data, corrected, times, scans
 
-casa, times, scans = read_corrected(os.environ["CASA_RS_CASA_MS"])
-rust, _, _ = read_corrected(os.environ["CASA_RS_RUST_MS"])
+casa_data, casa, times, scans = read_visibility(os.environ["CASA_RS_CASA_MS"])
+rust_data, rust, _, _ = read_visibility(os.environ["CASA_RS_RUST_MS"])
 diff = rust - casa
 amp_casa = np.abs(casa[0, :, :])
 amp_rust = np.abs(rust[0, :, :])
@@ -162,6 +163,103 @@ axes[1].set_ylabel("casa-rs - CASA")
 axes[1].grid(True, alpha=0.25)
 fig.tight_layout()
 fig.savefig(outdir / f"{label}-corrected-casa-vs-rust.png")
+plt.close(fig)
+
+casa_solution = np.divide(
+    casa_data,
+    casa,
+    out=np.full_like(casa_data, np.nan + 1j * np.nan),
+    where=np.abs(casa) > 0,
+)
+rust_solution = np.divide(
+    rust_data,
+    rust,
+    out=np.full_like(rust_data, np.nan + 1j * np.nan),
+    where=np.abs(rust) > 0,
+)
+solution_diff = rust_solution - casa_solution
+solution_amp_casa = np.abs(casa_solution[0, :, :])
+solution_amp_rust = np.abs(rust_solution[0, :, :])
+solution_phase_casa = np.angle(casa_solution[0, :, :])
+solution_phase_rust = np.angle(rust_solution[0, :, :])
+solution_phase_diff = np.angle(rust_solution[0, :, :] / casa_solution[0, :, :])
+solution_amp_diff = solution_amp_rust - solution_amp_casa
+solution_summary = {
+    "shape": list(casa_solution.shape),
+    "max_solution_abs_diff": float(np.nanmax(np.abs(solution_diff))),
+    "median_solution_abs_diff": float(np.nanmedian(np.abs(solution_diff))),
+    "median_amp_diff": float(np.nanmedian(solution_amp_diff)),
+    "min_amp_diff": float(np.nanmin(solution_amp_diff)),
+    "max_amp_diff": float(np.nanmax(solution_amp_diff)),
+    "median_phase_diff_rad": float(np.nanmedian(solution_phase_diff)),
+    "min_phase_diff_rad": float(np.nanmin(solution_phase_diff)),
+    "max_phase_diff_rad": float(np.nanmax(solution_phase_diff)),
+}
+(outdir / f"{label}-applied-solution-comparison.json").write_text(
+    json.dumps(solution_summary, indent=2)
+)
+
+fig, axes = plt.subplots(4, 1, figsize=(12, 12), dpi=150, sharex=True)
+axes[0].scatter(
+    channel,
+    solution_amp_casa[:, row_mask].reshape(-1, order="F"),
+    s=9,
+    alpha=0.4,
+    label="CASA",
+)
+axes[0].scatter(
+    channel,
+    solution_amp_rust[:, row_mask].reshape(-1, order="F"),
+    s=15,
+    marker="x",
+    alpha=0.6,
+    label="casa-rs",
+)
+axes[0].set_ylabel("RR correction amp")
+axes[0].set_title(
+    f"IRC+10216 #122 {label}: applied correction DATA/CORRECTED, field 2 scan 56"
+)
+axes[0].legend(loc="best")
+axes[1].scatter(
+    channel,
+    solution_amp_diff[:, row_mask].reshape(-1, order="F"),
+    s=9,
+    alpha=0.55,
+    color="black",
+)
+axes[1].axhline(0.0, color="tab:red", linewidth=1)
+axes[1].set_ylabel("amp diff")
+axes[2].scatter(
+    channel,
+    solution_phase_casa[:, row_mask].reshape(-1, order="F"),
+    s=9,
+    alpha=0.4,
+    label="CASA",
+)
+axes[2].scatter(
+    channel,
+    solution_phase_rust[:, row_mask].reshape(-1, order="F"),
+    s=15,
+    marker="x",
+    alpha=0.6,
+    label="casa-rs",
+)
+axes[2].set_ylabel("RR corr phase rad")
+axes[3].scatter(
+    channel,
+    solution_phase_diff[:, row_mask].reshape(-1, order="F"),
+    s=9,
+    alpha=0.55,
+    color="black",
+)
+axes[3].axhline(0.0, color="tab:red", linewidth=1)
+axes[3].set_ylabel("phase diff rad")
+axes[3].set_xlabel("Channel")
+for ax in axes:
+    ax.grid(True, alpha=0.25)
+fig.tight_layout()
+fig.savefig(outdir / f"{label}-applied-solution-casa-vs-rust.png")
+plt.close(fig)
 PY
 }
 
@@ -190,10 +288,12 @@ for label in ["prior-gctau", "prior-full"]:
     casa = json.loads((outdir / f"casa-{label}-timing.json").read_text())
     rust = json.loads((outdir / f"rust-{label}-timing.json").read_text())
     comparison = json.loads((outdir / f"{label}-corrected-comparison.json").read_text())
+    solution = json.loads((outdir / f"{label}-applied-solution-comparison.json").read_text())
     summary[label] = {
         "casa_elapsed_seconds": casa["elapsed_seconds"],
         "rust_elapsed_seconds": rust["elapsed_seconds"],
         "speedup_casa_over_rust": casa["elapsed_seconds"] / rust["elapsed_seconds"],
+        "applied_solution": solution,
         **comparison,
     }
 (outdir / "issue122-summary.json").write_text(json.dumps(summary, indent=2))

--- a/scripts/run-vla-irc10216-issue122.sh
+++ b/scripts/run-vla-irc10216-issue122.sh
@@ -28,7 +28,7 @@ rm -rf \
   "$outdir/casa-priorcal-cold" \
   "$outdir/rust-priorcal"
 scripts/run-vla-irc10216-issue121.sh "$outdir"
-cargo build -q -p casa-calibration --bin calibrate
+cargo build --release -q -p casa-calibration --bin calibrate
 
 base_ms="$outdir/TDRW0001_10s.ms"
 casa_prior="$outdir/casa-priorcal"
@@ -73,12 +73,7 @@ with open(os.environ["CASA_RS_OUT_JSON"], "w") as handle:
     json.dump({"elapsed_seconds": elapsed}, handle, indent=2)
 PY
 
-  start_ns="$(python3 - <<'PY'
-import time
-print(time.perf_counter_ns())
-PY
-)"
-  target/debug/calibrate apply \
+  target/release/calibrate apply \
     --ms "$rust_ms" \
     --field 2 \
     --apply-mode calonly \
@@ -87,19 +82,15 @@ PY
     --format json \
     --output "$outdir/rust-${label}-report.json" \
     --overwrite
-  end_ns="$(python3 - <<'PY'
-import time
-print(time.perf_counter_ns())
-PY
-)"
-  python3 - "$start_ns" "$end_ns" "$outdir/rust-${label}-timing.json" <<'PY'
+  python3 - "$outdir/rust-${label}-report.json" "$outdir/rust-${label}-timing.json" <<'PY'
 import json
 import sys
 
-start_ns = int(sys.argv[1])
-end_ns = int(sys.argv[2])
-with open(sys.argv[3], "w") as handle:
-    json.dump({"elapsed_seconds": (end_ns - start_ns) / 1.0e9}, handle, indent=2)
+# CASA timing starts inside an already-running Python/casatasks process, so use
+# the Rust task timing from the execution report rather than CLI process startup.
+report = json.loads(open(sys.argv[1]).read())
+with open(sys.argv[2], "w") as handle:
+    json.dump({"elapsed_seconds": report["timings"]["total_ns"] / 1.0e9}, handle, indent=2)
 PY
 
   CASA_RS_CASA_MS="$casa_ms" \

--- a/scripts/run-vla-irc10216-issue122.sh
+++ b/scripts/run-vla-irc10216-issue122.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if [[ -z "${CASA_RS_TUTORIAL_DATA_ROOT:-}" && -d "$HOME/SoftwareProjects/casa-tutorial-data" ]]; then
+  export CASA_RS_TUTORIAL_DATA_ROOT="$HOME/SoftwareProjects/casa-tutorial-data"
+fi
+if [[ -z "${CASA_RS_CASA_PYTHON:-}" && -x "$HOME/SoftwareProjects/casa-build/venv/bin/python" ]]; then
+  export CASA_RS_CASA_PYTHON="$HOME/SoftwareProjects/casa-build/venv/bin/python"
+fi
+
+outdir="${1:-target/wdad-wave4-122}"
+mkdir -p "$outdir"
+outdir="$(cd "$outdir" && pwd)"
+export MPLCONFIGDIR="${MPLCONFIGDIR:-$outdir/matplotlib}"
+mkdir -p "$MPLCONFIGDIR"
+
+if [[ -z "${CASA_RS_CASA_PYTHON:-}" || ! -x "$CASA_RS_CASA_PYTHON" ]]; then
+  echo "CASA_RS_CASA_PYTHON must point at a Python with casatasks/casatools" >&2
+  exit 2
+fi
+
+rm -rf \
+  "$outdir/TDRW0001_10s.ms" \
+  "$outdir/casa-priorcal" \
+  "$outdir/casa-priorcal-cold" \
+  "$outdir/rust-priorcal"
+scripts/run-vla-irc10216-issue121.sh "$outdir"
+cargo build -q -p casa-calibration --bin calibrate
+
+base_ms="$outdir/TDRW0001_10s.ms"
+casa_prior="$outdir/casa-priorcal"
+rust_prior="$outdir/rust-priorcal"
+
+run_apply_pair() {
+  local label="$1"
+  local casa_tables="$2"
+  local rust_tables="$3"
+  local casa_interp="$4"
+  local rust_interp="$5"
+  local casa_ms="$outdir/casa-${label}.ms"
+  local rust_ms="$outdir/rust-${label}.ms"
+
+  rm -rf "$casa_ms" "$rust_ms"
+  cp -R "$base_ms" "$casa_ms"
+  cp -R "$base_ms" "$rust_ms"
+
+  CASA_RS_MS_PATH="$casa_ms" \
+  CASA_RS_GAINTABLES="$casa_tables" \
+  CASA_RS_INTERP="$casa_interp" \
+  CASA_RS_OUT_JSON="$outdir/casa-${label}-timing.json" \
+  "$CASA_RS_CASA_PYTHON" - <<'PY'
+import json
+import os
+import time
+from casatasks import applycal
+
+tables = [item for item in os.environ["CASA_RS_GAINTABLES"].split(",") if item]
+interp = [item for item in os.environ["CASA_RS_INTERP"].split(",")]
+start = time.perf_counter()
+applycal(
+    vis=os.environ["CASA_RS_MS_PATH"],
+    field="2",
+    gaintable=tables,
+    interp=interp,
+    calwt=False,
+    applymode="calonly",
+)
+elapsed = time.perf_counter() - start
+with open(os.environ["CASA_RS_OUT_JSON"], "w") as handle:
+    json.dump({"elapsed_seconds": elapsed}, handle, indent=2)
+PY
+
+  start_ns="$(python3 - <<'PY'
+import time
+print(time.perf_counter_ns())
+PY
+)"
+  target/debug/calibrate apply \
+    --ms "$rust_ms" \
+    --field 2 \
+    --apply-mode calonly \
+    --interp "$rust_interp" \
+    --gaintables "$rust_tables" \
+    --format json \
+    --output "$outdir/rust-${label}-report.json" \
+    --overwrite
+  end_ns="$(python3 - <<'PY'
+import time
+print(time.perf_counter_ns())
+PY
+)"
+  python3 - "$start_ns" "$end_ns" "$outdir/rust-${label}-timing.json" <<'PY'
+import json
+import sys
+
+start_ns = int(sys.argv[1])
+end_ns = int(sys.argv[2])
+with open(sys.argv[3], "w") as handle:
+    json.dump({"elapsed_seconds": (end_ns - start_ns) / 1.0e9}, handle, indent=2)
+PY
+
+  CASA_RS_CASA_MS="$casa_ms" \
+  CASA_RS_RUST_MS="$rust_ms" \
+  CASA_RS_LABEL="$label" \
+  CASA_RS_OUTDIR="$outdir" \
+  "$CASA_RS_CASA_PYTHON" - <<'PY'
+import json
+import os
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+from casatools import table
+
+label = os.environ["CASA_RS_LABEL"]
+outdir = Path(os.environ["CASA_RS_OUTDIR"])
+
+def read_corrected(path):
+    tb = table()
+    tb.open(path)
+    qt = tb.query("FIELD_ID==2 && DATA_DESC_ID==0")
+    corrected = qt.getcol("CORRECTED_DATA")
+    times = qt.getcol("TIME")
+    scans = qt.getcol("SCAN_NUMBER")
+    qt.close()
+    tb.close()
+    return corrected, times, scans
+
+casa, times, scans = read_corrected(os.environ["CASA_RS_CASA_MS"])
+rust, _, _ = read_corrected(os.environ["CASA_RS_RUST_MS"])
+diff = rust - casa
+amp_casa = np.abs(casa[0, :, :])
+amp_rust = np.abs(rust[0, :, :])
+amp_diff = amp_rust - amp_casa
+
+summary = {
+    "shape": list(casa.shape),
+    "max_abs_diff": float(np.max(np.abs(diff))),
+    "median_abs_diff": float(np.median(np.abs(diff))),
+    "max_rel_diff": float(np.max(np.abs(diff) / np.maximum(np.abs(casa), 1.0e-12))),
+    "median_rel_diff": float(np.median(np.abs(diff) / np.maximum(np.abs(casa), 1.0e-12))),
+    "max_amp_diff": float(np.max(np.abs(amp_diff))),
+    "median_amp_diff": float(np.median(np.abs(amp_diff))),
+}
+(outdir / f"{label}-corrected-comparison.json").write_text(json.dumps(summary, indent=2))
+
+row_mask = scans == 56
+if not np.any(row_mask):
+    row_mask = np.ones_like(scans, dtype=bool)
+plot_casa = amp_casa[:, row_mask]
+plot_rust = amp_rust[:, row_mask]
+plot_diff = plot_rust - plot_casa
+channel = np.repeat(np.arange(plot_casa.shape[0]), plot_casa.shape[1])
+
+fig, axes = plt.subplots(2, 1, figsize=(12, 9), dpi=150, sharex=True)
+axes[0].scatter(channel, plot_casa.reshape(-1, order="F"), s=10, alpha=0.45, label="CASA")
+axes[0].scatter(channel, plot_rust.reshape(-1, order="F"), s=18, marker="x", alpha=0.65, label="casa-rs")
+axes[0].set_ylabel("RR amplitude")
+axes[0].set_title(f"IRC+10216 #122 {label}: corrected DATA, field 2 scan 56")
+axes[0].legend(loc="best")
+axes[0].grid(True, alpha=0.25)
+axes[1].scatter(channel, plot_diff.reshape(-1, order="F"), s=10, alpha=0.6, color="black")
+axes[1].axhline(0.0, color="tab:red", linewidth=1)
+axes[1].set_xlabel("Channel")
+axes[1].set_ylabel("casa-rs - CASA")
+axes[1].grid(True, alpha=0.25)
+fig.tight_layout()
+fig.savefig(outdir / f"{label}-corrected-casa-vs-rust.png")
+PY
+}
+
+run_apply_pair \
+  "prior-gctau" \
+  "$casa_prior/cal.gc,$casa_prior/cal.tau" \
+  "$rust_prior/cal.gc,$rust_prior/cal.tau" \
+  "nearest,nearest" \
+  "nearest;nearest"
+
+run_apply_pair \
+  "prior-full" \
+  "$casa_prior/cal.ant,$casa_prior/cal.gc,$casa_prior/cal.tau" \
+  "$rust_prior/cal.ant,$rust_prior/cal.gc,$rust_prior/cal.tau" \
+  ",nearest,nearest" \
+  "nearest;nearest;nearest"
+
+python3 - "$outdir" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+outdir = Path(sys.argv[1])
+summary = {}
+for label in ["prior-gctau", "prior-full"]:
+    casa = json.loads((outdir / f"casa-{label}-timing.json").read_text())
+    rust = json.loads((outdir / f"rust-{label}-timing.json").read_text())
+    comparison = json.loads((outdir / f"{label}-corrected-comparison.json").read_text())
+    summary[label] = {
+        "casa_elapsed_seconds": casa["elapsed_seconds"],
+        "rust_elapsed_seconds": rust["elapsed_seconds"],
+        "speedup_casa_over_rust": casa["elapsed_seconds"] / rust["elapsed_seconds"],
+        **comparison,
+    }
+(outdir / "issue122-summary.json").write_text(json.dumps(summary, indent=2))
+PY
+
+echo "Issue #122 artifacts written to $outdir"

--- a/scripts/run-vla-irc10216-issue123.sh
+++ b/scripts/run-vla-irc10216-issue123.sh
@@ -14,6 +14,26 @@ outdir="$(cd "$outdir" && pwd)"
 export MPLCONFIGDIR="${MPLCONFIGDIR:-$outdir/matplotlib}"
 mkdir -p "$MPLCONFIGDIR"
 
+profile_enabled() {
+  case "${1:-}" in
+    ""|0|false|False|FALSE|off|Off|OFF|no|No|NO)
+      return 1
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+
+profile_rust=false
+if profile_enabled "${CASA_RS_PROFILE_RUST:-}"; then
+  profile_rust=true
+fi
+if profile_enabled "${CASA_RS_PROFILE_CASA:-}"; then
+  export CASA_RS_CASA_PROFILE_DIR="${CASA_RS_CASA_PROFILE_DIR:-$outdir/casa-python-profile}"
+  mkdir -p "$CASA_RS_CASA_PROFILE_DIR"
+fi
+
 if [[ -z "${CASA_RS_CASA_PYTHON:-}" || ! -x "$CASA_RS_CASA_PYTHON" ]]; then
   echo "CASA_RS_CASA_PYTHON must point at a Python with casatasks/casatools" >&2
   exit 2
@@ -77,38 +97,139 @@ with open(outfile, "w") as handle:
 PY
 }
 
+time_json_stderr() {
+  local label="$1"
+  local outfile="$2"
+  local stderr_file="$3"
+  shift 3
+  python3 - "$label" "$outfile" "$stderr_file" "$@" <<'PY'
+import json
+import subprocess
+import sys
+import time
+
+label = sys.argv[1]
+outfile = sys.argv[2]
+stderr_file = sys.argv[3]
+cmd = sys.argv[4:]
+started = time.perf_counter()
+with open(stderr_file, "w") as stderr:
+    completed = subprocess.run(cmd, check=True, stderr=stderr)
+elapsed = time.perf_counter() - started
+with open(outfile, "w") as handle:
+    json.dump({"label": label, "elapsed_seconds": elapsed, "returncode": completed.returncode}, handle, indent=2)
+PY
+}
+
+time_json_stdout() {
+  local label="$1"
+  local outfile="$2"
+  local stdout_file="$3"
+  shift 3
+  python3 - "$label" "$outfile" "$stdout_file" "$@" <<'PY'
+import json
+import subprocess
+import sys
+import time
+
+label = sys.argv[1]
+outfile = sys.argv[2]
+stdout_file = sys.argv[3]
+cmd = sys.argv[4:]
+started = time.perf_counter()
+with open(stdout_file, "w") as stdout:
+    completed = subprocess.run(cmd, check=True, stdout=stdout)
+elapsed = time.perf_counter() - started
+with open(outfile, "w") as handle:
+    json.dump({"label": label, "elapsed_seconds": elapsed, "returncode": completed.returncode}, handle, indent=2)
+PY
+}
+
+time_json_stdout_stderr() {
+  local label="$1"
+  local outfile="$2"
+  local stdout_file="$3"
+  local stderr_file="$4"
+  shift 4
+  python3 - "$label" "$outfile" "$stdout_file" "$stderr_file" "$@" <<'PY'
+import json
+import subprocess
+import sys
+import time
+
+label = sys.argv[1]
+outfile = sys.argv[2]
+stdout_file = sys.argv[3]
+stderr_file = sys.argv[4]
+cmd = sys.argv[5:]
+started = time.perf_counter()
+with open(stdout_file, "w") as stdout, open(stderr_file, "w") as stderr:
+    completed = subprocess.run(cmd, check=True, stdout=stdout, stderr=stderr)
+elapsed = time.perf_counter() - started
+with open(outfile, "w") as handle:
+    json.dump({"label": label, "elapsed_seconds": elapsed, "returncode": completed.returncode}, handle, indent=2)
+PY
+}
+
 CASA_RS_MS_PATH="$outdir/casa-target-prior.ms" \
 CASA_RS_OUT_JSON="$outdir/casa-apply-timing.json" \
 CASA_RS_PRIOR="$issue122_dir/casa-priorcal" \
 "$CASA_RS_CASA_PYTHON" - <<'PY'
+import cProfile
 import json
 import os
+import pstats
+import io
 import time
 from casatasks import applycal
 
+profile_dir = os.environ.get("CASA_RS_CASA_PROFILE_DIR")
+
+def run_profiled(label, func):
+    if not profile_dir:
+        return func()
+    profiler = cProfile.Profile()
+    result = profiler.runcall(func)
+    profiler.dump_stats(os.path.join(profile_dir, f"{label}.cprofile"))
+    stream = io.StringIO()
+    pstats.Stats(profiler, stream=stream).sort_stats("cumulative").print_stats(80)
+    with open(os.path.join(profile_dir, f"{label}-pstats.txt"), "w") as handle:
+        handle.write(stream.getvalue())
+    return result
+
 prior = os.environ["CASA_RS_PRIOR"]
 started = time.perf_counter()
-applycal(
-    vis=os.environ["CASA_RS_MS_PATH"],
-    field="1",
-    gaintable=[f"{prior}/cal.ant", f"{prior}/cal.gc", f"{prior}/cal.tau"],
-    interp=["", "nearest", "nearest"],
-    calwt=False,
-    applymode="calonly",
+run_profiled(
+    "applycal",
+    lambda: applycal(
+        vis=os.environ["CASA_RS_MS_PATH"],
+        field="1",
+        gaintable=[f"{prior}/cal.ant", f"{prior}/cal.gc", f"{prior}/cal.tau"],
+        interp=["", "nearest", "nearest"],
+        calwt=False,
+        applymode="calonly",
+    ),
 )
 with open(os.environ["CASA_RS_OUT_JSON"], "w") as handle:
     json.dump({"elapsed_seconds": time.perf_counter() - started}, handle, indent=2)
 PY
 
-target/release/calibrate apply \
-  --ms "$outdir/rust-target-prior.ms" \
-  --field 1 \
-  --apply-mode calonly \
-  --interp "nearest;nearest;nearest" \
-  --gaintables "$issue122_dir/rust-priorcal/cal.ant,$issue122_dir/rust-priorcal/cal.gc,$issue122_dir/rust-priorcal/cal.tau" \
-  --format json \
-  --output "$outdir/rust-apply-report.json" \
+rust_apply_cmd=(
+  target/release/calibrate apply
+  --ms "$outdir/rust-target-prior.ms"
+  --field 1
+  --apply-mode calonly
+  --interp "nearest;nearest;nearest"
+  --gaintables "$issue122_dir/rust-priorcal/cal.ant,$issue122_dir/rust-priorcal/cal.gc,$issue122_dir/rust-priorcal/cal.tau"
+  --format json
+  --output "$outdir/rust-apply-report.json"
   --overwrite
+)
+if [[ "$profile_rust" == true ]]; then
+  CASA_RS_CALIBRATION_PROFILE=1 "${rust_apply_cmd[@]}" 2> "$outdir/rust-apply-profile.log"
+else
+  "${rust_apply_cmd[@]}"
+fi
 python3 - "$outdir/rust-apply-report.json" "$outdir/rust-apply-timing.json" <<'PY'
 import json
 import sys
@@ -117,67 +238,107 @@ with open(sys.argv[2], "w") as handle:
     json.dump({"elapsed_seconds": report["timings"]["total_ns"] / 1.0e9}, handle, indent=2)
 PY
 
-time_json rust-transform "$outdir/rust-transform-timing.json" \
+rust_transform_cmd=(
   target/release/mstransform \
   --ms "$outdir/rust-target-prior.ms" \
   --out "$outdir/rust-transform.ms" \
   --field 1 \
   --spw "0:7~58" \
   --datacolumn CORRECTED_DATA
+)
+if [[ "$profile_rust" == true ]]; then
+  time_json_stdout_stderr rust-transform "$outdir/rust-transform-wall-timing.json" "$outdir/rust-transform-report.json" "$outdir/rust-transform-profile.log" \
+    env CASA_RS_MSTRANSFORM_PROGRESS=1 "${rust_transform_cmd[@]}"
+else
+  time_json_stdout rust-transform "$outdir/rust-transform-wall-timing.json" "$outdir/rust-transform-report.json" "${rust_transform_cmd[@]}"
+fi
+python3 - "$outdir/rust-transform-report.json" "$outdir/rust-transform-timing.json" <<'PY'
+import json
+import sys
+report = json.loads(open(sys.argv[1]).read())
+with open(sys.argv[2], "w") as handle:
+    json.dump({"elapsed_seconds": report["elapsed_ns"] / 1.0e9}, handle, indent=2)
+PY
 
 CASA_RS_OUTDIR="$outdir" "$CASA_RS_CASA_PYTHON" - <<'PY'
+import cProfile
 import json
 import os
+import pstats
+import io
 import time
 from casatasks import mstransform, uvcontsub, tclean, imstat, immoments, impv
 
 outdir = os.environ["CASA_RS_OUTDIR"]
+profile_dir = os.environ.get("CASA_RS_CASA_PROFILE_DIR")
+
+def run_profiled(label, func):
+    if not profile_dir:
+        return func()
+    profiler = cProfile.Profile()
+    result = profiler.runcall(func)
+    profiler.dump_stats(os.path.join(profile_dir, f"{label}.cprofile"))
+    stream = io.StringIO()
+    pstats.Stats(profiler, stream=stream).sort_stats("cumulative").print_stats(80)
+    with open(os.path.join(profile_dir, f"{label}-pstats.txt"), "w") as handle:
+        handle.write(stream.getvalue())
+    return result
+
 started = time.perf_counter()
-mstransform(
-    vis=f"{outdir}/casa-target-prior.ms",
-    outputvis=f"{outdir}/casa-transform.ms",
-    field="1",
-    spw="0:7~58",
-    datacolumn="corrected",
-    reindex=False,
+run_profiled(
+    "mstransform",
+    lambda: mstransform(
+        vis=f"{outdir}/casa-target-prior.ms",
+        outputvis=f"{outdir}/casa-transform.ms",
+        field="1",
+        spw="0:7~58",
+        datacolumn="corrected",
+        reindex=False,
+    ),
 )
 with open(f"{outdir}/casa-transform-timing.json", "w") as handle:
     json.dump({"elapsed_seconds": time.perf_counter() - started}, handle, indent=2)
 
 started = time.perf_counter()
-uvcontsub(
-    vis=f"{outdir}/casa-transform.ms",
-    outputvis=f"{outdir}/casa-contsub.ms",
-    fitspec="0:0~7;44~51",
-    fitorder=0,
-    datacolumn="data",
-    fitmethod="casacore",
+run_profiled(
+    "uvcontsub",
+    lambda: uvcontsub(
+        vis=f"{outdir}/casa-transform.ms",
+        outputvis=f"{outdir}/casa-contsub.ms",
+        fitspec="0:0~7;44~51",
+        fitorder=0,
+        datacolumn="data",
+        fitmethod="casacore",
+    ),
 )
 with open(f"{outdir}/casa-uvcontsub-timing.json", "w") as handle:
     json.dump({"elapsed_seconds": time.perf_counter() - started}, handle, indent=2)
 
 started = time.perf_counter()
-tclean(
-    vis=f"{outdir}/casa-contsub.ms",
-    imagename=f"{outdir}/casa-HC3N-natural",
-    field="1",
-    spw="0",
-    specmode="cube",
-    nchan=20,
-    start="0",
-    width="1",
-    outframe="LSRK",
-    restfreq="36.39232GHz",
-    gridder="standard",
-    deconvolver="hogbom",
-    weighting="natural",
-    imsize=128,
-    cell="0.4arcsec",
-    phasecenter=1,
-    niter=0,
-    threshold="0Jy",
-    datacolumn="data",
-    interactive=False,
+run_profiled(
+    "tclean",
+    lambda: tclean(
+        vis=f"{outdir}/casa-contsub.ms",
+        imagename=f"{outdir}/casa-HC3N-natural",
+        field="1",
+        spw="0",
+        specmode="cube",
+        nchan=20,
+        start="0",
+        width="1",
+        outframe="LSRK",
+        restfreq="36.39232GHz",
+        gridder="standard",
+        deconvolver="hogbom",
+        weighting="natural",
+        imsize=128,
+        cell="0.4arcsec",
+        phasecenter=1,
+        niter=0,
+        threshold="0Jy",
+        datacolumn="data",
+        interactive=False,
+    ),
 )
 with open(f"{outdir}/casa-tclean-timing.json", "w") as handle:
     json.dump({"elapsed_seconds": time.perf_counter() - started}, handle, indent=2)
@@ -187,12 +348,18 @@ with open(f"{outdir}/casa-imstat.json", "w") as handle:
     json.dump({k: (v.tolist() if hasattr(v, "tolist") else v) for k, v in stats.items()}, handle, indent=2, default=str)
 
 started = time.perf_counter()
-immoments(imagename=f"{outdir}/casa-HC3N-natural.image", outfile=f"{outdir}/casa-HC3N-natural.mom0", moments=[0], chans="5~15")
+run_profiled(
+    "immoments",
+    lambda: immoments(imagename=f"{outdir}/casa-HC3N-natural.image", outfile=f"{outdir}/casa-HC3N-natural.mom0", moments=[0], chans="5~15"),
+)
 with open(f"{outdir}/casa-immoments-timing.json", "w") as handle:
     json.dump({"elapsed_seconds": time.perf_counter() - started}, handle, indent=2)
 
 started = time.perf_counter()
-impv(imagename=f"{outdir}/casa-HC3N-natural.image", outfile=f"{outdir}/casa-HC3N-natural.pv", mode="coords", start=[32,64], end=[96,64], width=3, unit="arcsec", chans="5~15", overwrite=True)
+run_profiled(
+    "impv",
+    lambda: impv(imagename=f"{outdir}/casa-HC3N-natural.image", outfile=f"{outdir}/casa-HC3N-natural.pv", mode="coords", start=[32,64], end=[96,64], width=3, unit="arcsec", chans="5~15", overwrite=True),
+)
 with open(f"{outdir}/casa-impv-timing.json", "w") as handle:
     json.dump({"elapsed_seconds": time.perf_counter() - started}, handle, indent=2)
 PY
@@ -215,7 +382,7 @@ with open(sys.argv[2], "w") as handle:
     json.dump({"elapsed_seconds": report["elapsed_ns"] / 1.0e9}, handle, indent=2)
 PY
 
-time_json rust-tclean "$outdir/rust-tclean-timing.json" \
+rust_tclean_cmd=(
   target/release/casars-imager \
   --ms "$outdir/rust-contsub.ms" \
   --imagename "$outdir/rust-HC3N-natural" \
@@ -235,23 +402,41 @@ time_json rust-tclean "$outdir/rust-tclean-timing.json" \
   --threshold-jy 0 \
   --datacolumn DATA \
   --no-preview-pngs \
-  --dirty-only
+  --dirty-only \
+  --managed-output true
+)
+if [[ "$profile_rust" == true ]]; then
+  time_json_stdout_stderr rust-tclean "$outdir/rust-tclean-wall-timing.json" "$outdir/rust-tclean-report.json" "$outdir/rust-tclean-profile.log" \
+    env CASA_RS_IMAGING_PROGRESS=1 "${rust_tclean_cmd[@]}"
+else
+  time_json_stdout rust-tclean "$outdir/rust-tclean-wall-timing.json" "$outdir/rust-tclean-report.json" "${rust_tclean_cmd[@]}"
+fi
+python3 - "$outdir/rust-tclean-report.json" "$outdir/rust-tclean-timing.json" <<'PY'
+import json
+import sys
+report = json.loads(open(sys.argv[1]).read())
+frontend = dict(report["run"]["frontend_timings"]["values_ns"])
+with open(sys.argv[2], "w") as handle:
+    json.dump({"elapsed_seconds": frontend["total"] / 1.0e9}, handle, indent=2)
+PY
 
 target/release/imexplore imstat "$outdir/rust-HC3N-natural.image" --box 48,48,80,80 --chans 5~15 --json > "$outdir/rust-imstat.json"
 time_json rust-immoments "$outdir/rust-immoments-timing.json" \
-  target/release/immoments "$outdir/rust-HC3N-natural.image" \
+  target/release/imexplore immoments "$outdir/rust-HC3N-natural.image" \
   --outfile "$outdir/rust-HC3N-natural.mom0" \
   --moments 0 \
   --chans 5~15 \
-  --overwrite
+  --overwrite \
+  --json
 time_json rust-impv "$outdir/rust-impv-timing.json" \
-  target/release/impv "$outdir/rust-HC3N-natural.image" \
+  target/release/imexplore impv "$outdir/rust-HC3N-natural.image" \
   --outfile "$outdir/rust-HC3N-natural.pv" \
   --start 32,64 \
   --end 96,64 \
   --width 3 \
   --chans 5~15 \
-  --overwrite
+  --overwrite \
+  --json
 
 CASA_RS_OUTDIR="$outdir" "$CASA_RS_CASA_PYTHON" - <<'PY'
 import json

--- a/scripts/run-vla-irc10216-issue123.sh
+++ b/scripts/run-vla-irc10216-issue123.sh
@@ -1,0 +1,365 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if [[ -z "${CASA_RS_CASA_PYTHON:-}" && -x "$HOME/SoftwareProjects/casa-build/venv/bin/python" ]]; then
+  export CASA_RS_CASA_PYTHON="$HOME/SoftwareProjects/casa-build/venv/bin/python"
+fi
+
+outdir="${1:-target/wdad-wave4-123}"
+mkdir -p "$outdir"
+outdir="$(cd "$outdir" && pwd)"
+export MPLCONFIGDIR="${MPLCONFIGDIR:-$outdir/matplotlib}"
+mkdir -p "$MPLCONFIGDIR"
+
+if [[ -z "${CASA_RS_CASA_PYTHON:-}" || ! -x "$CASA_RS_CASA_PYTHON" ]]; then
+  echo "CASA_RS_CASA_PYTHON must point at a Python with casatasks/casatools" >&2
+  exit 2
+fi
+
+issue122_dir="${CASA_RS_ISSUE122_ARTIFACTS:-target/wdad-wave4-122-middlefreq}"
+if [[ ! -d "$issue122_dir/TDRW0001_10s.ms" || ! -d "$issue122_dir/casa-priorcal" || ! -d "$issue122_dir/rust-priorcal" ]]; then
+  scripts/run-vla-irc10216-issue122.sh "$issue122_dir"
+fi
+issue122_dir="$(cd "$issue122_dir" && pwd)"
+
+cargo build --release -q \
+  -p casa-calibration --bin calibrate \
+  -p casa-ms --bin mstransform \
+  -p casars-imager --bin casars-imager \
+  -p casa-images --bin imexplore --bin immoments --bin impv
+
+rm -rf \
+  "$outdir/casa-target-prior.ms" \
+  "$outdir/rust-target-prior.ms" \
+  "$outdir/casa-transform.ms" \
+  "$outdir/rust-transform.ms" \
+  "$outdir/casa-contsub.ms" \
+  "$outdir/rust-contsub.ms" \
+  "$outdir/casa-HC3N-natural.image" \
+  "$outdir/casa-HC3N-natural.model" \
+  "$outdir/casa-HC3N-natural.psf" \
+  "$outdir/casa-HC3N-natural.residual" \
+  "$outdir/casa-HC3N-natural.sumwt" \
+  "$outdir/rust-HC3N-natural.image" \
+  "$outdir/rust-HC3N-natural.model" \
+  "$outdir/rust-HC3N-natural.psf" \
+  "$outdir/rust-HC3N-natural.residual" \
+  "$outdir/rust-HC3N-natural.sumwt" \
+  "$outdir/casa-HC3N-natural.mom0" \
+  "$outdir/rust-HC3N-natural.mom0" \
+  "$outdir/casa-HC3N-natural.pv" \
+  "$outdir/rust-HC3N-natural.pv"
+
+cp -R "$issue122_dir/TDRW0001_10s.ms" "$outdir/casa-target-prior.ms"
+cp -R "$issue122_dir/TDRW0001_10s.ms" "$outdir/rust-target-prior.ms"
+
+time_json() {
+  local label="$1"
+  local outfile="$2"
+  shift 2
+  python3 - "$label" "$outfile" "$@" <<'PY'
+import json
+import subprocess
+import sys
+import time
+
+label = sys.argv[1]
+outfile = sys.argv[2]
+cmd = sys.argv[3:]
+started = time.perf_counter()
+completed = subprocess.run(cmd, check=True)
+elapsed = time.perf_counter() - started
+with open(outfile, "w") as handle:
+    json.dump({"label": label, "elapsed_seconds": elapsed, "returncode": completed.returncode}, handle, indent=2)
+PY
+}
+
+CASA_RS_MS_PATH="$outdir/casa-target-prior.ms" \
+CASA_RS_OUT_JSON="$outdir/casa-apply-timing.json" \
+CASA_RS_PRIOR="$issue122_dir/casa-priorcal" \
+"$CASA_RS_CASA_PYTHON" - <<'PY'
+import json
+import os
+import time
+from casatasks import applycal
+
+prior = os.environ["CASA_RS_PRIOR"]
+started = time.perf_counter()
+applycal(
+    vis=os.environ["CASA_RS_MS_PATH"],
+    field="1",
+    gaintable=[f"{prior}/cal.ant", f"{prior}/cal.gc", f"{prior}/cal.tau"],
+    interp=["", "nearest", "nearest"],
+    calwt=False,
+    applymode="calonly",
+)
+with open(os.environ["CASA_RS_OUT_JSON"], "w") as handle:
+    json.dump({"elapsed_seconds": time.perf_counter() - started}, handle, indent=2)
+PY
+
+target/release/calibrate apply \
+  --ms "$outdir/rust-target-prior.ms" \
+  --field 1 \
+  --apply-mode calonly \
+  --interp "nearest;nearest;nearest" \
+  --gaintables "$issue122_dir/rust-priorcal/cal.ant,$issue122_dir/rust-priorcal/cal.gc,$issue122_dir/rust-priorcal/cal.tau" \
+  --format json \
+  --output "$outdir/rust-apply-report.json" \
+  --overwrite
+python3 - "$outdir/rust-apply-report.json" "$outdir/rust-apply-timing.json" <<'PY'
+import json
+import sys
+report = json.loads(open(sys.argv[1]).read())
+with open(sys.argv[2], "w") as handle:
+    json.dump({"elapsed_seconds": report["timings"]["total_ns"] / 1.0e9}, handle, indent=2)
+PY
+
+time_json rust-transform "$outdir/rust-transform-timing.json" \
+  target/release/mstransform \
+  --ms "$outdir/rust-target-prior.ms" \
+  --out "$outdir/rust-transform.ms" \
+  --field 1 \
+  --spw "0:7~58" \
+  --datacolumn CORRECTED_DATA
+
+CASA_RS_OUTDIR="$outdir" "$CASA_RS_CASA_PYTHON" - <<'PY'
+import json
+import os
+import time
+from casatasks import mstransform, uvcontsub, tclean, imstat, immoments, impv
+
+outdir = os.environ["CASA_RS_OUTDIR"]
+started = time.perf_counter()
+mstransform(
+    vis=f"{outdir}/casa-target-prior.ms",
+    outputvis=f"{outdir}/casa-transform.ms",
+    field="1",
+    spw="0:7~58",
+    datacolumn="corrected",
+    reindex=False,
+)
+with open(f"{outdir}/casa-transform-timing.json", "w") as handle:
+    json.dump({"elapsed_seconds": time.perf_counter() - started}, handle, indent=2)
+
+started = time.perf_counter()
+uvcontsub(
+    vis=f"{outdir}/casa-transform.ms",
+    outputvis=f"{outdir}/casa-contsub.ms",
+    fitspec="0:0~7;44~51",
+    fitorder=0,
+    datacolumn="data",
+    fitmethod="casacore",
+)
+with open(f"{outdir}/casa-uvcontsub-timing.json", "w") as handle:
+    json.dump({"elapsed_seconds": time.perf_counter() - started}, handle, indent=2)
+
+started = time.perf_counter()
+tclean(
+    vis=f"{outdir}/casa-contsub.ms",
+    imagename=f"{outdir}/casa-HC3N-natural",
+    field="1",
+    spw="0",
+    specmode="cube",
+    nchan=20,
+    start="0",
+    width="1",
+    outframe="LSRK",
+    restfreq="36.39232GHz",
+    gridder="standard",
+    deconvolver="hogbom",
+    weighting="natural",
+    imsize=128,
+    cell="0.4arcsec",
+    phasecenter=1,
+    niter=0,
+    threshold="0Jy",
+    datacolumn="data",
+    interactive=False,
+)
+with open(f"{outdir}/casa-tclean-timing.json", "w") as handle:
+    json.dump({"elapsed_seconds": time.perf_counter() - started}, handle, indent=2)
+
+stats = imstat(imagename=f"{outdir}/casa-HC3N-natural.image", box="48,48,80,80", chans="5~15")
+with open(f"{outdir}/casa-imstat.json", "w") as handle:
+    json.dump({k: (v.tolist() if hasattr(v, "tolist") else v) for k, v in stats.items()}, handle, indent=2, default=str)
+
+started = time.perf_counter()
+immoments(imagename=f"{outdir}/casa-HC3N-natural.image", outfile=f"{outdir}/casa-HC3N-natural.mom0", moments=[0], chans="5~15")
+with open(f"{outdir}/casa-immoments-timing.json", "w") as handle:
+    json.dump({"elapsed_seconds": time.perf_counter() - started}, handle, indent=2)
+
+started = time.perf_counter()
+impv(imagename=f"{outdir}/casa-HC3N-natural.image", outfile=f"{outdir}/casa-HC3N-natural.pv", mode="coords", start=[32,64], end=[96,64], width=3, unit="arcsec", chans="5~15", overwrite=True)
+with open(f"{outdir}/casa-impv-timing.json", "w") as handle:
+    json.dump({"elapsed_seconds": time.perf_counter() - started}, handle, indent=2)
+PY
+
+time_json rust-uvcontsub "$outdir/rust-uvcontsub-wall-timing.json" \
+  target/release/calibrate uvcontsub \
+  --ms "$outdir/rust-transform.ms" \
+  --out "$outdir/rust-contsub.ms" \
+  --fitspw "0:0~7;44~51" \
+  --fitorder 0 \
+  --datacolumn DATA \
+  --format json \
+  --output "$outdir/rust-uvcontsub-report.json" \
+  --overwrite
+python3 - "$outdir/rust-uvcontsub-report.json" "$outdir/rust-uvcontsub-timing.json" <<'PY'
+import json
+import sys
+report = json.loads(open(sys.argv[1]).read())
+with open(sys.argv[2], "w") as handle:
+    json.dump({"elapsed_seconds": report["elapsed_ns"] / 1.0e9}, handle, indent=2)
+PY
+
+time_json rust-tclean "$outdir/rust-tclean-timing.json" \
+  target/release/casars-imager \
+  --ms "$outdir/rust-contsub.ms" \
+  --imagename "$outdir/rust-HC3N-natural" \
+  --field 1 \
+  --spw 0 \
+  --specmode cube \
+  --channel-count 20 \
+  --start 0 \
+  --width 1 \
+  --outframe LSRK \
+  --restfreq 36.39232GHz \
+  --weighting natural \
+  --imsize 128 \
+  --cell-arcsec 0.4 \
+  --phasecenter-field 1 \
+  --niter 0 \
+  --threshold-jy 0 \
+  --datacolumn DATA \
+  --no-preview-pngs
+
+target/release/imexplore imstat "$outdir/rust-HC3N-natural.image" --box 48,48,80,80 --chans 5~15 --json > "$outdir/rust-imstat.json"
+time_json rust-immoments "$outdir/rust-immoments-timing.json" \
+  target/release/immoments "$outdir/rust-HC3N-natural.image" \
+  --outfile "$outdir/rust-HC3N-natural.mom0" \
+  --moments 0 \
+  --chans 5~15 \
+  --overwrite
+time_json rust-impv "$outdir/rust-impv-timing.json" \
+  target/release/impv "$outdir/rust-HC3N-natural.image" \
+  --outfile "$outdir/rust-HC3N-natural.pv" \
+  --start 32,64 \
+  --end 96,64 \
+  --width 3 \
+  --chans 5~15 \
+  --overwrite
+
+CASA_RS_OUTDIR="$outdir" "$CASA_RS_CASA_PYTHON" - <<'PY'
+import json
+import os
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+from casatools import image, table
+
+outdir = Path(os.environ["CASA_RS_OUTDIR"])
+
+def read_ms_data(path):
+    tb = table(); tb.open(str(path))
+    data = tb.getcol("DATA")
+    tb.close()
+    return data
+
+def image_chunk(path):
+    ia = image(); ia.open(str(path)); data = ia.getchunk(); ia.close()
+    return data
+
+def compare_array(name, casa, rust):
+    casa_cmp = np.squeeze(casa)
+    rust_cmp = np.squeeze(rust)
+    entry = {"casa_shape": list(casa.shape), "rust_shape": list(rust.shape)}
+    if casa_cmp.shape == rust_cmp.shape:
+        diff = rust_cmp - casa_cmp
+        entry.update({
+            "rms": float(np.sqrt(np.mean(np.abs(diff) ** 2))),
+            "max_abs": float(np.max(np.abs(diff))),
+            "relative_rms": float(np.sqrt(np.mean(np.abs(diff) ** 2)) / (np.sqrt(np.mean(np.abs(casa_cmp) ** 2)) + 1.0e-30)),
+        })
+    return entry
+
+summary = {}
+summary["transform_data"] = compare_array("transform", read_ms_data(outdir / "casa-transform.ms"), read_ms_data(outdir / "rust-transform.ms"))
+summary["contsub_data"] = compare_array("contsub", read_ms_data(outdir / "casa-contsub.ms"), read_ms_data(outdir / "rust-contsub.ms"))
+for product in ["image", "residual", "psf", "sumwt"]:
+    summary[f"cube_{product}"] = compare_array(
+        product,
+        image_chunk(outdir / f"casa-HC3N-natural.{product}"),
+        image_chunk(outdir / f"rust-HC3N-natural.{product}"),
+    )
+summary["mom0"] = compare_array("mom0", image_chunk(outdir / "casa-HC3N-natural.mom0"), image_chunk(outdir / "rust-HC3N-natural.mom0"))
+summary["pv"] = compare_array("pv", image_chunk(outdir / "casa-HC3N-natural.pv"), image_chunk(outdir / "rust-HC3N-natural.pv"))
+
+timings = {}
+for name in ["apply", "transform", "uvcontsub", "tclean", "immoments", "impv"]:
+    casa_path = outdir / f"casa-{name}-timing.json"
+    rust_path = outdir / f"rust-{name}-timing.json"
+    if casa_path.exists() and rust_path.exists():
+        casa = json.loads(casa_path.read_text())["elapsed_seconds"]
+        rust = json.loads(rust_path.read_text())["elapsed_seconds"]
+        timings[name] = {"casa_seconds": casa, "rust_seconds": rust, "speedup_casa_over_rust": casa / rust if rust else None}
+summary["timings"] = timings
+(outdir / "issue123-summary.json").write_text(json.dumps(summary, indent=2))
+
+casa_cube = image_chunk(outdir / "casa-HC3N-natural.image")
+rust_cube = image_chunk(outdir / "rust-HC3N-natural.image")
+chan = min(10, casa_cube.shape[3] - 1)
+vmax = max(float(np.nanmax(np.abs(casa_cube[:, :, 0, chan]))), float(np.nanmax(np.abs(rust_cube[:, :, 0, chan]))), 1.0e-12)
+fig, axes = plt.subplots(1, 3, figsize=(13, 4), dpi=150)
+for ax, title, data in [
+    (axes[0], "CASA cube channel 10", casa_cube[:, :, 0, chan]),
+    (axes[1], "casa-rs cube channel 10", rust_cube[:, :, 0, chan]),
+    (axes[2], "casa-rs - CASA", rust_cube[:, :, 0, chan] - casa_cube[:, :, 0, chan]),
+]:
+    im = ax.imshow(data.T, origin="lower", cmap="RdBu_r", vmin=-vmax, vmax=vmax)
+    ax.set_title(title)
+    ax.set_xticks([]); ax.set_yticks([])
+fig.colorbar(im, ax=axes.ravel().tolist(), shrink=0.8)
+fig.savefig(outdir / "cube-channel10-casa-vs-rust.png", bbox_inches="tight")
+plt.close(fig)
+
+casa_mom = np.squeeze(image_chunk(outdir / "casa-HC3N-natural.mom0"))
+rust_mom = np.squeeze(image_chunk(outdir / "rust-HC3N-natural.mom0"))
+vmax = max(float(np.nanmax(np.abs(casa_mom))), float(np.nanmax(np.abs(rust_mom))), 1.0e-12)
+fig, axes = plt.subplots(1, 3, figsize=(13, 4), dpi=150)
+for ax, title, data in [
+    (axes[0], "CASA moment 0", casa_mom),
+    (axes[1], "casa-rs moment 0", rust_mom),
+    (axes[2], "casa-rs - CASA", rust_mom - casa_mom),
+]:
+    im = ax.imshow(data.T, origin="lower", cmap="RdBu_r", vmin=-vmax, vmax=vmax)
+    ax.set_title(title)
+    ax.set_xticks([]); ax.set_yticks([])
+fig.colorbar(im, ax=axes.ravel().tolist(), shrink=0.8)
+fig.savefig(outdir / "moment0-casa-vs-rust.png", bbox_inches="tight")
+plt.close(fig)
+
+casa_pv = np.squeeze(image_chunk(outdir / "casa-HC3N-natural.pv"))
+rust_pv = np.squeeze(image_chunk(outdir / "rust-HC3N-natural.pv"))
+vmax = max(float(np.nanmax(np.abs(casa_pv))), float(np.nanmax(np.abs(rust_pv))), 1.0e-12)
+fig, axes = plt.subplots(1, 3, figsize=(13, 4), dpi=150)
+for ax, title, data in [
+    (axes[0], "CASA PV", casa_pv),
+    (axes[1], "casa-rs PV", rust_pv),
+    (axes[2], "casa-rs - CASA", rust_pv - casa_pv),
+]:
+    im = ax.imshow(data.T, origin="lower", aspect="auto", cmap="RdBu_r", vmin=-vmax, vmax=vmax)
+    ax.set_title(title)
+    ax.set_xlabel("offset pixel")
+    ax.set_ylabel("channel")
+fig.colorbar(im, ax=axes.ravel().tolist(), shrink=0.8)
+fig.savefig(outdir / "pv-casa-vs-rust.png", bbox_inches="tight")
+plt.close(fig)
+PY
+
+echo "Issue #123 artifacts written to $outdir"

--- a/scripts/run-vla-irc10216-issue123.sh
+++ b/scripts/run-vla-irc10216-issue123.sh
@@ -234,7 +234,8 @@ time_json rust-tclean "$outdir/rust-tclean-timing.json" \
   --niter 0 \
   --threshold-jy 0 \
   --datacolumn DATA \
-  --no-preview-pngs
+  --no-preview-pngs \
+  --dirty-only
 
 target/release/imexplore imstat "$outdir/rust-HC3N-natural.image" --box 48,48,80,80 --chans 5~15 --json > "$outdir/rust-imstat.json"
 time_json rust-immoments "$outdir/rust-immoments-timing.json" \

--- a/scripts/test-install-suite.sh
+++ b/scripts/test-install-suite.sh
@@ -20,9 +20,9 @@ echo "==> Building release binaries for suite install smoke test"
 cargo build --release -p casars --bin casars
 cargo build --release -p casa-calibration --bin calibrate
 cargo build --release -p casars-importvla --bin casars-importvla
-cargo build --release -p casa-ms --bin msexplore
+cargo build --release -p casa-ms --bin msexplore --bin mstransform
 cargo build --release -p casars-imager --bin casars-imager
-cargo build --release -p casa-images --bin imexplore --bin immoments --bin exportfits --bin importfits
+cargo build --release -p casa-images --bin imexplore --bin immoments --bin impv --bin exportfits --bin importfits
 
 echo "==> Building Python wheel artifacts for suite install smoke test"
 scripts/build-python-dist.sh "$wheel_dir"
@@ -65,9 +65,11 @@ echo "==> Verifying installed launchers"
 "$bin_dir/calibrate-stable" --protocol-info >/dev/null
 "$install_root/$version/bin/casars-importvla" --protocol-info >/dev/null
 "$install_root/$version/bin/msexplore" --protocol-info >/dev/null
+test -x "$install_root/$version/bin/mstransform"
 "$install_root/$version/bin/casars-imager" --protocol-info >/dev/null
 "$install_root/$version/bin/imexplore" --protocol-info >/dev/null
 "$install_root/$version/bin/immoments" --protocol-info >/dev/null
+"$install_root/$version/bin/impv" --protocol-info >/dev/null
 "$install_root/$version/bin/exportfits" --protocol-info >/dev/null
 "$install_root/$version/bin/importfits" --protocol-info >/dev/null
 
@@ -85,6 +87,7 @@ assert importvla.protocol_info().protocol_name == "casa_importvla_task"
 assert msexplore.protocol_info().protocol_name == "casa_msexplore_task"
 assert imager.protocol_info().protocol_name == "casa_imager_task"
 assert image_analysis.immoments_protocol_info().protocol_name == "casa_image_analysis_task"
+assert image_analysis.impv_protocol_info().protocol_name == "casa_image_analysis_task"
 assert image_analysis.exportfits_protocol_info().protocol_name == "casa_image_analysis_task"
 assert image_analysis.importfits_protocol_info().protocol_name == "casa_image_analysis_task"
 PY


### PR DESCRIPTION
Wave issue: #141

Includes issue: #121
Includes issue: #122
Includes issue: #123

Closes #121
Closes #122
Closes #123
Closes #141

Follow-up performance backlog:
- #154 apply performance
- #155 mstransform performance

## Summary

- Adds native `calibrate gencal` support for the IRC+10216 prior-cal slice: `antpos`, `gceff`, and `opac` float calibration tables.
- Adds native apply support for VLA prior tables (`KAntPos Jones`, `EGainCurve`, `TOpac`) by materializing row-dependent corrections from MS geometry.
- Adds the table-storage feature needed by real apply use: append a new tiled-shape array column to an existing disk table and persist only changed rows, so `CORRECTED_DATA` does not require rewriting every selected and unselected row.
- Adds tutorial-scoped native `mstransform` support for selected-row/channel materialization, including CASA-style time ordering, channel metadata updates, and UVW preservation.
- Adds native #123 line-imaging continuation through transform, `uvcontsub`, dirty cube imaging, `immoments`, and `impv`, with visible CASA-vs-casa-rs plots.
- Adds `imexplore immoments` and `imexplore impv` analysis entry points, plus the `impv` task/schema/Python surface.
- Extends install/package coverage for `mstransform` and `impv`.

## CASA Source Checks

- `KAntPosJones` in CASA `KJones.cc`: antenna offsets are projected through a frame built from antenna 0, epoch, and field direction.
- `EGainCurve` in CASA `EJones.cc`: gain curve uses zenith angle in degrees and a polynomial in that angle.
- `TOpac` in CASA `StandardVisCal.cc`: opacity uses zenith angle in radians and `sqrt(exp(-tau / cos(za)))`.
- `setjy` task/source was inspected; full `setjy` behavior is more complex than this wave slice and remains outside the completed #122/#123 work.
- `CalibratingVi2.cc`: CASA `applycal` corrects `VisBuffer2` chunks through `VisEquation::correct2` and caches correction per buffer. The remaining casa-rs apply gap is from row/cell-oriented update architecture, not a small missing coefficient.
- `MSTransformManager.cc`: CASA writes output planes/slices through `ArrayColumn::put` paths. casa-rs now uses column-wise selected reads and direct visibility-column writes, but still materializes non-visibility output row state.
- `GridFT.cc` and cube major/minor-cycle paths: dirty/PSF imaging avoids model interpolation work; casa-rs now skips natural-density/model-interpolation preparation for the same dirty-cube case.

## Evidence

- `just verify` passed on the final Wave 4 branch.
- `./scripts/test-python-package.sh` rerun with network access: 39 passed.
- `cargo fmt --all --check`
- `git diff --check`
- Focused issue-loop tests: `cargo test -p casa-calibration execute --lib`, `cargo test -p casa-tables prepared_row_reader_reuses_buffer_without_materializing_rows --lib`, `cargo test -p casa-tables save_with_bindings_ism_preserves_scalar_values_when_row_field_order_varies --lib`, `cargo test -p casa-tables tiled_selected_row_reads_reuse_shared_tile_cache --lib`, `cargo test -p casars-imager prepare_plane_input --lib`, `cargo test -p casars-imager cube_residual_refresh_wrappers_trace_single_plane_models --lib`, `cargo clippy -p casa-calibration --all-targets -- -D warnings`.
- `bash -n scripts/run-vla-irc10216-issue123.sh`
- `scripts/run-vla-irc10216-issue123.sh target/wdad-wave4-123-perf13`

## Latest #122 Comparison

Root-cause follow-up for the one-sided residual:

- CASA `EGainCurve` selects the VLA efficiency lookup frequency with `chanfreqs(chanfreqs.nelements()/2)`. casa-rs had used the arithmetic mean frequency. For a 64-channel SPW, that was channel 31.5 instead of CASA channel 32. At Q band the efficiency table is descending with frequency, so the lower mean frequency made casa-rs generate systematically larger `cal.gc` coefficients and therefore a positive applied-correction amplitude offset.
- After matching CASA, `priorcal-comparison.json` reports max FPARAM diff `0.0` for `cal.ant`, `cal.gc`, and `cal.tau`.

Latest comparison:

- `prior-gctau`: CASA `0.8726305419113487s`, casa-rs `0.477546083s`, max abs diff `1.1924653663481807e-06`, median abs diff `1.666000468656264e-08`.
- `prior-full`: CASA `0.9932168750092387s`, casa-rs `0.539794959s`, max abs diff `1.5497207641601562e-06`, median abs diff `2.9802322387695312e-08`.
- Applied-solution comparison (`DATA / CORRECTED_DATA`) after the fix: `prior-gctau` median correction amp diff `0.0`; `prior-full` median correction amp diff `-4.568093819878882e-11`.

## Latest #123 Comparison

From final corrected `target/wdad-wave4-123-signoff/issue123-summary.json`:

- Transform DATA: relative RMS `1.4523685897950337e-07`, max abs `1.6049041769309353e-07`.
- UV continuum-subtracted DATA: relative RMS `1.499122084806278e-07`, max abs `1.884864366154897e-07`.
- Dirty cube image/residual: relative RMS `0.008260635296420658`, max abs `0.00017252749967155978`.
- Cube PSF: relative RMS `0.0047146375086916876`, max abs `0.005382338538765907`.
- Cube SUMWT: relative RMS `0.0`.
- Moment 0: relative RMS `0.0021735787321394105`, max abs `2.6908121071755886e-05`.
- PV slice: relative RMS `0.000988729475640249`, max abs `8.956635610957164e-07` after squeezing the singleton Stokes axis.

## Performance Notes

From final corrected `target/wdad-wave4-123-signoff/issue123-summary.json` internal task timings:

- apply: CASA `3.3119s`, casa-rs `3.6415s`.
- transform: CASA `0.7315s`, casa-rs `1.1245s`.
- uvcontsub: CASA `6.5961s`, casa-rs `2.1604s`.
- tclean: CASA `2.7983s`, casa-rs `1.7220s`.
- immoments: CASA `0.2150s`, casa-rs `0.0074s`.
- impv: CASA `0.0113s`, casa-rs `0.0071s`.

Overall measured #123 workflow total:

- CASA `13.664s`
- casa-rs `8.663s`
- casa-rs is `1.58x` faster overall.

Remaining performance gap:

- casa-rs is faster for `uvcontsub`, the native dirty-cube imager task, `immoments`, and `impv`.
- casa-rs remains slower for apply and transform. The inspected CASA C++ paths show this is primarily a chunked `VisBuffer2`/direct column-slice write architecture difference. Follow-up backlog issues #154 and #155 track those gaps.

## Deferred outside current completed slices

- Full `setjy` model setup semantics are not implemented here.
- Full `mstransform` mode coverage is not implemented; the new transform path is tutorial-scoped.
- PV output currently retains a singleton Stokes axis (`[path, 1, 1, chan]`) while CASA squeezes that axis (`[path, 1, chan]`); comparison and plotting squeeze the singleton for parity checks.
