### PR TITLE
Restore long-gate coverage threshold

### DIFF
--- a/crates/casa-calibration/src/execute.rs
+++ b/crates/casa-calibration/src/execute.rs
@@ -4690,6 +4690,11 @@ mod tests {
     use ndarray::{ArrayD, IxDyn, ShapeBuilder};
     use tempfile::TempDir;
 
+    use crate::model::{
+        CalibrationColumnSummary, CalibrationKeywordSummary, CalibrationSubtableSummary,
+        CalibrationTableSummary,
+    };
+
     fn perf_env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))
@@ -4708,6 +4713,37 @@ mod tests {
             (actual - expected).norm() <= tolerance,
             "actual={actual:?} expected={expected:?}"
         );
+    }
+
+    fn empty_cal_summary(path: PathBuf) -> CalibrationTableSummary {
+        CalibrationTableSummary {
+            path,
+            table_type: "Calibration".to_string(),
+            table_subtype: "G Jones".to_string(),
+            row_count: 0,
+            columns: Vec::new(),
+            keywords: CalibrationKeywordSummary {
+                par_type: None,
+                vis_cal: None,
+                ms_name: None,
+                pol_basis: None,
+                casa_version: None,
+            },
+            subtables: Vec::<CalibrationSubtableSummary>::new(),
+            parameter_family: CalibrationParameterFamily::Complex,
+            parameter_column: CalibrationColumnSummary {
+                parameter_column: None,
+                parameter_primitive_type: None,
+                first_cell_shape: None,
+            },
+            field_ids: Vec::new(),
+            spectral_window_ids: Vec::new(),
+            antenna1_ids: Vec::new(),
+            antenna2_ids: Vec::new(),
+            observation_ids: Vec::new(),
+            time_coverage: None,
+            issues: Vec::new(),
+        }
     }
 
     #[test]
@@ -4787,6 +4823,143 @@ mod tests {
         let log = fs::read_to_string(log_paths[0].clone()).expect("summary log");
         assert!(log.contains("kind=ApplyCompleted"));
         assert!(log.contains("row_read_overhead_ms=0.00"));
+    }
+
+    #[test]
+    fn calibration_perf_tracer_emits_plan_and_completion_metadata() {
+        let _guard = perf_env_lock().lock().expect("perf env lock");
+        let tempdir = TempDir::new().expect("tempdir");
+        unsafe {
+            std::env::set_var(PERF_ENV, "1");
+            std::env::set_var(PERF_DIR_ENV, tempdir.path());
+        }
+
+        let cal_path = tempdir.path().join("gain.cal");
+        let spw_plan = crate::plan::SpectralWindowPlan {
+            spw_id: 2,
+            num_chan: 3,
+            ref_frequency_hz: 1.4e9,
+            channel_frequencies_hz: vec![1.399e9, 1.4e9, 1.401e9],
+        };
+        let plan = ApplyPlan {
+            measurement_set_path: Some(tempdir.path().join("input.ms")),
+            apply_mode: ApplyMode::CalFlag,
+            requires_corrected_data_column: true,
+            selected_rows: vec![ApplyRowPlan {
+                row_index: 4,
+                field_id: 5,
+                observation_id: 6,
+                data_desc_id: 7,
+                data_spw_id: 2,
+                polarization_id: 8,
+                antenna1: 9,
+                antenna2: 10,
+                feed1: 0,
+                feed2: 0,
+                time_seconds: 123.0,
+                interval_seconds: 2.0,
+            }],
+            selected_row_count: 1,
+            parang: true,
+            selected_field_ids: vec![5],
+            selected_data_desc_ids: vec![7],
+            selected_data_spw_ids: vec![2],
+            measurement_set_spectral_windows: vec![spw_plan.clone()],
+            calibration_tables: vec![ApplyCalibrationTablePlan {
+                spec: crate::plan::ApplyCalibrationTableSpec {
+                    path: cal_path.clone(),
+                    apply_to: Default::default(),
+                    gainfield: None,
+                    spwmap: vec![2],
+                    interp: ApplyInterpolationMode::Linear,
+                    calwt: true,
+                },
+                applicable_selected_row_count: 1,
+                summary: empty_cal_summary(cal_path.clone()),
+                resolved_gainfield: None,
+                resolved_nearest_gainfields: Vec::new(),
+                spw_mapping: vec![crate::plan::ApplySpwMapping {
+                    data_spw_id: 2,
+                    calibration_spw_id: 2,
+                }],
+                calibration_spectral_windows: vec![spw_plan],
+                interp: ApplyInterpolationMode::Linear,
+                calwt: true,
+            }],
+        };
+        let summary = ExecuteApplyPlanTraceSummary {
+            selected_row_count: 1,
+            calibration_table_count: 1,
+            parang: true,
+            created_corrected_data_column: true,
+            updated_row_count: 1,
+            flagged_row_count: 0,
+            flagged_sample_count: 2,
+            row_field_index_lookup_ns: 11,
+            ensure_corrected_data_ns: 12,
+            correlation_lookup_ns: 13,
+            calibration_load_ns: 14,
+            row_loop_ns: 15,
+            row_read_total_ns: 16,
+            row_fetch_ns: 17,
+            row_compute_ns: 18,
+            row_read_overhead_ns: 19,
+            row_writeback_ns: 20,
+            save_ns: 21,
+            execute_apply_plan_ns: 22,
+            execute_apply_plan_unattributed_ns: 23,
+        };
+        let report = ApplyExecutionReport {
+            plan,
+            created_corrected_data_column: true,
+            wrote_measurement_set: true,
+            updated_row_count: 1,
+            flagged_row_count: 0,
+            flagged_sample_count: 2,
+            timings: ApplyExecutionTimings {
+                planning_ns: 31,
+                planning_selection_ns: 32,
+                planning_selected_rows_ns: 33,
+                planning_measurement_set_spectral_windows_ns: 34,
+                planning_calibration_table_plans_ns: 35,
+                open_measurement_set_ns: 36,
+                row_field_index_lookup_ns: 37,
+                ensure_corrected_data_ns: 38,
+                correlation_lookup_ns: 39,
+                calibration_load_ns: 40,
+                row_compute_ns: 41,
+                row_writeback_ns: 42,
+                save_ns: 43,
+                total_ns: 44,
+            },
+        };
+
+        let mut tracer = CalibrationPerfTracer::from_env();
+        tracer.emit_apply_plan_summary("/tmp/input.ms", &report.plan, summary);
+        tracer.emit_apply_completed("/tmp/input.ms", &report, 55, summary);
+        drop(tracer);
+
+        unsafe {
+            std::env::remove_var(PERF_ENV);
+            std::env::remove_var(PERF_DIR_ENV);
+        }
+
+        let json_path = fs::read_dir(tempdir.path())
+            .expect("read perf dir")
+            .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+            .find(|path| {
+                path.extension()
+                    .is_some_and(|extension| extension == "jsonl")
+            })
+            .expect("json trace");
+        let json = fs::read_to_string(json_path).expect("json trace");
+        assert!(json.contains("\"kind\":\"apply_plan_summary\""));
+        assert!(json.contains("\"kind\":\"apply_completed\""));
+        assert!(json.contains("\"apply_mode\":\"CalFlag\""));
+        assert!(json.contains("\"parang\":true"));
+        assert!(json.contains("\"planning_calibration_table_plans_ns\":35"));
+        assert!(json.contains("\"drop_ns\":55"));
+        assert!(json.contains("\"execute_apply_plan_unattributed_ns\":23"));
     }
 
     fn default_main_value(column: &ColumnSchema) -> Value {
@@ -4920,6 +5093,126 @@ mod tests {
             .unwrap();
 
         assert!((feed - (base + 0.25)).abs() < 1.0e-12);
+    }
+
+    #[test]
+    fn row_geometry_cache_reuses_row_dependent_grids_and_fast_terms() {
+        let mut cache = RowGeometryCache::default();
+        let offset_a = [1_u64, 2, 3];
+        let offset_b = [4_u64, 5, 6];
+        cache.ensure_fast_term_context(12.5, 3);
+
+        assert_eq!(cache.cached_fast_antpos_delay(0, 2, offset_a), None);
+        cache.remember_fast_antpos_delay(0, 2, offset_a, 4.25);
+        assert_eq!(cache.cached_fast_antpos_delay(0, 2, offset_a), Some(4.25));
+        assert_eq!(cache.cached_fast_antpos_delay(0, 2, offset_b), None);
+
+        let gains = FastReceptorGains {
+            receptor_count: 2,
+            values: [1.5, 2.5, 0.0, 0.0],
+            flags: [false, true, false, false],
+        };
+        cache.remember_fast_gain_curve(1, 3, gains);
+        let cached_gains = cache.cached_fast_gain_curve(1, 3).expect("gain cache");
+        assert_eq!(cached_gains.sample(0), (1.5, false));
+        assert_eq!(cached_gains.sample(8), (2.5, true));
+
+        cache.remember_fast_opacity(2, 4, 0.875);
+        assert_eq!(cache.cached_fast_opacity(2, 4), Some(0.875));
+
+        cache.ensure_fast_term_context(12.5, 4);
+        assert_eq!(cache.cached_fast_antpos_delay(0, 2, offset_a), None);
+        assert_eq!(
+            cache
+                .cached_fast_gain_curve(1, 3)
+                .map(|value| value.sample(0)),
+            None
+        );
+        assert_eq!(cache.cached_fast_opacity(2, 4), None);
+
+        let antpos = Arc::new(CalibrationGrid::Antpos(AntposGrid {
+            offsets_m: [1.0, 2.0, 3.0],
+            flagged: false,
+        }));
+        let gain_curve = Arc::new(CalibrationGrid::GainCurve(GainCurveGrid {
+            receptor_count: 1,
+            coefficients: ArrayD::from_shape_vec(IxDyn(&[4, 1]).f(), vec![1.0_f32, 0.0, 0.0, 0.0])
+                .unwrap(),
+            flags: ArrayD::from_shape_vec(IxDyn(&[4, 1]).f(), vec![false; 4]).unwrap(),
+        }));
+        let opacity = Arc::new(CalibrationGrid::Opacity(OpacityGrid {
+            tau: 0.1,
+            flagged: true,
+        }));
+        let complex = Arc::new(CalibrationGrid::Complex(GainGrid {
+            receptor_count: 1,
+            channel_count: 1,
+            values: ArrayD::from_shape_vec(IxDyn(&[1, 1]).f(), vec![Complex32::new(1.0, 0.0)])
+                .unwrap(),
+            flags: ArrayD::from_shape_vec(IxDyn(&[1, 1]).f(), vec![false]).unwrap(),
+        }));
+
+        let antpos_key = materialized_grid_key(&antpos, 3, 2, 12.5, 7).expect("antpos key");
+        let gain_curve_key =
+            materialized_grid_key(&gain_curve, 3, 2, 12.5, 7).expect("gain curve key");
+        let opacity_key = materialized_grid_key(&opacity, 3, 2, 12.5, 7).expect("opacity key");
+        assert_eq!(antpos_key.kind, 1);
+        assert_eq!(gain_curve_key.kind, 2);
+        assert_eq!(opacity_key.kind, 3);
+        assert!(materialized_grid_key(&complex, 3, 2, 12.5, 7).is_none());
+
+        assert!(cache.materialized_grid(antpos_key).is_none());
+        cache.insert_materialized_grid(antpos_key, antpos.clone());
+        assert!(Arc::ptr_eq(
+            &cache
+                .materialized_grid(antpos_key)
+                .expect("materialized grid"),
+            &antpos
+        ));
+
+        let lookup_key =
+            calibration_lookup_key(5, 3, 7, 2, 12.5, ApplyInterpolationMode::NearestLinear);
+        assert_eq!(lookup_key.interp, 3);
+        assert_eq!(
+            calibration_lookup_key(5, 3, 7, 2, 12.5, ApplyInterpolationMode::Nearest).interp,
+            1
+        );
+        assert_eq!(
+            calibration_lookup_key(5, 3, 7, 2, 12.5, ApplyInterpolationMode::Linear).interp,
+            2
+        );
+
+        let mut load_count = 0;
+        let first = cache
+            .calibration_lookup(lookup_key, || {
+                load_count += 1;
+                Ok(Some(gain_curve.clone()))
+            })
+            .expect("first lookup")
+            .expect("grid");
+        let second = cache
+            .calibration_lookup(lookup_key, || {
+                load_count += 1;
+                Ok(Some(opacity.clone()))
+            })
+            .expect("cached lookup")
+            .expect("grid");
+        assert_eq!(load_count, 1);
+        assert!(Arc::ptr_eq(&first, &second));
+
+        let missing_key = calibration_lookup_key(6, 3, 7, 2, 12.5, ApplyInterpolationMode::Nearest);
+        assert!(
+            cache
+                .calibration_lookup(missing_key, || Ok(None))
+                .expect("missing lookup")
+                .is_none()
+        );
+        assert!(
+            cache
+                .calibration_lookup(missing_key, || panic!("cached None should not reload"))
+                .expect("cached missing lookup")
+                .is_none()
+        );
     }
 
     #[test]
@@ -5090,6 +5383,160 @@ mod tests {
             Err(ApplyExecutionError::UnsupportedInterpolation { .. }) => {}
             Err(other) => panic!("unexpected error: {other:?}"),
         }
+    }
+
+    #[test]
+    fn fast_gain_pair_application_covers_layouts_flags_and_frequency_errors() {
+        let scalar_ant1 = Arc::new(CalibrationGrid::Complex(GainGrid {
+            receptor_count: 2,
+            channel_count: 1,
+            values: ArrayD::from_shape_vec(
+                IxDyn(&[2, 1]).f(),
+                vec![Complex32::new(2.0, 0.0), Complex32::new(3.0, 0.0)],
+            )
+            .unwrap(),
+            flags: ArrayD::from_shape_vec(IxDyn(&[2, 1]).f(), vec![false, false]).unwrap(),
+        }));
+        let scalar_ant2 = Arc::new(CalibrationGrid::Complex(GainGrid {
+            receptor_count: 2,
+            channel_count: 1,
+            values: ArrayD::from_shape_vec(
+                IxDyn(&[2, 1]).f(),
+                vec![Complex32::new(4.0, 0.0), Complex32::new(5.0, 0.0)],
+            )
+            .unwrap(),
+            flags: ArrayD::from_shape_vec(IxDyn(&[2, 1]).f(), vec![false, false]).unwrap(),
+        }));
+        let channel_ant1 = Arc::new(CalibrationGrid::Complex(GainGrid {
+            receptor_count: 2,
+            channel_count: 2,
+            values: ArrayD::from_shape_vec(
+                IxDyn(&[2, 2]).f(),
+                vec![
+                    Complex32::new(1.0, 0.0),
+                    Complex32::new(2.0, 0.0),
+                    Complex32::new(3.0, 0.0),
+                    Complex32::new(4.0, 0.0),
+                ],
+            )
+            .unwrap(),
+            flags: ArrayD::from_shape_vec(IxDyn(&[2, 2]).f(), vec![false, false, false, true])
+                .unwrap(),
+        }));
+        let channel_ant2 = Arc::new(CalibrationGrid::Complex(GainGrid {
+            receptor_count: 2,
+            channel_count: 2,
+            values: ArrayD::from_shape_vec(
+                IxDyn(&[2, 2]).f(),
+                vec![
+                    Complex32::new(1.0, 0.0),
+                    Complex32::new(1.0, 0.0),
+                    Complex32::new(1.0, 0.0),
+                    Complex32::new(1.0, 0.0),
+                ],
+            )
+            .unwrap(),
+            flags: ArrayD::from_shape_vec(IxDyn(&[2, 2]).f(), vec![false; 4]).unwrap(),
+        }));
+
+        let mut corrected =
+            ArrayD::from_shape_vec(IxDyn(&[2, 2]), vec![Complex32::new(80.0, 0.0); 4]).unwrap();
+        let mut flags =
+            ArrayD::from_shape_vec(IxDyn(&[2, 2]), vec![false, false, false, false]).unwrap();
+        let mut newly_flagged_samples = 0;
+        apply_complex_gain_pairs_fast(
+            &[
+                FastGainPair::Complex(scalar_ant1.clone(), scalar_ant2.clone()),
+                FastGainPair::Complex(channel_ant1.clone(), channel_ant2.clone()),
+            ],
+            FastGainApply {
+                data_desc_id: 0,
+                correlation_types: &[5, 8],
+                data_frequencies_hz: &[1.0e9, 1.1e9],
+                corrected: &mut corrected,
+                flags: &mut flags,
+                apply_mode: ApplyMode::CalFlag,
+                newly_flagged_samples: &mut newly_flagged_samples,
+            },
+        )
+        .unwrap();
+        assert_complex_close(corrected[[0, 0]], Complex32::new(10.0, 0.0), 1.0e-6);
+        assert_complex_close(corrected[[1, 0]], Complex32::new(80.0 / 30.0, 0.0), 1.0e-6);
+        assert_complex_close(corrected[[0, 1]], Complex32::new(80.0 / 24.0, 0.0), 1.0e-6);
+        assert!(flags[[1, 1]]);
+        assert_eq!(newly_flagged_samples, 1);
+
+        let mut fortran_corrected =
+            ArrayD::from_shape_vec(IxDyn(&[2, 2]).f(), vec![Complex32::new(90.0, 0.0); 4]).unwrap();
+        let mut fortran_flags =
+            ArrayD::from_shape_vec(IxDyn(&[2, 2]).f(), vec![false, false, true, false]).unwrap();
+        let mut fortran_new_flags = 0;
+        apply_complex_gain_pairs_fast(
+            &[
+                FastGainPair::GainCurve {
+                    ant1: FastReceptorGains {
+                        receptor_count: 2,
+                        values: [2.0, 3.0, 0.0, 0.0],
+                        flags: [false, false, false, false],
+                    },
+                    ant2: FastReceptorGains {
+                        receptor_count: 2,
+                        values: [5.0, 7.0, 0.0, 0.0],
+                        flags: [false, false, false, false],
+                    },
+                },
+                FastGainPair::Opacity {
+                    denom: Complex32::new(0.5, 0.0),
+                    flagged: false,
+                },
+            ],
+            FastGainApply {
+                data_desc_id: 0,
+                correlation_types: &[5, 8],
+                data_frequencies_hz: &[1.0e9, 1.1e9],
+                corrected: &mut fortran_corrected,
+                flags: &mut fortran_flags,
+                apply_mode: ApplyMode::CalFlag,
+                newly_flagged_samples: &mut fortran_new_flags,
+            },
+        )
+        .unwrap();
+        assert_complex_close(fortran_corrected[[0, 0]], Complex32::new(18.0, 0.0), 1.0e-6);
+        assert_complex_close(
+            fortran_corrected[[1, 0]],
+            Complex32::new(90.0 / 21.0 / 0.5, 0.0),
+            1.0e-6,
+        );
+        assert_eq!(fortran_new_flags, 0);
+
+        let mut antpos_corrected =
+            ArrayD::from_shape_vec(IxDyn(&[1, 2]), vec![Complex32::new(1.0, 0.0); 2]).unwrap();
+        let mut antpos_flags = ArrayD::from_shape_vec(IxDyn(&[1, 2]), vec![false; 2]).unwrap();
+        let mut antpos_new_flags = 0;
+        assert!(matches!(
+            apply_complex_gain_pairs_fast(
+                &[FastGainPair::Antpos {
+                    delay_delta_ns: 1.0,
+                    flagged: false,
+                }],
+                FastGainApply {
+                    data_desc_id: 0,
+                    correlation_types: &[5],
+                    data_frequencies_hz: &[1.0e9],
+                    corrected: &mut antpos_corrected,
+                    flags: &mut antpos_flags,
+                    apply_mode: ApplyMode::Trial,
+                    newly_flagged_samples: &mut antpos_new_flags,
+                },
+            )
+            .unwrap_err(),
+            ApplyExecutionError::UnsupportedInterpolation { .. }
+        ));
+
+        assert!(matches!(
+            fast_pair_receptors(9, &[42], 1).unwrap_err(),
+            ApplyExecutionError::UnsupportedCorrelationLayout { .. }
+        ));
     }
 
     #[test]

