### PR TITLE
GUI-Wave-4: Add dirty imaging task execution

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -61,9 +61,12 @@ small UniFFI runtime boundary through `casars-frontend-services` for read-only
 project and dataset probing. GUI-Wave-3 extends that boundary with a narrow
 MeasurementSet explorer plot API: Rust owns `casa-ms` / `msexplore` plot payload
 construction and PNG rendering, while Swift owns native controls, layout, and
-debug-state projection. This is not a shared background service contract:
-long-running tasks, cancellation, and provider execution remain separate
-protocol work.
+debug-state projection. GUI-Wave-4 adds the first real task-execution vertical:
+the Swift workbench supervises a short-lived `casars-imager --json-run`
+process for dirty imaging, records logs/results/products in processing history,
+and exposes the request/run state through the debug snapshot. This remains a
+narrow process-supervision path, not a shared background service, provider
+daemon, or repo-wide async runtime contract.
 
 ## Persistence / external systems
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -53,10 +53,13 @@ Verification: just verify
 - GitHub tag CI: PR CI plus smoke, suite-install, and CI-like coverage
 - Native macOS GUI prototype and frontend services:
   `cargo test -p casars-frontend-services`,
+  `cargo test -p casars-imager dirty_imaging_json_request_accepts_gui_selection_fields`,
   `scripts/test-frontend-services-python.sh`, `swift test` from
   `apps/casars-mac`, and
-  `swift run casars-mac --dump-debug-state --simulate-main-flow` for the
-  headless debug-state smoke path.
+  `CASARS_IMAGER_BIN=target/debug/casars-imager swift run casars-mac
+  --dump-debug-state --simulate-main-flow --open-project <fixture-or-project>`
+  for the headless debug-state smoke path that includes the dirty-imaging task
+  run.
 
 ## Coverage / confidence policy
 

--- a/apps/casars-mac/Sources/CasarsMacApp/CasarsMacApp.swift
+++ b/apps/casars-mac/Sources/CasarsMacApp/CasarsMacApp.swift
@@ -142,6 +142,9 @@ struct CasarsMacApp: App {
                 store.openDefaultTab(kind: .history)
             } else if let dataset = store.state.selectedDataset, dataset.kind == .measurementSet {
                 store.runMeasurementSetPlot(datasetID: dataset.id)
+                store.openDefaultTab(kind: .task)
+                store.runTask()
+                Self.waitForTaskToFinish(store: store, timeoutSeconds: 120)
             }
         }
 
@@ -159,6 +162,13 @@ struct CasarsMacApp: App {
             return nil
         }
         return arguments[index + 1]
