### PR TITLE
Fix imager long-gate parity failures

### DIFF
--- a/crates/casars-imager/src/lib.rs
+++ b/crates/casars-imager/src/lib.rs
@@ -2259,6 +2259,18 @@ impl SelectedMainArrayColumn {
                 )
             })
     }
+
+    fn get_optional(&self, row_slot: usize) -> Result<Option<&ArrayValue>, String> {
+        self.values
+            .get(row_slot)
+            .map(|value| value.as_ref())
+            .ok_or_else(|| {
+                format!(
+                    "{} selected row slot {} is out of bounds",
+                    self.column_name, row_slot
+                )
+            })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -4287,8 +4299,9 @@ impl PreparedSelection {
         timings.weight_column += stage_started_at.elapsed();
         let stage_started_at = Instant::now();
         let weight_spectrum_row = weight_spectrum
-            .map(|column| column.get(row_slot))
+            .map(|column| column.get_optional(row_slot))
             .transpose()
+            .map(|row| row.flatten())
             .map_err(|error| format!("read WEIGHT_SPECTRUM row {row}: {error}"))?;
         timings.weight_spectrum += stage_started_at.elapsed();
         let adapt_started_at = Instant::now();
@@ -10130,6 +10143,22 @@ mod tests {
             resolve_weight_with_source(&weight_row, Some(&weight_spectrum), 1, 0).unwrap();
         assert_eq!(weight, 4.0);
         assert_eq!(source, WeightSourceKind::WeightSpectrum);
+    }
+
+    #[test]
+    fn selected_optional_array_column_allows_missing_cells() {
+        let column = SelectedMainArrayColumn {
+            column_name: "WEIGHT_SPECTRUM",
+            values: vec![None],
+        };
+
+        assert_eq!(column.get_optional(0).unwrap(), None);
+        assert!(
+            column
+                .get_optional(1)
+                .unwrap_err()
+                .contains("out of bounds")
+        );
     }
 
     #[test]

--- a/crates/casars-imager/tests/imager_casa_parity.rs
+++ b/crates/casars-imager/tests/imager_casa_parity.rs
@@ -250,8 +250,27 @@ fn dirty_cube_products_track_casa_on_simulated_jet() {
         stage_measurement_set(&ms_path, temp.path(), "sim_data_VLA_jet.ms").expect("stage ms");
     let rust_prefix = temp.path().join("rust-simjet-cube-dirty");
     let casa_prefix = temp.path().join("casa-simjet-cube-dirty");
+    let spw_selector = case.cube_channel_spw_selector();
+    let cube_options = CubeCaseOptions {
+        spw_selector: &spw_selector,
+        nchan: case.channel_count,
+        start: Some(CubeAxisStep::Text("1.0GHz")),
+        width: Some(CubeAxisStep::Text("0.2GHz")),
+        outframe: "LSRK",
+        interpolation: "nearest",
+        veltype: "radio",
+        restfreq: "1.25GHz",
+    };
 
-    run_rust_imager_cube_dirty(case, &staged_ms_path, &rust_prefix).expect("run rust imager");
+    run_rust_imager_cube_case_with_options(
+        case,
+        &staged_ms_path,
+        &rust_prefix,
+        cube_options,
+        true,
+        0,
+    )
+    .expect("run rust imager");
     run_casa_tclean_cube_dirty_case(
         case,
         &staged_ms_path,


### PR DESCRIPTION
Wave source: automation Long Gates PR Fixer

## Root causes
- Selected rows can legitimately have missing optional `WEIGHT_SPECTRUM` cells. The imager selection path treated a missing selected optional array cell as a hard read error instead of falling back to row-level `WEIGHT`.
- The simulated-jet dirty cube parity test ran Rust with the generic channel-index cube helper while the CASA side used an explicit frequency cube axis (`start="1.0GHz"`, `width="0.2GHz"`, `outframe="LSRK"`, nearest interpolation, `restfreq="1.25GHz"`). That mismatched cube axis produced residual/sumwt differences in channel 0.

## Files changed
- `crates/casars-imager/src/lib.rs`: added optional selected-array cell handling and a regression test for missing optional `WEIGHT_SPECTRUM` cells.
- `crates/casars-imager/tests/imager_casa_parity.rs`: aligned the Rust simulated-jet cube run with the explicit CASA frequency cube axis used by the parity case.

## Validation
- `cargo test -p casars-imager selected_optional_array_column_allows_missing_cells`
- `cargo test -p casars-imager --features slow-tests --test imager_casa_parity n2403 -- --nocapture`
- `cargo test -p casars-imager --features slow-tests --test imager_casa_parity dirty_cube_products_track_casa_on_simulated_jet -- --exact --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `scripts/test-slow.sh`
- `scripts/run-coverage.sh --ci-like`

Final CI-like coverage: 78.07% (79701/102089 lines covered).

## Residual risks / follow-up
- No known residual blocker. The optional-cell change intentionally preserves hard errors for selected row slots that are out of bounds while allowing missing optional array cells to fall back through the existing weight handling path.
- Repository labels `codex` and `codex-automation` were not present, so no automation labels were applied.