--- a/crates/casa-calibration/src/solve/trace.rs
+++ b/crates/casa-calibration/src/solve/trace.rs
@@ -3,7 +3,6 @@
 
 use std::fs::OpenOptions;
 use std::io::Write;
-use std::sync::OnceLock;
 
 use serde::Serialize;
 use serde_json::json;
@@ -14,18 +13,22 @@ use super::{GainSolveMode, GainSolveRequest, GainType};
 
 const TRACE_ENV: &str = "CASA_RS_GAIN_TRACE";
 
-fn trace_path() -> Option<&'static std::path::PathBuf> {
-    static PATH: OnceLock<Option<std::path::PathBuf>> = OnceLock::new();
-    PATH.get_or_init(|| {
-        let value = std::env::var_os(TRACE_ENV)?;
-        let path = std::path::PathBuf::from(value);
-        if path.as_os_str().is_empty() {
-            None
-        } else {
-            Some(path)
-        }
-    })
-    .as_ref()
+#[cfg(test)]
+thread_local! {
+    static TEST_TRACE_PATH: std::cell::RefCell<Option<std::path::PathBuf>> = const {
+        std::cell::RefCell::new(None)
+    };
+}
+
+fn trace_path() -> Option<std::path::PathBuf> {
+    #[cfg(test)]
+    if let Some(path) = TEST_TRACE_PATH.with(|path| path.borrow().clone()) {
+        return Some(path);
+    }
+
+    let value = std::env::var_os(TRACE_ENV)?;
+    let path = std::path::PathBuf::from(value);
+    (!path.as_os_str().is_empty()).then_some(path)
 }
 
 fn write_event(event: impl Serialize) {
@@ -35,7 +38,7 @@ fn write_event(event: impl Serialize) {
     let result = OpenOptions::new()
         .create(true)
         .append(true)
-        .open(path)
+        .open(&path)
         .and_then(|mut file| {
             serde_json::to_writer(&mut file, &event).map_err(std::io::Error::other)?;
             file.write_all(b"\n")
@@ -279,5 +282,190 @@ fn solve_mode_name(solve_mode: GainSolveMode) -> &'static str {
     match solve_mode {
         GainSolveMode::Phase => "p",
         GainSolveMode::AmplitudePhase => "ap",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeSet, HashMap};
+
+    use casa_ms::selection::MsSelection;
+    use casa_types::Complex32;
+    use num_complex::Complex64;
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::solve::grouping::SolveEdgeStats;
+    use crate::solve::kernel::PhaseStepTrace;
+    use crate::solve::{GainSolveCombine, GainSolveInterval, GainSolveModelSource, RefAntSelector};
+
+    fn test_request(output_table: impl Into<std::path::PathBuf>) -> GainSolveRequest {
+        GainSolveRequest {
+            selection: MsSelection::new(),
+            output_table: output_table.into(),
+            gain_type: GainType::G,
+            solve_mode: GainSolveMode::Phase,
+            solve_interval: GainSolveInterval::Integration,
+            combine: GainSolveCombine::default(),
+            refant: RefAntSelector::AntennaId(0),
+            prior_calibration_tables: Vec::new(),
+            parang: false,
+            model_source: GainSolveModelSource::PointSource,
+            normalize_average_amplitude: false,
+            min_snr: 0.0,
+            min_baselines_per_antenna: 1,
+            smodel: [1.0, 0.0, 0.0, 0.0],
+        }
+    }
+
+    #[test]
+    fn trace_writers_emit_group_solution_and_phase_iteration_jsonl() {
+        let dir = tempdir().expect("tempdir");
+        let trace_file = dir.path().join("gain-trace.jsonl");
+        TEST_TRACE_PATH.with(|path| *path.borrow_mut() = Some(trace_file.clone()));
+
+        let base_key = SolveBaseKey {
+            field_id: 3,
+            spw_id: 4,
+            observation_id: 5,
+            scan_number: 6,
+        };
+        let bucket_key = SolveBucketKey::Integration {
+            time_bits: 12.5_f64.to_bits(),
+            interval_bits: 2.0_f64.to_bits(),
+        };
+        let mut group = SolveAccumulator::new(3, 4, 5);
+        group.min_time = 10.0;
+        group.max_time = 20.0;
+        group.unique_time_sum = 30.0;
+        group.unique_time_count = 2;
+        group.time_centroid_weighted_sum = 61.0;
+        group.time_centroid_weight = 4.0;
+        group.total_interval = 8.0;
+        group.sample_rows = 2;
+        group.scan_numbers.insert(6);
+        group.antenna_ids.extend([0, 1]);
+        group.receptor_graphs = vec![HashMap::from([
+            ((0, 1), Complex32::new(2.0, -1.0)),
+            ((1, 0), Complex32::new(2.0, 1.0)),
+        ])];
+        group.receptor_weights = vec![HashMap::from([((0, 1), 3.5), ((1, 0), 3.5)])];
+        group.receptor_stats = vec![HashMap::from([(
+            (0, 1),
+            SolveEdgeStats {
+                weighted_sample_power: 7.0,
+                raw_weighted_sample_power: 8.0,
+                sample_count: 9,
+                collapsed_count: 10,
+            },
+        )])];
+        let request = test_request(dir.path().join("phase.cal"));
+
+        trace_group(&base_key, &bucket_key, &group, &request);
+        trace_solution_rows(
+            &base_key,
+            &SolveBucketKey::Seconds(2),
+            &[
+                SolutionRow {
+                    time_seconds: 20.0,
+                    interval_seconds: 4.0,
+                    field_id: 3,
+                    spw_id: 4,
+                    antenna_id: 2,
+                    scan_number: 6,
+                    observation_id: 5,
+                    gains: vec![Complex32::new(0.5, 0.25)],
+                    flags: vec![false],
+                    param_errors: vec![0.1],
+                    snrs: vec![12.0],
+                    weights: vec![99.0],
+                },
+                SolutionRow {
+                    time_seconds: 20.0,
+                    interval_seconds: 4.0,
+                    field_id: 3,
+                    spw_id: 4,
+                    antenna_id: 1,
+                    scan_number: 6,
+                    observation_id: 5,
+                    gains: vec![Complex32::new(1.0, 0.0)],
+                    flags: vec![true],
+                    param_errors: vec![0.0],
+                    snrs: vec![0.0],
+                    weights: vec![0.0],
+                },
+            ],
+            &request,
+            0,
+        );
+
+        let antenna_ids = BTreeSet::from([0, 1]);
+        let step = PhaseStepTrace {
+            x0: 0.0,
+            x1: 0.5,
+            x2: 1.0,
+            step: 0.25,
+            opt_factor: 0.75,
+            expanded: true,
+            iterations: 3,
+        };
+        let gains = HashMap::from([(1, Complex64::new(0.0, 1.0))]);
+        let last_gains = HashMap::from([(1, Complex64::new(1.0, 0.0))]);
+        let gradient = HashMap::from([(1, Complex64::new(0.1, -0.2))]);
+        let hessian = HashMap::from([(1, 2.0)]);
+        let delta = HashMap::from([(1, Complex64::new(-0.01, 0.02))]);
+        trace_phase_solver_iteration(PhaseSolverTraceEvent {
+            iteration: 7,
+            refant_id: 0,
+            chi_square: 1.0,
+            last_chi_square: 2.0,
+            delta_chi_square: -1.0,
+            fractional_delta: -0.5,
+            convergence_count: 2,
+            step: &step,
+            antenna_ids: &antenna_ids,
+            last_gains: &last_gains,
+            gains: &gains,
+            gradient: &gradient,
+            hessian: &hessian,
+            delta: &delta,
+        });
+
+        TEST_TRACE_PATH.with(|path| *path.borrow_mut() = None);
+
+        let lines = std::fs::read_to_string(&trace_file).expect("trace file");
+        assert!(lines.contains("\"event\":\"rust_group\""));
+        assert!(lines.contains("\"kind\":\"integration\""));
+        assert!(lines.contains("\"sample_count\":9"));
+        assert!(lines.contains("\"event\":\"rust_solution\""));
+        assert!(lines.contains("\"kind\":\"seconds\""));
+        assert!(
+            lines.find("\"antenna_id\":1").expect("antenna 1")
+                < lines.find("\"antenna_id\":2").expect("antenna 2")
+        );
+        assert!(lines.contains("\"event\":\"rust_phase_solver_iteration\""));
+        assert!(lines.contains("\"expanded\":true"));
+        assert!(lines.contains("\"gradient_im\":-0.2"));
+    }
+
+    #[test]
+    fn trace_name_helpers_cover_public_request_enums() {
+        assert_eq!(gain_type_name(GainType::G), "G");
+        assert_eq!(gain_type_name(GainType::T), "T");
+        assert_eq!(solve_mode_name(GainSolveMode::Phase), "p");
+        assert_eq!(solve_mode_name(GainSolveMode::AmplitudePhase), "ap");
+        assert_eq!(
+            base_key_json(&SolveBaseKey {
+                field_id: 1,
+                spw_id: 2,
+                observation_id: 3,
+                scan_number: 4,
+            })["scan_number"],
+            4
+        );
+        assert_eq!(
+            bucket_key_json(&SolveBucketKey::Infinite)["kind"],
+            "infinite"
+        );
     }
 }

--- a/crates/casa-calibration/tests/gencal.rs
+++ b/crates/casa-calibration/tests/gencal.rs
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+mod common;
+
+use casa_calibration::{GencalRequest, GencalType, gencal};
+use casa_tables::{ColumnSchema, DataManagerKind, Table, TableOptions, TableSchema};
+use casa_types::{ArrayValue, RecordField, RecordValue, ScalarValue, Value};
+use ndarray::{ArrayD, IxDyn, ShapeBuilder};
+
+#[test]
+fn gencal_antpos_writes_offsets_for_selected_antennas_and_zeroes_others() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let ms_path =
+        common::create_gain_solve_fixture_ms(dir.path(), common::SyntheticGainFixtureKind::G);
+    let caltable_path = dir.path().join("antpos.cal");
+
+    let report = gencal(&GencalRequest {
+        measurement_set: ms_path,
+        output_table: caltable_path.clone(),
+        caltype: GencalType::Antpos,
+        antenna: "ANT0,1".to_string(),
+        spw: String::new(),
+        parameter: vec![1.0, 2.0, 3.0, -4.0, -5.0, -6.0],
+        gaincurve_table: None,
+    })
+    .expect("antpos gencal");
+
+    assert_eq!(report.caltype, GencalType::Antpos);
+    assert_eq!(report.table_subtype, "KAntPos Jones");
+    assert_eq!(report.row_count, 3);
+    assert_eq!(report.spectral_window_ids, vec![0]);
+    assert_eq!(report.antenna_ids, vec![0, 1, 2]);
+
+    let table = Table::open(TableOptions::new(&caltable_path)).expect("open antpos table");
+    assert_eq!(table.row_count(), 3);
+    assert_eq!(
+        table.keywords().get("VisCal"),
+        Some(&Value::Scalar(ScalarValue::String(
+            "KAntPos Jones".to_string()
+        )))
+    );
+    assert_fparam(&table, 0, &[1.0, 2.0, 3.0]);
+    assert_fparam(&table, 1, &[-4.0, -5.0, -6.0]);
+    assert_fparam(&table, 2, &[0.0, 0.0, 0.0]);
+    assert!(caltable_path.join("ANTENNA").exists());
+    assert!(caltable_path.join("SPECTRAL_WINDOW").exists());
+}
+
+#[test]
+fn gencal_opacity_expands_selected_spws_across_antennas() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let ms_path =
+        common::create_gain_solve_fixture_ms(dir.path(), common::SyntheticGainFixtureKind::G);
+    let caltable_path = dir.path().join("opacity.cal");
+
+    let report = gencal(&GencalRequest {
+        measurement_set: ms_path.clone(),
+        output_table: caltable_path.clone(),
+        caltype: GencalType::Opac,
+        antenna: String::new(),
+        spw: "0~1".to_string(),
+        parameter: vec![0.11, 0.22],
+        gaincurve_table: None,
+    })
+    .expect("opac gencal");
+
+    assert_eq!(report.caltype, GencalType::Opac);
+    assert_eq!(report.table_subtype, "TOpac");
+    assert_eq!(report.row_count, 6);
+    assert_eq!(report.spectral_window_ids, vec![0, 1]);
+    assert_eq!(report.antenna_ids, vec![0, 1, 2]);
+
+    let table = Table::open(TableOptions::new(&caltable_path)).expect("open opacity table");
+    for row in 0..3 {
+        assert_scalar_i32(&table, row, "SPECTRAL_WINDOW_ID", 0);
+        assert_fparam(&table, row, &[0.11]);
+    }
+    for row in 3..6 {
+        assert_scalar_i32(&table, row, "SPECTRAL_WINDOW_ID", 1);
+        assert_fparam(&table, row, &[0.22]);
+    }
+
+    let err = gencal(&GencalRequest {
+        measurement_set: ms_path,
+        output_table: dir.path().join("bad-opacity.cal"),
+        caltype: GencalType::Opac,
+        antenna: String::new(),
+        spw: "0,1".to_string(),
+        parameter: vec![0.11],
+        gaincurve_table: None,
+    })
+    .unwrap_err();
+    assert!(err.to_string().contains("one parameter per selected SPW"));
+}
+
+#[test]
+fn gencal_gceff_uses_gaincurve_rows_and_vla_efficiency() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let ms_path =
+        common::create_gain_solve_fixture_ms(dir.path(), common::SyntheticGainFixtureKind::G);
+    let gaincurve_path = dir.path().join("GainCurves");
+    write_gaincurve_table(&gaincurve_path);
+    let caltable_path = dir.path().join("gceff.cal");
+
+    let report = gencal(&GencalRequest {
+        measurement_set: ms_path,
+        output_table: caltable_path.clone(),
+        caltype: GencalType::Gceff,
+        antenna: String::new(),
+        spw: String::new(),
+        parameter: vec![],
+        gaincurve_table: Some(gaincurve_path),
+    })
+    .expect("gceff gencal");
+
+    assert_eq!(report.caltype, GencalType::Gceff);
+    assert_eq!(report.table_subtype, "EGainCurve");
+    assert_eq!(report.row_count, 6);
+    assert_eq!(report.spectral_window_ids, vec![0, 1]);
+    assert_eq!(report.antenna_ids, vec![0, 1, 2]);
+
+    let table = Table::open(TableOptions::new(&caltable_path)).expect("open gceff table");
+    let row0 = fparam_vec(&table, 0);
+    let row1 = fparam_vec(&table, 1);
+    let row2 = fparam_vec(&table, 2);
+    assert_eq!(row0, row1);
+    assert!((row0[1] / row0[0] - 2.0).abs() < 1.0e-6);
+    assert!((row2[0] / row0[0] - 3.0).abs() < 1.0e-6);
+    assert!((row2[1] / row0[1] - 2.0).abs() < 1.0e-6);
+    assert_scalar_i32(&table, 3, "SPECTRAL_WINDOW_ID", 1);
+    assert_scalar_i32(&table, 0, "OBSERVATION_ID", -1);
+}
+
+#[test]
+fn gencal_rejects_invalid_antpos_and_spw_contracts() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let ms_path =
+        common::create_gain_solve_fixture_ms(dir.path(), common::SyntheticGainFixtureKind::G);
+
+    let err = gencal(&GencalRequest {
+        measurement_set: ms_path.clone(),
+        output_table: dir.path().join("missing-antpos.cal"),
+        caltype: GencalType::Antpos,
+        antenna: String::new(),
+        spw: String::new(),
+        parameter: vec![],
+        gaincurve_table: None,
+    })
+    .unwrap_err();
+    assert!(err.to_string().contains("requires explicit --antenna"));
+
+    let err = gencal(&GencalRequest {
+        measurement_set: ms_path,
+        output_table: dir.path().join("bad-spw.cal"),
+        caltype: GencalType::Opac,
+        antenna: String::new(),
+        spw: "9".to_string(),
+        parameter: vec![0.1],
+        gaincurve_table: None,
+    })
+    .unwrap_err();
+    assert!(err.to_string().contains("outside 0.."));
+}
+
+fn write_gaincurve_table(path: &std::path::Path) {
+    let schema = TableSchema::new(vec![
+        ColumnSchema::scalar("BFREQ", casa_types::PrimitiveType::Float64),
+        ColumnSchema::scalar("EFREQ", casa_types::PrimitiveType::Float64),
+        ColumnSchema::scalar("BTIME", casa_types::PrimitiveType::Float64),
+        ColumnSchema::scalar("ETIME", casa_types::PrimitiveType::Float64),
+        ColumnSchema::scalar("ANTENNA", casa_types::PrimitiveType::String),
+        ColumnSchema::array_variable("GAIN", casa_types::PrimitiveType::Float32, Some(2)),
+    ])
+    .expect("gaincurve schema");
+    let mut table = Table::with_schema(schema);
+    for (antenna, gain) in [("0", [1.0, 2.0]), ("2", [3.0, 4.0])] {
+        table
+            .add_row(RecordValue::new(vec![
+                RecordField::new("BFREQ", Value::Scalar(ScalarValue::Float64(0.0))),
+                RecordField::new("EFREQ", Value::Scalar(ScalarValue::Float64(50.0e9))),
+                RecordField::new("BTIME", Value::Scalar(ScalarValue::Float64(-1.0))),
+                RecordField::new("ETIME", Value::Scalar(ScalarValue::Float64(1.0e12))),
+                RecordField::new(
+                    "ANTENNA",
+                    Value::Scalar(ScalarValue::String(antenna.to_string())),
+                ),
+                RecordField::new(
+                    "GAIN",
+                    Value::Array(ArrayValue::Float32(
+                        ArrayD::from_shape_vec(IxDyn(&[2, 1]).f(), gain.to_vec())
+                            .expect("gain shape"),
+                    )),
+                ),
+            ]))
+            .expect("gaincurve row");
+    }
+    table
+        .save(TableOptions::new(path).with_data_manager(DataManagerKind::StandardStMan))
+        .expect("save gaincurve table");
+}
+
+fn assert_fparam(table: &Table, row: usize, expected: &[f32]) {
+    let value = table
+        .cell_accessor(row, "FPARAM")
+        .and_then(|cell| cell.array())
+        .expect("FPARAM");
+    let ArrayValue::Float32(values) = value else {
+        panic!("expected Float32 FPARAM");
+    };
+    assert_eq!(values.shape(), &[expected.len(), 1]);
+    for (index, expected) in expected.iter().copied().enumerate() {
+        assert!((values[[index, 0]] - expected).abs() < 1.0e-6);
+    }
+}
+
+fn fparam_vec(table: &Table, row: usize) -> Vec<f32> {
+    let value = table
+        .cell_accessor(row, "FPARAM")
+        .and_then(|cell| cell.array())
+        .expect("FPARAM");
+    let ArrayValue::Float32(values) = value else {
+        panic!("expected Float32 FPARAM");
+    };
+    values.iter().copied().collect()
+}
+
+fn assert_scalar_i32(table: &Table, row: usize, column: &str, expected: i32) {
+    assert_eq!(
+        table
+            .cell_accessor(row, column)
+            .and_then(|cell| cell.scalar())
+            .expect(column),
+        &ScalarValue::Int32(expected)
+    );
+}