+    }
+
+    private static func waitForTaskToFinish(store: WorkbenchStore, timeoutSeconds: TimeInterval) {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        while store.state.taskRun.state == .running && Date() < deadline {
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.05))
+        }
     }
 
     private func openStartupProjectIfNeeded() {

--- a/apps/casars-mac/Sources/CasarsMacApp/CentralWorkspaceView.swift
+++ b/apps/casars-mac/Sources/CasarsMacApp/CentralWorkspaceView.swift
@@ -60,10 +60,10 @@ struct CentralWorkspaceView: View {
                     store.openDefaultTab(kind: .datasetExplorer)
                 }
                 .disabled(store.state.selectedDataset == nil)
-                Button("Calibrate Task") {
+                Button(store.state.isDemoProject ? "Calibrate Task" : "Dirty Imaging Task") {
                     store.openDefaultTab(kind: .task)
                 }
-                .disabled(!store.state.isDemoProject)
+                .disabled(store.state.selectedDataset?.kind != .measurementSet)
                 Button("AI Chat") {
                     store.openDefaultTab(kind: .aiChat)
                 }
@@ -551,6 +551,14 @@ struct TaskPanel: View {
     @ObservedObject var store: WorkbenchStore
 
     var body: some View {
+        if store.state.isDemoProject {
+            fixtureTaskBody
+        } else {
+            DirtyImagingTaskPanel(store: store)
+        }
+    }
+
+    private var fixtureTaskBody: some View {
         VStack(spacing: 0) {
             HStack {
                 VStack(alignment: .leading, spacing: 2) {
@@ -680,6 +688,244 @@ struct TaskPanel: View {
         .padding()
         .background(.regularMaterial)
         .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+struct DirtyImagingTaskPanel: View {
+    @ObservedObject var store: WorkbenchStore
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    if let parameters = store.state.dirtyImagingTaskParameters {
+                        selectionBlock(parameters: parameters)
+                        imagingBlock(parameters: parameters)
+                        outputBlock(parameters: parameters)
+                        runBlock
+                    } else {
+                        PanelHeader(title: "Dirty Imaging", subtitle: "Select a MeasurementSet before opening this task")
+                    }
+                }
+                .padding(20)
+            }
+        }
+        .accessibilityIdentifier("panel.task.dirtyImaging")
+    }
+
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Dirty Imaging")
+                    .workbenchFont(.title3, weight: .semibold)
+                Text(selectedDatasetSubtitle)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Button {
+                store.runTask()
+            } label: {
+                Label(store.state.taskRun.state == .running ? "Running" : "Run", systemImage: "play.fill")
+            }
+            .disabled(store.state.taskRun.state == .running || store.state.dirtyImagingTaskParameters == nil)
+            .accessibilityIdentifier("task.run")
+
+            Button {
+                store.stopTask()
+            } label: {
+                Label("Stop", systemImage: "stop.fill")
+            }
+            .disabled(store.state.taskRun.state != .running)
+            .accessibilityIdentifier("task.stop")
+        }
+        .padding()
+        .background(.bar)
+    }
+
+    private var selectedDatasetSubtitle: String {
+        guard let dataset = store.state.selectedDataset else {
+            return "No MeasurementSet selected"
+        }
+        return "\(dataset.name) - \(dataset.size)"
+    }
+
+    private func selectionBlock(parameters: DirtyImagingTaskParameters) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Selections")
+                .workbenchFont(.headline)
+
+            Picker("Source / field", selection: Binding(
+                get: { parameters.selectedField ?? "all" },
+                set: { store.setDirtyImagingField($0) }
+            )) {
+                Text("all").tag("all")
+                ForEach(store.state.selectedDataset?.fields ?? [], id: \.self) { field in
+                    Text(field).tag(field)
+                }
+            }
+            .accessibilityIdentifier("task.parameter.field")
+
+            LabeledContent("Phase center", value: parameters.phaseCenterField ?? "auto")
+
+            Picker("Spectral window", selection: Binding(
+                get: { parameters.selectedSpectralWindow ?? "all" },
+                set: { store.setDirtyImagingSpectralWindow($0) }
+            )) {
+                Text("all").tag("all")
+                ForEach(store.state.selectedDataset?.spectralWindows ?? [], id: \.self) { spw in
+                    Text(spw).tag(spw)
+                }
+            }
+            .accessibilityIdentifier("task.parameter.spw")
+
+            HStack {
+                TextField("Channel start", text: Binding(
+                    get: { parameters.channelStart },
+                    set: { store.setDirtyImagingChannelStart($0) }
+                ))
+                .textFieldStyle(.roundedBorder)
+                .accessibilityIdentifier("task.parameter.channelStart")
+
+                TextField("Channel count", text: Binding(
+                    get: { parameters.channelCount },
+                    set: { store.setDirtyImagingChannelCount($0) }
+                ))
+                .textFieldStyle(.roundedBorder)
+                .accessibilityIdentifier("task.parameter.channelCount")
+            }
+
+            Picker("Data column", selection: Binding(
+                get: { parameters.dataColumn },
+                set: { store.setDirtyImagingDataColumn($0) }
+            )) {
+                ForEach(store.state.selectedDataset?.dataColumns.isEmpty == false ? store.state.selectedDataset?.dataColumns ?? [] : ["DATA"], id: \.self) { column in
+                    Text(column).tag(column)
+                }
+            }
+            .accessibilityIdentifier("task.parameter.dataColumn")
+        }
+        .taskCard()
+    }
+
+    private func imagingBlock(parameters: DirtyImagingTaskParameters) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Image")
+                .workbenchFont(.headline)
+
+            Stepper(value: Binding(
+                get: { parameters.imageSize },
+                set: { store.setDirtyImagingImageSize($0) }
+            ), in: 32...8192, step: 32) {
+                LabeledContent("Image size", value: "\(parameters.imageSize) px")
+            }
+            .accessibilityIdentifier("task.parameter.imageSize")
+
+            TextField("Cell size (arcsec)", text: Binding(
+                get: { String(format: "%.3f", parameters.cellArcsec) },
+                set: { value in
+                    if let parsed = Double(value) {
+                        store.setDirtyImagingCellArcsec(parsed)
+                    }
+                }
+            ))
+            .textFieldStyle(.roundedBorder)
+            .accessibilityIdentifier("task.parameter.cellArcsec")
+
+            Picker("Weighting", selection: Binding(
+                get: { parameters.weighting },
+                set: { store.setDirtyImagingWeighting($0) }
+            )) {
+                ForEach(DirtyImagingWeighting.allCases) { weighting in
+                    Text(weighting.title).tag(weighting)
+                }
+            }
+            .accessibilityIdentifier("task.parameter.weighting")
+
+            Toggle("Dirty only", isOn: .constant(parameters.dirtyOnly))
+                .disabled(true)
+                .accessibilityIdentifier("task.parameter.dirtyOnly")
+        }
+        .taskCard()
+    }
+
+    private func outputBlock(parameters: DirtyImagingTaskParameters) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Output")
+                .workbenchFont(.headline)
+
+            TextField("Image prefix", text: Binding(
+                get: { parameters.outputPrefix },
+                set: { store.setDirtyImagingOutputPrefix($0) }
+            ))
+            .textFieldStyle(.roundedBorder)
+            .accessibilityIdentifier("task.parameter.outputPrefix")
+
+            TextField("Run reason", text: Binding(
+                get: { parameters.runReason },
+                set: { store.setDirtyImagingRunReason($0) }
+            ))
+            .textFieldStyle(.roundedBorder)
+            .accessibilityIdentifier("task.parameter.runReason")
+
+            Text(parameters.requestSummary)
+                .workbenchFont(.caption, design: .monospaced)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .accessibilityIdentifier("task.parameter.requestSummary")
+        }
+        .taskCard()
+    }
+
+    private var runBlock: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Run")
+                .workbenchFont(.headline)
+            ProgressView(value: store.state.taskRun.progress)
+            Text(store.state.taskRun.state.rawValue)
+                .workbenchFont(.caption)
+                .foregroundStyle(.secondary)
+
+            valueList("Log", values: store.state.taskRun.logLines)
+            valueList("Warnings", values: store.state.taskRun.warnings)
+            valueList("Diagnostics", values: store.state.taskRun.diagnostics)
+            valueList("Products", values: store.state.taskRun.products)
+            valueList("Artifacts", values: store.state.taskRun.outputPaths)
+        }
+        .taskCard()
+        .accessibilityIdentifier("task.runState")
+    }
+
+    private func valueList(_ title: String, values: [String]) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .workbenchFont(.subheadline, weight: .semibold)
+            if values.isEmpty {
+                Text("None")
+                    .workbenchFont(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(values, id: \.self) { value in
+                    Text(value)
+                        .workbenchFont(.caption, design: .monospaced)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+    }
+}
+
+private extension View {
+    func taskCard() -> some View {
+        self
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.regularMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
     }
 }
 

--- a/apps/casars-mac/Sources/CasarsMacApp/CentralWorkspaceView.swift
+++ b/apps/casars-mac/Sources/CasarsMacApp/CentralWorkspaceView.swift
@@ -364,6 +364,13 @@ struct MeasurementSetPlotPanel: View {
         store.state.measurementSetPlots[dataset.id] ?? MeasurementSetExplorerPlotState.defaultState(for: dataset)
     }
 
+    private var visiblePlotResult: MeasurementSetPlotResultSummary? {
+        guard let result = plotState.result, result.matches(plotState: plotState) else {
+            return nil
+        }
+        return result
+    }
+
     private var plotCommandBar: some View {
         HStack(spacing: 10) {
             Picker("Plot", selection: Binding(
@@ -468,7 +475,7 @@ struct MeasurementSetPlotPanel: View {
             VStack(alignment: .leading, spacing: 12) {
                 Text(dataset.name)
                     .workbenchFont(.caption, weight: .semibold)
-                Text(plotState.result?.selectionSummary ?? "Select a plot and generate it")
+                Text(visiblePlotResult?.selectionSummary ?? "Select a plot and generate it")
                     .workbenchFont(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -482,7 +489,7 @@ struct MeasurementSetPlotPanel: View {
 
     @ViewBuilder
     private var plotMetadata: some View {
-        if let result = plotState.result {
+        if let result = visiblePlotResult {
             VStack(alignment: .leading, spacing: 5) {
                 Text(result.presetLabel)
                     .workbenchFont(.subheadline, weight: .semibold)
@@ -509,11 +516,12 @@ struct MeasurementSetPlotPanel: View {
 
     @ViewBuilder
     private var plotImage: some View {
-        if let result = plotState.result {
+        if let result = visiblePlotResult {
             VStack(alignment: .leading, spacing: 8) {
                 Text(result.title)
                     .workbenchFont(.subheadline, weight: .semibold)
                 CachedPlotImage(result: result)
+                    .id(result.imageCacheID)
                 Text(result.summary)
                     .workbenchFont(.caption)
                     .foregroundStyle(.secondary)

--- a/apps/casars-mac/Sources/CasarsMacApp/CentralWorkspaceView.swift
+++ b/apps/casars-mac/Sources/CasarsMacApp/CentralWorkspaceView.swift
@@ -509,16 +509,11 @@ struct MeasurementSetPlotPanel: View {
 
     @ViewBuilder
     private var plotImage: some View {
-        if let result = plotState.result, let image = NSImage(data: result.imageBytes) {
+        if let result = plotState.result {
             VStack(alignment: .leading, spacing: 8) {
                 Text(result.title)
                     .workbenchFont(.subheadline, weight: .semibold)
-                Image(nsImage: image)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(Color(nsColor: .windowBackgroundColor))
-                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                CachedPlotImage(result: result)
                 Text(result.summary)
                     .workbenchFont(.caption)
                     .foregroundStyle(.secondary)
@@ -544,6 +539,44 @@ struct MeasurementSetPlotPanel: View {
             .padding(16)
             .accessibilityIdentifier("msPlot.empty.\(dataset.id)")
         }
+    }
+}
+
+private struct CachedPlotImage: View {
+    let result: MeasurementSetPlotResultSummary
+    @State private var image: NSImage?
+    @State private var imageCacheID: String?
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFit()
+            } else {
+                ZStack {
+                    Color(nsColor: .windowBackgroundColor)
+                    Text("Unable to decode plot image")
+                        .workbenchFont(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .onAppear(perform: refreshImageIfNeeded)
+        .onChange(of: result.imageCacheID) { _ in
+            refreshImageIfNeeded()
+        }
+    }
+
+    private func refreshImageIfNeeded() {
+        guard imageCacheID != result.imageCacheID else {
+            return
+        }
+        image = NSImage(data: result.imageBytes)
+        imageCacheID = result.imageCacheID
     }
 }
 

--- a/apps/casars-mac/Sources/CasarsMacApp/CentralWorkspaceView.swift
+++ b/apps/casars-mac/Sources/CasarsMacApp/CentralWorkspaceView.swift
@@ -63,7 +63,7 @@ struct CentralWorkspaceView: View {
                 Button(store.state.isDemoProject ? "Calibrate Task" : "Dirty Imaging Task") {
                     store.openDefaultTab(kind: .task)
                 }
-                .disabled(store.state.selectedDataset?.kind != .measurementSet)
+                .disabled(store.state.selectedDataset == nil)
                 Button("AI Chat") {
                     store.openDefaultTab(kind: .aiChat)
                 }
@@ -788,23 +788,37 @@ struct DirtyImagingTaskPanel: View {
     }
 
     private var selectedDatasetSubtitle: String {
-        guard let dataset = store.state.selectedDataset else {
+        guard let parameters = store.state.dirtyImagingTaskParameters,
+              let dataset = taskDataset(for: parameters)
+        else {
             return "No MeasurementSet selected"
         }
         return "\(dataset.name) - \(dataset.size)"
     }
 
     private func selectionBlock(parameters: DirtyImagingTaskParameters) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
+        let dataset = taskDataset(for: parameters)
+        return VStack(alignment: .leading, spacing: 12) {
             Text("Selections")
                 .workbenchFont(.headline)
+
+            Picker("MeasurementSet", selection: Binding(
+                get: { parameters.datasetID },
+                set: { store.setDirtyImagingDataset($0) }
+            )) {
+                Text("Select MeasurementSet").tag("")
+                ForEach(measurementSetDatasets) { dataset in
+                    Text(dataset.name).tag(dataset.id)
+                }
+            }
+            .accessibilityIdentifier("task.parameter.measurementSet")
 
             Picker("Source / field", selection: Binding(
                 get: { parameters.selectedField ?? "all" },
                 set: { store.setDirtyImagingField($0) }
             )) {
                 Text("all").tag("all")
-                ForEach(store.state.selectedDataset?.fields ?? [], id: \.self) { field in
+                ForEach(dataset?.fields ?? [], id: \.self) { field in
                     Text(field).tag(field)
                 }
             }
@@ -817,7 +831,7 @@ struct DirtyImagingTaskPanel: View {
                 set: { store.setDirtyImagingSpectralWindow($0) }
             )) {
                 Text("all").tag("all")
-                ForEach(store.state.selectedDataset?.spectralWindows ?? [], id: \.self) { spw in
+                ForEach(dataset?.spectralWindows ?? [], id: \.self) { spw in
                     Text(spw).tag(spw)
                 }
             }
@@ -843,7 +857,7 @@ struct DirtyImagingTaskPanel: View {
                 get: { parameters.dataColumn },
                 set: { store.setDirtyImagingDataColumn($0) }
             )) {
-                ForEach(store.state.selectedDataset?.dataColumns.isEmpty == false ? store.state.selectedDataset?.dataColumns ?? [] : ["DATA"], id: \.self) { column in
+                ForEach(dataset?.dataColumns.isEmpty == false ? dataset?.dataColumns ?? [] : ["DATA"], id: \.self) { column in
                     Text(column).tag(column)
                 }
             }
@@ -852,29 +866,59 @@ struct DirtyImagingTaskPanel: View {
         .taskCard()
     }
 
+    private var measurementSetDatasets: [DatasetSummary] {
+        store.state.project.datasets.filter { $0.kind == .measurementSet }
+    }
+
+    private func taskDataset(for parameters: DirtyImagingTaskParameters) -> DatasetSummary? {
+        store.state.project.datasets.first { $0.id == parameters.datasetID }
+    }
+
     private func imagingBlock(parameters: DirtyImagingTaskParameters) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Image")
                 .workbenchFont(.headline)
 
-            Stepper(value: Binding(
-                get: { parameters.imageSize },
-                set: { store.setDirtyImagingImageSize($0) }
-            ), in: 32...8192, step: 32) {
-                LabeledContent("Image size", value: "\(parameters.imageSize) px")
-            }
-            .accessibilityIdentifier("task.parameter.imageSize")
+            imageDimensionRow(
+                label: "Image width",
+                value: parameters.imageSize,
+                setValue: store.setDirtyImagingImageSize,
+                adjust: store.adjustDirtyImagingImageWidthToNiceSize,
+                accessibilityID: "task.parameter.imageWidth"
+            )
 
-            TextField("Cell size (arcsec)", text: Binding(
-                get: { String(format: "%.3f", parameters.cellArcsec) },
-                set: { value in
-                    if let parsed = Double(value) {
-                        store.setDirtyImagingCellArcsec(parsed)
+            imageDimensionRow(
+                label: "Image height",
+                value: parameters.imageHeight,
+                setValue: store.setDirtyImagingImageHeight,
+                adjust: store.adjustDirtyImagingImageHeightToNiceSize,
+                accessibilityID: "task.parameter.imageHeight"
+            )
+
+            HStack(spacing: 8) {
+                TextField("Cell size", text: Binding(
+                    get: { String(format: "%.3f", parameters.cellArcsec) },
+                    set: { value in
+                        if let parsed = Double(value) {
+                            store.setDirtyImagingCellArcsec(parsed)
+                        }
                     }
-                }
-            ))
-            .textFieldStyle(.roundedBorder)
-            .accessibilityIdentifier("task.parameter.cellArcsec")
+                ))
+                .textFieldStyle(.roundedBorder)
+                .accessibilityIdentifier("task.parameter.cellArcsec")
+
+                Text("arcsec")
+                    .foregroundStyle(.secondary)
+                    .workbenchFont(.caption)
+                    .accessibilityIdentifier("task.parameter.cellArcsec.unit")
+            }
+
+            if parameters.imageSize != parameters.imageHeight {
+                Label("Rectangular image sizes are not runnable yet.", systemImage: "exclamationmark.triangle")
+                    .foregroundStyle(.secondary)
+                    .workbenchFont(.caption)
+                    .accessibilityIdentifier("task.parameter.imageShape.warning")
+            }
 
             Picker("Weighting", selection: Binding(
                 get: { parameters.weighting },
@@ -891,6 +935,78 @@ struct DirtyImagingTaskPanel: View {
                 .accessibilityIdentifier("task.parameter.dirtyOnly")
         }
         .taskCard()
+    }
+
+    private func imageDimensionRow(
+        label: String,
+        value: Int,
+        setValue: @escaping (Int) -> Void,
+        adjust: @escaping () -> Void,
+        accessibilityID: String
+    ) -> some View {
+        let assessment = DirtyImagingTaskParameters.imageDimensionAssessment(value)
+        return HStack(spacing: 8) {
+            Text(label)
+                .frame(width: 96, alignment: .leading)
+
+            TextField(label, text: Binding(
+                get: { "\(value)" },
+                set: { text in
+                    if let parsed = Int(text.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                        setValue(parsed)
+                    }
+                }
+            ))
+            .textFieldStyle(.plain)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 4)
+            .frame(width: 82)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(dimensionFill(for: assessment.severity))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .stroke(dimensionStroke(for: assessment.severity), lineWidth: assessment.severity == .good ? 1 : 1.5)
+            )
+            .help(assessment.message)
+            .accessibilityIdentifier(accessibilityID)
+
+            Text("px")
+                .foregroundStyle(.secondary)
+                .workbenchFont(.caption)
+
+            Button {
+                adjust()
+            } label: {
+                Label("Adjust", systemImage: "wand.and.stars")
+            }
+            .disabled(!assessment.needsAdjustment)
+            .help("Adjust to \(assessment.adjustedValue) px")
+            .accessibilityIdentifier("\(accessibilityID).adjust")
+        }
+    }
+
+    private func dimensionFill(for severity: DirtyImagingDimensionSeverity) -> Color {
+        switch severity {
+        case .good:
+            Color(nsColor: .textBackgroundColor).opacity(0.25)
+        case .warning:
+            .yellow.opacity(0.40)
+        case .terrible:
+            .red.opacity(0.40)
+        }
+    }
+
+    private func dimensionStroke(for severity: DirtyImagingDimensionSeverity) -> Color {
+        switch severity {
+        case .good:
+            .secondary.opacity(0.35)
+        case .warning:
+            .yellow.opacity(0.85)
+        case .terrible:
+            .red.opacity(0.85)
+        }
     }
 
     private func outputBlock(parameters: DirtyImagingTaskParameters) -> some View {

--- a/apps/casars-mac/Sources/CasarsMacApp/WorkbenchView.swift
+++ b/apps/casars-mac/Sources/CasarsMacApp/WorkbenchView.swift
@@ -175,7 +175,12 @@ struct LeftDockView: View {
                 )) {
                     ForEach(store.state.project.datasets) { dataset in
                         DatasetRow(dataset: dataset)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .contentShape(Rectangle())
                             .tag(Optional(dataset.id))
+                            .onTapGesture {
+                                store.selectDataset(dataset.id)
+                            }
                             .onTapGesture(count: 2) {
                                 store.openDatasetExplorer(dataset.id)
                             }

--- a/apps/casars-mac/Sources/CasarsMacApp/WorkbenchView.swift
+++ b/apps/casars-mac/Sources/CasarsMacApp/WorkbenchView.swift
@@ -1,5 +1,17 @@
 import CasarsMacCore
+import AppKit
+import OSLog
 import SwiftUI
+
+private let inspectorLogger = Logger(
+    subsystem: "org.casa-rs.casars-mac",
+    category: "Inspector"
+)
+
+private let datasetClickLogger = Logger(
+    subsystem: "org.casa-rs.casars-mac",
+    category: "DatasetClick"
+)
 
 struct WorkbenchView: View {
     @ObservedObject var store: WorkbenchStore
@@ -178,11 +190,16 @@ struct LeftDockView: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .contentShape(Rectangle())
                             .tag(Optional(dataset.id))
-                            .onTapGesture {
-                                store.selectDataset(dataset.id)
-                            }
-                            .onTapGesture(count: 2) {
-                                store.openDatasetExplorer(dataset.id)
+                            .overlay {
+                                DatasetRowClickTarget(
+                                    datasetID: dataset.id,
+                                    onSingleClick: {
+                                        store.selectDataset(dataset.id)
+                                    },
+                                    onDoubleClick: {
+                                        store.openDatasetExplorer(dataset.id)
+                                    }
+                                )
                             }
                             .accessibilityIdentifier("dataset.row.\(dataset.id)")
                     }
@@ -294,6 +311,45 @@ struct LeftDockView: View {
                     store.openFixtureProject()
                 }
             )
+        }
+    }
+}
+
+private struct DatasetRowClickTarget: NSViewRepresentable {
+    let datasetID: String
+    let onSingleClick: () -> Void
+    let onDoubleClick: () -> Void
+
+    func makeNSView(context: Context) -> DatasetRowClickView {
+        let view = DatasetRowClickView()
+        view.datasetID = datasetID
+        view.onSingleClick = onSingleClick
+        view.onDoubleClick = onDoubleClick
+        return view
+    }
+
+    func updateNSView(_ nsView: DatasetRowClickView, context: Context) {
+        nsView.datasetID = datasetID
+        nsView.onSingleClick = onSingleClick
+        nsView.onDoubleClick = onDoubleClick
+    }
+}
+
+private final class DatasetRowClickView: NSView {
+    var datasetID = ""
+    var onSingleClick: (() -> Void)?
+    var onDoubleClick: (() -> Void)?
+
+    override var acceptsFirstResponder: Bool { false }
+
+    override func mouseDown(with event: NSEvent) {
+        let clickedDatasetID = datasetID
+        if event.clickCount >= 2 {
+            datasetClickLogger.debug("row_mouse_down double id=\(clickedDatasetID, privacy: .public)")
+            onDoubleClick?()
+        } else {
+            datasetClickLogger.debug("row_mouse_down single id=\(clickedDatasetID, privacy: .public)")
+            onSingleClick?()
         }
     }
 }
@@ -451,6 +507,9 @@ struct InspectorView: View {
         }
         .padding()
         .accessibilityIdentifier("inspector.panel")
+        .background {
+            InspectorUpdateTelemetry(dataset: store.state.selectedDataset)
+        }
     }
 
     private var inspectorSourceLabel: String {
@@ -497,6 +556,24 @@ struct InspectorView: View {
             return values.joined(separator: ", ")
         }
         return "\(values.count)"
+    }
+}
+
+private struct InspectorUpdateTelemetry: NSViewRepresentable {
+    let dataset: DatasetSummary?
+
+    func makeNSView(context: Context) -> NSView {
+        NSView(frame: .zero)
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        guard let dataset else {
+            inspectorLogger.debug("inspector_update empty")
+            return
+        }
+        inspectorLogger.debug(
+            "inspector_update dataset=\(dataset.id, privacy: .public) fields=\(dataset.fields.count, privacy: .public) spws=\(dataset.spectralWindows.count, privacy: .public) antennas=\(dataset.antennas.count, privacy: .public) columns=\(dataset.columns.count, privacy: .public) subtables=\(dataset.subtables.count, privacy: .public)"
+        )
     }
 }
 

--- a/apps/casars-mac/Sources/CasarsMacApp/WorkbenchView.swift
+++ b/apps/casars-mac/Sources/CasarsMacApp/WorkbenchView.swift
@@ -178,6 +178,9 @@ struct LeftDockView: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .contentShape(Rectangle())
                             .tag(Optional(dataset.id))
+                            .onTapGesture {
+                                store.selectDataset(dataset.id)
+                            }
                             .onTapGesture(count: 2) {
                                 store.openDatasetExplorer(dataset.id)
                             }

--- a/apps/casars-mac/Sources/CasarsMacApp/WorkbenchView.swift
+++ b/apps/casars-mac/Sources/CasarsMacApp/WorkbenchView.swift
@@ -178,9 +178,6 @@ struct LeftDockView: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .contentShape(Rectangle())
                             .tag(Optional(dataset.id))
-                            .onTapGesture {
-                                store.selectDataset(dataset.id)
-                            }
                             .onTapGesture(count: 2) {
                                 store.openDatasetExplorer(dataset.id)
                             }

--- a/apps/casars-mac/Sources/CasarsMacApp/WorkbenchView.swift
+++ b/apps/casars-mac/Sources/CasarsMacApp/WorkbenchView.swift
@@ -456,36 +456,7 @@ struct InspectorView: View {
 
                 Divider()
 
-                compactSection(
-                    title: "Fields",
-                    count: dataset.fields.count,
-                    values: dataset.fields,
-                    isExpanded: $showFields
-                )
-                compactSection(
-                    title: "SPWs",
-                    count: dataset.spectralWindows.count,
-                    values: dataset.spectralWindows,
-                    isExpanded: $showSpectralWindows
-                )
-                compactSection(
-                    title: "Antennas",
-                    count: dataset.antennas.count,
-                    values: dataset.antennas,
-                    isExpanded: $showAntennas
-                )
-                InfoRow(label: "Correlations", value: compactList(dataset.correlations))
-                InfoRow(label: "Data", value: compactList(dataset.dataColumns))
-
-                DisclosureGroup("Columns (\(dataset.columns.count))", isExpanded: $showColumns) {
-                    valueList(dataset.columns)
-                }
-                .workbenchFont(.caption)
-
-                DisclosureGroup("Subtables (\(dataset.subtables.count))", isExpanded: $showSubtables) {
-                    valueList(dataset.subtables)
-                }
-                .workbenchFont(.caption)
+                inspectorDetails(for: dataset)
 
                 Divider()
 
@@ -517,6 +488,70 @@ struct InspectorView: View {
         case .none: "No project"
         case .fixture: "Demo metadata"
         case .probed: "Real probe metadata"
+        }
+    }
+
+    @ViewBuilder
+    private func inspectorDetails(for dataset: DatasetSummary) -> some View {
+        switch dataset.kind {
+        case .measurementSet:
+            compactSection(
+                title: "Fields",
+                count: dataset.fields.count,
+                values: dataset.fields,
+                isExpanded: $showFields
+            )
+            compactSection(
+                title: "SPWs",
+                count: dataset.spectralWindows.count,
+                values: dataset.spectralWindows,
+                isExpanded: $showSpectralWindows
+            )
+            compactSection(
+                title: "Antennas",
+                count: dataset.antennas.count,
+                values: dataset.antennas,
+                isExpanded: $showAntennas
+            )
+            InfoRow(label: "Correlations", value: compactList(dataset.correlations))
+            InfoRow(label: "Data", value: compactList(dataset.dataColumns))
+
+            DisclosureGroup("Columns (\(dataset.columns.count))", isExpanded: $showColumns) {
+                valueList(dataset.columns)
+            }
+            .workbenchFont(.caption)
+
+            DisclosureGroup("Subtables (\(dataset.subtables.count))", isExpanded: $showSubtables) {
+                valueList(dataset.subtables)
+            }
+            .workbenchFont(.caption)
+
+        case .imageCube:
+            InfoRow(label: "Shape", value: formatShape(dataset.shape))
+            InfoRow(label: "Pixel type", value: dataset.units)
+            if !dataset.diagnostics.isEmpty {
+                DisclosureGroup("Image details (\(dataset.diagnostics.count))", isExpanded: $showColumns) {
+                    valueList(dataset.diagnostics)
+                }
+                .workbenchFont(.caption)
+            }
+
+        case .calibrationTable, .table, .runProduct:
+            if !dataset.shape.isEmpty {
+                InfoRow(label: "Shape", value: formatShape(dataset.shape))
+            }
+            if !dataset.columns.isEmpty {
+                DisclosureGroup("Columns (\(dataset.columns.count))", isExpanded: $showColumns) {
+                    valueList(dataset.columns)
+                }
+                .workbenchFont(.caption)
+            }
+            if !dataset.subtables.isEmpty {
+                DisclosureGroup("Subtables (\(dataset.subtables.count))", isExpanded: $showSubtables) {
+                    valueList(dataset.subtables)
+                }
+                .workbenchFont(.caption)
+            }
         }
     }
 
@@ -596,4 +631,8 @@ struct InfoRow: View {
 
 private func byteCount(_ bytes: UInt64) -> String {
     ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file)
+}
+
+private func formatShape(_ shape: [UInt64]) -> String {
+    shape.isEmpty ? "Unknown" : shape.map(String.init).joined(separator: " x ")
 }

--- a/apps/casars-mac/Sources/CasarsMacCore/DirtyImagingTask.swift
+++ b/apps/casars-mac/Sources/CasarsMacCore/DirtyImagingTask.swift
@@ -19,6 +19,23 @@ public enum DirtyImagingWeighting: String, CaseIterable, Codable, Equatable, Ide
     }
 }
 
+public enum DirtyImagingDimensionSeverity: String, Equatable {
+    case good
+    case warning
+    case terrible
+}
+
+public struct DirtyImagingDimensionAssessment: Equatable {
+    public var value: Int
+    public var severity: DirtyImagingDimensionSeverity
+    public var adjustedValue: Int
+    public var message: String
+
+    public var needsAdjustment: Bool {
+        adjustedValue != value
+    }
+}
+
 public struct DirtyImagingTaskParameters: Codable, Equatable {
     public var datasetID: String
     public var measurementSetPath: String
@@ -30,6 +47,7 @@ public struct DirtyImagingTaskParameters: Codable, Equatable {
     public var channelCount: String
     public var dataColumn: String
     public var imageSize: Int
+    public var imageHeight: Int
     public var cellArcsec: Double
     public var weighting: DirtyImagingWeighting
     public var dirtyOnly: Bool
@@ -46,6 +64,7 @@ public struct DirtyImagingTaskParameters: Codable, Equatable {
         channelCount: String = "",
         dataColumn: String,
         imageSize: Int = 512,
+        imageHeight: Int? = nil,
         cellArcsec: Double = 1.0,
         weighting: DirtyImagingWeighting = .natural,
         dirtyOnly: Bool = true,
@@ -61,6 +80,7 @@ public struct DirtyImagingTaskParameters: Codable, Equatable {
         self.channelCount = channelCount
         self.dataColumn = dataColumn
         self.imageSize = imageSize
+        self.imageHeight = imageHeight ?? imageSize
         self.cellArcsec = cellArcsec
         self.weighting = weighting
         self.dirtyOnly = dirtyOnly
@@ -75,7 +95,7 @@ public struct DirtyImagingTaskParameters: Codable, Equatable {
             "phasecenter=\(phaseCenterField ?? "auto")",
             "spw=\(selectedSpectralWindow ?? "all")",
             "data=\(dataColumn)",
-            "imsize=\(imageSize)",
+            "image=\(imageSize)x\(imageHeight) px",
             "cell=\(cellArcsec) arcsec",
             "weighting=\(weighting.rawValue)",
             "dirty-only=\(dirtyOnly)"
@@ -91,7 +111,13 @@ public struct DirtyImagingTaskParameters: Codable, Equatable {
             errors.append("Output image prefix is required.")
         }
         if imageSize <= 0 {
-            errors.append("Image size must be positive.")
+            errors.append("Image width must be positive.")
+        }
+        if imageHeight <= 0 {
+            errors.append("Image height must be positive.")
+        }
+        if imageSize != imageHeight {
+            errors.append("Rectangular image sizes are not supported by the current casars-imager backend yet.")
         }
         if !(cellArcsec.isFinite && cellArcsec > 0) {
             errors.append("Cell size must be a positive finite arcsecond value.")
@@ -104,6 +130,88 @@ public struct DirtyImagingTaskParameters: Codable, Equatable {
         }
         return errors
     }
+
+    public static func imageDimensionAssessment(_ value: Int) -> DirtyImagingDimensionAssessment {
+        guard value > 0 else {
+            return DirtyImagingDimensionAssessment(
+                value: value,
+                severity: .terrible,
+                adjustedValue: 512,
+                message: "must be positive"
+            )
+        }
+
+        let adjusted = nearestNiceImageDimension(to: value)
+        if isNiceImageDimension(value) {
+            return DirtyImagingDimensionAssessment(
+                value: value,
+                severity: .good,
+                adjustedValue: value,
+                message: "FFT-friendly"
+            )
+        }
+
+        let largestFactor = largestPrimeFactor(value)
+        let severity: DirtyImagingDimensionSeverity = largestFactor >= 127 ? .terrible : .warning
+        let message = severity == .terrible ? "large prime factor" : "awkward FFT factors"
+        return DirtyImagingDimensionAssessment(
+            value: value,
+            severity: severity,
+            adjustedValue: adjusted,
+            message: message
+        )
+    }
+
+    public static func nearestNiceImageDimension(to value: Int) -> Int {
+        guard value > 0 else { return 512 }
+        let clamped = min(max(value, 32), 8192)
+        if isNiceImageDimension(clamped) {
+            return clamped
+        }
+
+        for candidate in clamped...8192 {
+            if isNiceImageDimension(candidate) {
+                return candidate
+            }
+        }
+
+        for delta in 1...8192 {
+            let lower = clamped - delta
+            if lower >= 32, isNiceImageDimension(lower) {
+                return lower
+            }
+        }
+
+        return clamped
+    }
+}
+
+private func isNiceImageDimension(_ value: Int) -> Bool {
+    guard value > 0 else { return false }
+    var remainder = value
+    for factor in [2, 3, 5] {
+        while remainder % factor == 0 {
+            remainder /= factor
+        }
+    }
+    return remainder == 1
+}
+
+private func largestPrimeFactor(_ value: Int) -> Int {
+    var remaining = abs(value)
+    var largest = 1
+    var factor = 2
+    while factor * factor <= remaining {
+        while remaining % factor == 0 {
+            largest = factor
+            remaining /= factor
+        }
+        factor += factor == 2 ? 1 : 2
+    }
+    if remaining > 1 {
+        largest = remaining
+    }
+    return largest
 }
 
 public struct DirtyImagingTaskRequest: Codable, Equatable {
@@ -248,11 +356,31 @@ public final class ProcessDirtyImagingTaskClient: DirtyImagingTaskClient {
     private let queue: DispatchQueue
 
     public init(
-        executablePath: String? = ProcessInfo.processInfo.environment["CASARS_IMAGER_BIN"],
+        executablePath: String? = nil,
         queue: DispatchQueue = DispatchQueue(label: "casars.mac.dirty-imaging-task", qos: .userInitiated)
     ) {
-        self.executablePath = executablePath
+        self.executablePath = executablePath ?? Self.resolvedExecutablePath()
         self.queue = queue
+    }
+
+    static func resolvedExecutablePath(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        bundleExecutableURL: URL? = Bundle.main.executableURL,
+        isExecutable: (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) }
+    ) -> String? {
+        if let path = environment["CASARS_IMAGER_BIN"], !path.isEmpty {
+            return path
+        }
+
+        let bundledPath = bundleExecutableURL?
+            .deletingLastPathComponent()
+            .appendingPathComponent("casars-imager")
+            .path
+        if let bundledPath, isExecutable(bundledPath) {
+            return bundledPath
+        }
+
+        return nil
     }
 
     public func startDirtyImaging(

--- a/apps/casars-mac/Sources/CasarsMacCore/DirtyImagingTask.swift
+++ b/apps/casars-mac/Sources/CasarsMacCore/DirtyImagingTask.swift
@@ -1,0 +1,610 @@
+import Foundation
+
+public enum DirtyImagingWeighting: String, CaseIterable, Codable, Equatable, Identifiable {
+    case natural
+    case uniform
+    case briggs
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .natural:
+            "Natural"
+        case .uniform:
+            "Uniform"
+        case .briggs:
+            "Briggs"
+        }
+    }
+}
+
+public struct DirtyImagingTaskParameters: Codable, Equatable {
+    public var datasetID: String
+    public var measurementSetPath: String
+    public var outputPrefix: String
+    public var selectedField: String?
+    public var phaseCenterField: String?
+    public var selectedSpectralWindow: String?
+    public var channelStart: String
+    public var channelCount: String
+    public var dataColumn: String
+    public var imageSize: Int
+    public var cellArcsec: Double
+    public var weighting: DirtyImagingWeighting
+    public var dirtyOnly: Bool
+    public var runReason: String
+
+    public init(
+        datasetID: String,
+        measurementSetPath: String,
+        outputPrefix: String,
+        selectedField: String?,
+        phaseCenterField: String?,
+        selectedSpectralWindow: String?,
+        channelStart: String = "",
+        channelCount: String = "",
+        dataColumn: String,
+        imageSize: Int = 512,
+        cellArcsec: Double = 1.0,
+        weighting: DirtyImagingWeighting = .natural,
+        dirtyOnly: Bool = true,
+        runReason: String = "Initial dirty image from selected MeasurementSet."
+    ) {
+        self.datasetID = datasetID
+        self.measurementSetPath = measurementSetPath
+        self.outputPrefix = outputPrefix
+        self.selectedField = selectedField
+        self.phaseCenterField = phaseCenterField
+        self.selectedSpectralWindow = selectedSpectralWindow
+        self.channelStart = channelStart
+        self.channelCount = channelCount
+        self.dataColumn = dataColumn
+        self.imageSize = imageSize
+        self.cellArcsec = cellArcsec
+        self.weighting = weighting
+        self.dirtyOnly = dirtyOnly
+        self.runReason = runReason
+    }
+
+    public var requestSummary: String {
+        [
+            "ms=\(measurementSetPath)",
+            "imagename=\(outputPrefix)",
+            "field=\(selectedField ?? "all")",
+            "phasecenter=\(phaseCenterField ?? "auto")",
+            "spw=\(selectedSpectralWindow ?? "all")",
+            "data=\(dataColumn)",
+            "imsize=\(imageSize)",
+            "cell=\(cellArcsec) arcsec",
+            "weighting=\(weighting.rawValue)",
+            "dirty-only=\(dirtyOnly)"
+        ].joined(separator: ", ")
+    }
+
+    public func validationErrors() -> [String] {
+        var errors: [String] = []
+        if measurementSetPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            errors.append("MeasurementSet path is required.")
+        }
+        if outputPrefix.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            errors.append("Output image prefix is required.")
+        }
+        if imageSize <= 0 {
+            errors.append("Image size must be positive.")
+        }
+        if !(cellArcsec.isFinite && cellArcsec > 0) {
+            errors.append("Cell size must be a positive finite arcsecond value.")
+        }
+        if parseOptionalNonNegativeInt(channelStart) == nil && !channelStart.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            errors.append("Channel start must be a non-negative integer.")
+        }
+        if parseOptionalPositiveInt(channelCount) == nil && !channelCount.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            errors.append("Channel count must be a positive integer.")
+        }
+        return errors
+    }
+}
+
+public struct DirtyImagingTaskRequest: Codable, Equatable {
+    public var runID: String
+    public var parameters: DirtyImagingTaskParameters
+
+    public init(runID: String, parameters: DirtyImagingTaskParameters) {
+        self.runID = runID
+        self.parameters = parameters
+    }
+
+    public func encodedImagerJSON() throws -> Data {
+        let request = ImagerTaskRequestEnvelope(
+            request: ImagerRunRequestPayload(
+                measurementSet: parameters.measurementSetPath,
+                imageName: parameters.outputPrefix,
+                imageSize: parameters.imageSize,
+                cellArcsec: parameters.cellArcsec,
+                fieldIDs: parsedFieldIDs(),
+                phasecenterField: parsedPhaseCenterField(),
+                spwSelector: selectorToken(parameters.selectedSpectralWindow),
+                channelStart: parseOptionalNonNegativeInt(parameters.channelStart),
+                channelCount: parseOptionalPositiveInt(parameters.channelCount),
+                dataColumn: parameters.dataColumn.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    ? nil
+                    : parameters.dataColumn,
+                weighting: ImagerWeightingPayload(weighting: parameters.weighting),
+                niter: 0,
+                dirtyOnly: parameters.dirtyOnly,
+                writePreviewPngs: true
+            )
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return try encoder.encode(request)
+    }
+
+    private func parsedFieldIDs() -> [Int]? {
+        guard let selectedField = selectorToken(parameters.selectedField),
+              let fieldID = Int(selectedField)
+        else {
+            return nil
+        }
+        return [fieldID]
+    }
+
+    private func parsedPhaseCenterField() -> Int? {
+        guard let phaseCenterField = selectorToken(parameters.phaseCenterField) else {
+            return nil
+        }
+        return Int(phaseCenterField)
+    }
+}
+
+public struct DirtyImagingArtifact: Codable, Equatable, Identifiable {
+    public var kind: String
+    public var label: String
+    public var path: String
+    public var exists: Bool
+    public var previewPngPath: String?
+    public var previewPngExists: Bool
+
+    public var id: String { path }
+}
+
+public struct DirtyImagingRunReport: Codable, Equatable {
+    public var warnings: [String]
+    public var griddedSamples: UInt64
+    public var majorCycles: UInt64
+    public var minorIterations: UInt64
+    public var channelCount: Int
+
+    public var summary: String {
+        "\(griddedSamples) gridded samples, \(majorCycles) major cycles, \(minorIterations) minor iterations"
+    }
+}
+
+public struct DirtyImagingTaskResult: Codable, Equatable {
+    public var request: DirtyImagingTaskRequest
+    public var report: DirtyImagingRunReport
+    public var artifacts: [DirtyImagingArtifact]
+    public var requestJSONPath: String
+    public var stdoutPath: String
+    public var stderrPath: String
+    public var protocolSummary: String
+    public var diagnostics: [String]
+
+    public var outputPaths: [String] {
+        var paths = artifacts.flatMap { artifact -> [String] in
+            var values = [artifact.path]
+            if let preview = artifact.previewPngPath {
+                values.append(preview)
+            }
+            return values
+        }
+        paths.append(contentsOf: [requestJSONPath, stdoutPath, stderrPath])
+        return paths
+    }
+}
+
+public struct DirtyImagingTaskFailure: Error, Codable, Equatable {
+    public var message: String
+    public var requestJSONPath: String?
+    public var stdoutPath: String?
+    public var stderrPath: String?
+    public var diagnostics: [String]
+
+    public init(
+        message: String,
+        requestJSONPath: String? = nil,
+        stdoutPath: String? = nil,
+        stderrPath: String? = nil,
+        diagnostics: [String] = []
+    ) {
+        self.message = message
+        self.requestJSONPath = requestJSONPath
+        self.stdoutPath = stdoutPath
+        self.stderrPath = stderrPath
+        self.diagnostics = diagnostics
+    }
+}
+
+public enum DirtyImagingTaskEvent {
+    case succeeded(DirtyImagingTaskResult)
+    case failed(DirtyImagingTaskFailure)
+    case cancelled(DirtyImagingTaskFailure)
+}
+
+public protocol DirtyImagingTaskExecution {
+    func cancel()
+}
+
+public protocol DirtyImagingTaskClient {
+    func startDirtyImaging(
+        request: DirtyImagingTaskRequest,
+        eventHandler: @escaping (DirtyImagingTaskEvent) -> Void
+    ) throws -> DirtyImagingTaskExecution
+}
+
+public final class ProcessDirtyImagingTaskClient: DirtyImagingTaskClient {
+    private let executablePath: String?
+    private let queue: DispatchQueue
+
+    public init(
+        executablePath: String? = ProcessInfo.processInfo.environment["CASARS_IMAGER_BIN"],
+        queue: DispatchQueue = DispatchQueue(label: "casars.mac.dirty-imaging-task", qos: .userInitiated)
+    ) {
+        self.executablePath = executablePath
+        self.queue = queue
+    }
+
+    public func startDirtyImaging(
+        request: DirtyImagingTaskRequest,
+        eventHandler: @escaping (DirtyImagingTaskEvent) -> Void
+    ) throws -> DirtyImagingTaskExecution {
+        let execution = ProcessDirtyImagingTaskExecution()
+        queue.async {
+            self.run(request: request, execution: execution, eventHandler: eventHandler)
+        }
+        return execution
+    }
+
+    private func run(
+        request: DirtyImagingTaskRequest,
+        execution: ProcessDirtyImagingTaskExecution,
+        eventHandler: @escaping (DirtyImagingTaskEvent) -> Void
+    ) {
+        let outputPrefix = URL(fileURLWithPath: request.parameters.outputPrefix)
+        let outputDirectory = outputPrefix.deletingLastPathComponent()
+        let requestURL = outputPrefix.appendingPathExtension("casars-request.json")
+        let stdoutURL = outputPrefix.appendingPathExtension("casars-result.json")
+        let stderrURL = outputPrefix.appendingPathExtension("casars-stderr.log")
+
+        do {
+            try FileManager.default.createDirectory(at: outputDirectory, withIntermediateDirectories: true)
+            try request.encodedImagerJSON().write(to: requestURL, options: .atomic)
+
+            let protocolOutput = try runProcess(["--protocol-info"], execution: execution)
+            if execution.isCancelled {
+                eventHandler(.cancelled(cancelledFailure(requestURL: requestURL, stdoutURL: stdoutURL, stderrURL: stderrURL)))
+                return
+            }
+            guard protocolOutput.exitCode == 0 else {
+                eventHandler(.failed(DirtyImagingTaskFailure(
+                    message: "casars-imager --protocol-info failed with exit \(protocolOutput.exitCode)",
+                    requestJSONPath: requestURL.path,
+                    stdoutPath: stdoutURL.path,
+                    stderrPath: stderrURL.path,
+                    diagnostics: [protocolOutput.stderr, protocolOutput.stdout].filter { !$0.isEmpty }
+                )))
+                return
+            }
+
+            let output = try runProcess(["--json-run", requestURL.path], execution: execution)
+            try output.stdout.data(using: .utf8)?.write(to: stdoutURL, options: .atomic)
+            try output.stderr.data(using: .utf8)?.write(to: stderrURL, options: .atomic)
+
+            if execution.isCancelled {
+                eventHandler(.cancelled(cancelledFailure(requestURL: requestURL, stdoutURL: stdoutURL, stderrURL: stderrURL)))
+                return
+            }
+            guard output.exitCode == 0 else {
+                eventHandler(.failed(DirtyImagingTaskFailure(
+                    message: "casars-imager --json-run failed with exit \(output.exitCode)",
+                    requestJSONPath: requestURL.path,
+                    stdoutPath: stdoutURL.path,
+                    stderrPath: stderrURL.path,
+                    diagnostics: [output.stderr, output.stdout].filter { !$0.isEmpty }
+                )))
+                return
+            }
+
+            let taskResult = try parseResult(
+                output.stdout,
+                request: request,
+                protocolSummary: protocolOutput.stdout,
+                requestURL: requestURL,
+                stdoutURL: stdoutURL,
+                stderrURL: stderrURL
+            )
+            eventHandler(.succeeded(taskResult))
+        } catch {
+            if execution.isCancelled {
+                eventHandler(.cancelled(cancelledFailure(requestURL: requestURL, stdoutURL: stdoutURL, stderrURL: stderrURL)))
+            } else {
+                eventHandler(.failed(DirtyImagingTaskFailure(
+                    message: "\(error)",
+                    requestJSONPath: requestURL.path,
+                    stdoutPath: stdoutURL.path,
+                    stderrPath: stderrURL.path
+                )))
+            }
+        }
+    }
+
+    private func runProcess(_ arguments: [String], execution: ProcessDirtyImagingTaskExecution) throws -> ProcessOutput {
+        if execution.isCancelled {
+            return ProcessOutput(exitCode: -1, stdout: "", stderr: "cancelled before launch")
+        }
+
+        let process = Process()
+        if let executablePath, !executablePath.isEmpty {
+            process.executableURL = URL(fileURLWithPath: executablePath)
+            process.arguments = arguments
+        } else {
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            process.arguments = ["casars-imager"] + arguments
+        }
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+        guard execution.setProcess(process) else {
+            return ProcessOutput(exitCode: -1, stdout: "", stderr: "cancelled before launch")
+        }
+        do {
+            try process.run()
+            process.waitUntilExit()
+            execution.clearProcess(process)
+        } catch {
+            execution.clearProcess(process)
+            throw error
+        }
+
+        return ProcessOutput(
+            exitCode: process.terminationStatus,
+            stdout: String(decoding: stdout.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self),
+            stderr: String(decoding: stderr.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        )
+    }
+
+    private func parseResult(
+        _ text: String,
+        request: DirtyImagingTaskRequest,
+        protocolSummary: String,
+        requestURL: URL,
+        stdoutURL: URL,
+        stderrURL: URL
+    ) throws -> DirtyImagingTaskResult {
+        let data = Data(text.utf8)
+        let envelope = try JSONDecoder().decode(ImagerTaskResultEnvelope.self, from: data)
+        return DirtyImagingTaskResult(
+            request: request,
+            report: DirtyImagingRunReport(
+                warnings: envelope.result.run.warnings,
+                griddedSamples: envelope.result.run.griddedSamples,
+                majorCycles: envelope.result.run.majorCycles,
+                minorIterations: envelope.result.run.minorIterations,
+                channelCount: envelope.result.run.channels.count
+            ),
+            artifacts: envelope.result.artifacts.map(DirtyImagingArtifact.init(artifact:)),
+            requestJSONPath: requestURL.path,
+            stdoutPath: stdoutURL.path,
+            stderrPath: stderrURL.path,
+            protocolSummary: protocolSummary.trimmingCharacters(in: .whitespacesAndNewlines),
+            diagnostics: envelope.result.run.warnings
+        )
+    }
+
+    private func cancelledFailure(requestURL: URL, stdoutURL: URL, stderrURL: URL) -> DirtyImagingTaskFailure {
+        DirtyImagingTaskFailure(
+            message: "Dirty imaging run was cancelled.",
+            requestJSONPath: requestURL.path,
+            stdoutPath: stdoutURL.path,
+            stderrPath: stderrURL.path
+        )
+    }
+}
+
+private final class ProcessDirtyImagingTaskExecution: DirtyImagingTaskExecution {
+    private let lock = NSLock()
+    private var process: Process?
+    private var cancelled = false
+
+    var isCancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        let process = process
+        lock.unlock()
+        process?.terminate()
+    }
+
+    func setProcess(_ process: Process) -> Bool {
+        lock.lock()
+        if cancelled {
+            lock.unlock()
+            return false
+        }
+        self.process = process
+        lock.unlock()
+        return true
+    }
+
+    func clearProcess(_ process: Process) {
+        lock.lock()
+        if self.process === process {
+            self.process = nil
+        }
+        lock.unlock()
+    }
+}
+
+private struct ProcessOutput {
+    var exitCode: Int32
+    var stdout: String
+    var stderr: String
+}
+
+private struct ImagerTaskRequestEnvelope: Encodable {
+    var kind = "run"
+    var request: ImagerRunRequestPayload
+}
+
+private struct ImagerRunRequestPayload: Encodable {
+    var measurementSet: String
+    var imageName: String
+    var imageSize: Int
+    var cellArcsec: Double
+    var fieldIDs: [Int]?
+    var phasecenterField: Int?
+    var spwSelector: String?
+    var channelStart: Int?
+    var channelCount: Int?
+    var dataColumn: String?
+    var weighting: ImagerWeightingPayload
+    var niter: Int
+    var dirtyOnly: Bool
+    var writePreviewPngs: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case measurementSet = "measurement_set"
+        case imageName = "image_name"
+        case imageSize = "image_size"
+        case cellArcsec = "cell_arcsec"
+        case fieldIDs = "field_ids"
+        case phasecenterField = "phasecenter_field"
+        case spwSelector = "spw_selector"
+        case channelStart = "channel_start"
+        case channelCount = "channel_count"
+        case dataColumn = "data_column"
+        case weighting
+        case niter
+        case dirtyOnly = "dirty_only"
+        case writePreviewPngs = "write_preview_pngs"
+    }
+}
+
+private struct ImagerWeightingPayload: Encodable {
+    var kind: String
+    var robust: Double?
+
+    init(weighting: DirtyImagingWeighting) {
+        switch weighting {
+        case .natural:
+            kind = "natural"
+            robust = nil
+        case .uniform:
+            kind = "uniform"
+            robust = nil
+        case .briggs:
+            kind = "briggs"
+            robust = 0.5
+        }
+    }
+}
+
+private struct ImagerTaskResultEnvelope: Decodable {
+    var kind: String
+    var result: ImagerRunResultPayload
+}
+
+private struct ImagerRunResultPayload: Decodable {
+    var run: ImagerRunReportPayload
+    var artifacts: [ImagerArtifactPayload]
+}
+
+private struct ImagerRunReportPayload: Decodable {
+    var warnings: [String]
+    var griddedSamples: UInt64
+    var majorCycles: UInt64
+    var minorIterations: UInt64
+    var channels: [ImagerChannelPayload]
+
+    enum CodingKeys: String, CodingKey {
+        case warnings
+        case griddedSamples = "gridded_samples"
+        case majorCycles = "major_cycles"
+        case minorIterations = "minor_iterations"
+        case channels
+    }
+}
+
+private struct ImagerChannelPayload: Decodable {}
+
+private struct ImagerArtifactPayload: Decodable {
+    var kind: String
+    var label: String
+    var path: String
+    var exists: Bool
+    var previewPngPath: String?
+    var previewPngExists: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case label
+        case path
+        case exists
+        case previewPngPath = "preview_png_path"
+        case previewPngExists = "preview_png_exists"
+    }
+}
+
+private extension DirtyImagingArtifact {
+    init(artifact: ImagerArtifactPayload) {
+        self.init(
+            kind: artifact.kind,
+            label: artifact.label,
+            path: artifact.path,
+            exists: artifact.exists,
+            previewPngPath: artifact.previewPngPath,
+            previewPngExists: artifact.previewPngExists
+        )
+    }
+}
+
+private func selectorToken(_ value: String?) -> String? {
+    guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+          !value.isEmpty,
+          value != "all"
+    else {
+        return nil
+    }
+    if value.hasPrefix("spw ") {
+        let remainder = value.dropFirst(4)
+        return String(remainder.prefix { $0.isNumber })
+    }
+    if let colon = value.firstIndex(of: ":") {
+        return String(value[..<colon]).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    return value
+}
+
+private func parseOptionalNonNegativeInt(_ value: String) -> Int? {
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty, let parsed = Int(trimmed), parsed >= 0 else {
+        return nil
+    }
+    return parsed
+}
+
+private func parseOptionalPositiveInt(_ value: String) -> Int? {
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty, let parsed = Int(trimmed), parsed > 0 else {
+        return nil
+    }
+    return parsed
+}

--- a/apps/casars-mac/Sources/CasarsMacCore/WorkbenchModels.swift
+++ b/apps/casars-mac/Sources/CasarsMacCore/WorkbenchModels.swift
@@ -194,7 +194,10 @@ public enum TaskRunState: String, Codable, Equatable {
     case idle
     case running
     case completed
+    case succeeded
+    case failed
     case stopped
+    case cancelled
 }
 
 public struct TaskParameters: Codable, Equatable {
@@ -220,24 +223,36 @@ public struct TaskParameters: Codable, Equatable {
 }
 
 public struct TaskRun: Codable, Equatable {
+    public var runID: String?
     public var state: TaskRunState
     public var progress: Double
     public var logLines: [String]
     public var warnings: [String]
     public var products: [String]
+    public var diagnostics: [String]
+    public var outputPaths: [String]
+    public var requestSummary: String?
 
     public init(
+        runID: String? = nil,
         state: TaskRunState,
         progress: Double,
         logLines: [String],
         warnings: [String],
-        products: [String]
+        products: [String],
+        diagnostics: [String] = [],
+        outputPaths: [String] = [],
+        requestSummary: String? = nil
     ) {
+        self.runID = runID
         self.state = state
         self.progress = progress
         self.logLines = logLines
         self.warnings = warnings
         self.products = products
+        self.diagnostics = diagnostics
+        self.outputPaths = outputPaths
+        self.requestSummary = requestSummary
     }
 }
 
@@ -514,6 +529,7 @@ public struct WorkbenchState: Codable, Equatable {
     public var tabs: [WorkbenchTab]
     public var activeTabID: String
     public var taskParameters: TaskParameters
+    public var dirtyImagingTaskParameters: DirtyImagingTaskParameters?
     public var taskRun: TaskRun
     public var aiMessages: [AIChatMessage]
     public var aiProposals: [AIProposal]
@@ -534,6 +550,7 @@ public struct WorkbenchState: Codable, Equatable {
         tabs: [WorkbenchTab],
         activeTabID: String,
         taskParameters: TaskParameters,
+        dirtyImagingTaskParameters: DirtyImagingTaskParameters? = nil,
         taskRun: TaskRun,
         aiMessages: [AIChatMessage],
         aiProposals: [AIProposal],
@@ -553,6 +570,7 @@ public struct WorkbenchState: Codable, Equatable {
         self.tabs = tabs
         self.activeTabID = activeTabID
         self.taskParameters = taskParameters
+        self.dirtyImagingTaskParameters = dirtyImagingTaskParameters
         self.taskRun = taskRun
         self.aiMessages = aiMessages
         self.aiProposals = aiProposals
@@ -634,6 +652,9 @@ public struct DebugStateSnapshot: Codable, Equatable {
     public var openTabs: [String]
     public var activeTab: String
     public var taskState: TaskRunState
+    public var taskRequest: DirtyImagingTaskParameters?
+    public var taskDiagnostics: [String]
+    public var taskOutputPaths: [String]
     public var aiProposalStates: [String: AIProposalState]
     public var pythonOwner: PythonOwner
     public var measurementSetPlots: [String: DebugMeasurementSetPlotSnapshot]
@@ -656,6 +677,9 @@ public struct DebugStateSnapshot: Codable, Equatable {
         openTabs = state.tabs.map(\.title)
         activeTab = state.tabs.first { $0.id == state.activeTabID }?.title ?? state.activeTabID
         taskState = state.taskRun.state
+        taskRequest = state.dirtyImagingTaskParameters
+        taskDiagnostics = state.taskRun.diagnostics
+        taskOutputPaths = state.taskRun.outputPaths
         aiProposalStates = Dictionary(
             uniqueKeysWithValues: state.aiProposals.map { ($0.id, $0.state) }
         )

--- a/apps/casars-mac/Sources/CasarsMacCore/WorkbenchModels.swift
+++ b/apps/casars-mac/Sources/CasarsMacCore/WorkbenchModels.swift
@@ -403,6 +403,24 @@ public struct MeasurementSetPlotResultSummary: Codable, Equatable {
     public var imageWidth: UInt32
     public var imageHeight: UInt32
     public var imageBytes: Data
+    public var imageCacheID: String {
+        "\(imageFormat):\(imageWidth)x\(imageHeight):\(imageBytes.count):\(imageByteFingerprint):\(renderedPointCount):\(selectionSummary):\(renderer)"
+    }
+
+    private var imageByteFingerprint: UInt64 {
+        var hash: UInt64 = 1_469_598_103_934_665_603
+        let prefix = imageBytes.prefix(64)
+        let suffix = imageBytes.suffix(64)
+        for byte in prefix {
+            hash ^= UInt64(byte)
+            hash &*= 1_099_511_628_211
+        }
+        for byte in suffix {
+            hash ^= UInt64(byte)
+            hash &*= 1_099_511_628_211
+        }
+        return hash
+    }
 
     public init(
         presetLabel: String,

--- a/apps/casars-mac/Sources/CasarsMacCore/WorkbenchModels.swift
+++ b/apps/casars-mac/Sources/CasarsMacCore/WorkbenchModels.swift
@@ -553,6 +553,7 @@ public struct WorkbenchState: Codable, Equatable {
     public var aiProposals: [AIProposal]
     public var python: PythonPanelState
     public var measurementSetPlots: [String: MeasurementSetExplorerPlotState]
+    public var measurementSetPlotResultCache: [String: MeasurementSetPlotResultSummary]
     public var history: [ProcessingHistoryEvent]
     public var commandQuery: String
     public var lastErrors: [String]
@@ -574,6 +575,7 @@ public struct WorkbenchState: Codable, Equatable {
         aiProposals: [AIProposal],
         python: PythonPanelState,
         measurementSetPlots: [String: MeasurementSetExplorerPlotState] = [:],
+        measurementSetPlotResultCache: [String: MeasurementSetPlotResultSummary] = [:],
         history: [ProcessingHistoryEvent],
         commandQuery: String,
         lastErrors: [String],
@@ -594,6 +596,7 @@ public struct WorkbenchState: Codable, Equatable {
         self.aiProposals = aiProposals
         self.python = python
         self.measurementSetPlots = measurementSetPlots
+        self.measurementSetPlotResultCache = measurementSetPlotResultCache
         self.history = history
         self.commandQuery = commandQuery
         self.lastErrors = lastErrors

--- a/apps/casars-mac/Sources/CasarsMacCore/WorkbenchModels.swift
+++ b/apps/casars-mac/Sources/CasarsMacCore/WorkbenchModels.swift
@@ -518,7 +518,11 @@ public struct MeasurementSetExplorerPlotState: Codable, Equatable {
 public extension MeasurementSetPlotResultSummary {
     func matches(plotState: MeasurementSetExplorerPlotState) -> Bool {
         preset == plotState.preset
-            && dataColumn == plotState.dataColumn
+            && Self.canonicalDataColumn(dataColumn) == Self.canonicalDataColumn(plotState.dataColumn)
+    }
+
+    private static func canonicalDataColumn(_ dataColumn: String) -> String {
+        dataColumn.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 }
 

--- a/apps/casars-mac/Sources/CasarsMacCore/WorkbenchModels.swift
+++ b/apps/casars-mac/Sources/CasarsMacCore/WorkbenchModels.swift
@@ -386,6 +386,7 @@ public struct PlotSeriesSummary: Codable, Equatable {
 }
 
 public struct MeasurementSetPlotResultSummary: Codable, Equatable {
+    public var preset: MeasurementSetExplorerPlotPreset
     public var presetLabel: String
     public var title: String
     public var summary: String
@@ -406,6 +407,7 @@ public struct MeasurementSetPlotResultSummary: Codable, Equatable {
     public var imageCacheID: String
 
     public init(
+        preset: MeasurementSetExplorerPlotPreset,
         presetLabel: String,
         title: String,
         summary: String,
@@ -424,6 +426,7 @@ public struct MeasurementSetPlotResultSummary: Codable, Equatable {
         imageHeight: UInt32,
         imageBytes: Data
     ) {
+        self.preset = preset
         self.presetLabel = presetLabel
         self.title = title
         self.summary = summary
@@ -509,6 +512,13 @@ public struct MeasurementSetExplorerPlotState: Codable, Equatable {
             lastError: nil,
             result: nil
         )
+    }
+}
+
+public extension MeasurementSetPlotResultSummary {
+    func matches(plotState: MeasurementSetExplorerPlotState) -> Bool {
+        preset == plotState.preset
+            && dataColumn == plotState.dataColumn
     }
 }
 
@@ -728,6 +738,7 @@ public struct DebugMeasurementSetPlotSnapshot: Codable, Equatable {
     public var selectedCorrelation: String?
     public var dataColumn: String
     public var lastError: String?
+    public var resultPreset: MeasurementSetExplorerPlotPreset?
     public var title: String?
     public var xAxis: PlotAxisSummary?
     public var yAxis: PlotAxisSummary?
@@ -745,13 +756,15 @@ public struct DebugMeasurementSetPlotSnapshot: Codable, Equatable {
         selectedCorrelation = plotState.selectedCorrelation
         dataColumn = plotState.dataColumn
         lastError = plotState.lastError
-        title = plotState.result?.title
-        xAxis = plotState.result?.xAxis
-        yAxis = plotState.result?.yAxis
-        renderedPointCount = plotState.result?.renderedPointCount
-        seriesCount = plotState.result?.series.count
-        imageByteCount = plotState.result?.imageBytes.count
-        renderer = plotState.result?.renderer
-        diagnostics = plotState.result?.diagnostics ?? []
+        let visibleResult = plotState.result?.matches(plotState: plotState) == true ? plotState.result : nil
+        resultPreset = visibleResult?.preset
+        title = visibleResult?.title
+        xAxis = visibleResult?.xAxis
+        yAxis = visibleResult?.yAxis
+        renderedPointCount = visibleResult?.renderedPointCount
+        seriesCount = visibleResult?.series.count
+        imageByteCount = visibleResult?.imageBytes.count
+        renderer = visibleResult?.renderer
+        diagnostics = visibleResult?.diagnostics ?? []
     }
 }

--- a/apps/casars-mac/Sources/CasarsMacCore/WorkbenchModels.swift
+++ b/apps/casars-mac/Sources/CasarsMacCore/WorkbenchModels.swift
@@ -403,24 +403,7 @@ public struct MeasurementSetPlotResultSummary: Codable, Equatable {
     public var imageWidth: UInt32
     public var imageHeight: UInt32
     public var imageBytes: Data
-    public var imageCacheID: String {
-        "\(imageFormat):\(imageWidth)x\(imageHeight):\(imageBytes.count):\(imageByteFingerprint):\(renderedPointCount):\(selectionSummary):\(renderer)"
-    }
-
-    private var imageByteFingerprint: UInt64 {
-        var hash: UInt64 = 1_469_598_103_934_665_603
-        let prefix = imageBytes.prefix(64)
-        let suffix = imageBytes.suffix(64)
-        for byte in prefix {
-            hash ^= UInt64(byte)
-            hash &*= 1_099_511_628_211
-        }
-        for byte in suffix {
-            hash ^= UInt64(byte)
-            hash &*= 1_099_511_628_211
-        }
-        return hash
-    }
+    public var imageCacheID: String
 
     public init(
         presetLabel: String,
@@ -458,6 +441,26 @@ public struct MeasurementSetPlotResultSummary: Codable, Equatable {
         self.imageWidth = imageWidth
         self.imageHeight = imageHeight
         self.imageBytes = imageBytes
+        self.imageCacheID = Self.makeImageCacheID(
+            imageFormat: imageFormat,
+            imageWidth: imageWidth,
+            imageHeight: imageHeight,
+            imageBytes: imageBytes
+        )
+    }
+
+    private static func makeImageCacheID(
+        imageFormat: String,
+        imageWidth: UInt32,
+        imageHeight: UInt32,
+        imageBytes: Data
+    ) -> String {
+        var hash: UInt64 = 1_469_598_103_934_665_603
+        for byte in imageBytes {
+            hash ^= UInt64(byte)
+            hash &*= 1_099_511_628_211
+        }
+        return "\(imageFormat):\(imageWidth)x\(imageHeight):\(imageBytes.count):\(hash)"
     }
 }
 

--- a/apps/casars-mac/Sources/CasarsMacCore/WorkbenchStore.swift
+++ b/apps/casars-mac/Sources/CasarsMacCore/WorkbenchStore.swift
@@ -1,5 +1,11 @@
 import Foundation
 import CasarsFrontendServices
+import OSLog
+
+private let datasetSelectionLogger = Logger(
+    subsystem: "org.casa-rs.casars-mac",
+    category: "DatasetSelection"
+)
 
 public protocol ProjectProbeClient {
     func probeProject(path: String) throws -> ProjectFixtureProbe
@@ -151,12 +157,29 @@ public final class WorkbenchStore: ObservableObject {
     }
 
     public func selectDataset(_ datasetID: String) {
+        let started = DispatchTime.now().uptimeNanoseconds
+        let previousDatasetID = state.selectedDatasetID
         guard state.project.datasets.contains(where: { $0.id == datasetID }) else {
             state.lastErrors.append("Unknown dataset \(datasetID)")
+            datasetSelectionLogger.error("select_dataset unknown id=\(datasetID, privacy: .public)")
+            return
+        }
+        guard previousDatasetID != datasetID else {
+            let elapsedMilliseconds = Double(DispatchTime.now().uptimeNanoseconds - started) / 1_000_000
+            datasetSelectionLogger.debug(
+                "select_dataset noop id=\(datasetID, privacy: .public) elapsed_ms=\(elapsedMilliseconds, privacy: .public)"
+            )
             return
         }
 
         state.selectedDatasetID = datasetID
+        let elapsedMilliseconds = Double(DispatchTime.now().uptimeNanoseconds - started) / 1_000_000
+        let datasetCount = state.project.datasets.count
+        let inspectorCollapsed = state.inspectorCollapsed
+        let activeTabID = state.activeTabID
+        datasetSelectionLogger.info(
+            "select_dataset changed from=\(previousDatasetID ?? "none", privacy: .public) to=\(datasetID, privacy: .public) dataset_count=\(datasetCount, privacy: .public) inspector_collapsed=\(inspectorCollapsed, privacy: .public) active_tab=\(activeTabID, privacy: .public) elapsed_ms=\(elapsedMilliseconds, privacy: .public)"
+        )
     }
 
     public func openSelectedDatasetExplorer() {

--- a/apps/casars-mac/Sources/CasarsMacCore/WorkbenchStore.swift
+++ b/apps/casars-mac/Sources/CasarsMacCore/WorkbenchStore.swift
@@ -181,40 +181,40 @@ public final class WorkbenchStore: ObservableObject {
     public func setMeasurementSetPlotPreset(_ preset: MeasurementSetExplorerPlotPreset, datasetID: String) {
         var plotState = measurementSetPlotState(for: datasetID)
         plotState.preset = preset
-        plotState.status = .idle
         plotState.lastError = nil
+        refreshMeasurementSetPlotStateFromCache(&plotState, datasetID: datasetID)
         state.measurementSetPlots[datasetID] = plotState
     }
 
     public func setMeasurementSetPlotField(_ field: String?, datasetID: String) {
         var plotState = measurementSetPlotState(for: datasetID)
         plotState.selectedField = normalizedPickerValue(field)
-        plotState.status = .idle
         plotState.lastError = nil
+        refreshMeasurementSetPlotStateFromCache(&plotState, datasetID: datasetID)
         state.measurementSetPlots[datasetID] = plotState
     }
 
     public func setMeasurementSetPlotSpectralWindow(_ spectralWindow: String?, datasetID: String) {
         var plotState = measurementSetPlotState(for: datasetID)
         plotState.selectedSpectralWindow = normalizedPickerValue(spectralWindow)
-        plotState.status = .idle
         plotState.lastError = nil
+        refreshMeasurementSetPlotStateFromCache(&plotState, datasetID: datasetID)
         state.measurementSetPlots[datasetID] = plotState
     }
 
     public func setMeasurementSetPlotCorrelation(_ correlation: String?, datasetID: String) {
         var plotState = measurementSetPlotState(for: datasetID)
         plotState.selectedCorrelation = normalizedPickerValue(correlation)
-        plotState.status = .idle
         plotState.lastError = nil
+        refreshMeasurementSetPlotStateFromCache(&plotState, datasetID: datasetID)
         state.measurementSetPlots[datasetID] = plotState
     }
 
     public func setMeasurementSetPlotDataColumn(_ dataColumn: String, datasetID: String) {
         var plotState = measurementSetPlotState(for: datasetID)
         plotState.dataColumn = dataColumn
-        plotState.status = .idle
         plotState.lastError = nil
+        refreshMeasurementSetPlotStateFromCache(&plotState, datasetID: datasetID)
         state.measurementSetPlots[datasetID] = plotState
     }
 
@@ -233,6 +233,13 @@ public final class WorkbenchStore: ObservableObject {
         }
 
         var plotState = measurementSetPlotState(for: datasetID)
+        if let cached = cachedMeasurementSetPlotResult(for: dataset, plotState: plotState) {
+            plotState.result = cached
+            plotState.status = .ready
+            plotState.lastError = nil
+            state.measurementSetPlots[datasetID] = plotState
+            return
+        }
         plotState.status = .running
         plotState.lastError = nil
         state.measurementSetPlots[datasetID] = plotState
@@ -250,6 +257,7 @@ public final class WorkbenchStore: ObservableObject {
             )
             plotState.result = result
             plotState.status = .ready
+            cacheMeasurementSetPlotResult(result, for: dataset, plotState: plotState)
             state.measurementSetPlots[datasetID] = plotState
         } catch {
             plotState.status = .failed
@@ -707,6 +715,61 @@ public final class WorkbenchStore: ObservableObject {
         let plotState = MeasurementSetExplorerPlotState.defaultState(for: dataset)
         state.measurementSetPlots[datasetID] = plotState
         return plotState
+    }
+
+    private func refreshMeasurementSetPlotStateFromCache(
+        _ plotState: inout MeasurementSetExplorerPlotState,
+        datasetID: String
+    ) {
+        guard let dataset = state.project.datasets.first(where: { $0.id == datasetID }),
+              let cached = cachedMeasurementSetPlotResult(for: dataset, plotState: plotState)
+        else {
+            plotState.status = .idle
+            plotState.result = nil
+            return
+        }
+
+        plotState.status = .ready
+        plotState.result = cached
+    }
+
+    private func cachedMeasurementSetPlotResult(
+        for dataset: DatasetSummary,
+        plotState: MeasurementSetExplorerPlotState
+    ) -> MeasurementSetPlotResultSummary? {
+        state.measurementSetPlotResultCache[
+            measurementSetPlotCacheKey(for: dataset, plotState: plotState)
+        ]
+    }
+
+    private func cacheMeasurementSetPlotResult(
+        _ result: MeasurementSetPlotResultSummary,
+        for dataset: DatasetSummary,
+        plotState: MeasurementSetExplorerPlotState
+    ) {
+        state.measurementSetPlotResultCache[
+            measurementSetPlotCacheKey(for: dataset, plotState: plotState)
+        ] = result
+    }
+
+    private func measurementSetPlotCacheKey(
+        for dataset: DatasetSummary,
+        plotState: MeasurementSetExplorerPlotState
+    ) -> String {
+        [
+            "ms-plot",
+            dataset.id,
+            dataset.path,
+            "bytes:\(dataset.sizeBytes)",
+            "modified:\(dataset.modifiedUnixSeconds.map(String.init) ?? "unknown")",
+            "preset:\(plotState.preset.rawValue)",
+            "field:\(plotState.selectedField ?? "all")",
+            "spw:\(plotState.selectedSpectralWindow ?? "all")",
+            "corr:\(plotState.selectedCorrelation ?? "all")",
+            "data:\(plotState.dataColumn)",
+            "size:960x600",
+            "maxPoints:250000"
+        ].joined(separator: "|")
     }
 
     private func defaultDirtyImagingParameters(for dataset: DatasetSummary) -> DirtyImagingTaskParameters {

--- a/apps/casars-mac/Sources/CasarsMacCore/WorkbenchStore.swift
+++ b/apps/casars-mac/Sources/CasarsMacCore/WorkbenchStore.swift
@@ -87,15 +87,19 @@ public final class WorkbenchStore: ObservableObject {
     @Published public private(set) var state: WorkbenchState
     private let probeClient: ProjectProbeClient
     private let plotClient: MeasurementSetPlotClient
+    private let dirtyImagingClient: DirtyImagingTaskClient
+    private var activeTaskExecution: DirtyImagingTaskExecution?
 
     public init(
         state: WorkbenchState = EmptyWorkbench.makeState(),
         probeClient: ProjectProbeClient = UniFFIProjectProbeClient(),
-        plotClient: MeasurementSetPlotClient = UniFFIMeasurementSetPlotClient()
+        plotClient: MeasurementSetPlotClient = UniFFIMeasurementSetPlotClient(),
+        dirtyImagingClient: DirtyImagingTaskClient = ProcessDirtyImagingTaskClient()
     ) {
         self.state = state
         self.probeClient = probeClient
         self.plotClient = plotClient
+        self.dirtyImagingClient = dirtyImagingClient
     }
 
     public static func empty() -> WorkbenchStore {
@@ -290,7 +294,7 @@ public final class WorkbenchStore: ObservableObject {
             selectDockMode(.history)
         } else if normalized.contains("left dock") || normalized.contains("sidebar") {
             setLeftDockCollapsed(false)
-        } else if normalized.contains("task") || normalized.contains("calibrate") {
+        } else if normalized.contains("task") || normalized.contains("calibrate") || normalized.contains("image") || normalized.contains("tclean") {
             openDefaultTab(kind: .task)
         } else if normalized.contains("inspector") {
             setInspectorCollapsed(false)
@@ -352,11 +356,11 @@ public final class WorkbenchStore: ObservableObject {
         case .datasetExplorer:
             openSelectedDatasetExplorer()
         case .task:
-            guard state.isDemoProject else {
-                state.lastErrors.append("Task panels are not connected for real projects yet")
-                return
+            if state.isDemoProject {
+                openTab(WorkbenchTab(id: "tab-task", title: "Calibrate", kind: .task, datasetID: state.selectedDatasetID))
+            } else {
+                openDirtyImagingTaskForSelectedDataset()
             }
-            openTab(WorkbenchTab(id: "tab-task", title: "Calibrate", kind: .task, datasetID: state.selectedDatasetID))
         case .aiChat:
             guard state.isDemoProject else {
                 state.lastErrors.append("AI chat is not connected yet")
@@ -372,6 +376,99 @@ public final class WorkbenchStore: ObservableObject {
         case .history:
             openTab(WorkbenchTab(id: "tab-history", title: "History", kind: .history))
         }
+    }
+
+    public func openDirtyImagingTaskForSelectedDataset() {
+        guard let dataset = state.selectedDataset else {
+            state.lastErrors.append("Select a MeasurementSet before opening an imaging task")
+            return
+        }
+        guard dataset.kind == .measurementSet else {
+            state.lastErrors.append("Dataset \(dataset.name) is not a MeasurementSet")
+            return
+        }
+
+        if state.dirtyImagingTaskParameters?.datasetID != dataset.id {
+            state.dirtyImagingTaskParameters = defaultDirtyImagingParameters(for: dataset)
+            state.taskRun = TaskRun(
+                state: .idle,
+                progress: 0,
+                logLines: ["Dirty imaging task initialized from selected MeasurementSet metadata."],
+                warnings: [],
+                products: [],
+                requestSummary: state.dirtyImagingTaskParameters?.requestSummary
+            )
+        }
+
+        openTab(
+            WorkbenchTab(
+                id: "tab-dirty-imaging-\(dataset.id)",
+                title: "Dirty Image: \(dataset.name)",
+                kind: .task,
+                datasetID: dataset.id
+            )
+        )
+    }
+
+    public func setDirtyImagingField(_ field: String?) {
+        guard var parameters = state.dirtyImagingTaskParameters else { return }
+        parameters.selectedField = normalizedPickerValue(field)
+        parameters.phaseCenterField = parameters.selectedField
+        updateDirtyImagingParameters(parameters)
+    }
+
+    public func setDirtyImagingSpectralWindow(_ spectralWindow: String?) {
+        guard var parameters = state.dirtyImagingTaskParameters else { return }
+        parameters.selectedSpectralWindow = normalizedPickerValue(spectralWindow)
+        updateDirtyImagingParameters(parameters)
+    }
+
+    public func setDirtyImagingDataColumn(_ dataColumn: String) {
+        guard var parameters = state.dirtyImagingTaskParameters else { return }
+        parameters.dataColumn = dataColumn
+        updateDirtyImagingParameters(parameters)
+    }
+
+    public func setDirtyImagingOutputPrefix(_ outputPrefix: String) {
+        guard var parameters = state.dirtyImagingTaskParameters else { return }
+        parameters.outputPrefix = outputPrefix
+        updateDirtyImagingParameters(parameters)
+    }
+
+    public func setDirtyImagingImageSize(_ imageSize: Int) {
+        guard var parameters = state.dirtyImagingTaskParameters else { return }
+        parameters.imageSize = imageSize
+        updateDirtyImagingParameters(parameters)
+    }
+
+    public func setDirtyImagingCellArcsec(_ cellArcsec: Double) {
+        guard var parameters = state.dirtyImagingTaskParameters else { return }
+        parameters.cellArcsec = cellArcsec
+        updateDirtyImagingParameters(parameters)
+    }
+
+    public func setDirtyImagingWeighting(_ weighting: DirtyImagingWeighting) {
+        guard var parameters = state.dirtyImagingTaskParameters else { return }
+        parameters.weighting = weighting
+        updateDirtyImagingParameters(parameters)
+    }
+
+    public func setDirtyImagingChannelStart(_ channelStart: String) {
+        guard var parameters = state.dirtyImagingTaskParameters else { return }
+        parameters.channelStart = channelStart
+        updateDirtyImagingParameters(parameters)
+    }
+
+    public func setDirtyImagingChannelCount(_ channelCount: String) {
+        guard var parameters = state.dirtyImagingTaskParameters else { return }
+        parameters.channelCount = channelCount
+        updateDirtyImagingParameters(parameters)
+    }
+
+    public func setDirtyImagingRunReason(_ reason: String) {
+        guard var parameters = state.dirtyImagingTaskParameters else { return }
+        parameters.runReason = reason
+        updateDirtyImagingParameters(parameters)
     }
 
     public func applyAIProposal(_ proposalID: String) {
@@ -432,41 +529,115 @@ public final class WorkbenchStore: ObservableObject {
     }
 
     public func runTask() {
-        guard state.isDemoProject else {
-            state.lastErrors.append("Task execution is not connected yet")
+        if state.isDemoProject {
+            state.taskRun = TaskRun(
+                state: .completed,
+                progress: 1.0,
+                logLines: [
+                    "Started fixture calibrate dry run.",
+                    "Resolved field \(state.taskParameters.selectedField).",
+                    "Resolved spectral window \(state.taskParameters.selectedSpectralWindow).",
+                    "Recorded fixture product \(state.taskParameters.outputName)."
+                ],
+                warnings: ["Fixture run: no science data was modified."],
+                products: ["project/products/\(state.taskParameters.outputName)"]
+            )
+            state.history.append(
+                ProcessingHistoryEvent(
+                    id: "hist-run-\(state.history.count + 1)",
+                    timestamp: currentTimestamp(),
+                    title: "Fixture task completed",
+                    reason: "User ran the dry-run task from the task tab.",
+                    affectedPaths: state.taskRun.products,
+                    approval: "user"
+                )
+            )
             return
         }
-        state.taskRun = TaskRun(
-            state: .completed,
-            progress: 1.0,
-            logLines: [
-                "Started fixture calibrate dry run.",
-                "Resolved field \(state.taskParameters.selectedField).",
-                "Resolved spectral window \(state.taskParameters.selectedSpectralWindow).",
-                "Recorded fixture product \(state.taskParameters.outputName)."
-            ],
-            warnings: ["Fixture run: no science data was modified."],
-            products: ["project/products/\(state.taskParameters.outputName)"]
-        )
-        state.history.append(
-            ProcessingHistoryEvent(
-                id: "hist-run-\(state.history.count + 1)",
-                timestamp: "2026-05-04 09:24",
-                title: "Fixture task completed",
-                reason: "User ran the dry-run task from the task tab.",
-                affectedPaths: state.taskRun.products,
-                approval: "user"
+
+        guard let parameters = state.dirtyImagingTaskParameters else {
+            state.lastErrors.append("Open a dirty-imaging task before running it")
+            return
+        }
+        let validationErrors = parameters.validationErrors()
+        guard validationErrors.isEmpty else {
+            state.taskRun = TaskRun(
+                state: .failed,
+                progress: 0,
+                logLines: ["Dirty imaging request validation failed."],
+                warnings: [],
+                products: [],
+                diagnostics: validationErrors,
+                requestSummary: parameters.requestSummary
             )
+            state.lastErrors.append(contentsOf: validationErrors)
+            return
+        }
+
+        let runID = "dirty-imaging-\(nextDirtyImagingRunIndex())"
+        let request = DirtyImagingTaskRequest(runID: runID, parameters: parameters)
+        state.taskRun = TaskRun(
+            runID: runID,
+            state: .running,
+            progress: 0.05,
+            logLines: [
+                "Starting casars-imager dirty imaging task.",
+                parameters.requestSummary
+            ],
+            warnings: [],
+            products: [],
+            diagnostics: [],
+            requestSummary: parameters.requestSummary
         )
+
+        do {
+            let execution = try dirtyImagingClient.startDirtyImaging(request: request) { [weak self] event in
+                self?.handleDirtyImagingEvent(event, runID: runID)
+            }
+            if state.taskRun.runID == runID && state.taskRun.state == .running {
+                activeTaskExecution = execution
+            }
+        } catch {
+            state.taskRun = TaskRun(
+                runID: runID,
+                state: .failed,
+                progress: 1.0,
+                logLines: ["Failed to start casars-imager."],
+                warnings: [],
+                products: [],
+                diagnostics: ["\(error)"],
+                requestSummary: parameters.requestSummary
+            )
+            state.lastErrors.append("Start dirty imaging: \(error)")
+        }
     }
 
     public func stopTask() {
-        guard state.isDemoProject else {
-            state.lastErrors.append("Task execution is not connected yet")
+        if state.isDemoProject {
+            state.taskRun.state = .stopped
+            state.taskRun.logLines.append("Stopped fixture task.")
             return
         }
-        state.taskRun.state = .stopped
-        state.taskRun.logLines.append("Stopped fixture task.")
+
+        guard state.taskRun.state == .running else {
+            state.lastErrors.append("No dirty imaging task is running")
+            return
+        }
+        activeTaskExecution?.cancel()
+        activeTaskExecution = nil
+        state.taskRun.state = .cancelled
+        state.taskRun.progress = 1.0
+        state.taskRun.logLines.append("Cancellation requested for dirty imaging task.")
+        state.history.append(
+            ProcessingHistoryEvent(
+                id: "hist-run-\(state.history.count + 1)",
+                timestamp: currentTimestamp(),
+                title: "Dirty imaging cancelled",
+                reason: state.dirtyImagingTaskParameters?.runReason ?? "User cancelled the dirty imaging run.",
+                affectedPaths: state.taskRun.outputPaths,
+                approval: "user"
+            )
+        )
     }
 
     public func setPythonOwner(_ owner: PythonOwner) {
@@ -536,6 +707,153 @@ public final class WorkbenchStore: ObservableObject {
         let plotState = MeasurementSetExplorerPlotState.defaultState(for: dataset)
         state.measurementSetPlots[datasetID] = plotState
         return plotState
+    }
+
+    private func defaultDirtyImagingParameters(for dataset: DatasetSummary) -> DirtyImagingTaskParameters {
+        let firstField = dataset.fields.first
+        let outputPrefix = defaultDirtyImagingOutputPrefix(for: dataset)
+        return DirtyImagingTaskParameters(
+            datasetID: dataset.id,
+            measurementSetPath: dataset.path,
+            outputPrefix: outputPrefix,
+            selectedField: firstField,
+            phaseCenterField: firstField,
+            selectedSpectralWindow: dataset.spectralWindows.first,
+            dataColumn: dataset.dataColumns.first ?? "DATA"
+        )
+    }
+
+    private func defaultDirtyImagingOutputPrefix(for dataset: DatasetSummary) -> String {
+        let root = state.project.rootPath.isEmpty ? FileManager.default.currentDirectoryPath : state.project.rootPath
+        let runDirectory = URL(fileURLWithPath: root)
+            .appendingPathComponent("casa-rs-runs", isDirectory: true)
+            .appendingPathComponent("dirty-imaging-\(nextDirtyImagingRunIndex())", isDirectory: true)
+        return runDirectory.appendingPathComponent("\(sanitizedPathComponent(dataset.name))-dirty").path
+    }
+
+    private func nextDirtyImagingRunIndex() -> Int {
+        state.history.filter { $0.title.hasPrefix("Dirty imaging") }.count + 1
+    }
+
+    private func sanitizedPathComponent(_ value: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_."))
+        let scalars = value.unicodeScalars.map { allowed.contains($0) ? Character($0) : "-" }
+        let sanitized = String(scalars).trimmingCharacters(in: CharacterSet(charactersIn: "-."))
+        return sanitized.isEmpty ? "dataset" : sanitized
+    }
+
+    private func updateDirtyImagingParameters(_ parameters: DirtyImagingTaskParameters) {
+        state.dirtyImagingTaskParameters = parameters
+        if state.taskRun.state == .idle || state.taskRun.state == .failed {
+            state.taskRun.requestSummary = parameters.requestSummary
+        }
+    }
+
+    private func handleDirtyImagingEvent(_ event: DirtyImagingTaskEvent, runID: String) {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak self] in
+                self?.handleDirtyImagingEvent(event, runID: runID)
+            }
+            return
+        }
+
+        guard state.taskRun.runID == runID else {
+            return
+        }
+
+        switch event {
+        case .succeeded(let result):
+            guard state.taskRun.state != .cancelled else {
+                return
+            }
+            activeTaskExecution = nil
+            state.taskRun = TaskRun(
+                runID: runID,
+                state: .succeeded,
+                progress: 1.0,
+                logLines: [
+                    "casars-imager completed dirty imaging.",
+                    result.report.summary,
+                    "Protocol: \(result.protocolSummary)"
+                ],
+                warnings: result.report.warnings,
+                products: result.artifacts.map(\.path),
+                diagnostics: result.diagnostics,
+                outputPaths: result.outputPaths,
+                requestSummary: result.request.parameters.requestSummary
+            )
+            appendProducedDatasets(from: result)
+            state.history.append(
+                ProcessingHistoryEvent(
+                    id: "hist-run-\(state.history.count + 1)",
+                    timestamp: currentTimestamp(),
+                    title: "Dirty imaging completed",
+                    reason: result.request.parameters.runReason,
+                    affectedPaths: result.outputPaths,
+                    approval: "user"
+                )
+            )
+
+        case .failed(let failure):
+            activeTaskExecution = nil
+            state.taskRun = TaskRun(
+                runID: runID,
+                state: .failed,
+                progress: 1.0,
+                logLines: ["casars-imager dirty imaging failed.", failure.message],
+                warnings: [],
+                products: [],
+                diagnostics: failure.diagnostics,
+                outputPaths: [failure.requestJSONPath, failure.stdoutPath, failure.stderrPath].compactMap { $0 },
+                requestSummary: state.dirtyImagingTaskParameters?.requestSummary
+            )
+            state.lastErrors.append("Dirty imaging failed: \(failure.message)")
+
+        case .cancelled(let failure):
+            activeTaskExecution = nil
+            if state.taskRun.state != .cancelled {
+                state.taskRun.state = .cancelled
+                state.taskRun.progress = 1.0
+                state.taskRun.logLines.append(failure.message)
+                state.taskRun.outputPaths = [failure.requestJSONPath, failure.stdoutPath, failure.stderrPath].compactMap { $0 }
+                state.history.append(
+                    ProcessingHistoryEvent(
+                        id: "hist-run-\(state.history.count + 1)",
+                        timestamp: currentTimestamp(),
+                        title: "Dirty imaging cancelled",
+                        reason: state.dirtyImagingTaskParameters?.runReason ?? "User cancelled the dirty imaging run.",
+                        affectedPaths: state.taskRun.outputPaths,
+                        approval: "user"
+                    )
+                )
+            }
+        }
+    }
+
+    private func appendProducedDatasets(from result: DirtyImagingTaskResult) {
+        for artifact in result.artifacts where artifact.exists {
+            guard !state.project.datasets.contains(where: { $0.path == artifact.path }) else {
+                continue
+            }
+            state.project.datasets.append(
+                DatasetSummary(
+                    id: artifact.path,
+                    name: URL(fileURLWithPath: artifact.path).lastPathComponent,
+                    path: artifact.path,
+                    kind: .imageCube,
+                    size: artifact.label,
+                    units: "CASA image",
+                    notes: "Produced by \(result.request.runID) from \(result.request.parameters.measurementSetPath).",
+                    diagnostics: artifact.previewPngExists
+                        ? ["preview: \(artifact.previewPngPath ?? "")"]
+                        : []
+                )
+            )
+        }
+    }
+
+    private func currentTimestamp() -> String {
+        ISO8601DateFormatter().string(from: Date())
     }
 
     private func normalizedPickerValue(_ value: String?) -> String? {

--- a/apps/casars-mac/Sources/CasarsMacCore/WorkbenchStore.swift
+++ b/apps/casars-mac/Sources/CasarsMacCore/WorkbenchStore.swift
@@ -737,9 +737,12 @@ public final class WorkbenchStore: ObservableObject {
         for dataset: DatasetSummary,
         plotState: MeasurementSetExplorerPlotState
     ) -> MeasurementSetPlotResultSummary? {
-        state.measurementSetPlotResultCache[
+        guard let result = state.measurementSetPlotResultCache[
             measurementSetPlotCacheKey(for: dataset, plotState: plotState)
-        ]
+        ] else {
+            return nil
+        }
+        return result.matches(plotState: plotState) ? result : nil
     }
 
     private func cacheMeasurementSetPlotResult(
@@ -1009,6 +1012,23 @@ extension CasarsFrontendServices.MeasurementSetPlotPreset {
     }
 }
 
+extension MeasurementSetExplorerPlotPreset {
+    init(preset: CasarsFrontendServices.MeasurementSetPlotPreset) {
+        switch preset {
+        case .uvCoverage:
+            self = .uvCoverage
+        case .amplitudeVsFrequency:
+            self = .amplitudeVsFrequency
+        case .amplitudeVsChannel:
+            self = .amplitudeVsChannel
+        case .amplitudeVsUvDistance:
+            self = .amplitudeVsUvDistance
+        case .amplitudeVsTime:
+            self = .amplitudeVsTime
+        }
+    }
+}
+
 extension PlotAxisSummary {
     init(axis: CasarsFrontendServices.PlotAxisMetadata) {
         self.init(id: axis.id, label: axis.label, unit: axis.unit)
@@ -1030,6 +1050,7 @@ extension PlotSeriesSummary {
 extension MeasurementSetPlotResultSummary {
     init(result: CasarsFrontendServices.MeasurementSetPlotResult) {
         self.init(
+            preset: MeasurementSetExplorerPlotPreset(preset: result.preset),
             presetLabel: result.presetLabel,
             title: result.title,
             summary: result.summary,

--- a/apps/casars-mac/Sources/CasarsMacCore/WorkbenchStore.swift
+++ b/apps/casars-mac/Sources/CasarsMacCore/WorkbenchStore.swift
@@ -9,6 +9,7 @@ private let datasetSelectionLogger = Logger(
 
 public protocol ProjectProbeClient {
     func probeProject(path: String) throws -> ProjectFixtureProbe
+    func probePath(path: String) throws -> DatasetSummary?
 }
 
 public struct ProjectFixtureProbe: Equatable {
@@ -27,6 +28,10 @@ public struct UniFFIProjectProbeClient: ProjectProbeClient {
     public func probeProject(path: String) throws -> ProjectFixtureProbe {
         let probe = try CasarsFrontendServices.probeProject(path: path)
         return ProjectFixtureProbe(project: ProjectFixture(probe: probe), diagnostics: probe.diagnostics)
+    }
+
+    public func probePath(path: String) throws -> DatasetSummary? {
+        try CasarsFrontendServices.probePath(path: path).map(DatasetSummary.init(probe:))
     }
 }
 
@@ -410,35 +415,51 @@ public final class WorkbenchStore: ObservableObject {
     }
 
     public func openDirtyImagingTaskForSelectedDataset() {
-        guard let dataset = state.selectedDataset else {
-            state.lastErrors.append("Select a MeasurementSet before opening an imaging task")
-            return
-        }
-        guard dataset.kind == .measurementSet else {
-            state.lastErrors.append("Dataset \(dataset.name) is not a MeasurementSet")
+        guard state.selectedDataset != nil else {
+            state.lastErrors.append("Open a project with a dataset before opening an imaging task")
             return
         }
 
-        if state.dirtyImagingTaskParameters?.datasetID != dataset.id {
-            state.dirtyImagingTaskParameters = defaultDirtyImagingParameters(for: dataset)
+        if let dataset = state.selectedDataset, dataset.kind == .measurementSet {
+            if state.dirtyImagingTaskParameters?.datasetID != dataset.id {
+                state.dirtyImagingTaskParameters = defaultDirtyImagingParameters(for: dataset)
+                state.taskRun = TaskRun(
+                    state: .idle,
+                    progress: 0,
+                    logLines: ["Dirty imaging task initialized from selected MeasurementSet metadata."],
+                    warnings: [],
+                    products: [],
+                    requestSummary: state.dirtyImagingTaskParameters?.requestSummary
+                )
+            }
+
+            openTab(
+                WorkbenchTab(
+                    id: "tab-dirty-imaging-\(dataset.id)",
+                    title: "Dirty Image: \(dataset.name)",
+                    kind: .task,
+                    datasetID: dataset.id
+                )
+            )
+        } else {
+            state.dirtyImagingTaskParameters = blankDirtyImagingParameters()
             state.taskRun = TaskRun(
                 state: .idle,
                 progress: 0,
-                logLines: ["Dirty imaging task initialized from selected MeasurementSet metadata."],
+                logLines: ["Dirty imaging task opened. Select a MeasurementSet before running."],
                 warnings: [],
                 products: [],
                 requestSummary: state.dirtyImagingTaskParameters?.requestSummary
             )
-        }
 
-        openTab(
-            WorkbenchTab(
-                id: "tab-dirty-imaging-\(dataset.id)",
-                title: "Dirty Image: \(dataset.name)",
-                kind: .task,
-                datasetID: dataset.id
+            openTab(
+                WorkbenchTab(
+                    id: "tab-dirty-imaging-unbound",
+                    title: "Dirty Image",
+                    kind: .task
+                )
             )
-        )
+        }
     }
 
     public func setDirtyImagingField(_ field: String?) {
@@ -472,6 +493,24 @@ public final class WorkbenchStore: ObservableObject {
         updateDirtyImagingParameters(parameters)
     }
 
+    public func setDirtyImagingImageHeight(_ imageHeight: Int) {
+        guard var parameters = state.dirtyImagingTaskParameters else { return }
+        parameters.imageHeight = imageHeight
+        updateDirtyImagingParameters(parameters)
+    }
+
+    public func adjustDirtyImagingImageWidthToNiceSize() {
+        guard var parameters = state.dirtyImagingTaskParameters else { return }
+        parameters.imageSize = DirtyImagingTaskParameters.nearestNiceImageDimension(to: parameters.imageSize)
+        updateDirtyImagingParameters(parameters)
+    }
+
+    public func adjustDirtyImagingImageHeightToNiceSize() {
+        guard var parameters = state.dirtyImagingTaskParameters else { return }
+        parameters.imageHeight = DirtyImagingTaskParameters.nearestNiceImageDimension(to: parameters.imageHeight)
+        updateDirtyImagingParameters(parameters)
+    }
+
     public func setDirtyImagingCellArcsec(_ cellArcsec: Double) {
         guard var parameters = state.dirtyImagingTaskParameters else { return }
         parameters.cellArcsec = cellArcsec
@@ -500,6 +539,63 @@ public final class WorkbenchStore: ObservableObject {
         guard var parameters = state.dirtyImagingTaskParameters else { return }
         parameters.runReason = reason
         updateDirtyImagingParameters(parameters)
+    }
+
+    public func setDirtyImagingDataset(_ datasetID: String) {
+        guard let current = state.dirtyImagingTaskParameters else { return }
+        guard !datasetID.isEmpty else {
+            state.dirtyImagingTaskParameters = blankDirtyImagingParameters()
+            state.dirtyImagingTaskParameters?.imageSize = current.imageSize
+            state.dirtyImagingTaskParameters?.imageHeight = current.imageHeight
+            state.dirtyImagingTaskParameters?.cellArcsec = current.cellArcsec
+            state.dirtyImagingTaskParameters?.weighting = current.weighting
+            state.dirtyImagingTaskParameters?.dirtyOnly = current.dirtyOnly
+            state.dirtyImagingTaskParameters?.runReason = current.runReason
+            state.taskRun = TaskRun(
+                state: .idle,
+                progress: 0,
+                logLines: ["Dirty imaging task input MeasurementSet cleared."],
+                warnings: [],
+                products: [],
+                requestSummary: state.dirtyImagingTaskParameters?.requestSummary
+            )
+            if let activeIndex = state.tabs.firstIndex(where: { $0.id == state.activeTabID && $0.kind == .task }) {
+                state.tabs[activeIndex].title = "Dirty Image"
+                state.tabs[activeIndex].datasetID = nil
+            }
+            return
+        }
+        guard let dataset = state.project.datasets.first(where: { $0.id == datasetID }) else {
+            state.lastErrors.append("Unknown dataset \(datasetID)")
+            return
+        }
+        guard dataset.kind == .measurementSet else {
+            state.lastErrors.append("Dataset \(dataset.name) is not a MeasurementSet")
+            return
+        }
+
+        state.selectedDatasetID = datasetID
+        var parameters = defaultDirtyImagingParameters(for: dataset)
+        parameters.imageSize = current.imageSize
+        parameters.imageHeight = current.imageHeight
+        parameters.cellArcsec = current.cellArcsec
+        parameters.weighting = current.weighting
+        parameters.dirtyOnly = current.dirtyOnly
+        parameters.runReason = current.runReason
+        state.dirtyImagingTaskParameters = parameters
+        state.taskRun = TaskRun(
+            state: .idle,
+            progress: 0,
+            logLines: ["Dirty imaging task input MeasurementSet changed to \(dataset.name)."],
+            warnings: [],
+            products: [],
+            requestSummary: parameters.requestSummary
+        )
+
+        if let activeIndex = state.tabs.firstIndex(where: { $0.id == state.activeTabID && $0.kind == .task }) {
+            state.tabs[activeIndex].title = "Dirty Image: \(dataset.name)"
+            state.tabs[activeIndex].datasetID = dataset.id
+        }
     }
 
     public func applyAIProposal(_ proposalID: String) {
@@ -812,12 +908,29 @@ public final class WorkbenchStore: ObservableObject {
         )
     }
 
+    private func blankDirtyImagingParameters() -> DirtyImagingTaskParameters {
+        DirtyImagingTaskParameters(
+            datasetID: "",
+            measurementSetPath: "",
+            outputPrefix: defaultDirtyImagingOutputPrefix(baseName: "dirty-image"),
+            selectedField: nil,
+            phaseCenterField: nil,
+            selectedSpectralWindow: nil,
+            dataColumn: "DATA",
+            runReason: "Initial dirty image from selected MeasurementSet."
+        )
+    }
+
     private func defaultDirtyImagingOutputPrefix(for dataset: DatasetSummary) -> String {
+        defaultDirtyImagingOutputPrefix(baseName: dataset.name)
+    }
+
+    private func defaultDirtyImagingOutputPrefix(baseName: String) -> String {
         let root = state.project.rootPath.isEmpty ? FileManager.default.currentDirectoryPath : state.project.rootPath
         let runDirectory = URL(fileURLWithPath: root)
             .appendingPathComponent("casa-rs-runs", isDirectory: true)
             .appendingPathComponent("dirty-imaging-\(nextDirtyImagingRunIndex())", isDirectory: true)
-        return runDirectory.appendingPathComponent("\(sanitizedPathComponent(dataset.name))-dirty").path
+        return runDirectory.appendingPathComponent("\(sanitizedPathComponent(baseName))-dirty").path
     }
 
     private func nextDirtyImagingRunIndex() -> Int {
@@ -924,13 +1037,17 @@ public final class WorkbenchStore: ObservableObject {
             guard !state.project.datasets.contains(where: { $0.path == artifact.path }) else {
                 continue
             }
+            if let probed = try? probeClient.probePath(path: artifact.path) {
+                state.project.datasets.append(probed)
+                continue
+            }
             state.project.datasets.append(
                 DatasetSummary(
                     id: artifact.path,
                     name: URL(fileURLWithPath: artifact.path).lastPathComponent,
                     path: artifact.path,
                     kind: .imageCube,
-                    size: artifact.label,
+                    size: "Unprobed image product",
                     units: "CASA image",
                     notes: "Produced by \(result.request.runID) from \(result.request.parameters.measurementSetPath).",
                     diagnostics: artifact.previewPngExists

--- a/apps/casars-mac/Tests/CasarsMacCoreTests/WorkbenchStoreTests.swift
+++ b/apps/casars-mac/Tests/CasarsMacCoreTests/WorkbenchStoreTests.swift
@@ -503,7 +503,7 @@ private final class StubMeasurementSetPlotClient: MeasurementSetPlotClient {
             presetLabel: request.preset.title,
             title: request.preset.title,
             datasetPath: request.datasetPath,
-            dataColumn: request.dataColumn,
+            dataColumn: request.dataColumn.lowercased(),
             requestedMaxPoints: request.maxPlotPoints,
             imageWidth: request.width,
             imageHeight: request.height

--- a/apps/casars-mac/Tests/CasarsMacCoreTests/WorkbenchStoreTests.swift
+++ b/apps/casars-mac/Tests/CasarsMacCoreTests/WorkbenchStoreTests.swift
@@ -468,6 +468,13 @@ final class WorkbenchStoreTests: XCTestCase {
         store.resetInterfaceFontSize()
         XCTAssertEqual(store.state.interfaceFontSize, WorkbenchState.defaultInterfaceFontSize)
     }
+
+    func testPlotImageCacheIDTracksFullImageBytes() {
+        let first = makePlotResult(imageBytes: Data([0x89, 0x50, 1, 2, 3, 0x0a]))
+        let second = makePlotResult(imageBytes: Data([0x89, 0x50, 1, 9, 3, 0x0a]))
+
+        XCTAssertNotEqual(first.imageCacheID, second.imageCacheID)
+    }
 }
 
 private struct StubProjectProbeClient: ProjectProbeClient {
@@ -483,28 +490,50 @@ private final class StubMeasurementSetPlotClient: MeasurementSetPlotClient {
 
     func buildPlot(request: MeasurementSetPlotBuildRequest) throws -> MeasurementSetPlotResultSummary {
         requests.append(request)
-        return MeasurementSetPlotResultSummary(
+        return makePlotResult(
             presetLabel: request.preset.title,
             title: request.preset.title,
-            summary: "Synthetic plot result for tests.",
             datasetPath: request.datasetPath,
             dataColumn: request.dataColumn,
-            selectionSummary: "data column \(request.dataColumn)",
-            xAxis: PlotAxisSummary(id: "frequency", label: "Frequency (Hz)", unit: "Hz"),
-            yAxis: PlotAxisSummary(id: "amplitude", label: "Amplitude", unit: ""),
-            series: [
-                PlotSeriesSummary(label: "Target", colorGroup: "field-0", pointCount: 42, firstRow: 0, lastRow: 11)
-            ],
             requestedMaxPoints: request.maxPlotPoints,
-            renderedPointCount: 42,
-            diagnostics: [],
-            renderer: "stub renderer",
-            imageFormat: "png",
             imageWidth: request.width,
-            imageHeight: request.height,
-            imageBytes: Data([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+            imageHeight: request.height
         )
     }
+}
+
+private func makePlotResult(
+    presetLabel: String = "UV Coverage",
+    title: String = "UV Coverage",
+    datasetPath: String = "/data/probed.ms",
+    dataColumn: String = "DATA",
+    requestedMaxPoints: UInt64 = 250_000,
+    imageWidth: UInt32 = 960,
+    imageHeight: UInt32 = 600,
+    imageBytes: Data
+        = Data([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+) -> MeasurementSetPlotResultSummary {
+    MeasurementSetPlotResultSummary(
+        presetLabel: presetLabel,
+        title: title,
+        summary: "Synthetic plot result for tests.",
+        datasetPath: datasetPath,
+        dataColumn: dataColumn,
+        selectionSummary: "data column \(dataColumn)",
+        xAxis: PlotAxisSummary(id: "frequency", label: "Frequency (Hz)", unit: "Hz"),
+        yAxis: PlotAxisSummary(id: "amplitude", label: "Amplitude", unit: ""),
+        series: [
+            PlotSeriesSummary(label: "Target", colorGroup: "field-0", pointCount: 42, firstRow: 0, lastRow: 11)
+        ],
+        requestedMaxPoints: requestedMaxPoints,
+        renderedPointCount: 42,
+        diagnostics: [],
+        renderer: "stub renderer",
+        imageFormat: "png",
+        imageWidth: imageWidth,
+        imageHeight: imageHeight,
+        imageBytes: imageBytes
+    )
 }
 
 private final class StubDirtyImagingTaskClient: DirtyImagingTaskClient {

--- a/apps/casars-mac/Tests/CasarsMacCoreTests/WorkbenchStoreTests.swift
+++ b/apps/casars-mac/Tests/CasarsMacCoreTests/WorkbenchStoreTests.swift
@@ -280,6 +280,63 @@ final class WorkbenchStoreTests: XCTestCase {
         XCTAssertTrue(store.state.tabs.contains { $0.kind == .task })
     }
 
+    func testDirtyImagingTaskCanOpenWhenSelectedDatasetIsAnImage() {
+        let msDataset = DatasetSummary(
+            id: "/data/probed.ms",
+            name: "probed.ms",
+            path: "/data/probed.ms",
+            kind: .measurementSet,
+            size: "12 rows, 1 fields, 1 spw, 2 antennas",
+            units: "Jy, Hz, seconds",
+            fields: ["0: Target"],
+            spectralWindows: ["spw 0: 4 chan, 1.420000 GHz center"],
+            dataColumns: ["DATA"],
+            notes: "Recognized by Rust probe."
+        )
+        let imageDataset = DatasetSummary(
+            id: "/data/output.image",
+            name: "output.image",
+            path: "/data/output.image",
+            kind: .imageCube,
+            size: "256 x 256",
+            units: "float32",
+            shape: [256, 256],
+            notes: "Produced image."
+        )
+        let store = WorkbenchStore(
+            probeClient: StubProjectProbeClient(
+                result: ProjectFixtureProbe(
+                    project: ProjectFixture(
+                        name: "Real Project",
+                        rootPath: "/data",
+                        datasets: [msDataset, imageDataset],
+                        source: .probed
+                    ),
+                    diagnostics: []
+                )
+            )
+        )
+
+        store.openProject(path: "/data")
+        store.selectDataset(imageDataset.id)
+        store.openDefaultTab(kind: .task)
+
+        XCTAssertEqual(store.state.selectedDatasetID, imageDataset.id)
+        XCTAssertEqual(store.state.dirtyImagingTaskParameters?.datasetID, "")
+        XCTAssertEqual(store.state.dirtyImagingTaskParameters?.measurementSetPath, "")
+        XCTAssertEqual(store.state.dirtyImagingTaskParameters?.selectedField, nil)
+        XCTAssertEqual(store.state.dirtyImagingTaskParameters?.selectedSpectralWindow, nil)
+        XCTAssertEqual(store.state.tabs.first(where: { $0.kind == .task })?.title, "Dirty Image")
+        XCTAssertFalse(store.state.lastErrors.contains("Dataset output.image is not a MeasurementSet"))
+
+        store.setDirtyImagingDataset(msDataset.id)
+
+        XCTAssertEqual(store.state.selectedDatasetID, msDataset.id)
+        XCTAssertEqual(store.state.dirtyImagingTaskParameters?.datasetID, msDataset.id)
+        XCTAssertEqual(store.state.dirtyImagingTaskParameters?.measurementSetPath, msDataset.path)
+        XCTAssertEqual(store.state.tabs.first(where: { $0.kind == .task })?.title, "Dirty Image: probed.ms")
+    }
+
     func testRealDirtyImagingRunUsesTaskClientAndRecordsDebugHistory() throws {
         let probedDataset = DatasetSummary(
             id: "/data/probed.ms",
@@ -305,7 +362,20 @@ final class WorkbenchStoreTests: XCTestCase {
                     source: .probed
                 ),
                 diagnostics: []
-            )
+            ),
+            probedPaths: [
+                "/data/casa-rs-runs/output.image": DatasetSummary(
+                    id: "/data/casa-rs-runs/output.image",
+                    name: "output.image",
+                    path: "/data/casa-rs-runs/output.image",
+                    kind: .imageCube,
+                    size: "256 x 256",
+                    units: "float32",
+                    sizeBytes: 4096,
+                    shape: [256, 256],
+                    notes: "Recognized by opening the path as a casa-rs image."
+                )
+            ]
         )
         let taskClient = StubDirtyImagingTaskClient()
         let store = WorkbenchStore(probeClient: probeClient, dirtyImagingClient: taskClient)
@@ -313,6 +383,7 @@ final class WorkbenchStoreTests: XCTestCase {
         store.openProject(path: "/data")
         store.openDefaultTab(kind: .task)
         store.setDirtyImagingImageSize(256)
+        store.setDirtyImagingImageHeight(256)
         store.setDirtyImagingCellArcsec(0.25)
         store.setDirtyImagingWeighting(.briggs)
         store.setDirtyImagingChannelStart("2")
@@ -332,11 +403,74 @@ final class WorkbenchStoreTests: XCTestCase {
         let snapshot = store.debugSnapshot()
         XCTAssertEqual(snapshot.taskState, .succeeded)
         XCTAssertEqual(snapshot.taskRequest?.imageSize, 256)
+        XCTAssertEqual(snapshot.taskRequest?.imageHeight, 256)
         XCTAssertEqual(snapshot.taskRequest?.cellArcsec, 0.25)
         XCTAssertTrue(snapshot.taskOutputPaths.contains("/data/casa-rs-runs/output.image"))
         XCTAssertTrue(snapshot.processingHistoryEvents.contains("Dirty imaging completed"))
-        XCTAssertTrue(store.state.project.datasets.contains { $0.path == "/data/casa-rs-runs/output.image" })
+        let producedDataset = store.state.project.datasets.first { $0.path == "/data/casa-rs-runs/output.image" }
+        XCTAssertEqual(producedDataset?.kind, .imageCube)
+        XCTAssertEqual(producedDataset?.size, "256 x 256")
+        XCTAssertEqual(producedDataset?.units, "float32")
+        XCTAssertEqual(producedDataset?.shape, [256, 256])
         XCTAssertNoThrow(try store.debugJSON())
+    }
+
+    func testDirtyImagingTaskInputMeasurementSetCanBeChangedInsideTaskTab() {
+        let first = DatasetSummary(
+            id: "/data/first.ms",
+            name: "first.ms",
+            path: "/data/first.ms",
+            kind: .measurementSet,
+            size: "12 rows, 1 fields, 1 spw, 2 antennas",
+            units: "Jy, Hz, seconds",
+            fields: ["0: First"],
+            spectralWindows: ["spw 0: 4 chan, 1.420000 GHz center"],
+            dataColumns: ["DATA"],
+            notes: "First MS."
+        )
+        let second = DatasetSummary(
+            id: "/data/second.ms",
+            name: "second.ms",
+            path: "/data/second.ms",
+            kind: .measurementSet,
+            size: "24 rows, 1 fields, 2 spw, 3 antennas",
+            units: "Jy, Hz, seconds",
+            fields: ["1: Second"],
+            spectralWindows: ["spw 1: 8 chan, 1.500000 GHz center"],
+            dataColumns: ["CORRECTED_DATA"],
+            notes: "Second MS."
+        )
+        let store = WorkbenchStore(
+            probeClient: StubProjectProbeClient(
+                result: ProjectFixtureProbe(
+                    project: ProjectFixture(
+                        name: "Real Project",
+                        rootPath: "/data",
+                        datasets: [first, second],
+                        source: .probed
+                    ),
+                    diagnostics: []
+                )
+            )
+        )
+
+        store.openProject(path: "/data")
+        store.openDefaultTab(kind: .task)
+        store.setDirtyImagingImageSize(1024)
+        store.setDirtyImagingImageHeight(768)
+        store.setDirtyImagingCellArcsec(0.5)
+        store.setDirtyImagingDataset(second.id)
+
+        XCTAssertEqual(store.state.selectedDatasetID, second.id)
+        XCTAssertEqual(store.state.dirtyImagingTaskParameters?.datasetID, second.id)
+        XCTAssertEqual(store.state.dirtyImagingTaskParameters?.measurementSetPath, second.path)
+        XCTAssertEqual(store.state.dirtyImagingTaskParameters?.selectedField, "1: Second")
+        XCTAssertEqual(store.state.dirtyImagingTaskParameters?.selectedSpectralWindow, "spw 1: 8 chan, 1.500000 GHz center")
+        XCTAssertEqual(store.state.dirtyImagingTaskParameters?.dataColumn, "CORRECTED_DATA")
+        XCTAssertEqual(store.state.dirtyImagingTaskParameters?.imageSize, 1024)
+        XCTAssertEqual(store.state.dirtyImagingTaskParameters?.imageHeight, 768)
+        XCTAssertEqual(store.state.dirtyImagingTaskParameters?.cellArcsec, 0.5)
+        XCTAssertEqual(store.state.tabs.first(where: { $0.kind == .task })?.title, "Dirty Image: second.ms")
     }
 
     func testDirtyImagingValidationFailuresAreDebugVisible() {
@@ -368,13 +502,99 @@ final class WorkbenchStoreTests: XCTestCase {
         store.openProject(path: "/data")
         store.openDefaultTab(kind: .task)
         store.setDirtyImagingImageSize(0)
+        store.setDirtyImagingImageHeight(128)
         store.setDirtyImagingCellArcsec(-1)
         store.runTask()
 
         XCTAssertEqual(taskClient.requests.count, 0)
         XCTAssertEqual(store.debugSnapshot().taskState, .failed)
-        XCTAssertTrue(store.debugSnapshot().taskDiagnostics.contains("Image size must be positive."))
+        XCTAssertTrue(store.debugSnapshot().taskDiagnostics.contains("Image width must be positive."))
         XCTAssertTrue(store.debugSnapshot().taskDiagnostics.contains("Cell size must be a positive finite arcsecond value."))
+    }
+
+    func testDirtyImagingRectangularImageSizeIsVisibleButNotRunnableYet() {
+        let probedDataset = DatasetSummary(
+            id: "/data/probed.ms",
+            name: "probed.ms",
+            path: "/data/probed.ms",
+            kind: .measurementSet,
+            size: "12 rows, 1 fields, 1 spw, 2 antennas",
+            units: "Jy, Hz, seconds",
+            fields: ["0: Target"],
+            spectralWindows: ["spw 0: 4 chan, 1.420000 GHz center"],
+            notes: "Recognized by Rust probe."
+        )
+        let store = WorkbenchStore(
+            probeClient: StubProjectProbeClient(
+                result: ProjectFixtureProbe(
+                    project: ProjectFixture(
+                        name: "Real Project",
+                        rootPath: "/data",
+                        datasets: [probedDataset],
+                        source: .probed
+                    ),
+                    diagnostics: []
+                )
+            ),
+            dirtyImagingClient: StubDirtyImagingTaskClient()
+        )
+
+        store.openProject(path: "/data")
+        store.openDefaultTab(kind: .task)
+        store.setDirtyImagingImageSize(512)
+        store.setDirtyImagingImageHeight(256)
+        store.runTask()
+
+        XCTAssertEqual(store.state.dirtyImagingTaskParameters?.imageSize, 512)
+        XCTAssertEqual(store.state.dirtyImagingTaskParameters?.imageHeight, 256)
+        XCTAssertEqual(store.debugSnapshot().taskState, .failed)
+        XCTAssertTrue(store.debugSnapshot().taskDiagnostics.contains("Rectangular image sizes are not supported by the current casars-imager backend yet."))
+    }
+
+    func testDirtyImagingImageSizeAssessmentAndAdjustmentPreferFftFriendlyValues() {
+        XCTAssertEqual(DirtyImagingTaskParameters.imageDimensionAssessment(512).severity, .good)
+        XCTAssertEqual(DirtyImagingTaskParameters.imageDimensionAssessment(1000).severity, .good)
+        XCTAssertEqual(DirtyImagingTaskParameters.imageDimensionAssessment(511).severity, .warning)
+        XCTAssertEqual(DirtyImagingTaskParameters.imageDimensionAssessment(257).severity, .terrible)
+        XCTAssertEqual(DirtyImagingTaskParameters.nearestNiceImageDimension(to: 257), 270)
+        XCTAssertEqual(DirtyImagingTaskParameters.nearestNiceImageDimension(to: 511), 512)
+        XCTAssertEqual(DirtyImagingTaskParameters.nearestNiceImageDimension(to: 513), 540)
+        XCTAssertEqual(DirtyImagingTaskParameters.nearestNiceImageDimension(to: 8191), 8192)
+
+        let probedDataset = DatasetSummary(
+            id: "/data/probed.ms",
+            name: "probed.ms",
+            path: "/data/probed.ms",
+            kind: .measurementSet,
+            size: "12 rows, 1 fields, 1 spw, 2 antennas",
+            units: "Jy, Hz, seconds",
+            fields: ["0: Target"],
+            spectralWindows: ["spw 0: 4 chan, 1.420000 GHz center"],
+            notes: "Recognized by Rust probe."
+        )
+        let store = WorkbenchStore(
+            probeClient: StubProjectProbeClient(
+                result: ProjectFixtureProbe(
+                    project: ProjectFixture(
+                        name: "Real Project",
+                        rootPath: "/data",
+                        datasets: [probedDataset],
+                        source: .probed
+                    ),
+                    diagnostics: []
+                )
+            )
+        )
+
+        store.openProject(path: "/data")
+        store.openDefaultTab(kind: .task)
+        store.setDirtyImagingImageSize(257)
+        store.setDirtyImagingImageHeight(511)
+        store.adjustDirtyImagingImageWidthToNiceSize()
+        store.adjustDirtyImagingImageHeightToNiceSize()
+
+        XCTAssertEqual(store.state.dirtyImagingTaskParameters?.imageSize, 270)
+        XCTAssertEqual(store.state.dirtyImagingTaskParameters?.imageHeight, 512)
     }
 
     func testRealMeasurementSetPlotRunUsesPlotClientAndDebugState() {
@@ -483,13 +703,46 @@ final class WorkbenchStoreTests: XCTestCase {
 
         XCTAssertNotEqual(first.imageCacheID, second.imageCacheID)
     }
+
+    func testDirtyImagingClientFindsBundledImagerHelperAfterEnvironmentOverride() {
+        let bundleExecutable = URL(fileURLWithPath: "/Applications/casars-mac.app/Contents/MacOS/casars-mac")
+
+        XCTAssertEqual(
+            ProcessDirtyImagingTaskClient.resolvedExecutablePath(
+                environment: ["CASARS_IMAGER_BIN": "/custom/casars-imager"],
+                bundleExecutableURL: bundleExecutable,
+                isExecutable: { _ in true }
+            ),
+            "/custom/casars-imager"
+        )
+        XCTAssertEqual(
+            ProcessDirtyImagingTaskClient.resolvedExecutablePath(
+                environment: [:],
+                bundleExecutableURL: bundleExecutable,
+                isExecutable: { $0 == "/Applications/casars-mac.app/Contents/MacOS/casars-imager" }
+            ),
+            "/Applications/casars-mac.app/Contents/MacOS/casars-imager"
+        )
+        XCTAssertNil(
+            ProcessDirtyImagingTaskClient.resolvedExecutablePath(
+                environment: [:],
+                bundleExecutableURL: bundleExecutable,
+                isExecutable: { _ in false }
+            )
+        )
+    }
 }
 
 private struct StubProjectProbeClient: ProjectProbeClient {
     var result: ProjectFixtureProbe
+    var probedPaths: [String: DatasetSummary] = [:]
 
     func probeProject(path: String) throws -> ProjectFixtureProbe {
         result
+    }
+
+    func probePath(path: String) throws -> DatasetSummary? {
+        probedPaths[path]
     }
 }
 

--- a/apps/casars-mac/Tests/CasarsMacCoreTests/WorkbenchStoreTests.swift
+++ b/apps/casars-mac/Tests/CasarsMacCoreTests/WorkbenchStoreTests.swift
@@ -221,7 +221,7 @@ final class WorkbenchStoreTests: XCTestCase {
         XCTAssertEqual(store.state.tabs.first { $0.id == store.state.activeTabID }?.title, "MS: probed.ms")
     }
 
-    func testFakeExecutionTabsAreGatedOutsideDemoProject() {
+    func testFakeExecutionTabsAreGatedOutsideDemoProjectButRealImagingTaskOpens() {
         let probedDataset = DatasetSummary(
             id: "/data/probed.ms",
             name: "probed.ms",
@@ -258,11 +258,17 @@ final class WorkbenchStoreTests: XCTestCase {
         store.openDefaultTab(kind: .python)
         store.openDefaultTab(kind: .task)
 
-        XCTAssertEqual(store.state.tabs.count, 1)
+        XCTAssertEqual(store.state.tabs.count, 2)
         XCTAssertEqual(store.state.tabs.first?.kind, .datasetExplorer)
+        XCTAssertEqual(store.state.tabs.last?.title, "Dirty Image: probed.ms")
+        XCTAssertEqual(store.state.dirtyImagingTaskParameters?.measurementSetPath, "/data/probed.ms")
+        XCTAssertEqual(store.state.dirtyImagingTaskParameters?.selectedField, "0: Target")
+        XCTAssertEqual(store.state.dirtyImagingTaskParameters?.phaseCenterField, "0: Target")
+        XCTAssertEqual(store.state.dirtyImagingTaskParameters?.selectedSpectralWindow, "spw 0: 4 chan, 1.420000 GHz center")
+        XCTAssertEqual(store.state.dirtyImagingTaskParameters?.outputPrefix, "/data/casa-rs-runs/dirty-imaging-1/probed.ms-dirty")
         XCTAssertTrue(store.state.lastErrors.contains("AI chat is not connected yet"))
         XCTAssertTrue(store.state.lastErrors.contains("Python is not connected yet"))
-        XCTAssertTrue(store.state.lastErrors.contains("Task panels are not connected for real projects yet"))
+        XCTAssertFalse(store.state.lastErrors.contains("Task panels are not connected for real projects yet"))
 
         store.openFixtureProject()
         store.openDefaultTab(kind: .aiChat)
@@ -272,6 +278,103 @@ final class WorkbenchStoreTests: XCTestCase {
         XCTAssertTrue(store.state.tabs.contains { $0.kind == .aiChat })
         XCTAssertTrue(store.state.tabs.contains { $0.kind == .python })
         XCTAssertTrue(store.state.tabs.contains { $0.kind == .task })
+    }
+
+    func testRealDirtyImagingRunUsesTaskClientAndRecordsDebugHistory() throws {
+        let probedDataset = DatasetSummary(
+            id: "/data/probed.ms",
+            name: "probed.ms",
+            path: "/data/probed.ms",
+            kind: .measurementSet,
+            size: "12 rows, 1 fields, 1 spw, 2 antennas",
+            units: "Jy, Hz, seconds",
+            fields: ["0: Target"],
+            spectralWindows: ["spw 0: 4 chan, 1.420000 GHz center"],
+            scans: ["scan 1: 12 rows, Target"],
+            correlations: ["XX", "YY"],
+            columns: ["UVW", "DATA", "FLAG"],
+            dataColumns: ["DATA"],
+            notes: "Recognized by Rust probe."
+        )
+        let probeClient = StubProjectProbeClient(
+            result: ProjectFixtureProbe(
+                project: ProjectFixture(
+                    name: "Real Project",
+                    rootPath: "/data",
+                    datasets: [probedDataset],
+                    source: .probed
+                ),
+                diagnostics: []
+            )
+        )
+        let taskClient = StubDirtyImagingTaskClient()
+        let store = WorkbenchStore(probeClient: probeClient, dirtyImagingClient: taskClient)
+
+        store.openProject(path: "/data")
+        store.openDefaultTab(kind: .task)
+        store.setDirtyImagingImageSize(256)
+        store.setDirtyImagingCellArcsec(0.25)
+        store.setDirtyImagingWeighting(.briggs)
+        store.setDirtyImagingChannelStart("2")
+        store.setDirtyImagingChannelCount("4")
+        store.runTask()
+
+        XCTAssertEqual(taskClient.requests.count, 1)
+        let encoded = String(decoding: try taskClient.requests[0].encodedImagerJSON(), as: UTF8.self)
+        XCTAssertTrue(encoded.contains(#""dirty_only" : true"#))
+        XCTAssertTrue(encoded.contains(#""field_ids" : ["#))
+        XCTAssertTrue(encoded.contains(#""phasecenter_field" : 0"#))
+        XCTAssertTrue(encoded.contains(#""spw_selector" : "0""#))
+        XCTAssertTrue(encoded.contains(#""channel_start" : 2"#))
+        XCTAssertTrue(encoded.contains(#""channel_count" : 4"#))
+        XCTAssertTrue(encoded.contains(#""kind" : "briggs""#))
+
+        let snapshot = store.debugSnapshot()
+        XCTAssertEqual(snapshot.taskState, .succeeded)
+        XCTAssertEqual(snapshot.taskRequest?.imageSize, 256)
+        XCTAssertEqual(snapshot.taskRequest?.cellArcsec, 0.25)
+        XCTAssertTrue(snapshot.taskOutputPaths.contains("/data/casa-rs-runs/output.image"))
+        XCTAssertTrue(snapshot.processingHistoryEvents.contains("Dirty imaging completed"))
+        XCTAssertTrue(store.state.project.datasets.contains { $0.path == "/data/casa-rs-runs/output.image" })
+        XCTAssertNoThrow(try store.debugJSON())
+    }
+
+    func testDirtyImagingValidationFailuresAreDebugVisible() {
+        let probedDataset = DatasetSummary(
+            id: "/data/probed.ms",
+            name: "probed.ms",
+            path: "/data/probed.ms",
+            kind: .measurementSet,
+            size: "12 rows, 1 fields, 1 spw, 2 antennas",
+            units: "Jy, Hz, seconds",
+            fields: ["0: Target"],
+            spectralWindows: ["spw 0: 4 chan, 1.420000 GHz center"],
+            notes: "Recognized by Rust probe."
+        )
+        let probeClient = StubProjectProbeClient(
+            result: ProjectFixtureProbe(
+                project: ProjectFixture(
+                    name: "Real Project",
+                    rootPath: "/data",
+                    datasets: [probedDataset],
+                    source: .probed
+                ),
+                diagnostics: []
+            )
+        )
+        let taskClient = StubDirtyImagingTaskClient()
+        let store = WorkbenchStore(probeClient: probeClient, dirtyImagingClient: taskClient)
+
+        store.openProject(path: "/data")
+        store.openDefaultTab(kind: .task)
+        store.setDirtyImagingImageSize(0)
+        store.setDirtyImagingCellArcsec(-1)
+        store.runTask()
+
+        XCTAssertEqual(taskClient.requests.count, 0)
+        XCTAssertEqual(store.debugSnapshot().taskState, .failed)
+        XCTAssertTrue(store.debugSnapshot().taskDiagnostics.contains("Image size must be positive."))
+        XCTAssertTrue(store.debugSnapshot().taskDiagnostics.contains("Cell size must be a positive finite arcsecond value."))
     }
 
     func testRealMeasurementSetPlotRunUsesPlotClientAndDebugState() {
@@ -386,5 +489,52 @@ private final class StubMeasurementSetPlotClient: MeasurementSetPlotClient {
             imageHeight: request.height,
             imageBytes: Data([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
         )
+    }
+}
+
+private final class StubDirtyImagingTaskClient: DirtyImagingTaskClient {
+    var requests: [DirtyImagingTaskRequest] = []
+    var event: DirtyImagingTaskEvent?
+
+    func startDirtyImaging(
+        request: DirtyImagingTaskRequest,
+        eventHandler: @escaping (DirtyImagingTaskEvent) -> Void
+    ) throws -> DirtyImagingTaskExecution {
+        requests.append(request)
+        let result = DirtyImagingTaskResult(
+            request: request,
+            report: DirtyImagingRunReport(
+                warnings: ["synthetic warning"],
+                griddedSamples: 128,
+                majorCycles: 1,
+                minorIterations: 0,
+                channelCount: 1
+            ),
+            artifacts: [
+                DirtyImagingArtifact(
+                    kind: "image",
+                    label: "Dirty Image",
+                    path: "/data/casa-rs-runs/output.image",
+                    exists: true,
+                    previewPngPath: "/data/casa-rs-runs/output.image.png",
+                    previewPngExists: true
+                )
+            ],
+            requestJSONPath: "/data/casa-rs-runs/output.casars-request.json",
+            stdoutPath: "/data/casa-rs-runs/output.casars-result.json",
+            stderrPath: "/data/casa-rs-runs/output.casars-stderr.log",
+            protocolSummary: #"{"protocol_name":"casars_imager_task"}"#,
+            diagnostics: ["synthetic warning"]
+        )
+        eventHandler(event ?? .succeeded(result))
+        return StubDirtyImagingExecution()
+    }
+}
+
+private final class StubDirtyImagingExecution: DirtyImagingTaskExecution {
+    var didCancel = false
+
+    func cancel() {
+        didCancel = true
     }
 }

--- a/apps/casars-mac/Tests/CasarsMacCoreTests/WorkbenchStoreTests.swift
+++ b/apps/casars-mac/Tests/CasarsMacCoreTests/WorkbenchStoreTests.swift
@@ -421,6 +421,7 @@ final class WorkbenchStoreTests: XCTestCase {
         XCTAssertEqual(plotClient.requests.last?.preset, .uvCoverage)
         XCTAssertNil(plotClient.requests.last?.field)
         XCTAssertNil(plotClient.requests.last?.spectralWindow)
+        XCTAssertEqual(plotClient.requests.count, 1)
 
         store.setMeasurementSetPlotPreset(.amplitudeVsUvDistance, datasetID: probedDataset.id)
         store.setMeasurementSetPlotField("0: Target", datasetID: probedDataset.id)
@@ -432,6 +433,20 @@ final class WorkbenchStoreTests: XCTestCase {
         XCTAssertEqual(plotClient.requests.last?.field, "0")
         XCTAssertEqual(plotClient.requests.last?.spectralWindow, "0")
         XCTAssertEqual(plotClient.requests.last?.dataColumn, "DATA")
+        XCTAssertEqual(plotClient.requests.count, 2)
+
+        store.setMeasurementSetPlotField("all", datasetID: probedDataset.id)
+        store.setMeasurementSetPlotSpectralWindow("all", datasetID: probedDataset.id)
+        store.setMeasurementSetPlotPreset(.uvCoverage, datasetID: probedDataset.id)
+
+        snapshot = store.debugSnapshot()
+        XCTAssertEqual(snapshot.measurementSetPlots[probedDataset.id]?.status, .ready)
+        XCTAssertEqual(snapshot.measurementSetPlots[probedDataset.id]?.title, "UV Coverage")
+        XCTAssertEqual(plotClient.requests.count, 2)
+
+        store.runMeasurementSetPlot(datasetID: probedDataset.id)
+
+        XCTAssertEqual(plotClient.requests.count, 2)
     }
 
     func testInterfaceFontSizeIsAdjustableClampedAndPreservedAcrossFixtureOpen() {

--- a/apps/casars-mac/Tests/CasarsMacCoreTests/WorkbenchStoreTests.swift
+++ b/apps/casars-mac/Tests/CasarsMacCoreTests/WorkbenchStoreTests.swift
@@ -424,12 +424,19 @@ final class WorkbenchStoreTests: XCTestCase {
         XCTAssertEqual(plotClient.requests.count, 1)
 
         store.setMeasurementSetPlotPreset(.amplitudeVsUvDistance, datasetID: probedDataset.id)
+        snapshot = store.debugSnapshot()
+        XCTAssertEqual(snapshot.measurementSetPlots[probedDataset.id]?.preset, .amplitudeVsUvDistance)
+        XCTAssertEqual(snapshot.measurementSetPlots[probedDataset.id]?.status, .idle)
+        XCTAssertNil(snapshot.measurementSetPlots[probedDataset.id]?.resultPreset)
+        XCTAssertNil(snapshot.measurementSetPlots[probedDataset.id]?.title)
+
         store.setMeasurementSetPlotField("0: Target", datasetID: probedDataset.id)
         store.setMeasurementSetPlotSpectralWindow("spw 0: 4 chan, 1.420000 GHz center", datasetID: probedDataset.id)
         store.runMeasurementSetPlot(datasetID: probedDataset.id)
 
         snapshot = store.debugSnapshot()
         XCTAssertEqual(snapshot.measurementSetPlots[probedDataset.id]?.preset, .amplitudeVsUvDistance)
+        XCTAssertEqual(snapshot.measurementSetPlots[probedDataset.id]?.resultPreset, .amplitudeVsUvDistance)
         XCTAssertEqual(plotClient.requests.last?.field, "0")
         XCTAssertEqual(plotClient.requests.last?.spectralWindow, "0")
         XCTAssertEqual(plotClient.requests.last?.dataColumn, "DATA")
@@ -441,6 +448,7 @@ final class WorkbenchStoreTests: XCTestCase {
 
         snapshot = store.debugSnapshot()
         XCTAssertEqual(snapshot.measurementSetPlots[probedDataset.id]?.status, .ready)
+        XCTAssertEqual(snapshot.measurementSetPlots[probedDataset.id]?.resultPreset, .uvCoverage)
         XCTAssertEqual(snapshot.measurementSetPlots[probedDataset.id]?.title, "UV Coverage")
         XCTAssertEqual(plotClient.requests.count, 2)
 
@@ -491,6 +499,7 @@ private final class StubMeasurementSetPlotClient: MeasurementSetPlotClient {
     func buildPlot(request: MeasurementSetPlotBuildRequest) throws -> MeasurementSetPlotResultSummary {
         requests.append(request)
         return makePlotResult(
+            preset: request.preset,
             presetLabel: request.preset.title,
             title: request.preset.title,
             datasetPath: request.datasetPath,
@@ -503,6 +512,7 @@ private final class StubMeasurementSetPlotClient: MeasurementSetPlotClient {
 }
 
 private func makePlotResult(
+    preset: MeasurementSetExplorerPlotPreset = .uvCoverage,
     presetLabel: String = "UV Coverage",
     title: String = "UV Coverage",
     datasetPath: String = "/data/probed.ms",
@@ -514,6 +524,7 @@ private func makePlotResult(
         = Data([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
 ) -> MeasurementSetPlotResultSummary {
     MeasurementSetPlotResultSummary(
+        preset: preset,
         presetLabel: presetLabel,
         title: title,
         summary: "Synthetic plot result for tests.",

--- a/apps/casars-mac/script/build_and_run.sh
+++ b/apps/casars-mac/script/build_and_run.sh
@@ -16,9 +16,11 @@ APP_CONTENTS="$APP_BUNDLE/Contents"
 APP_MACOS="$APP_CONTENTS/MacOS"
 APP_FRAMEWORKS="$APP_CONTENTS/Frameworks"
 APP_BINARY="$APP_MACOS/$APP_NAME"
+IMAGER_HELPER="$APP_MACOS/casars-imager"
 INFO_PLIST="$APP_CONTENTS/Info.plist"
 FRONTEND_DYLIB_NAME="libcasars_frontend_services.dylib"
 FRONTEND_DYLIB="$REPO_ROOT/target/debug/$FRONTEND_DYLIB_NAME"
+IMAGER_BINARY="$REPO_ROOT/target/debug/casars-imager"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -43,6 +45,7 @@ done
 
 cd "$REPO_ROOT"
 "$REPO_ROOT/scripts/generate-frontend-bindings.sh" "$REPO_ROOT/target/frontend-bindings"
+cargo build -p casars-imager
 
 cd "$ROOT_DIR"
 
@@ -55,7 +58,8 @@ rm -rf "$APP_BUNDLE"
 mkdir -p "$APP_MACOS" "$APP_FRAMEWORKS"
 cp "$BUILD_BINARY" "$APP_BINARY"
 cp "$FRONTEND_DYLIB" "$APP_FRAMEWORKS/$FRONTEND_DYLIB_NAME"
-chmod +x "$APP_BINARY"
+cp "$IMAGER_BINARY" "$IMAGER_HELPER"
+chmod +x "$APP_BINARY" "$IMAGER_HELPER"
 
 frontend_dependency="$(
   otool -L "$APP_BINARY" \
@@ -89,6 +93,7 @@ cat >"$INFO_PLIST" <<PLIST
 PLIST
 
 codesign --force --sign - "$APP_FRAMEWORKS/$FRONTEND_DYLIB_NAME" >/dev/null
+codesign --force --sign - "$IMAGER_HELPER" >/dev/null
 codesign --force --sign - "$APP_BINARY" >/dev/null
 codesign --force --sign - "$APP_BUNDLE" >/dev/null
 

--- a/crates/casa-ms/src/plot.rs
+++ b/crates/casa-ms/src/plot.rs
@@ -129,7 +129,7 @@ impl ListObsPlotKind {
         let mut options = BTreeMap::new();
         match self {
             Self::UvCoverage => {
-                options.insert("draw_mode".to_string(), "tracks".to_string());
+                options.insert("draw_mode".to_string(), "points".to_string());
                 options.insert("mirror".to_string(), "on".to_string());
                 options.insert("axis_extent".to_string(), "auto".to_string());
             }
@@ -574,7 +574,7 @@ pub fn build_listobs_uv_plot_payload(
             spec.kind
         ));
     }
-    let draw_points = match spec.option("draw_mode").unwrap_or("tracks") {
+    let draw_points = match spec.option("draw_mode").unwrap_or("points") {
         "tracks" => false,
         "points" => true,
         value => return Err(format!("invalid draw_mode {value:?} for uv_coverage")),
@@ -1829,6 +1829,10 @@ mod tests {
         let coverage = synthetic_uv_coverage();
         let spec = ListObsPlotKind::UvCoverage.default_spec();
         let payload = build_listobs_uv_plot_payload(&coverage, &spec).unwrap();
+        let ListObsPlotPayload::UvCoverage(uv_payload) = &payload else {
+            panic!("expected uv payload");
+        };
+        assert!(uv_payload.draw_points);
         let image =
             render_listobs_plot_image(&payload, ListObsPlotTheme::dark(), 640, 640).unwrap();
         assert_eq!(image.width(), 640);
@@ -1849,6 +1853,21 @@ mod tests {
             render_listobs_plot_image(&payload, ListObsPlotTheme::dark(), 512, 512).unwrap();
         assert_eq!(image.width(), 512);
         assert_eq!(image.height(), 512);
+    }
+
+    #[test]
+    fn uv_tracks_mode_remains_explicitly_available() {
+        let coverage = synthetic_uv_coverage();
+        let spec = ListObsPlotSpec::from_cli_assignments(
+            ListObsPlotKind::UvCoverage,
+            &["draw_mode=tracks".to_string()],
+        )
+        .unwrap();
+        let payload = build_listobs_uv_plot_payload(&coverage, &spec).unwrap();
+        let ListObsPlotPayload::UvCoverage(payload) = payload else {
+            panic!("expected uv payload");
+        };
+        assert!(!payload.draw_points);
     }
 
     #[test]

--- a/crates/casars-frontend-services/src/lib.rs
+++ b/crates/casars-frontend-services/src/lib.rs
@@ -620,51 +620,26 @@ fn probe_measurement_set(
         Ok(ms) => ms,
         Err(_) => return Ok(None),
     };
-    let summary = match ms.summary() {
-        Ok(summary) => summary,
+    let fields = match ms_field_labels(&ms) {
+        Ok(fields) => fields,
+        Err(_) => return Ok(None),
+    };
+    let spectral_windows = match ms_spectral_window_labels(&ms) {
+        Ok(spectral_windows) => spectral_windows,
+        Err(_) => return Ok(None),
+    };
+    let antennas = match ms_antenna_labels(&ms) {
+        Ok(antennas) => antennas,
+        Err(_) => return Ok(None),
+    };
+    let correlations = match ms_correlation_labels(&ms) {
+        Ok(correlations) => correlations,
         Err(_) => return Ok(None),
     };
     let columns = table_columns(ms.main_table());
     let data_columns = visibility_data_columns(&columns);
     let subtables = ms_subtables(&ms);
-    let fields = summary
-        .fields
-        .iter()
-        .map(|field| format!("{}: {}", field.field_id, field.name))
-        .collect();
-    let spectral_windows = summary
-        .spectral_windows
-        .iter()
-        .map(|spw| {
-            format!(
-                "spw {}: {} chan, {:.6} GHz center",
-                spw.spectral_window_id,
-                spw.num_channels,
-                spw.center_frequency_hz / 1.0e9
-            )
-        })
-        .collect();
-    let scans = summary
-        .scans
-        .iter()
-        .map(|scan| {
-            format!(
-                "scan {}: {} rows, {}",
-                scan.scan_number, scan.row_count, scan.field_name
-            )
-        })
-        .collect();
-    let antennas = summary
-        .antennas
-        .iter()
-        .map(|antenna| antenna.name.clone())
-        .collect();
-    let correlations = unique_sorted(
-        summary
-            .polarization_setups
-            .iter()
-            .flat_map(|polarization| polarization.correlation_types.iter().cloned()),
-    );
+    let row_count = ms.row_count();
 
     Ok(Some(DatasetProbe {
         id: stable_id(path),
@@ -676,25 +651,111 @@ fn probe_measurement_set(
         probed_unix_seconds: now_unix_seconds(),
         logical_size: format!(
             "{} rows, {} fields, {} spw, {} antennas",
-            summary.measurement_set.row_count,
-            summary.measurement_set.field_count,
-            summary.measurement_set.spectral_window_count,
-            summary.measurement_set.antenna_count
+            row_count,
+            fields.len(),
+            spectral_windows.len(),
+            antennas.len()
         ),
         units: "Jy, Hz, seconds".to_string(),
         fields,
         spectral_windows,
-        scans,
+        scans: vec![],
         antennas,
         correlations,
         columns,
         data_columns,
         subtables,
-        shape: vec![summary.measurement_set.row_count as u64],
-        notes: "Recognized by opening the path as a MeasurementSet and reading MS metadata."
+        shape: vec![row_count as u64],
+        notes: "Recognized by opening the path as a MeasurementSet and reading lightweight MS metadata."
             .to_string(),
         diagnostics,
     }))
+}
+
+fn ms_field_labels(ms: &MeasurementSet) -> Result<Vec<String>, String> {
+    let fields = ms.field().map_err(|error| error.to_string())?;
+    (0..fields.row_count())
+        .map(|row| {
+            fields
+                .name(row)
+                .map(|name| format!("{row}: {name}"))
+                .map_err(|error| error.to_string())
+        })
+        .collect()
+}
+
+fn ms_spectral_window_labels(ms: &MeasurementSet) -> Result<Vec<String>, String> {
+    let spectral_windows = ms.spectral_window().map_err(|error| error.to_string())?;
+    (0..spectral_windows.row_count())
+        .map(|row| {
+            let num_chan = spectral_windows
+                .num_chan(row)
+                .map_err(|error| error.to_string())?;
+            let chan_freq = spectral_windows.chan_freq(row).unwrap_or_default();
+            let center_hz = if chan_freq.is_empty() {
+                spectral_windows
+                    .ref_frequency(row)
+                    .map_err(|error| error.to_string())?
+            } else {
+                mean_or_zero(&chan_freq)
+            };
+            Ok(format!(
+                "spw {}: {} chan, {:.6} GHz center",
+                row,
+                num_chan,
+                center_hz / 1.0e9
+            ))
+        })
+        .collect()
+}
+
+fn ms_antenna_labels(ms: &MeasurementSet) -> Result<Vec<String>, String> {
+    let antennas = ms.antenna().map_err(|error| error.to_string())?;
+    (0..antennas.row_count())
+        .map(|row| antennas.name(row).map_err(|error| error.to_string()))
+        .collect()
+}
+
+fn ms_correlation_labels(ms: &MeasurementSet) -> Result<Vec<String>, String> {
+    let polarization = ms.polarization().map_err(|error| error.to_string())?;
+    let mut labels = Vec::new();
+    for row in 0..polarization.row_count() {
+        labels.extend(
+            polarization
+                .corr_type(row)
+                .map_err(|error| error.to_string())?
+                .into_iter()
+                .map(stokes_name)
+                .map(str::to_string),
+        );
+    }
+    Ok(unique_sorted(labels))
+}
+
+fn stokes_name(code: i32) -> &'static str {
+    match code {
+        1 => "I",
+        2 => "Q",
+        3 => "U",
+        4 => "V",
+        5 => "RR",
+        6 => "RL",
+        7 => "LR",
+        8 => "LL",
+        9 => "XX",
+        10 => "XY",
+        11 => "YX",
+        12 => "YY",
+        _ => "??",
+    }
+}
+
+fn mean_or_zero(values: &[f64]) -> f64 {
+    if values.is_empty() {
+        0.0
+    } else {
+        values.iter().sum::<f64>() / values.len() as f64
+    }
 }
 
 fn probe_image(path: &Path, metadata: &fs::Metadata) -> Result<Option<DatasetProbe>, String> {

--- a/crates/casars-imager/src/task_contract.rs
+++ b/crates/casars-imager/src/task_contract.rs
@@ -2007,4 +2007,58 @@ mod tests {
                 .all(|artifact| artifact.preview_png_path.is_none())
         );
     }
+
+    #[test]
+    fn dirty_imaging_json_request_accepts_gui_selection_fields() {
+        let payload = r#"{
+          "kind": "run",
+          "request": {
+            "measurement_set": "/data/probed.ms",
+            "image_name": "/data/casa-rs-runs/probed-dirty",
+            "image_size": 256,
+            "cell_arcsec": 0.25,
+            "field_ids": [0],
+            "phasecenter_field": 0,
+            "spw_selector": "0",
+            "channel_start": 2,
+            "channel_count": 4,
+            "data_column": "DATA",
+            "weighting": {
+              "kind": "briggs",
+              "robust": 0.5
+            },
+            "niter": 0,
+            "dirty_only": true,
+            "write_preview_pngs": true
+          }
+        }"#;
+        let request: ImagerTaskRequest =
+            serde_json::from_str(payload).expect("parse GUI dirty-imaging request");
+        let ImagerTaskRequest::Run(request) = request;
+        assert_eq!(request.measurement_set, PathBuf::from("/data/probed.ms"));
+        assert_eq!(
+            request.image_name,
+            PathBuf::from("/data/casa-rs-runs/probed-dirty")
+        );
+        assert_eq!(request.field_ids, Some(vec![0]));
+        assert_eq!(request.phasecenter_field, Some(0));
+        assert_eq!(request.spw_selector.as_deref(), Some("0"));
+        assert_eq!(request.channel_start, Some(2));
+        assert_eq!(request.channel_count, Some(4));
+        assert_eq!(request.data_column.as_deref(), Some("DATA"));
+        assert_eq!(request.weighting, ImagerWeighting::Briggs { robust: 0.5 });
+        assert_eq!(request.niter, 0);
+        assert!(request.dirty_only);
+        assert!(request.write_preview_pngs);
+
+        let config = request.to_cli_config().expect("restore CLI config");
+        assert_eq!(config.field_ids, Some(vec![0]));
+        assert_eq!(config.phasecenter_field, Some(0));
+        assert_eq!(config.spw_selector.as_deref(), Some("0"));
+        assert_eq!(config.channel_start, Some(2));
+        assert_eq!(config.channel_count, Some(4));
+        assert_eq!(config.datacolumn.as_deref(), Some("DATA"));
+        assert_eq!(config.weighting, WeightingMode::Briggs { robust: 0.5 });
+        assert!(config.dirty_only);
+    }
 }

--- a/docs/mac-native-gui-spec.md
+++ b/docs/mac-native-gui-spec.md
@@ -238,9 +238,14 @@ why, and what changed?"
 
 Task panels configure and execute casa-rs processing tasks.
 
-The first real task family is a pre-implementation decision, not a detail to
-defer until after the task-panel framework exists. Choose it with a small
-decision matrix:
+The first real task family is dirty imaging through `casars-imager --json-run`,
+the casa-rs equivalent of a common `tclean(..., niter=0)` pass. This was chosen
+because imaging is one of the two dominant radio astronomy workflows, the task
+takes a selected MeasurementSet as input, it produces visible image products,
+and it can exercise the run/provenance/debug spine without mutating the input
+science data.
+
+Future task families should still be chosen with a small decision matrix:
 
 - provider maturity
 - dataset-aware parameter richness
@@ -250,8 +255,9 @@ decision matrix:
 - validation needs
 - provenance and run-manifest needs
 
-Likely candidates are `calibrate` and `casars-imager`. The UI-first prototype
-may use a mocked task contract while this decision is still open.
+Calibration is the next primary task family to expose, but it should enter as a
+real `gaincal`/`bandpass`-class vertical rather than a rare prior-calibration
+task used only because it is easy to wire.
 
 Task panels are projected from provider schema bundles. The GUI may add native
 layout and interaction, but it must not invent a separate semantic schema.
@@ -262,8 +268,9 @@ work around it locally in the app.
 Task parameters should be context-sensitive:
 
 - dataset picker constrained to compatible inputs
-- field/spw/scan/antenna/correlation choices populated from the selected
+- source/field and phase-center defaults populated from the selected
   MeasurementSet
+- spw/channel/correlation choices populated from the selected MeasurementSet
 - output paths defaulted relative to the project
 - advanced parameters hidden until requested
 - validation errors tied to both schema rules and dataset-specific facts
@@ -273,7 +280,7 @@ Execution should produce a durable run record:
 
 - canonical JSON request
 - resolved dataset context
-- command or provider version
+- command or provider protocol/version
 - stdout/stderr
 - generated products
 - diagnostics
@@ -550,8 +557,11 @@ GUI-Wave-0 implements this in `apps/casars-mac` as a SwiftPM package with a
 `CasarsMacCore` library and `casars-mac` SwiftUI executable. GUI-Wave-1 adds
 `casars-frontend-services` for read-only real project/dataset probing. GUI-Wave-3
 adds a first real MeasurementSet plot API through the same frontend-service
-boundary while keeping task execution, image exploration, Python execution, and
-AI behavior stubbed unless separately approved.
+boundary. GUI-Wave-4 adds the first real task run by supervising a short-lived
+`casars-imager --json-run` dirty-imaging process from the Swift workbench,
+recording request/result/log artifacts in processing history, and surfacing run
+state through debug JSON. Image exploration, Python execution, and AI behavior
+remain stubbed unless separately approved.
 
 ## Testability And Debuggability
 
@@ -588,6 +598,7 @@ should include:
 - active central tab
 - command/search query state when present
 - task run states
+- current task request, diagnostics, logs, and output paths
 - AI chat messages and proposal states
 - Python terminal ownership state
 - processing-history events


### PR DESCRIPTION
Wave issue: #192

Closes #192

## Summary
- Add a real native macOS dirty-imaging task tab for selected MeasurementSets, including context-derived field, SPW, and data-column defaults, run and stop lifecycle, logs, diagnostics, and output artifacts.
- Supervise casars-imager protocol-info and json-run from Swift, capture request, result, and stderr artifacts, append produced image datasets, and expose request, output, and history state through debug JSON.
- Add Swift store tests, an imager JSON contract test, headless debug-state smoke support, and update GUI architecture, testing, and spec docs.

## Verification
- git diff --check
- just verify, after an initial sandboxed run reached Python package install and failed on blocked PyPI access; escalated rerun passed, including 45 Python package tests
- swift test from apps/casars-mac after final Swift edits
- Headless GUI smoke with CASARS_IMAGER_BIN pointing at target/debug/casars-imager and open-project set to /Users/brianglendenning/SoftwareProjects/casatestdata/measurementset/vla/ngc5921.ms; debug state showed UV coverage ready, taskState succeeded, produced image/PSF/residual/model artifacts, dirty-imaging-1 run paths, and no lastErrors
- just docs-check

Generated smoke-test products under the shared NGC5921 test-data project were removed after verification.