--- a/crates/casa-ms/Cargo.toml
+++ b/crates/casa-ms/Cargo.toml
@@ -91,6 +91,10 @@ name = "source_subtable_regression"
 path = "tests/source_subtable_regression.rs"
 
 [[test]]
+name = "transform"
+path = "tests/transform.rs"
+
+[[test]]
 name = "spectral_frame_parity"
 path = "tests/spectral_frame_parity.rs"
 required-features = ["cpp-interop-tests"]

--- a/crates/casa-ms/src/msexplore/task_contract.rs
+++ b/crates/casa-ms/src/msexplore/task_contract.rs
@@ -330,11 +330,29 @@ fn write_output(path: &Path, overwrite: bool, text: &str) -> Result<(), String> 
 #[cfg(test)]
 mod tests {
     use casa_provider_contracts::ProviderSurfaceKind;
+    use tempfile::tempdir;
 
     use super::{
         MSEXPLORE_TASK_PROTOCOL_NAME, MSEXPLORE_TASK_PROTOCOL_VERSION, MsExploreProtocolInfo,
-        MsExploreTaskSchemaBundle,
+        MsExploreRunTaskRequest, MsExploreTaskRequest, MsExploreTaskSchemaBundle, write_output,
     };
+    use crate::{
+        MeasurementSetSummaryOutputFormat, MsExploreSpec, MsPageExportRange, MsPlotPreset,
+        MsPlotSpec, MsSelectionSpec,
+    };
+
+    fn test_spec(ms_path: &str) -> MsExploreSpec {
+        MsExploreSpec {
+            ms_path: ms_path.into(),
+            summary_format: MeasurementSetSummaryOutputFormat::Text,
+            selection: MsSelectionSpec::default(),
+            header_items: Vec::new(),
+            page_title: None,
+            exprange: MsPageExportRange::Current,
+            max_plot_points: 100,
+            plots: vec![MsPlotSpec::from_preset(MsPlotPreset::AmplitudeVsTime)],
+        }
+    }
 
     #[test]
     fn schema_bundle_uses_current_protocol_and_projection() {
@@ -358,5 +376,97 @@ mod tests {
         assert_eq!(info.protocol_name, MSEXPLORE_TASK_PROTOCOL_NAME);
         assert_eq!(info.protocol_version, MSEXPLORE_TASK_PROTOCOL_VERSION);
         assert_eq!(info.surface_kind, ProviderSurfaceKind::Task);
+    }
+
+    #[test]
+    fn request_and_result_envelopes_round_trip_with_stable_kind_tags() {
+        let request = MsExploreTaskRequest::Run(MsExploreRunTaskRequest {
+            spec: test_spec("example.ms"),
+            summary_output_path: None,
+            overwrite_outputs: true,
+            flag_edit: None,
+            plot_export: None,
+        });
+        let request_json = serde_json::to_string_pretty(&request).expect("serialize request");
+        assert!(request_json.contains("\"kind\": \"run\""));
+        assert!(request_json.contains("\"ms_path\": \"example.ms\""));
+        assert_eq!(
+            serde_json::from_str::<MsExploreTaskRequest>(&request_json).expect("parse request"),
+            request
+        );
+    }
+
+    #[test]
+    fn read_from_source_reports_file_and_json_errors_and_parses_valid_files() {
+        let dir = tempdir().expect("tempdir");
+        let missing = dir.path().join("missing.json");
+        let missing_error =
+            MsExploreTaskRequest::read_from_source(missing.to_str().expect("utf8 path"))
+                .expect_err("missing file should fail");
+        assert!(missing_error.contains("failed to read JSON request"));
+        assert!(missing_error.contains("missing.json"));
+
+        let invalid = dir.path().join("invalid.json");
+        std::fs::write(&invalid, "{not json").expect("write invalid json");
+        let parse_error =
+            MsExploreTaskRequest::read_from_source(invalid.to_str().expect("utf8 path"))
+                .expect_err("invalid JSON should fail");
+        assert!(parse_error.contains("failed to parse msexplore task request"));
+
+        let valid = dir.path().join("valid.json");
+        let request = MsExploreTaskRequest::Run(MsExploreRunTaskRequest {
+            spec: test_spec("valid.ms"),
+            summary_output_path: Some("summary.md".into()),
+            overwrite_outputs: false,
+            flag_edit: None,
+            plot_export: None,
+        });
+        std::fs::write(
+            &valid,
+            serde_json::to_string(&request).expect("serialize valid request"),
+        )
+        .expect("write valid json");
+        assert_eq!(
+            MsExploreTaskRequest::read_from_source(valid.to_str().expect("utf8 path"))
+                .expect("read valid request"),
+            request
+        );
+    }
+
+    #[test]
+    fn write_output_refuses_existing_files_unless_overwrite_is_enabled() {
+        let dir = tempdir().expect("tempdir");
+        let output = dir.path().join("summary.txt");
+        write_output(&output, false, "first").expect("first write");
+        let error = write_output(&output, false, "second").expect_err("overwrite guard");
+        assert!(error.contains("refusing to overwrite existing output"));
+        assert_eq!(
+            std::fs::read_to_string(&output).expect("read output"),
+            "first"
+        );
+
+        write_output(&output, true, "second").expect("overwrite");
+        assert_eq!(
+            std::fs::read_to_string(&output).expect("read output"),
+            "second"
+        );
+    }
+
+    #[test]
+    fn ui_schema_projection_reports_missing_or_malformed_projection() {
+        let mut bundle = MsExploreTaskSchemaBundle::current();
+        bundle.projections.ui_schema = None;
+        assert_eq!(
+            bundle
+                .ui_schema_projection()
+                .expect_err("missing projection"),
+            "missing ui_schema projection"
+        );
+
+        bundle.projections.ui_schema = Some(serde_json::json!({"command_id": 5}));
+        let error = bundle
+            .ui_schema_projection()
+            .expect_err("malformed projection");
+        assert!(error.contains("parse msexplore ui schema"));
     }
 }

--- a/crates/casa-ms/src/transform.rs
+++ b/crates/casa-ms/src/transform.rs
@@ -1080,3 +1080,93 @@ fn prepare_output_root(path: &Path) -> Result<(), MsTransformError> {
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use casa_types::Complex32;
+
+    #[test]
+    fn select_channels_covers_contiguous_noncontiguous_and_full_width_paths() {
+        let complex = ArrayValue::Complex32(
+            ArrayD::from_shape_vec(
+                IxDyn(&[2, 4]).f(),
+                (0..8)
+                    .map(|value| Complex32::new(value as f32, value as f32 + 0.5))
+                    .collect(),
+            )
+            .unwrap(),
+        );
+        let selected = select_channels(complex, &[1, 2]).expect("contiguous selection");
+        let ArrayValue::Complex32(selected) = selected else {
+            panic!("expected Complex32");
+        };
+        assert_eq!(selected.shape(), &[2, 2]);
+        assert_eq!(selected[[0, 0]], Complex32::new(2.0, 2.5));
+        assert_eq!(selected[[1, 1]], Complex32::new(5.0, 5.5));
+
+        let flags = ArrayValue::Bool(
+            ArrayD::from_shape_vec(
+                IxDyn(&[2, 4]).f(),
+                vec![false, true, false, true, true, false, true, false],
+            )
+            .unwrap(),
+        );
+        let selected = select_channels(flags, &[0, 3]).expect("non-contiguous selection");
+        let ArrayValue::Bool(selected) = selected else {
+            panic!("expected Bool");
+        };
+        assert_eq!(selected.shape(), &[2, 2]);
+        assert!(!selected[[0, 0]]);
+        assert!(!selected[[1, 1]]);
+
+        let weights = ArrayValue::Float32(
+            ArrayD::from_shape_vec(IxDyn(&[1, 3]).f(), vec![1.0, 2.0, 3.0]).unwrap(),
+        );
+        let selected = select_channels(weights, &[0, 1, 2]).expect("full-width selection");
+        let ArrayValue::Float32(selected) = selected else {
+            panic!("expected Float32");
+        };
+        assert_eq!(selected.shape(), &[1, 3]);
+        assert_eq!(selected[[0, 2]], 3.0);
+    }
+
+    #[test]
+    fn select_channels_rejects_wrong_rank_and_unsupported_arrays() {
+        let wrong_rank =
+            ArrayValue::Bool(ArrayD::from_shape_vec(IxDyn(&[2, 2, 1]), vec![false; 4]).unwrap());
+        let err = select_channels(wrong_rank, &[0]).unwrap_err();
+        assert!(err.to_string().contains("rank-2"));
+
+        let unsupported =
+            ArrayValue::Float64(ArrayD::from_shape_vec(IxDyn(&[2, 2]), vec![0.0; 4]).unwrap());
+        let err = select_channels(unsupported, &[0]).unwrap_err();
+        assert!(err.to_string().contains("unsupported rank-2"));
+    }
+
+    #[test]
+    fn scalar_helpers_accept_expected_numeric_types_and_reject_missing_cells() {
+        assert_eq!(
+            scalar_i32(Some(&ScalarValue::Int32(7)), "DATA_DESC_ID", 3).unwrap(),
+            7
+        );
+        assert_eq!(
+            scalar_f64(Some(&ScalarValue::Float64(1.25)), "TIME", 3).unwrap(),
+            1.25
+        );
+        assert_eq!(
+            scalar_f64(Some(&ScalarValue::Float32(2.5)), "TIME", 3).unwrap(),
+            2.5
+        );
+        assert!(scalar_i32(None, "DATA_DESC_ID", 3).is_err());
+        assert!(scalar_f64(Some(&ScalarValue::Bool(false)), "TIME", 3).is_err());
+    }
+
+    #[test]
+    fn channel_range_helpers_identify_full_and_contiguous_selections() {
+        assert_eq!(contiguous_channel_range(&[2, 3, 4]), Some((2, 5)));
+        assert_eq!(contiguous_channel_range(&[2, 4]), None);
+        assert!(all_channels_selected(&[0, 1, 2], 3));
+        assert!(!all_channels_selected(&[0, 2], 3));
+    }
+}

--- a/crates/casa-ms/tests/msexplore_cli.rs
+++ b/crates/casa-ms/tests/msexplore_cli.rs
@@ -13,10 +13,11 @@ use casa_ms::msexplore::cli::{UiArgumentParser, UiValueKind};
 use casa_ms::subtables::SubTable;
 use casa_ms::{
     DEFAULT_MAX_PLOT_POINTS, MSEXPLORE_TASK_PROTOCOL_NAME, MeasurementSet, MeasurementSetPlotTheme,
-    MeasurementSetSummaryOutputFormat, MsAxis, MsColorAxis, MsDataColumn, MsExploreSpec,
-    MsFlagAction, MsFlagEditSpec, MsFlagRegion, MsIterationAxis, MsLayoutSpec, MsLegendPosition,
-    MsPageExportRange, MsPageHeaderItem, MsPlotPayload, MsPlotPreset, MsPlotSpec, MsSelectionSpec,
-    apply_msexplore_flag_edit, apply_msexplore_flag_edit_for_request, build_msexplore_payload,
+    MeasurementSetSummaryOutputFormat, MsAxis, MsColorAxis, MsDataColumn, MsExploreFlagEditRequest,
+    MsExploreRunTaskRequest, MsExploreSpec, MsFlagAction, MsFlagEditSpec, MsFlagRegion,
+    MsIterationAxis, MsLayoutSpec, MsLegendPosition, MsPageExportRange, MsPageHeaderItem,
+    MsPlotPayload, MsPlotPreset, MsPlotSpec, MsSelectionSpec, apply_msexplore_flag_edit,
+    apply_msexplore_flag_edit_for_request, build_msexplore_payload,
     build_msexplore_payload_from_spec, build_msexplore_plot_payload, export_msexplore_plot,
     preview_msexplore_flag_edit, preview_msexplore_flag_edit_for_request,
     render_msexplore_plot_image,
@@ -86,6 +87,69 @@ fn msexplore_help_mentions_plot_controls() {
     assert!(stdout.contains("--json-schema"));
     assert!(stdout.contains("--protocol-info"));
     assert!(stdout.contains("--json-run <SOURCE>"));
+}
+
+#[test]
+fn msexplore_run_task_writes_summary_and_flag_preview_artifacts() {
+    let temp = tempdir().expect("tempdir");
+    let ms_path = create_msexplore_fixture_ms(temp.path());
+    let summary_output = temp.path().join("summary.txt");
+    let flag_output = temp.path().join("flag-preview.json");
+    let request = MsExploreRunTaskRequest {
+        spec: MsExploreSpec {
+            ms_path,
+            summary_format: MeasurementSetSummaryOutputFormat::Text,
+            selection: MsSelectionSpec::default(),
+            header_items: Vec::new(),
+            page_title: None,
+            exprange: MsPageExportRange::Current,
+            max_plot_points: DEFAULT_MAX_PLOT_POINTS,
+            plots: vec![MsPlotSpec::from_preset(MsPlotPreset::AmplitudeVsTime)],
+        },
+        summary_output_path: Some(summary_output.clone()),
+        overwrite_outputs: false,
+        flag_edit: Some(MsExploreFlagEditRequest {
+            edit: MsFlagEditSpec {
+                action: MsFlagAction::Flag,
+                region: MsFlagRegion {
+                    x_min: TIME_BASE_SECONDS - 1.0,
+                    x_max: TIME_BASE_SECONDS + 100.0,
+                    y_min: -10.0,
+                    y_max: 10.0,
+                },
+                plot_index: None,
+                panel_key: None,
+                extcorr: true,
+                extchannel: true,
+            },
+            apply: false,
+            output_path: Some(flag_output.clone()),
+        }),
+        plot_export: None,
+    };
+
+    let result = request.execute().expect("run msexplore task request");
+    assert_eq!(result.summary_output_path, Some(summary_output.clone()));
+    assert_eq!(result.flag_edit_output_path, Some(flag_output.clone()));
+    assert!(result.summary.measurement_set.row_count > 0);
+    assert!(
+        result
+            .flag_edit_preview
+            .as_ref()
+            .expect("flag preview")
+            .affected_samples
+            > 0
+    );
+    assert!(
+        std::fs::read_to_string(summary_output)
+            .expect("summary output")
+            .contains("MeasurementSet")
+    );
+    assert!(
+        std::fs::read_to_string(flag_output)
+            .expect("flag preview output")
+            .contains("affected_samples")
+    );
 }
 
 #[test]

--- a/crates/casa-ms/tests/transform.rs
+++ b/crates/casa-ms/tests/transform.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+mod common;
+
+use casa_ms::{
+    MeasurementSet, MsTransformRequest, SubTable, TransformDataColumn, mstransform,
+    schema::main_table::VisibilityDataColumn, selection::MsSelection,
+};
+use casa_types::{ArrayValue, ScalarValue};
+
+#[test]
+fn mstransform_selects_channels_updates_metadata_and_weight_spectrum() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let input_ms = common::create_msexplore_spectrum_fixture_ms(dir.path(), true, &[]);
+    let output_ms = dir.path().join("transformed.ms");
+
+    let report = mstransform(&MsTransformRequest {
+        input_ms: input_ms.clone(),
+        output_ms: output_ms.clone(),
+        spw: "0:2~5".to_string(),
+        data_column: TransformDataColumn::Data,
+        selection: MsSelection::new(),
+    })
+    .expect("mstransform");
+
+    assert_eq!(report.row_count, 4);
+    assert_eq!(report.source_column, "DATA");
+    assert_eq!(report.output_column, "DATA");
+    assert_eq!(report.spectral_window_ids, vec![0]);
+    assert_eq!(report.output_channels_by_spw[&0], 4);
+
+    let output = MeasurementSet::open(&output_ms).expect("open transformed MS");
+    assert_eq!(output.row_count(), 4);
+    let data = output
+        .data_column(VisibilityDataColumn::Data)
+        .expect("DATA column");
+    let row = data.get(1).expect("row 1 DATA");
+    let ArrayValue::Complex32(row) = row else {
+        panic!("expected Complex32 DATA");
+    };
+    assert_eq!(row.shape(), &[common::NUM_CORR, 4]);
+    for corr in 0..common::NUM_CORR {
+        for (out_chan, source_chan) in (2..=5).enumerate() {
+            let expected_index =
+                common::NUM_CORR * common::NUM_CHAN + source_chan * common::NUM_CORR + corr;
+            assert_eq!(
+                row[[corr, out_chan]],
+                casa_types::Complex32::new(expected_index as f32, -(expected_index as f32) * 0.5)
+            );
+        }
+    }
+
+    let flags = output
+        .main_table()
+        .cell_accessor(0, "FLAG")
+        .and_then(|cell| cell.array())
+        .expect("FLAG row");
+    assert_eq!(flags.shape(), &[common::NUM_CORR, 4]);
+    let weights = output
+        .main_table()
+        .cell_accessor(1, "WEIGHT_SPECTRUM")
+        .and_then(|cell| cell.array())
+        .expect("WEIGHT_SPECTRUM row");
+    let ArrayValue::Float32(weights) = weights else {
+        panic!("expected Float32 WEIGHT_SPECTRUM");
+    };
+    assert_eq!(weights.shape(), &[common::NUM_CORR, 4]);
+    assert_eq!(weights[[0, 0]], 2008.0);
+    assert_eq!(weights[[3, 3]], 2107.0);
+
+    let spw = output.spectral_window().expect("SPECTRAL_WINDOW");
+    assert_eq!(spw.num_chan(0).expect("NUM_CHAN"), 4);
+    assert_eq!(
+        spw.chan_freq(0).expect("CHAN_FREQ"),
+        vec![1.002e9, 1.003e9, 1.004e9, 1.005e9]
+    );
+    let spw_table = spw.table();
+    assert_eq!(
+        spw_table
+            .cell_accessor(0, "REF_FREQUENCY")
+            .and_then(|cell| cell.scalar())
+            .expect("REF_FREQUENCY"),
+        &ScalarValue::Float64(1.002e9)
+    );
+    assert_eq!(
+        spw_table
+            .cell_accessor(0, "TOTAL_BANDWIDTH")
+            .and_then(|cell| cell.scalar())
+            .expect("TOTAL_BANDWIDTH"),
+        &ScalarValue::Float64(4.0e6)
+    );
+}
+
+#[test]
+fn mstransform_filters_rows_by_selected_spw_and_preserves_time_order() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let input_ms = common::create_msexplore_averaging_fixture_ms(dir.path());
+    let output_ms = dir.path().join("spw1.ms");
+
+    let report = mstransform(&MsTransformRequest {
+        input_ms: input_ms.clone(),
+        output_ms: output_ms.clone(),
+        spw: "1:0~5".to_string(),
+        data_column: TransformDataColumn::Data,
+        selection: MsSelection::new().field(&[0]),
+    })
+    .expect("mstransform spw 1");
+
+    assert_eq!(report.row_count, 3);
+    assert_eq!(report.spectral_window_ids, vec![1]);
+    assert_eq!(report.output_channels_by_spw[&1], 6);
+
+    let output = MeasurementSet::open(&output_ms).expect("open transformed MS");
+    let data = output
+        .data_column(VisibilityDataColumn::Data)
+        .expect("DATA column");
+    for row_index in 0..output.row_count() {
+        assert_eq!(data.shape(row_index).expect("DATA shape"), vec![4, 6]);
+        assert_eq!(
+            output
+                .main_table()
+                .cell_accessor(row_index, "DATA_DESC_ID")
+                .and_then(|cell| cell.scalar())
+                .expect("DATA_DESC_ID"),
+            &ScalarValue::Int32(1)
+        );
+    }
+    assert_eq!(
+        output
+            .main_table()
+            .cell_accessor(0, "TIME")
+            .and_then(|cell| cell.scalar())
+            .expect("first TIME"),
+        &ScalarValue::Float64(common::TIME_BASE_SECONDS)
+    );
+    assert_eq!(
+        output
+            .main_table()
+            .cell_accessor(1, "TIME")
+            .and_then(|cell| cell.scalar())
+            .expect("second TIME"),
+        &ScalarValue::Float64(common::TIME_BASE_SECONDS)
+    );
+    assert_eq!(
+        output
+            .main_table()
+            .cell_accessor(2, "TIME")
+            .and_then(|cell| cell.scalar())
+            .expect("third TIME"),
+        &ScalarValue::Float64(common::TIME_BASE_SECONDS + 30.0)
+    );
+}
+
+#[test]
+fn mstransform_reports_contract_errors_before_mutating_outputs() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let input_ms = common::create_msexplore_fixture_ms(dir.path());
+    let output_ms = dir.path().join("bad.ms");
+
+    let same_path = mstransform(&MsTransformRequest {
+        input_ms: input_ms.clone(),
+        output_ms: input_ms.clone(),
+        spw: "0".to_string(),
+        data_column: TransformDataColumn::Data,
+        selection: MsSelection::new(),
+    })
+    .unwrap_err();
+    assert!(same_path.to_string().contains("must differ"));
+
+    let invalid_spw = mstransform(&MsTransformRequest {
+        input_ms: input_ms.clone(),
+        output_ms: output_ms.clone(),
+        spw: "9".to_string(),
+        data_column: TransformDataColumn::Data,
+        selection: MsSelection::new(),
+    })
+    .unwrap_err();
+    assert!(invalid_spw.to_string().contains("outside SPECTRAL_WINDOW"));
+    assert!(!output_ms.exists());
+
+    let missing_column = mstransform(&MsTransformRequest {
+        input_ms,
+        output_ms,
+        spw: "0".to_string(),
+        data_column: TransformDataColumn::CorrectedData,
+        selection: MsSelection::new(),
+    })
+    .unwrap_err();
+    assert!(missing_column.to_string().contains("CORRECTED_DATA"));
+}

--- a/crates/casa-table-read/src/incremental_stman.rs
+++ b/crates/casa-table-read/src/incremental_stman.rs
@@ -645,3 +645,322 @@ fn read_u32(data: &[u8], offset: usize, big_endian: bool) -> Result<u32, TableRe
         u32::from_le_bytes(bytes.try_into().expect("u32"))
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scalar_desc(name: &str, data_type: CasacoreDataType) -> ColumnDesc {
+        ColumnDesc {
+            col_name: name.to_string(),
+            data_type,
+            is_array: false,
+            option: 0,
+            shape: Vec::new(),
+            dm_seq_nr: 0,
+        }
+    }
+
+    fn array_desc(name: &str, shape: Vec<i32>, direct: bool) -> ColumnDesc {
+        ColumnDesc {
+            col_name: name.to_string(),
+            data_type: CasacoreDataType::TpDouble,
+            is_array: true,
+            option: i32::from(direct),
+            shape,
+            dm_seq_nr: 0,
+        }
+    }
+
+    fn push_u32(bytes: &mut Vec<u8>, value: u32, big_endian: bool) {
+        if big_endian {
+            bytes.extend(value.to_be_bytes());
+        } else {
+            bytes.extend(value.to_le_bytes());
+        }
+    }
+
+    fn push_u64(bytes: &mut Vec<u8>, value: u64, big_endian: bool) {
+        if big_endian {
+            bytes.extend(value.to_be_bytes());
+        } else {
+            bytes.extend(value.to_le_bytes());
+        }
+    }
+
+    fn push_string(bytes: &mut Vec<u8>, value: &str, big_endian: bool) {
+        push_u32(bytes, value.len() as u32, big_endian);
+        bytes.extend(value.as_bytes());
+    }
+
+    fn push_object_start(bytes: &mut Vec<u8>, type_name: &str, version: u32, big_endian: bool) {
+        push_u32(bytes, AIPSIO_MAGIC, big_endian);
+        push_u32(bytes, 0, big_endian);
+        push_string(bytes, type_name, big_endian);
+        push_u32(bytes, version, big_endian);
+    }
+
+    fn aipsio_object(type_name: &str, version: u32, payload: &[u8], big_endian: bool) -> Vec<u8> {
+        let mut content = Vec::new();
+        push_string(&mut content, type_name, big_endian);
+        push_u32(&mut content, version, big_endian);
+        content.extend(payload);
+
+        let mut bytes = Vec::new();
+        push_u32(&mut bytes, AIPSIO_MAGIC, big_endian);
+        push_u32(&mut bytes, (content.len() + 4) as u32, big_endian);
+        bytes.extend(content);
+        bytes
+    }
+
+    #[test]
+    fn column_builder_covers_supported_scalars_arrays_and_errors() {
+        let mut float_builder =
+            ColumnBuilder::new(&scalar_desc("AMP", CasacoreDataType::TpDouble)).unwrap();
+        float_builder
+            .push_value(
+                &1.5_f64.to_be_bytes(),
+                0,
+                true,
+                &scalar_desc("AMP", CasacoreDataType::TpDouble),
+                None,
+            )
+            .unwrap();
+        float_builder.push_default().unwrap();
+        assert_eq!(float_builder.len(), 2);
+        assert!(matches!(
+            float_builder.finish().unwrap(),
+            ColumnData::Float64(values) if values == vec![1.5, 0.0]
+        ));
+
+        let mut string_payload = Vec::new();
+        push_u32(&mut string_payload, 14, true);
+        string_payload.extend(b"calibrator");
+        let mut string_builder =
+            ColumnBuilder::new(&scalar_desc("NAME", CasacoreDataType::TpString)).unwrap();
+        string_builder
+            .push_value(
+                &string_payload,
+                0,
+                true,
+                &scalar_desc("NAME", CasacoreDataType::TpString),
+                None,
+            )
+            .unwrap();
+        string_builder.push_default().unwrap();
+        assert!(matches!(
+            string_builder.finish().unwrap(),
+            ColumnData::String(values) if values == vec!["calibrator".to_string(), String::new()]
+        ));
+
+        let direct_desc = array_desc("SPECTRUM", vec![2], true);
+        let mut array_payload = Vec::new();
+        array_payload.extend(2.0_f64.to_le_bytes());
+        array_payload.extend(3.0_f64.to_le_bytes());
+        let mut array_builder = ColumnBuilder::new(&direct_desc).unwrap();
+        array_builder
+            .push_value(&array_payload, 0, false, &direct_desc, None)
+            .unwrap();
+        array_builder.push_default().unwrap();
+        assert_eq!(array_builder.len(), 2);
+        assert!(matches!(
+            array_builder.finish().unwrap(),
+            ColumnData::ArrayFloat64 { values, shape }
+                if values == vec![2.0, 3.0, 0.0, 0.0] && shape == vec![2]
+        ));
+
+        let mut missing_shape =
+            ColumnBuilder::new(&array_desc("UNKNOWN", Vec::new(), true)).unwrap();
+        assert!(
+            missing_shape
+                .push_value(
+                    &array_payload,
+                    0,
+                    false,
+                    &array_desc("UNKNOWN", Vec::new(), true),
+                    None
+                )
+                .unwrap_err()
+                .to_string()
+                .contains("missing shape metadata")
+        );
+        let unsupported = ColumnBuilder::new(&scalar_desc("FLAG", CasacoreDataType::TpBool));
+        assert!(unsupported.is_err());
+        assert!(
+            unsupported
+                .err()
+                .expect("unsupported type error")
+                .to_string()
+                .contains("unsupported IncrementalStMan column")
+        );
+    }
+
+    #[test]
+    fn ism_primitive_readers_cover_byte_order_strings_and_bounds() {
+        assert!(detect_ism_aipsio_byte_order(&[0, 1, 2]).is_err());
+        let mut be = vec![0, 0, 0, 0];
+        push_u32(&mut be, 8, true);
+        assert_eq!(
+            detect_ism_aipsio_byte_order(&be).unwrap(),
+            ByteOrder::BigEndian
+        );
+
+        let mut le = vec![0, 0, 0, 0];
+        push_u32(&mut le, 8, false);
+        assert_eq!(
+            detect_ism_aipsio_byte_order(&le).unwrap(),
+            ByteOrder::LittleEndian
+        );
+
+        assert_eq!(read_f64_at(&1.25_f64.to_be_bytes(), 0, true).unwrap(), 1.25);
+        assert_eq!(
+            read_i64_at(&(-12_i64).to_le_bytes(), 0, false).unwrap(),
+            -12
+        );
+        assert!(read_f64_at(&[1, 2, 3], 0, true).is_err());
+        assert!(read_i64_at(&[1, 2, 3], 0, true).is_err());
+
+        let mut single = Vec::new();
+        push_u32(&mut single, 7, true);
+        single.extend(b"abc");
+        assert_eq!(read_ism_string(&single, 1, true).unwrap(), vec!["abc"]);
+
+        let mut many = Vec::new();
+        push_u32(&mut many, 0, false);
+        push_u32(&mut many, 2, false);
+        many.extend(b"hi");
+        push_u32(&mut many, 3, false);
+        many.extend(b"bye");
+        assert_eq!(
+            read_ism_string(&many, 2, false).unwrap(),
+            vec!["hi".to_string(), "bye".to_string()]
+        );
+        assert!(read_ism_string(&[0, 0], 1, true).is_err());
+        assert!(read_string_at(&single, 10, 1, true).is_err());
+        assert_eq!(read_string_at(&single, 0, 1, true).unwrap(), "abc");
+        assert_eq!(
+            read_array_f64_at(&array_bytes(&[4.0, 5.0], true), 0, 2, true).unwrap(),
+            vec![4.0, 5.0]
+        );
+        assert!(read_array_f64_at(&[0; 4], 0, 1, true).is_err());
+    }
+
+    fn array_bytes(values: &[f64], big_endian: bool) -> Vec<u8> {
+        values
+            .iter()
+            .flat_map(|value| {
+                if big_endian {
+                    value.to_be_bytes()
+                } else {
+                    value.to_le_bytes()
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn ism_aipsio_blocks_and_bucket_index_helpers_cover_success_and_errors() {
+        let mut block = Vec::new();
+        push_object_start(&mut block, "Block", 1, true);
+        push_u32(&mut block, 2, true);
+        push_u32(&mut block, 11, true);
+        push_u32(&mut block, 12, true);
+        let mut io = IsmAipsIoBuf::new(&block, ByteOrder::BigEndian);
+        assert_eq!(io.read_block_u32().unwrap(), vec![11, 12]);
+
+        let mut block64 = Vec::new();
+        push_object_start(&mut block64, "Block", 1, false);
+        push_u32(&mut block64, 2, false);
+        push_u64(&mut block64, 21, false);
+        push_u64(&mut block64, 22, false);
+        let mut io = IsmAipsIoBuf::new(&block64, ByteOrder::LittleEndian);
+        assert_eq!(io.read_block_u64().unwrap(), vec![21, 22]);
+
+        let mut wrong = Vec::new();
+        push_object_start(&mut wrong, "Other", 1, true);
+        let mut io = IsmAipsIoBuf::new(&wrong, ByteOrder::BigEndian);
+        assert!(
+            io.getstart("Block")
+                .unwrap_err()
+                .to_string()
+                .contains("type mismatch")
+        );
+
+        let index = IsmBucketColIndex {
+            row_nrs: vec![0, 3, 8],
+            offsets: vec![10, 20, 30],
+        };
+        assert_eq!(get_interval(&index, 0), 0);
+        assert_eq!(get_interval(&index, 4), 1);
+        assert_eq!(get_interval(&index, 9), 2);
+        assert_eq!(
+            append_path_suffix(Path::new("table.f0"), "i"),
+            PathBuf::from("table.f0i")
+        );
+        assert_eq!(shape_nrelem(&[2, 3]).unwrap(), 6);
+        assert!(
+            shape_nrelem(&[-1])
+                .unwrap_err()
+                .to_string()
+                .contains("negative")
+        );
+        assert!(shape_nrelem(&[usize::MAX as i32, 2]).err().is_some());
+    }
+
+    #[test]
+    fn parse_ism_bucket_decodes_column_intervals_and_rejects_bad_headers() {
+        let mut raw = Vec::new();
+        push_u32(&mut raw, 12, true);
+        raw.extend(1.0_f64.to_be_bytes());
+        push_u32(&mut raw, 2, true);
+        push_u32(&mut raw, 0, true);
+        push_u32(&mut raw, 4, true);
+        push_u32(&mut raw, 0, true);
+        push_u32(&mut raw, 8, true);
+
+        let bucket = parse_ism_bucket(&raw, 1, true).unwrap();
+        assert_eq!(bucket.data, 1.0_f64.to_be_bytes());
+        assert_eq!(bucket.col_indices.len(), 1);
+        assert_eq!(bucket.col_indices[0].row_nrs, vec![0, 4]);
+        assert_eq!(bucket.col_indices[0].offsets, vec![0, 8]);
+
+        assert!(parse_ism_bucket(&[1, 2, 3], 1, true).is_err());
+        let mut unsupported = Vec::new();
+        push_u32(&mut unsupported, 0x80000000, true);
+        assert!(
+            parse_ism_bucket(&unsupported, 1, true)
+                .unwrap_err()
+                .to_string()
+                .contains("64-bit row numbers")
+        );
+    }
+
+    #[test]
+    fn parse_ism_header_and_manager_blob_cover_aipsio_wrappers() {
+        let mut dm_payload = Vec::new();
+        push_string(&mut dm_payload, "ISMDataManager", true);
+        let dm_blob = aipsio_object("ISM", 1, &dm_payload, true);
+        assert_eq!(parse_ism_dm_blob(&dm_blob).unwrap(), "ISMDataManager");
+
+        let mut header_payload = Vec::new();
+        header_payload.push(0);
+        push_u32(&mut header_payload, 128, true);
+        push_u32(&mut header_payload, 3, true);
+        push_u32(&mut header_payload, 7, true);
+        push_u32(&mut header_payload, 99, true);
+        push_u32(&mut header_payload, 1, true);
+        header_payload.extend((-1_i32).to_be_bytes());
+        let mut header = aipsio_object("IncrementalStMan", 5, &header_payload, true);
+        header.resize(ISM_HEADER_SIZE as usize, 0);
+        let mut cursor = std::io::Cursor::new(header);
+        let parsed = parse_ism_header(&mut cursor).unwrap();
+        assert_eq!(parsed.bucket_size, 128);
+        assert_eq!(parsed.nr_buckets, 3);
+        assert!(!parsed.big_endian);
+        assert_eq!(parsed.io_order, ByteOrder::BigEndian);
+
+        let too_short = std::io::Cursor::new(vec![0; 8]);
+        let mut too_short = too_short;
+        assert!(parse_ism_header(&mut too_short).is_err());
+    }
+}

--- a/crates/casa-table-read/src/table_control.rs
+++ b/crates/casa-table-read/src/table_control.rs
@@ -482,3 +482,147 @@ fn is_array_data_type(dt: CasacoreDataType) -> bool {
             | CasacoreDataType::TpArrayInt64
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::aipsio_buf::ByteOrder;
+
+    fn be_u16(value: u16) -> Vec<u8> {
+        value.to_be_bytes().to_vec()
+    }
+
+    fn be_u32(value: u32) -> Vec<u8> {
+        value.to_be_bytes().to_vec()
+    }
+
+    fn be_i16(value: i16) -> Vec<u8> {
+        value.to_be_bytes().to_vec()
+    }
+
+    fn be_i32(value: i32) -> Vec<u8> {
+        value.to_be_bytes().to_vec()
+    }
+
+    fn be_i64(value: i64) -> Vec<u8> {
+        value.to_be_bytes().to_vec()
+    }
+
+    fn string_bytes(value: &str) -> Vec<u8> {
+        let mut bytes = be_u32(value.len() as u32);
+        bytes.extend(value.as_bytes());
+        bytes
+    }
+
+    #[test]
+    fn column_desc_array_helpers_follow_option_bits() {
+        let scalar = ColumnDesc {
+            col_name: "TIME".to_string(),
+            data_type: CasacoreDataType::TpDouble,
+            is_array: false,
+            option: 1,
+            shape: Vec::new(),
+            dm_seq_nr: 0,
+        };
+        assert!(!scalar.is_direct_array());
+        assert!(!scalar.is_indirect_array());
+
+        let direct = ColumnDesc {
+            is_array: true,
+            ..scalar.clone()
+        };
+        assert!(direct.is_direct_array());
+        assert!(!direct.is_indirect_array());
+
+        let indirect = ColumnDesc {
+            option: 0,
+            ..direct
+        };
+        assert!(!indirect.is_direct_array());
+        assert!(indirect.is_indirect_array());
+    }
+
+    #[test]
+    fn default_value_skipper_consumes_supported_scalar_payloads() {
+        let cases = vec![
+            (CasacoreDataType::TpBool, vec![1]),
+            (CasacoreDataType::TpUChar, vec![7]),
+            (CasacoreDataType::TpChar, vec![8]),
+            (CasacoreDataType::TpShort, be_i16(-2)),
+            (CasacoreDataType::TpUShort, be_u16(2)),
+            (CasacoreDataType::TpInt, be_i32(-3)),
+            (CasacoreDataType::TpUInt, be_u32(3)),
+            (
+                CasacoreDataType::TpFloat,
+                1.25_f32.to_bits().to_be_bytes().to_vec(),
+            ),
+            (
+                CasacoreDataType::TpDouble,
+                1.5_f64.to_bits().to_be_bytes().to_vec(),
+            ),
+            (
+                CasacoreDataType::TpComplex,
+                [
+                    1.0_f32.to_bits().to_be_bytes(),
+                    2.0_f32.to_bits().to_be_bytes(),
+                ]
+                .concat(),
+            ),
+            (
+                CasacoreDataType::TpDComplex,
+                [
+                    1.0_f64.to_bits().to_be_bytes(),
+                    2.0_f64.to_bits().to_be_bytes(),
+                ]
+                .concat(),
+            ),
+            (CasacoreDataType::TpString, string_bytes("name")),
+            (CasacoreDataType::TpInt64, be_i64(-4)),
+            (CasacoreDataType::TpRecord, Vec::new()),
+        ];
+
+        for (data_type, payload) in cases {
+            let mut io = AipsIoBuf::new(&payload, ByteOrder::BigEndian);
+            skip_default_value(&mut io, data_type)
+                .unwrap_or_else(|error| panic!("skip default for {data_type:?} failed: {error}"));
+        }
+
+        let mut io = AipsIoBuf::new(&[], ByteOrder::BigEndian);
+        assert!(
+            skip_default_value(&mut io, CasacoreDataType::TpQuantity)
+                .unwrap_err()
+                .to_string()
+                .contains("cannot skip default value")
+        );
+    }
+
+    #[test]
+    fn array_data_type_classifier_covers_supported_and_scalar_values() {
+        for data_type in [
+            CasacoreDataType::TpArrayBool,
+            CasacoreDataType::TpArrayChar,
+            CasacoreDataType::TpArrayUChar,
+            CasacoreDataType::TpArrayShort,
+            CasacoreDataType::TpArrayUShort,
+            CasacoreDataType::TpArrayInt,
+            CasacoreDataType::TpArrayUInt,
+            CasacoreDataType::TpArrayFloat,
+            CasacoreDataType::TpArrayDouble,
+            CasacoreDataType::TpArrayComplex,
+            CasacoreDataType::TpArrayDComplex,
+            CasacoreDataType::TpArrayString,
+            CasacoreDataType::TpArrayInt64,
+        ] {
+            assert!(is_array_data_type(data_type), "{data_type:?}");
+        }
+        for data_type in [
+            CasacoreDataType::TpBool,
+            CasacoreDataType::TpDouble,
+            CasacoreDataType::TpString,
+            CasacoreDataType::TpRecord,
+            CasacoreDataType::TpArrayQuantity,
+        ] {
+            assert!(!is_array_data_type(data_type), "{data_type:?}");
+        }
+    }
+}

--- a/crates/casa-tables/src/taql/format.rs
+++ b/crates/casa-tables/src/taql/format.rs
@@ -222,7 +222,10 @@ pub fn format_result(result: &TaqlResult) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Table;
     use casa_types::RecordField;
+    use casa_types::{ArrayValue, Complex32, Complex64};
+    use ndarray::{ArrayD, IxDyn};
 
     #[test]
     fn format_value_scalars() {
@@ -230,15 +233,110 @@ mod tests {
             format_value(&Value::Scalar(ScalarValue::Bool(true))),
             "true"
         );
+        assert_eq!(format_value(&Value::Scalar(ScalarValue::UInt8(7))), "7");
+        assert_eq!(format_value(&Value::Scalar(ScalarValue::Int16(-7))), "-7");
+        assert_eq!(format_value(&Value::Scalar(ScalarValue::UInt16(17))), "17");
         assert_eq!(format_value(&Value::Scalar(ScalarValue::Int32(42))), "42");
+        assert_eq!(format_value(&Value::Scalar(ScalarValue::UInt32(42))), "42");
+        assert_eq!(format_value(&Value::Scalar(ScalarValue::Int64(-42))), "-42");
+        assert_eq!(
+            format_value(&Value::Scalar(ScalarValue::Float32(1.25))),
+            "1.250000"
+        );
         assert_eq!(
             format_value(&Value::Scalar(ScalarValue::Float64(1.5))),
             "1.500000"
         );
         assert_eq!(
+            format_value(&Value::Scalar(ScalarValue::Complex32(Complex32::new(
+                1.0, -2.0
+            )))),
+            "(1.000000,-2.000000)"
+        );
+        assert_eq!(
+            format_value(&Value::Scalar(ScalarValue::Complex64(Complex64::new(
+                -3.0, 4.0
+            )))),
+            "(-3.000000,4.000000)"
+        );
+        assert_eq!(
             format_value(&Value::Scalar(ScalarValue::String("hello".into()))),
             "hello"
         );
+        assert!(format_value(&Value::Record(RecordValue::default())).contains("RecordValue"));
+        assert_eq!(
+            format_value(&Value::TableRef("subtable.tbl".into())),
+            "table(subtable.tbl)"
+        );
+    }
+
+    #[test]
+    fn format_value_arrays_cover_supported_element_types() {
+        let cases = [
+            (
+                ArrayValue::Bool(ArrayD::from_shape_vec(IxDyn(&[2]), vec![true, false]).unwrap()),
+                "[true, false]",
+            ),
+            (
+                ArrayValue::UInt8(ArrayD::from_shape_vec(IxDyn(&[2]), vec![1u8, 2]).unwrap()),
+                "[1, 2]",
+            ),
+            (
+                ArrayValue::UInt16(ArrayD::from_shape_vec(IxDyn(&[2]), vec![1u16, 2]).unwrap()),
+                "[1, 2]",
+            ),
+            (
+                ArrayValue::UInt32(ArrayD::from_shape_vec(IxDyn(&[2]), vec![1u32, 2]).unwrap()),
+                "[1, 2]",
+            ),
+            (
+                ArrayValue::Int16(ArrayD::from_shape_vec(IxDyn(&[2]), vec![-1i16, 2]).unwrap()),
+                "[-1, 2]",
+            ),
+            (
+                ArrayValue::Int32(ArrayD::from_shape_vec(IxDyn(&[2]), vec![-1i32, 2]).unwrap()),
+                "[-1, 2]",
+            ),
+            (
+                ArrayValue::Int64(ArrayD::from_shape_vec(IxDyn(&[2]), vec![-1i64, 2]).unwrap()),
+                "[-1, 2]",
+            ),
+            (
+                ArrayValue::Float32(
+                    ArrayD::from_shape_vec(IxDyn(&[2]), vec![1.0f32, 2.5]).unwrap(),
+                ),
+                "[1.000000, 2.500000]",
+            ),
+            (
+                ArrayValue::Float64(
+                    ArrayD::from_shape_vec(IxDyn(&[2]), vec![1.0f64, 2.5]).unwrap(),
+                ),
+                "[1.000000, 2.500000]",
+            ),
+            (
+                ArrayValue::Complex32(
+                    ArrayD::from_shape_vec(IxDyn(&[1]), vec![Complex32::new(1.0, -1.0)]).unwrap(),
+                ),
+                "[(1.000000,-1.000000)]",
+            ),
+            (
+                ArrayValue::Complex64(
+                    ArrayD::from_shape_vec(IxDyn(&[1]), vec![Complex64::new(2.0, -2.0)]).unwrap(),
+                ),
+                "[(2.000000,-2.000000)]",
+            ),
+            (
+                ArrayValue::String(
+                    ArrayD::from_shape_vec(IxDyn(&[2]), vec!["a".to_string(), "bc".to_string()])
+                        .unwrap(),
+                ),
+                "[a, bc]",
+            ),
+        ];
+
+        for (array, expected) in cases {
+            assert_eq!(format_value(&Value::Array(array)), expected);
+        }
     }
 
     #[test]
@@ -272,6 +370,19 @@ mod tests {
     }
 
     #[test]
+    fn format_rows_truncates_long_cells_and_leaves_missing_cells_blank() {
+        let columns = vec!["long".to_string(), "missing".to_string()];
+        let rows = vec![RecordValue::new(vec![RecordField::new(
+            "long",
+            Value::Scalar(ScalarValue::String("x".repeat(60))),
+        )])];
+
+        let out = format_rows(&columns, &rows);
+        assert!(out.contains("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx…"));
+        assert!(out.contains("(1 row)"));
+    }
+
+    #[test]
     fn format_rows_no_columns() {
         let out = format_rows(&[], &[]);
         assert_eq!(out, "(no columns)\n");
@@ -284,6 +395,45 @@ mod tests {
             columns: vec!["a".into()],
         };
         assert_eq!(format_result(&r), "Selected 3 row(s), 1 column(s)");
+
+        let all_columns = TaqlResult::Select {
+            row_indices: vec![0],
+            columns: vec![],
+        };
+        assert_eq!(
+            format_result(&all_columns),
+            "Selected 1 row(s), all column(s)"
+        );
+    }
+
+    #[test]
+    fn format_result_covers_non_select_variants() {
+        assert_eq!(
+            format_result(&TaqlResult::Materialized {
+                table: Box::new(Table::from_rows(Vec::new()))
+            }),
+            "Materialized result: 0 row(s)"
+        );
+        assert_eq!(
+            format_result(&TaqlResult::Insert { rows_inserted: 2 }),
+            "Inserted 2 row(s)"
+        );
+        assert_eq!(
+            format_result(&TaqlResult::Delete { rows_deleted: 3 }),
+            "Deleted 3 row(s)"
+        );
+        assert_eq!(
+            format_result(&TaqlResult::CreateTable {
+                table_name: "created.tbl".into()
+            }),
+            "Created table: created.tbl"
+        );
+        assert_eq!(
+            format_result(&TaqlResult::DropTable {
+                table_name: "dropped.tbl".into()
+            }),
+            "Dropped table: dropped.tbl"
+        );
     }
 
     #[test]

--- a/crates/casa-test-support/src/lib.rs
+++ b/crates/casa-test-support/src/lib.rs
@@ -2557,7 +2557,17 @@ fn cpp_decode_value(
 mod tests {
     use super::*;
     use casa_types::{PrimitiveType, RecordValue};
+    use std::sync::Mutex;
     use tempfile::tempdir;
+
+    static TEST_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    unsafe fn restore_env_var(key: &str, value: Option<std::ffi::OsString>) {
+        match value {
+            Some(value) => unsafe { std::env::set_var(key, value) },
+            None => unsafe { std::env::remove_var(key) },
+        }
+    }
 
     #[test]
     fn primitive_case_set_is_non_empty() {
@@ -2704,6 +2714,44 @@ mod tests {
     }
 
     #[test]
+    fn tutorial_data_root_uses_home_workspace_fallback_and_reports_missing() {
+        let dir = tempdir().unwrap();
+        let tutorial_root = dir
+            .path()
+            .join("SoftwareProjects")
+            .join("casa-tutorial-data");
+        std::fs::create_dir_all(&tutorial_root).unwrap();
+
+        let _guard = TEST_ENV_LOCK.lock().unwrap();
+        let old_tutorial_root = std::env::var_os("CASA_RS_TUTORIAL_DATA_ROOT");
+        let old_home = std::env::var_os("HOME");
+        unsafe {
+            std::env::remove_var("CASA_RS_TUTORIAL_DATA_ROOT");
+            std::env::set_var("HOME", dir.path());
+        }
+
+        assert_eq!(
+            casa_tutorial_data_root(),
+            Some(normalize_existing_path(&tutorial_root))
+        );
+        assert_eq!(
+            tutorial_dataset_path("simulation/vla-ppdisk/model-fits"),
+            Some(
+                normalize_existing_path(&tutorial_root)
+                    .join("tutorial-parity/simulation/vla-ppdisk/ppdisk672_GHz_50pc.fits")
+            )
+        );
+
+        std::fs::remove_dir(&tutorial_root).unwrap();
+        assert_eq!(casa_tutorial_data_root(), None);
+
+        unsafe {
+            restore_env_var("CASA_RS_TUTORIAL_DATA_ROOT", old_tutorial_root);
+            restore_env_var("HOME", old_home);
+        }
+    }
+
+    #[test]
     fn tutorial_dataset_registry_contains_first_wave_candidates() {
         let twhya = tutorial_dataset("alma/first-look/twhya/calibrated-ms").unwrap();
         assert_eq!(twhya.expected_filename, "twhya_calibrated.ms.tar");
@@ -2728,6 +2776,228 @@ mod tests {
 
         let ppdisk = tutorial_dataset("simulation/vla-ppdisk/model-fits").unwrap();
         assert_eq!(ppdisk.casa_guide_version, Some("6.7.2"));
+
+        assert_eq!(CasaTestDataTier::DefaultFixture.as_str(), "default-fixture");
+        assert_eq!(CasaTestDataTier::TutorialParity.as_str(), "tutorial-parity");
+        assert_eq!(CasaTestDataTier::SlowParity.as_str(), "slow-parity");
+        assert!(tutorial_dataset("missing/key").is_none());
+    }
+
+    #[test]
+    fn source_root_discovery_prefers_existing_env_over_fallbacks() {
+        let dir = tempdir().unwrap();
+        let casa_root = dir.path().join("casa-src");
+        let casacore_root = dir.path().join("casacore-src");
+        std::fs::create_dir(&casa_root).unwrap();
+        std::fs::create_dir(&casacore_root).unwrap();
+
+        let _guard = TEST_ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::set_var("CASA_RS_CASA_ROOT", &casa_root);
+            std::env::set_var("CASA_RS_CASACORE_ROOT", &casacore_root);
+            std::env::set_var("CASA_ROOT", dir.path().join("ignored-casa"));
+            std::env::set_var("CASACORE_ROOT", dir.path().join("ignored-casacore"));
+        }
+
+        assert_eq!(
+            casa_source_root(),
+            Some(normalize_existing_path(&casa_root))
+        );
+        assert_eq!(
+            casacore_source_root(),
+            Some(normalize_existing_path(&casacore_root))
+        );
+
+        unsafe {
+            std::env::remove_var("CASA_RS_CASA_ROOT");
+            std::env::remove_var("CASA_RS_CASACORE_ROOT");
+            std::env::remove_var("CASA_ROOT");
+            std::env::remove_var("CASACORE_ROOT");
+        }
+    }
+
+    #[test]
+    fn source_root_discovery_uses_legacy_env_home_fallback_and_deduplicates_candidates() {
+        let dir = tempdir().unwrap();
+        let casa_root = dir.path().join("legacy-casa");
+        let casacore_root = dir.path().join("legacy-casacore");
+        let home_casa = dir.path().join("SoftwareProjects").join("casa");
+        let home_casacore = dir.path().join("SoftwareProjects").join("casacore");
+        std::fs::create_dir_all(&home_casa).unwrap();
+        std::fs::create_dir_all(&home_casacore).unwrap();
+        std::fs::create_dir(&casa_root).unwrap();
+        std::fs::create_dir(&casacore_root).unwrap();
+
+        let _guard = TEST_ENV_LOCK.lock().unwrap();
+        let old_casa_rs_root = std::env::var_os("CASA_RS_CASA_ROOT");
+        let old_casa_root = std::env::var_os("CASA_ROOT");
+        let old_casacore_rs_root = std::env::var_os("CASA_RS_CASACORE_ROOT");
+        let old_casacore_root = std::env::var_os("CASACORE_ROOT");
+        let old_home = std::env::var_os("HOME");
+        unsafe {
+            std::env::remove_var("CASA_RS_CASA_ROOT");
+            std::env::remove_var("CASA_RS_CASACORE_ROOT");
+            std::env::set_var("CASA_ROOT", &casa_root);
+            std::env::set_var("CASACORE_ROOT", &casacore_root);
+            std::env::set_var("HOME", dir.path());
+        }
+
+        assert_eq!(
+            casa_source_root(),
+            Some(normalize_existing_path(&casa_root))
+        );
+        assert_eq!(
+            casacore_source_root(),
+            Some(normalize_existing_path(&casacore_root))
+        );
+
+        unsafe {
+            std::env::remove_var("CASA_ROOT");
+            std::env::remove_var("CASACORE_ROOT");
+        }
+        assert_eq!(
+            casa_source_root(),
+            Some(normalize_existing_path(&home_casa))
+        );
+        assert_eq!(
+            casacore_source_root(),
+            Some(normalize_existing_path(&home_casacore))
+        );
+
+        let duplicated = vec![
+            PathBuf::from("python3"),
+            PathBuf::from("python"),
+            PathBuf::from("python3"),
+        ];
+        assert_eq!(
+            dedup_paths(duplicated),
+            vec![PathBuf::from("python3"), PathBuf::from("python")]
+        );
+        assert_eq!(
+            existing_path_from_candidates([None, Some(home_casa.clone())]),
+            Some(normalize_existing_path(&home_casa))
+        );
+
+        unsafe {
+            restore_env_var("CASA_RS_CASA_ROOT", old_casa_rs_root);
+            restore_env_var("CASA_ROOT", old_casa_root);
+            restore_env_var("CASA_RS_CASACORE_ROOT", old_casacore_rs_root);
+            restore_env_var("CASACORE_ROOT", old_casacore_root);
+            restore_env_var("HOME", old_home);
+        }
+    }
+
+    #[test]
+    fn casa_python_discovery_uses_env_candidates_and_callable_probes() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let dir = tempdir().unwrap();
+            let fake_python = dir.path().join("python");
+            std::fs::write(
+                &fake_python,
+                "#!/bin/sh\nscript=\"$2\"\ncase \"$script\" in\n  *\"import casatasks\"*\"plotms\"*) echo 1; exit 0 ;;\n  *\"import casatasks\"*\"tclean\"*) echo 1; exit 0 ;;\n  *\"import casatasks\"*) exit 0 ;;\nesac\nexit 1\n",
+            )
+            .unwrap();
+            let mut perms = std::fs::metadata(&fake_python).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&fake_python, perms).unwrap();
+
+            let _guard = TEST_ENV_LOCK.lock().unwrap();
+            let old_casa_rs_python = std::env::var_os("CASA_RS_CASA_PYTHON");
+            let old_casa_python = std::env::var_os("CASA_PYTHON");
+            let old_home = std::env::var_os("HOME");
+            unsafe {
+                std::env::set_var("CASA_RS_CASA_PYTHON", &fake_python);
+                std::env::set_var("CASA_PYTHON", &fake_python);
+                std::env::set_var("HOME", dir.path());
+            }
+
+            let candidates = casa_python_candidates();
+            assert_eq!(candidates.first(), Some(&fake_python));
+            assert_eq!(
+                candidates
+                    .iter()
+                    .filter(|path| *path == &fake_python)
+                    .count(),
+                1
+            );
+            assert!(python_can_import(&fake_python, "casatasks"));
+            assert!(!python_can_import(&fake_python, "not_casa"));
+            assert!(python_has_callable(&fake_python, "plotms"));
+            assert!(python_has_callable(&fake_python, "tclean"));
+
+            let discovered = discover_casa_python().unwrap();
+            assert_eq!(discovered.program, fake_python);
+            assert!(discovered.plotms_available);
+            assert!(discovered.tclean_available);
+
+            unsafe {
+                restore_env_var("CASA_RS_CASA_PYTHON", old_casa_rs_python);
+                restore_env_var("CASA_PYTHON", old_casa_python);
+                restore_env_var("HOME", old_home);
+            }
+        }
+    }
+
+    #[test]
+    fn git_head_commit_reports_only_successful_nonempty_revisions() {
+        let dir = tempdir().unwrap();
+        assert_eq!(git_head_commit(dir.path()), None);
+
+        let repo = dir.path().join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        assert!(
+            Command::new("git")
+                .arg("-C")
+                .arg(&repo)
+                .arg("init")
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert!(
+            Command::new("git")
+                .arg("-C")
+                .arg(&repo)
+                .args(["config", "user.email", "codex@example.invalid"])
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert!(
+            Command::new("git")
+                .arg("-C")
+                .arg(&repo)
+                .args(["config", "user.name", "Codex"])
+                .status()
+                .unwrap()
+                .success()
+        );
+        std::fs::write(repo.join("README.md"), "fixture\n").unwrap();
+        assert!(
+            Command::new("git")
+                .arg("-C")
+                .arg(&repo)
+                .args(["add", "README.md"])
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert!(
+            Command::new("git")
+                .arg("-C")
+                .arg(&repo)
+                .args(["commit", "-m", "fixture"])
+                .status()
+                .unwrap()
+                .success()
+        );
+
+        let head = git_head_commit(&repo).unwrap();
+        assert_eq!(head.len(), 40);
+        assert!(head.chars().all(|ch| ch.is_ascii_hexdigit()));
     }
 
     #[test]

--- a/crates/casa-test-support/src/table_interop.rs
+++ b/crates/casa-test-support/src/table_interop.rs
@@ -707,6 +707,114 @@ mod tests {
         assert_eq!(leaked, "hello");
     }
 
+    #[cfg(not(has_casacore_cpp))]
+    #[test]
+    fn cpp_matrix_cells_report_unavailable_backend_cleanly() {
+        let mut fixture = scalar_fixture();
+        fixture.cpp_fixture = Some(CppTableFixture::ScalarPrimitives);
+
+        let cc = run_cc(CppTableFixture::ScalarPrimitives);
+        assert_eq!(cc.label, "CC");
+        assert!(!cc.passed);
+        assert!(
+            cc.error
+                .as_deref()
+                .is_some_and(|err| err.contains("C++ write failed"))
+        );
+
+        let cr = run_cr(
+            &fixture,
+            ManagerKind::StandardStMan,
+            CppTableFixture::ScalarPrimitives,
+        );
+        assert_eq!(cr.label, "CR");
+        assert!(!cr.passed);
+        assert!(
+            cr.error
+                .as_deref()
+                .is_some_and(|err| err.contains("C++ write failed"))
+        );
+
+        let rc = run_rc(
+            &fixture,
+            ManagerKind::StandardStMan,
+            CppTableFixture::ScalarPrimitives,
+        );
+        assert_eq!(rc.label, "RC");
+        assert!(!rc.passed);
+        assert!(
+            rc.error
+                .as_deref()
+                .is_some_and(|err| err.contains("C++ verify failed"))
+        );
+
+        let rc_le = run_rc_with_endian(
+            &fixture,
+            ManagerKind::StandardStMan,
+            CppTableFixture::ScalarPrimitives,
+            EndianFormat::LittleEndian,
+        );
+        assert_eq!(rc_le.label, "RC-LE");
+        assert!(!rc_le.passed);
+        assert!(
+            rc_le
+                .error
+                .as_deref()
+                .is_some_and(|err| err.contains("C++ verify failed"))
+        );
+    }
+
+    #[test]
+    fn manager_mapping_and_save_options_cover_all_fixture_shapes() {
+        assert_eq!(
+            to_dm_kind(ManagerKind::StManAipsIO),
+            casa_tables::DataManagerKind::StManAipsIO
+        );
+        assert_eq!(
+            to_dm_kind(ManagerKind::IncrementalStMan),
+            casa_tables::DataManagerKind::IncrementalStMan
+        );
+        assert_eq!(
+            to_dm_kind(ManagerKind::TiledColumnStMan),
+            casa_tables::DataManagerKind::TiledColumnStMan
+        );
+        assert_eq!(
+            to_dm_kind(ManagerKind::TiledShapeStMan),
+            casa_tables::DataManagerKind::TiledShapeStMan
+        );
+        assert_eq!(
+            to_dm_kind(ManagerKind::TiledCellStMan),
+            casa_tables::DataManagerKind::TiledCellStMan
+        );
+
+        let mut fixture = scalar_fixture();
+        fixture.tile_shape = Some(vec![2, 3, 4]);
+        let dir = tempfile::tempdir().unwrap();
+        let opts = save_opts(&fixture, ManagerKind::TiledColumnStMan, dir.path());
+        assert_eq!(opts.path(), dir.path());
+        assert_eq!(
+            opts.data_manager(),
+            casa_tables::DataManagerKind::TiledColumnStMan
+        );
+        assert_eq!(opts.tile_shape(), Some(&[2, 3, 4][..]));
+
+        let endian_opts = save_opts_endian(
+            &fixture,
+            ManagerKind::TiledCellStMan,
+            dir.path(),
+            EndianFormat::LittleEndian,
+        );
+        assert_eq!(
+            endian_opts.data_manager(),
+            casa_tables::DataManagerKind::TiledCellStMan
+        );
+        assert_eq!(endian_opts.endian_format(), EndianFormat::LittleEndian);
+        assert!(values_equal(
+            &Value::Scalar(ScalarValue::Int32(1)),
+            &Value::Scalar(ScalarValue::Int32(1))
+        ));
+    }
+
     #[test]
     fn read_and_verify_reports_missing_table() {
         let fixture = scalar_fixture();

--- a/crates/casa-vla/src/importer.rs
+++ b/crates/casa-vla/src/importer.rs
@@ -3732,6 +3732,172 @@ mod tests {
     }
 
     #[test]
+    fn helper_paths_cover_import_options_arrays_and_frequency_metadata() {
+        let mut options = ImportVlaOptions {
+            archivefiles: vec![PathBuf::from("input.xp1")],
+            ..ImportVlaOptions::default()
+        };
+        assert!(validate_import_options(&options).is_ok());
+        options.bandname = Some(crate::BandName::L);
+        assert!(matches!(
+            validate_import_options(&options),
+            Err(VlaError::InvalidArgument {
+                argument: "bandname",
+                ..
+            })
+        ));
+        options.bandname = None;
+        options.starttime = Some("01-Jan-1985/00:00:00".to_string());
+        assert!(matches!(
+            validate_import_options(&options),
+            Err(VlaError::InvalidArgument {
+                argument: "starttime",
+                ..
+            })
+        ));
+        options.starttime = None;
+        options.stoptime = Some("01-Jan-1985/01:00:00".to_string());
+        assert!(matches!(
+            validate_import_options(&options),
+            Err(VlaError::InvalidArgument {
+                argument: "stoptime",
+                ..
+            })
+        ));
+        options.stoptime = None;
+        options.evlabands = true;
+        assert!(matches!(
+            validate_import_options(&options),
+            Err(VlaError::InvalidArgument {
+                argument: "evlabands",
+                ..
+            })
+        ));
+
+        assert_eq!(
+            [
+                frequency_reference_for_frame(FrequencyFrame::Topocentric),
+                frequency_reference_for_frame(FrequencyFrame::Geocentric),
+                frequency_reference_for_frame(FrequencyFrame::Barycentric),
+                frequency_reference_for_frame(FrequencyFrame::Lsrk),
+            ],
+            [
+                FrequencyRef::TOPO,
+                FrequencyRef::GEO,
+                FrequencyRef::BARY,
+                FrequencyRef::LSRK,
+            ]
+        );
+        assert_eq!(
+            doppler_reference_for_definition(DopplerDefinition::Optical),
+            DopplerRef::Z
+        );
+        assert_eq!(
+            doppler_reference_for_definition(DopplerDefinition::Unknown),
+            DopplerRef::RADIO
+        );
+        assert_eq!(
+            direction_reference_for_epoch(DirectionEpoch::Unknown(17)),
+            DirectionRef::J2000
+        );
+        assert_eq!(format_sigfigs(0.0, 3), "0");
+        assert_eq!(format_sigfigs(12_345.0, 3), "12345");
+        assert_eq!(format_sigfigs(12.340, 4), "12.34");
+        assert_eq!(
+            spectral_window_name(&test_descriptor(327.5e6), 327.5e6, FrequencyRef::TOPO),
+            "1*50 MHz channels @ 328 MHz (TOPO)"
+        );
+
+        assert_eq!(
+            [
+                stokes_code(StokesProduct::Rr),
+                stokes_code(StokesProduct::Rl)
+            ],
+            [5, 6]
+        );
+        assert_eq!(
+            [
+                stokes_code(StokesProduct::Lr),
+                stokes_code(StokesProduct::Ll)
+            ],
+            [7, 8]
+        );
+        assert_eq!(
+            build_model_data(&[5, 6, 7, 8], 2),
+            vec![
+                Complex32::new(1.0, 0.0),
+                Complex32::new(0.0, 0.0),
+                Complex32::new(0.0, 0.0),
+                Complex32::new(1.0, 0.0),
+                Complex32::new(1.0, 0.0),
+                Complex32::new(0.0, 0.0),
+                Complex32::new(0.0, 0.0),
+                Complex32::new(1.0, 0.0),
+            ]
+        );
+        assert_eq!(flag_category_index(1, 2, 3, 4, 5), 69);
+
+        let (weight, sigma) = visibility_weight_sigma(1.0e6, 10.0, 4.0, true, false);
+        assert!((weight - 30.0).abs() < 1.0e-6);
+        assert!((sigma - (1.0_f32 / 120.0_f32.sqrt() * 2.0)).abs() < 1.0e-6);
+        assert_eq!(
+            visibility_weight_sigma(0.0, 10.0, 1.0, true, false),
+            (0.0, 0.0)
+        );
+
+        let all_flagged =
+            ArrayValue::Bool(ArrayD::from_shape_vec(IxDyn(&[2, 1]).f(), vec![true, true]).unwrap());
+        let partly_flagged = ArrayValue::Bool(
+            ArrayD::from_shape_vec(IxDyn(&[2, 1]).f(), vec![true, false]).unwrap(),
+        );
+        assert!(flag_row_value(&all_flagged).unwrap());
+        assert!(!flag_row_value(&partly_flagged).unwrap());
+        assert!(
+            flag_row_value(&ArrayValue::Float32(
+                ArrayD::from_shape_vec(IxDyn(&[1]).f(), vec![1.0_f32]).unwrap()
+            ))
+            .is_err()
+        );
+
+        let weights = ArrayValue::Float32(
+            ArrayD::from_shape_vec(IxDyn(&[4]).f(), vec![1.0, 2.0, 3.0, 4.0]).unwrap(),
+        );
+        let reordered = reorder_vector_array(&weights, &[5, 6, 7, 8], &[5, 7, 6, 8]).unwrap();
+        let ArrayValue::Float32(reordered) = reordered else {
+            panic!("expected float vector");
+        };
+        assert_eq!(
+            reordered.iter().copied().collect::<Vec<_>>(),
+            vec![1.0, 3.0, 2.0, 4.0]
+        );
+        assert!(reorder_vector_array(&all_flagged, &[5], &[5]).is_err());
+        assert!(reorder_index_map(&[5, 6], &[5, 7], "test").is_err());
+
+        let flags = ArrayValue::Bool(
+            ArrayD::from_shape_vec(IxDyn(&[2, 2]).f(), vec![false, true, true, false]).unwrap(),
+        );
+        let reordered_flags = reorder_bool_array_generic(&flags, &[5, 8], &[8, 5], "flag").unwrap();
+        let ArrayValue::Bool(reordered_flags) = reordered_flags else {
+            panic!("expected bool flags");
+        };
+        assert_eq!(
+            reordered_flags.iter().copied().collect::<Vec<_>>(),
+            vec![true, false, false, true]
+        );
+        assert!(reorder_bool_array_generic(&weights, &[5], &[5], "flag").is_err());
+
+        let corr_product = corr_product_array(&[5, 6, 7, 8]).unwrap();
+        let ArrayValue::Int32(corr_product) = corr_product else {
+            panic!("expected int corr product");
+        };
+        assert_eq!(
+            corr_product.iter().copied().collect::<Vec<_>>(),
+            vec![0, 0, 1, 1, 0, 1, 0, 1]
+        );
+        assert!(corr_product_array(&[42]).is_err());
+    }
+
+    #[test]
     fn new_spectral_windows_use_the_most_recently_added_source_row() {
         let tempdir = tempfile::tempdir().unwrap();
         let ms_path = tempdir.path().join("doppler-update.ms");

--- a/crates/casa-vla/src/record.rs
+++ b/crates/casa-vla/src/record.rs
@@ -1372,23 +1372,54 @@ mod tests {
 
     use super::{
         AntennaDataArea, BaselineRecord, CdaId, CircularPolarization, CorrelatorDataArea,
-        CorrelatorMode, IfId, IfUsage, RecordControlArea, SubarrayDataArea,
+        CorrelatorMode, DirectionEpoch, DopplerDefinition, FrequencyFrame, IfId, IfUsage,
+        RecordControlArea, SubarrayDataArea,
     };
 
     #[test]
     fn rca_decodes_ada_layout() {
         let mut bytes = vec![0_u8; 128];
         bytes[0..4].copy_from_slice(&(64_i32).to_be_bytes());
+        bytes[2 * 3..2 * 3 + 2].copy_from_slice(&27_u16.to_be_bytes());
+        bytes[2 * 4..2 * 4 + 4].copy_from_slice(&12345_u32.to_be_bytes());
         bytes[2 * 12..2 * 12 + 4].copy_from_slice(&100_u32.to_be_bytes());
         bytes[2 * 14..2 * 14 + 4].copy_from_slice(&150_u32.to_be_bytes());
         bytes[2 * 16..2 * 16 + 2].copy_from_slice(&8_u16.to_be_bytes());
         bytes[2 * 17..2 * 17 + 2].copy_from_slice(&3_u16.to_be_bytes());
+        bytes[2 * 18..2 * 18 + 4].copy_from_slice(&200_u32.to_be_bytes());
+        bytes[2 * 20..2 * 20 + 2].copy_from_slice(&14_u16.to_be_bytes());
+        bytes[2 * 21..2 * 21 + 2].copy_from_slice(&28_u16.to_be_bytes());
+        bytes[2 * 22..2 * 22 + 4].copy_from_slice(&300_u32.to_be_bytes());
 
         let rca = RecordControlArea::new(&bytes);
+        assert_eq!(rca.length_bytes().unwrap(), 128);
+        assert_eq!(rca.revision().unwrap(), 27);
+        assert_eq!(rca.obs_day().unwrap(), 12345);
         assert_eq!(rca.sda_offset_bytes().unwrap(), 200);
         assert_eq!(rca.ada_size_bytes().unwrap(), 16);
         assert_eq!(rca.ada_offset_bytes(0).unwrap(), 300);
         assert_eq!(rca.ada_offset_bytes(2).unwrap(), 332);
+        assert_eq!(rca.cda_offset_bytes(0).unwrap(), 400);
+        assert_eq!(rca.cda_header_bytes(0).unwrap(), 28);
+        assert_eq!(rca.cda_baseline_bytes(0).unwrap(), 56);
+        assert_eq!(rca.cda_offset_bytes(1).unwrap(), 600);
+        assert_eq!(rca.used_cda_count().unwrap(), 2);
+        assert!(
+            rca.ada_offset_bytes(3)
+                .unwrap_err()
+                .contains("out of range")
+        );
+        assert!(
+            rca.cda_offset_bytes(4)
+                .unwrap_err()
+                .contains("out of range")
+        );
+        assert!(
+            RecordControlArea::new(&[0, 0, 0, 0])
+                .length_bytes()
+                .unwrap_err()
+                .contains("invalid logical-record length")
+        );
     }
 
     #[test]
@@ -1419,12 +1450,192 @@ mod tests {
         assert_eq!(sda.integration_time_seconds().unwrap(), 10.0);
         assert!(sda.smoothed().unwrap());
         assert_eq!(
+            sda.observation_mode_description().unwrap(),
+            "Single dish pointing mode (IF A)"
+        );
+        assert_eq!(sda.direction_epoch().unwrap(), DirectionEpoch::J2000);
+        assert_eq!(sda.electronic_path(CdaId::Cda2).unwrap(), 0);
+        assert_eq!(
             sda.if_usage(CdaId::Cda2).unwrap(),
             vec![IfUsage {
                 ant1: IfId::A,
                 ant2: IfId::C
             }]
         );
+    }
+
+    #[test]
+    fn sda_mode_tables_cover_casa_if_usage_and_observing_codes() {
+        let cases = [
+            (
+                b"    ",
+                CorrelatorMode::Continuum,
+                CdaId::Cda0,
+                vec![
+                    (IfId::A, IfId::A),
+                    (IfId::C, IfId::C),
+                    (IfId::A, IfId::C),
+                    (IfId::C, IfId::A),
+                ],
+            ),
+            (
+                b"1A  ",
+                CorrelatorMode::A,
+                CdaId::Cda0,
+                vec![(IfId::A, IfId::A)],
+            ),
+            (
+                b"1B  ",
+                CorrelatorMode::B,
+                CdaId::Cda1,
+                vec![(IfId::B, IfId::B)],
+            ),
+            (
+                b"1C  ",
+                CorrelatorMode::C,
+                CdaId::Cda2,
+                vec![(IfId::C, IfId::C)],
+            ),
+            (
+                b"1D  ",
+                CorrelatorMode::D,
+                CdaId::Cda3,
+                vec![(IfId::D, IfId::D)],
+            ),
+            (
+                b"2AB ",
+                CorrelatorMode::Ab,
+                CdaId::Cda1,
+                vec![(IfId::B, IfId::B)],
+            ),
+            (
+                b"2AC ",
+                CorrelatorMode::Ac,
+                CdaId::Cda2,
+                vec![(IfId::C, IfId::C)],
+            ),
+            (
+                b"2AD ",
+                CorrelatorMode::Ad,
+                CdaId::Cda3,
+                vec![(IfId::D, IfId::D)],
+            ),
+            (
+                b"2BC ",
+                CorrelatorMode::Bc,
+                CdaId::Cda1,
+                vec![(IfId::B, IfId::B)],
+            ),
+            (
+                b"2BD ",
+                CorrelatorMode::Bd,
+                CdaId::Cda3,
+                vec![(IfId::D, IfId::D)],
+            ),
+            (
+                b"2CD ",
+                CorrelatorMode::Cd,
+                CdaId::Cda2,
+                vec![(IfId::C, IfId::C)],
+            ),
+            (
+                b"4   ",
+                CorrelatorMode::Abcd,
+                CdaId::Cda3,
+                vec![(IfId::D, IfId::D)],
+            ),
+            (
+                b"PB  ",
+                CorrelatorMode::Pb,
+                CdaId::Cda2,
+                vec![(IfId::B, IfId::D)],
+            ),
+            (b"ZZ  ", CorrelatorMode::Unknown, CdaId::Cda0, vec![]),
+        ];
+        for (raw_mode, expected_mode, cda, expected_usage) in cases {
+            let mut bytes = vec![0_u8; 512];
+            bytes[2 * 157..2 * 157 + 4].copy_from_slice(raw_mode);
+            let sda = SubarrayDataArea::new(&bytes, 0).unwrap();
+            assert_eq!(sda.correlator_mode().unwrap(), expected_mode);
+            let usage = expected_usage
+                .into_iter()
+                .map(|(ant1, ant2)| IfUsage { ant1, ant2 })
+                .collect::<Vec<_>>();
+            assert_eq!(sda.if_usage(cda).unwrap(), usage);
+        }
+
+        let mut bytes = vec![0_u8; 512];
+        for (code, expected) in [
+            (b"D ", "Delay center determination mode"),
+            (b"IR", "Interferometer reference pointing mode"),
+            (b"TB", "Test back-end and front-end"),
+            (
+                b"VA",
+                "Self-phasing mode for VLBI phased-array (IFs A and D)",
+            ),
+            (b"??", "Unknown mode: ??"),
+        ] {
+            bytes[2 * 15..2 * 15 + 2].copy_from_slice(code);
+            let sda = SubarrayDataArea::new(&bytes, 0).unwrap();
+            assert_eq!(sda.observation_mode_description().unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn sda_frequency_metadata_decodes_doppler_and_bandwidth_branches() {
+        let mut bytes = vec![0_u8; 512];
+        bytes[2 * 18] = 0x10;
+        bytes[2 * 100] = 0x70;
+        bytes[2 * 101] = 0x30;
+        bytes[2 * 153] = b'L';
+        bytes[2 * 153 + 1] = b'V';
+        bytes[2 * 154] = b'B';
+        bytes[2 * 154 + 1] = b'Z';
+        bytes[2 * 159 + 1] = b'H';
+        bytes[2 * 161..2 * 161 + 2].copy_from_slice(&1950_i16.to_be_bytes());
+        bytes[2 * 166..2 * 166 + 2].copy_from_slice(&2_i16.to_be_bytes());
+
+        let sda = SubarrayDataArea::new(&bytes, 0).unwrap();
+        assert_eq!(sda.true_channels(CdaId::Cda0).unwrap(), 2);
+        assert_eq!(sda.n_channels(CdaId::Cda0).unwrap(), 1);
+        assert_eq!(sda.channel_width_hz(CdaId::Cda0).unwrap(), 12.5e6);
+        assert_eq!(
+            sda.correlated_bandwidth_hz(CdaId::Cda0).unwrap(),
+            25.0 / 32.0 * 1.0e6
+        );
+        assert_eq!(sda.filter_bandwidth_hz(CdaId::Cda0).unwrap(), 1.0e200);
+        assert!(sda.doppler_tracking(CdaId::Cda0).unwrap());
+        assert_eq!(sda.rest_frame(CdaId::Cda0).unwrap(), FrequencyFrame::Lsrk);
+        assert_eq!(
+            sda.doppler_definition(CdaId::Cda0).unwrap(),
+            DopplerDefinition::Radio
+        );
+        assert_eq!(
+            sda.rest_frame(CdaId::Cda1).unwrap(),
+            FrequencyFrame::Barycentric
+        );
+        assert_eq!(
+            sda.doppler_definition(CdaId::Cda1).unwrap(),
+            DopplerDefinition::Optical
+        );
+        assert!(sda.smoothed().unwrap());
+        assert_eq!(sda.direction_epoch().unwrap(), DirectionEpoch::B1950Vla);
+
+        bytes[2 * 18] = 0x00;
+        bytes[2 * 100] = 0x90;
+        bytes[2 * 101] = 0x40;
+        bytes[2 * 153 + 1] = b'F';
+        bytes[2 * 161..2 * 161 + 2].copy_from_slice(&(-1_i16).to_be_bytes());
+        let sda = SubarrayDataArea::new(&bytes, 0).unwrap();
+        assert_eq!(sda.true_channels(CdaId::Cda0).unwrap(), 1);
+        assert!(
+            sda.correlated_bandwidth_hz(CdaId::Cda0)
+                .unwrap()
+                .is_infinite()
+        );
+        assert!(sda.filter_bandwidth_hz(CdaId::Cda0).unwrap().is_nan());
+        assert!(!sda.doppler_tracking(CdaId::Cda0).unwrap());
+        assert_eq!(sda.direction_epoch().unwrap(), DirectionEpoch::Apparent);
     }
 
     #[test]
@@ -1440,6 +1651,8 @@ mod tests {
         let ada = AntennaDataArea::new(&bytes, 0).unwrap();
         assert_eq!(ada.antenna_id().unwrap(), 12);
         assert_eq!(ada.antenna_name(true).unwrap(), "EA12");
+        assert_eq!(ada.antenna_name(false).unwrap(), "12");
+        assert_eq!(ada.array_name().unwrap(), "EVLA:");
         assert_eq!(ada.if_status(IfId::A).unwrap(), 0x0a);
         assert_eq!(ada.if_status(IfId::D).unwrap(), 0x00);
         assert_eq!(
@@ -1451,6 +1664,25 @@ mod tests {
             CircularPolarization::Right
         );
         assert!(ada.nominal_sensitivity_applied(IfId::B, 25).unwrap());
+        assert!(ada.nominal_sensitivity_applied(IfId::B, 24).unwrap());
+
+        bytes[0] = 29;
+        let ada = AntennaDataArea::new(&bytes, 0).unwrap();
+        assert_eq!(ada.antenna_name(true).unwrap(), "VA29");
+        assert_eq!(ada.array_name().unwrap(), "VLA:_");
+    }
+
+    #[test]
+    fn ada_pad_names_and_offsets_cover_position_helpers() {
+        let mut bytes = vec![0_u8; 256];
+        bytes[0] = 1;
+        // Zero-valued ModComp doubles decode to zero ns, outside the 0.5 m pad-name tolerance.
+        let ada = AntennaDataArea::new(&bytes, 0).unwrap();
+        assert_eq!(ada.position_meters().unwrap(), [0.0, 0.0, 0.0]);
+        assert_eq!(ada.u_meters().unwrap(), 0.0);
+        assert_eq!(ada.v_meters().unwrap(), 0.0);
+        assert_eq!(ada.w_meters().unwrap(), 0.0);
+        assert_eq!(ada.pad_name().unwrap(), "UNKNOWN");
     }
 
     #[test]
@@ -1475,6 +1707,12 @@ mod tests {
         }
 
         let cda = CorrelatorDataArea::new(&bytes, offset, 28, 1, 1).unwrap();
+        assert!(cda.is_valid());
+        assert_eq!(cda.n_antennas(), 1);
+        assert_eq!(cda.baseline_size_bytes(), 28);
+        assert_eq!(cda.n_channels_true(), 1);
+        assert_eq!(cda.n_cross_correlations(), 0);
+        assert!(cda.cross_corr(0).unwrap_err().contains("out of range"));
         let baseline = cda.auto_corr(0).unwrap();
         assert_eq!(baseline.scale().unwrap(), 256);
         assert_eq!(baseline.ant1().unwrap(), 10);
@@ -1536,5 +1774,40 @@ mod tests {
         let cda = CorrelatorDataArea::new(&bytes, offset, 28, 1, 1).unwrap();
         let baseline = cda.auto_corr(0).unwrap();
         assert_eq!(baseline.scale().unwrap(), 16_777_216);
+    }
+
+    #[test]
+    fn cda_constructor_and_cross_correlation_validate_layout() {
+        assert!(
+            CorrelatorDataArea::new(&[0; 16], 0, 8, 2, 1)
+                .unwrap_err()
+                .contains("not present")
+        );
+        assert!(
+            CorrelatorDataArea::new(&[0; 16], u32::MAX - 1, 8, 2, 1)
+                .unwrap_err()
+                .contains("out of range")
+        );
+
+        let mut bytes = vec![0_u8; 128];
+        let offset = 8_u32;
+        let baseline_size = 28_u16;
+        let cross_offset = offset as usize + baseline_size as usize * 2;
+        bytes[cross_offset + 1] = 0;
+        bytes[cross_offset + 2] = 0x60;
+        bytes[cross_offset + 3] = 0x03;
+        bytes[cross_offset + 4..cross_offset + 6].copy_from_slice(&64_i16.to_be_bytes());
+        bytes[cross_offset + 6..cross_offset + 8].copy_from_slice(&(-128_i16).to_be_bytes());
+
+        let cda = CorrelatorDataArea::new(&bytes, offset, baseline_size, 2, 1).unwrap();
+        assert_eq!(cda.n_cross_correlations(), 1);
+        assert!(cda.auto_corr(2).unwrap_err().contains("out of range"));
+        let cross = cda.cross_corr(0).unwrap();
+        assert_eq!(cross.ant1().unwrap(), 15);
+        assert_eq!(cross.ant2().unwrap(), 3);
+        assert_eq!(
+            cross.data().unwrap()[0],
+            Complex32::new(64.0 / 256.0, -128.0 / 256.0)
+        );
     }
 }


### PR DESCRIPTION
Wave source: automation long-gates-pr-fixer

## Root causes

- The long-gate CI-like coverage run was below the automation threshold: the first run reported 76.27%, and focused coverage work was needed to restore the 78.0% floor.
- `casa-ms` has `autotests = false`, so the new `tests/transform.rs` integration coverage needed an explicit test target registration in `crates/casa-ms/Cargo.toml`.
- Calibration trace output used a `OnceLock`-cached environment lookup, which made `CASA_RS_GAIN_TRACE` stale after earlier solver calls and left trace tests order-dependent. The trace path now reads the environment when needed, with a thread-local test override to avoid process-env races in parallel tests.
- Coverage gaps were concentrated in risky cross-module logic: `mstransform`, calibration tracing/execution helpers, VLA record/import decoding, low-level table reader/control paths, test-data discovery, and TaQL formatting.

## Files changed

- `crates/casa-calibration/src/execute.rs`
- `crates/casa-calibration/src/solve/trace.rs`
- `crates/casa-calibration/tests/gencal.rs`
- `crates/casa-ms/Cargo.toml`
- `crates/casa-ms/src/msexplore/task_contract.rs`
- `crates/casa-ms/src/transform.rs`
- `crates/casa-ms/tests/msexplore_cli.rs`
- `crates/casa-ms/tests/transform.rs`
- `crates/casa-table-read/src/incremental_stman.rs`
- `crates/casa-table-read/src/table_control.rs`
- `crates/casa-tables/src/taql/format.rs`
- `crates/casa-test-support/src/lib.rs`
- `crates/casa-test-support/src/table_interop.rs`
- `crates/casa-vla/src/importer.rs`
- `crates/casa-vla/src/record.rs`

## Validation

Commands run, in the requested long-gate order:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `scripts/test-slow.sh`
- `scripts/run-coverage.sh --ci-like`

Additional relevant rerun after the final test-support-only coverage edit:

- `cargo clippy -p casa-test-support --all-targets -- -D warnings`
- `cargo test -p casa-test-support`
- `cargo fmt --all -- --check`

Final CI-like coverage: `78.00% coverage, 78400/100518 lines covered`.

## Residual risks / follow-up

- Coverage is exactly at the 78.0% automation threshold, so unrelated future line-total changes can move it below the floor again.
- No release versions or tags were changed.
- This PR is intentionally not merged by the automation.
