### PR TITLE
GUI tab runtime for independent workbench jobs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Architecture
 
 Truth class: current descriptive
-Last reality check: 2026-05-04
+Last reality check: 2026-05-05
 Verification: just docs-check
 
 ## System purpose
@@ -66,7 +66,13 @@ the Swift workbench supervises a short-lived `casars-imager --json-run`
 process for dirty imaging, records logs/results/products in processing history,
 and exposes the request/run state through the debug snapshot. This remains a
 narrow process-supervision path, not a shared background service, provider
-daemon, or repo-wide async runtime contract.
+daemon, or repo-wide async runtime contract. Issue #194 adds the first durable
+Swift-side workbench job coordinator for independent tab work: MeasurementSet
+plot rendering and dirty-imaging subprocess runs register per-tab jobs with
+pending/running/succeeded/failed/cancelled state, cancellation projection, logs,
+results/errors, and debug-snapshot visibility. The coordinator is intentionally
+local to `apps/casars-mac`; it does not introduce a provider daemon, durable
+project-history format, or repo-wide async runtime contract.
 
 ## Persistence / external systems
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,6 +799,7 @@ dependencies = [
  "anyhow",
  "camino",
  "cargo_metadata",
+ "casa-coordinates",
  "casa-images",
  "casa-ms",
  "casa-tables",

--- a/apps/casars-mac/README.md
+++ b/apps/casars-mac/README.md
@@ -1,13 +1,14 @@
 # casars-mac
 
 Truth class: current descriptive
-Last reality check: 2026-05-04
-Verification: swift test; swift run casars-mac --dump-debug-state --simulate-main-flow
+Last reality check: 2026-05-05
+Verification: swift test; swift run casars-mac --dump-debug-state --simulate-main-flow; ./script/build_and_run.sh --verify
 
 `casars-mac` is the SwiftUI prototype for the native macOS `casa-rs`
-workbench. GUI-Wave-0 is fixture-only: it demonstrates layout, actions,
-headless model tests, and debug-state inspection before real provider, Python,
-matplotlib, or AI execution is connected.
+workbench. The app keeps a synthetic demo fixture for layout and dry-run
+coverage, but the normal interactive launcher opens a fresh temporary project
+from a bundled real MeasurementSet fixture so plot and imaging paths exercise
+real dataset discovery.
 
 ## Commands
 
@@ -19,6 +20,8 @@ swift build
 swift run casars-mac --dump-debug-state --simulate-main-flow
 ./script/build_and_run.sh
 ./script/build_and_run.sh --verify
+./script/build_and_run.sh --project /path/to/project
+./script/build_and_run.sh --empty
 ```
 
 The `--dump-debug-state` path is intentionally non-interactive so local
@@ -30,7 +33,14 @@ actions in the testable core state. The runnable app also configures the
 primary macOS window for normal resizable and full-screen Space behavior.
 
 Use `./script/build_and_run.sh` for interactive GUI inspection. It stages a
-local `.app` bundle under `dist/` and launches that bundle with `/usr/bin/open`
-so Dock activation, menus, and native full-screen Spaces behave like a normal
-macOS app. `swift run casars-mac` is reserved for non-interactive debug-state
-commands and low-level executable diagnosis.
+local `.app` bundle under `dist/`, unpacks
+`crates/casa-ms/tests/fixtures/mssel_test_small_multifield_spw.ms.tgz` into a
+temporary project, and launches that project with `/usr/bin/open` so Dock
+activation, menus, and native full-screen Spaces behave like a normal macOS app.
+Dirty Imaging defaults for the bundled sample pick the NGC4826-F3 field, SPW 5
+(a 64-channel line window near the NGC4826 rest frequency), and raw YY because
+the sample has only one correlation plane. The temporary project is removed
+after the launched app exits. Pass `--project` to inspect an existing project
+directory, or `--empty` to start without opening a project. `swift run
+casars-mac` is reserved for non-interactive debug-state commands and low-level
+executable diagnosis.

--- a/apps/casars-mac/README.md
+++ b/apps/casars-mac/README.md
@@ -7,8 +7,8 @@ Verification: swift test; swift run casars-mac --dump-debug-state --simulate-mai
 `casars-mac` is the SwiftUI prototype for the native macOS `casa-rs`
 workbench. The app keeps a synthetic demo fixture for layout and dry-run
 coverage, but the normal interactive launcher opens a fresh temporary project
-from a bundled real MeasurementSet fixture so plot and imaging paths exercise
-real dataset discovery.
+from the local TW Hya tutorial MeasurementSet when available so plot and
+imaging paths exercise real dataset discovery with known tutorial parameters.
 
 ## Commands
 
@@ -33,14 +33,18 @@ actions in the testable core state. The runnable app also configures the
 primary macOS window for normal resizable and full-screen Space behavior.
 
 Use `./script/build_and_run.sh` for interactive GUI inspection. It stages a
-local `.app` bundle under `dist/`, unpacks
-`crates/casa-ms/tests/fixtures/mssel_test_small_multifield_spw.ms.tgz` into a
-temporary project, and launches that project with `/usr/bin/open` so Dock
+local `.app` bundle under `dist/`, unpacks the tutorial-registry
+`alma/first-look/twhya/calibrated-ms` archive from
+`${CASA_RS_TUTORIAL_DATA_ROOT}` or `~/SoftwareProjects/casa-tutorial-data` into
+a temporary project, and launches that project with `/usr/bin/open` so Dock
 activation, menus, and native full-screen Spaces behave like a normal macOS app.
-Dirty Imaging defaults for the bundled sample pick the NGC4826-F3 field, SPW 5
-(a 64-channel line window near the NGC4826 rest frequency), and raw YY because
-the sample has only one correlation plane. The temporary project is removed
-after the launched app exits. Pass `--project` to inspect an existing project
-directory, or `--empty` to start without opening a project. `swift run
+Dirty Imaging defaults for the TW Hya tutorial sample pick field 5, SPW 0,
+250 px, and 0.1 arcsec cells, matching the documented ALMA First Look MFS
+imaging slice. If the local tutorial archive is not staged, the launcher falls
+back to the bundled `mssel_test_small_multifield_spw.ms.tgz` fixture and its
+NGC4826-F3/SPW 5/raw YY defaults. Demo-mode temporary projects are removed
+after the launched app exits; the default launcher stays attached until that
+exit so cleanup is deterministic. Pass `--project` to inspect an existing
+project directory, or `--empty` to start without opening a project. `swift run
 casars-mac` is reserved for non-interactive debug-state commands and low-level
 executable diagnosis.

--- a/apps/casars-mac/Sources/CasarsMacApp/CentralWorkspaceView.swift
+++ b/apps/casars-mac/Sources/CasarsMacApp/CentralWorkspaceView.swift
@@ -862,6 +862,22 @@ struct DirtyImagingTaskPanel: View {
                 }
             }
             .accessibilityIdentifier("task.parameter.dataColumn")
+
+            Picker("Image plane", selection: Binding(
+                get: { parameters.correlation ?? "I" },
+                set: { store.setDirtyImagingCorrelation($0) }
+            )) {
+                Text("Stokes I").tag("I")
+                ForEach(dataset?.correlations ?? [], id: \.self) { correlation in
+                    Text("Raw \(correlation)").tag(correlation)
+                }
+            }
+            .accessibilityIdentifier("task.parameter.correlation")
+
+            Text(selectionHint(for: parameters))
+                .foregroundStyle(.secondary)
+                .workbenchFont(.caption)
+                .accessibilityIdentifier("task.parameter.selectionHint")
         }
         .taskCard()
     }
@@ -872,6 +888,16 @@ struct DirtyImagingTaskPanel: View {
 
     private func taskDataset(for parameters: DirtyImagingTaskParameters) -> DatasetSummary? {
         store.state.project.datasets.first { $0.id == parameters.datasetID }
+    }
+
+    private func selectionHint(for parameters: DirtyImagingTaskParameters) -> String {
+        guard let dataset = taskDataset(for: parameters) else {
+            return "Pick a MeasurementSet before running dirty imaging."
+        }
+        if dataset.name == "mssel_test_small_multifield_spw.ms" {
+            return "Sample defaults pick NGC4826-F3, spw 5, and raw YY: a target field with a 64-channel line window near the NGC4826 rest frequency."
+        }
+        return "Defaults prefer a science-like field, a multi-channel spectral window, and Stokes I when the MeasurementSet supports paired correlations."
     }
 
     private func imagingBlock(parameters: DirtyImagingTaskParameters) -> some View {

--- a/apps/casars-mac/Sources/CasarsMacApp/CentralWorkspaceView.swift
+++ b/apps/casars-mac/Sources/CasarsMacApp/CentralWorkspaceView.swift
@@ -894,6 +894,9 @@ struct DirtyImagingTaskPanel: View {
         guard let dataset = taskDataset(for: parameters) else {
             return "Pick a MeasurementSet before running dirty imaging."
         }
+        if dataset.name.lowercased().contains("twhya_calibrated.ms") {
+            return "Tutorial defaults pick TW Hya, spw 0, 250 px, and 0.1 arcsec cells from the ALMA First Look imaging guide."
+        }
         if dataset.name == "mssel_test_small_multifield_spw.ms" {
             return "Sample defaults pick NGC4826-F3, spw 5, and raw YY: a target field with a 64-channel line window near the NGC4826 rest frequency."
         }

--- a/apps/casars-mac/Sources/CasarsMacApp/WorkbenchView.swift
+++ b/apps/casars-mac/Sources/CasarsMacApp/WorkbenchView.swift
@@ -528,7 +528,6 @@ struct InspectorView: View {
 
         case .imageCube:
             InfoRow(label: "Shape", value: formatShape(dataset.shape))
-            InfoRow(label: "Pixel type", value: dataset.units)
             if !dataset.diagnostics.isEmpty {
                 DisclosureGroup("Image details (\(dataset.diagnostics.count))", isExpanded: $showColumns) {
                     valueList(dataset.diagnostics)

--- a/apps/casars-mac/Sources/CasarsMacCore/DirtyImagingTask.swift
+++ b/apps/casars-mac/Sources/CasarsMacCore/DirtyImagingTask.swift
@@ -46,6 +46,7 @@ public struct DirtyImagingTaskParameters: Codable, Equatable {
     public var channelStart: String
     public var channelCount: String
     public var dataColumn: String
+    public var correlation: String?
     public var imageSize: Int
     public var imageHeight: Int
     public var cellArcsec: Double
@@ -63,6 +64,7 @@ public struct DirtyImagingTaskParameters: Codable, Equatable {
         channelStart: String = "",
         channelCount: String = "",
         dataColumn: String,
+        correlation: String? = nil,
         imageSize: Int = 512,
         imageHeight: Int? = nil,
         cellArcsec: Double = 1.0,
@@ -79,6 +81,7 @@ public struct DirtyImagingTaskParameters: Codable, Equatable {
         self.channelStart = channelStart
         self.channelCount = channelCount
         self.dataColumn = dataColumn
+        self.correlation = correlation
         self.imageSize = imageSize
         self.imageHeight = imageHeight ?? imageSize
         self.cellArcsec = cellArcsec
@@ -95,6 +98,7 @@ public struct DirtyImagingTaskParameters: Codable, Equatable {
             "phasecenter=\(phaseCenterField ?? "auto")",
             "spw=\(selectedSpectralWindow ?? "all")",
             "data=\(dataColumn)",
+            "plane=\(correlation ?? "Stokes I")",
             "image=\(imageSize)x\(imageHeight) px",
             "cell=\(cellArcsec) arcsec",
             "weighting=\(weighting.rawValue)",
@@ -238,6 +242,7 @@ public struct DirtyImagingTaskRequest: Codable, Equatable {
                 dataColumn: parameters.dataColumn.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                     ? nil
                     : parameters.dataColumn,
+                correlation: selectorToken(parameters.correlation),
                 weighting: ImagerWeightingPayload(weighting: parameters.weighting),
                 niter: 0,
                 dirtyOnly: parameters.dirtyOnly,
@@ -603,6 +608,7 @@ private struct ImagerRunRequestPayload: Encodable {
     var channelStart: Int?
     var channelCount: Int?
     var dataColumn: String?
+    var correlation: String?
     var weighting: ImagerWeightingPayload
     var niter: Int
     var dirtyOnly: Bool
@@ -619,6 +625,7 @@ private struct ImagerRunRequestPayload: Encodable {
         case channelStart = "channel_start"
         case channelCount = "channel_count"
         case dataColumn = "data_column"
+        case correlation
         case weighting
         case niter
         case dirtyOnly = "dirty_only"

--- a/apps/casars-mac/Sources/CasarsMacCore/WorkbenchModels.swift
+++ b/apps/casars-mac/Sources/CasarsMacCore/WorkbenchModels.swift
@@ -190,6 +190,70 @@ public struct WorkbenchTab: Identifiable, Codable, Equatable {
     }
 }
 
+public enum WorkbenchJobKind: String, Codable, Equatable {
+    case measurementSetPlot
+    case dirtyImagingTask
+}
+
+public enum WorkbenchJobOwner: String, Codable, Equatable {
+    case user
+    case ai
+}
+
+public enum WorkbenchJobStatus: String, Codable, Equatable {
+    case pending
+    case running
+    case succeeded
+    case failed
+    case cancelled
+}
+
+public struct WorkbenchJob: Identifiable, Codable, Equatable {
+    public let id: String
+    public var tabID: String
+    public var kind: WorkbenchJobKind
+    public var owner: WorkbenchJobOwner
+    public var status: WorkbenchJobStatus
+    public var progress: Double
+    public var title: String
+    public var detail: String
+    public var logLines: [String]
+    public var resultSummary: String?
+    public var error: String?
+    public var cancellationRequested: Bool
+    public var lastEvent: String
+
+    public init(
+        id: String,
+        tabID: String,
+        kind: WorkbenchJobKind,
+        owner: WorkbenchJobOwner,
+        status: WorkbenchJobStatus = .pending,
+        progress: Double = 0,
+        title: String,
+        detail: String,
+        logLines: [String] = [],
+        resultSummary: String? = nil,
+        error: String? = nil,
+        cancellationRequested: Bool = false,
+        lastEvent: String = "created"
+    ) {
+        self.id = id
+        self.tabID = tabID
+        self.kind = kind
+        self.owner = owner
+        self.status = status
+        self.progress = progress
+        self.title = title
+        self.detail = detail
+        self.logLines = logLines
+        self.resultSummary = resultSummary
+        self.error = error
+        self.cancellationRequested = cancellationRequested
+        self.lastEvent = lastEvent
+    }
+}
+
 public enum TaskRunState: String, Codable, Equatable {
     case idle
     case running
@@ -571,6 +635,8 @@ public struct WorkbenchState: Codable, Equatable {
     public var python: PythonPanelState
     public var measurementSetPlots: [String: MeasurementSetExplorerPlotState]
     public var measurementSetPlotResultCache: [String: MeasurementSetPlotResultSummary]
+    public var jobs: [String: WorkbenchJob]
+    public var activeJobIDsByTab: [String: String]
     public var history: [ProcessingHistoryEvent]
     public var commandQuery: String
     public var lastErrors: [String]
@@ -593,6 +659,8 @@ public struct WorkbenchState: Codable, Equatable {
         python: PythonPanelState,
         measurementSetPlots: [String: MeasurementSetExplorerPlotState] = [:],
         measurementSetPlotResultCache: [String: MeasurementSetPlotResultSummary] = [:],
+        jobs: [String: WorkbenchJob] = [:],
+        activeJobIDsByTab: [String: String] = [:],
         history: [ProcessingHistoryEvent],
         commandQuery: String,
         lastErrors: [String],
@@ -614,6 +682,8 @@ public struct WorkbenchState: Codable, Equatable {
         self.python = python
         self.measurementSetPlots = measurementSetPlots
         self.measurementSetPlotResultCache = measurementSetPlotResultCache
+        self.jobs = jobs
+        self.activeJobIDsByTab = activeJobIDsByTab
         self.history = history
         self.commandQuery = commandQuery
         self.lastErrors = lastErrors
@@ -696,6 +766,9 @@ public struct DebugStateSnapshot: Codable, Equatable {
     public var aiProposalStates: [String: AIProposalState]
     public var pythonOwner: PythonOwner
     public var measurementSetPlots: [String: DebugMeasurementSetPlotSnapshot]
+    public var jobs: [DebugWorkbenchJobSnapshot]
+    public var activeJobIDsByTab: [String: String]
+    public var runningJobCount: Int
     public var processingHistoryEvents: [String]
     public var commandQuery: String
     public var lastErrors: [String]
@@ -727,10 +800,47 @@ public struct DebugStateSnapshot: Codable, Equatable {
                 (datasetID, DebugMeasurementSetPlotSnapshot(plotState: plotState))
             }
         )
+        jobs = state.jobs.values
+            .sorted { $0.id < $1.id }
+            .map(DebugWorkbenchJobSnapshot.init(job:))
+        activeJobIDsByTab = state.activeJobIDsByTab
+        runningJobCount = state.jobs.values.filter { $0.status == .running || $0.status == .pending }.count
         processingHistoryEvents = state.history.map(\.title)
         commandQuery = state.commandQuery
         lastErrors = state.lastErrors
         interfaceFontSize = state.interfaceFontSize
+    }
+}
+
+public struct DebugWorkbenchJobSnapshot: Codable, Equatable {
+    public var id: String
+    public var tabID: String
+    public var kind: WorkbenchJobKind
+    public var owner: WorkbenchJobOwner
+    public var status: WorkbenchJobStatus
+    public var progress: Double
+    public var title: String
+    public var detail: String
+    public var logLines: [String]
+    public var resultSummary: String?
+    public var error: String?
+    public var cancellationRequested: Bool
+    public var lastEvent: String
+
+    public init(job: WorkbenchJob) {
+        id = job.id
+        tabID = job.tabID
+        kind = job.kind
+        owner = job.owner
+        status = job.status
+        progress = job.progress
+        title = job.title
+        detail = job.detail
+        logLines = job.logLines
+        resultSummary = job.resultSummary
+        error = job.error
+        cancellationRequested = job.cancellationRequested
+        lastEvent = job.lastEvent
     }
 }
 

--- a/apps/casars-mac/Sources/CasarsMacCore/WorkbenchStore.swift
+++ b/apps/casars-mac/Sources/CasarsMacCore/WorkbenchStore.swift
@@ -99,7 +99,8 @@ public final class WorkbenchStore: ObservableObject {
     private let probeClient: ProjectProbeClient
     private let plotClient: MeasurementSetPlotClient
     private let dirtyImagingClient: DirtyImagingTaskClient
-    private var activeTaskExecution: DirtyImagingTaskExecution?
+    private let plotQueue = DispatchQueue(label: "casars.mac.ms-plot-job", qos: .userInitiated)
+    private var activeTaskExecutions: [String: DirtyImagingTaskExecution] = [:]
 
     public init(
         state: WorkbenchState = EmptyWorkbench.makeState(),
@@ -268,30 +269,58 @@ public final class WorkbenchStore: ObservableObject {
             state.measurementSetPlots[datasetID] = plotState
             return
         }
+
+        let request = MeasurementSetPlotBuildRequest(
+            datasetPath: dataset.path,
+            preset: plotState.preset,
+            field: selectorToken(plotState.selectedField),
+            spectralWindow: selectorToken(plotState.selectedSpectralWindow),
+            correlation: selectorToken(plotState.selectedCorrelation),
+            dataColumn: plotState.dataColumn
+        )
+        let tabID = dataset.explorerTabID
+        let jobID = nextJobID(prefix: "ms-plot")
+        startJob(
+            WorkbenchJob(
+                id: jobID,
+                tabID: tabID,
+                kind: .measurementSetPlot,
+                owner: .user,
+                status: .running,
+                progress: 0.05,
+                title: "Generate \(plotState.preset.title)",
+                detail: dataset.name,
+                logLines: ["Queued MeasurementSet plot render.", request.preset.title],
+                lastEvent: "started"
+            )
+        )
+
         plotState.status = .running
         plotState.lastError = nil
         state.measurementSetPlots[datasetID] = plotState
 
-        do {
-            let result = try plotClient.buildPlot(
-                request: MeasurementSetPlotBuildRequest(
-                    datasetPath: dataset.path,
-                    preset: plotState.preset,
-                    field: selectorToken(plotState.selectedField),
-                    spectralWindow: selectorToken(plotState.selectedSpectralWindow),
-                    correlation: selectorToken(plotState.selectedCorrelation),
-                    dataColumn: plotState.dataColumn
-                )
-            )
-            plotState.result = result
-            plotState.status = .ready
-            cacheMeasurementSetPlotResult(result, for: dataset, plotState: plotState)
-            state.measurementSetPlots[datasetID] = plotState
-        } catch {
-            plotState.status = .failed
-            plotState.lastError = "\(error)"
-            state.measurementSetPlots[datasetID] = plotState
-            state.lastErrors.append("Render plot for \(dataset.name): \(error)")
+        let requestedPlotState = plotState
+        plotQueue.async { [plotClient] in
+            do {
+                let result = try plotClient.buildPlot(request: request)
+                DispatchQueue.main.async { [weak self] in
+                    self?.finishMeasurementSetPlotJob(
+                        jobID: jobID,
+                        dataset: dataset,
+                        plotState: requestedPlotState,
+                        result: result
+                    )
+                }
+            } catch {
+                DispatchQueue.main.async { [weak self] in
+                    self?.failMeasurementSetPlotJob(
+                        jobID: jobID,
+                        datasetID: datasetID,
+                        datasetName: dataset.name,
+                        error: "\(error)"
+                    )
+                }
+            }
         }
     }
 
@@ -701,8 +730,23 @@ public final class WorkbenchStore: ObservableObject {
             return
         }
 
-        let runID = "dirty-imaging-\(nextDirtyImagingRunIndex())"
+        let runID = nextJobID(prefix: "dirty-imaging")
         let request = DirtyImagingTaskRequest(runID: runID, parameters: parameters)
+        let tabID = activeTaskTabID(parameters: parameters)
+        startJob(
+            WorkbenchJob(
+                id: runID,
+                tabID: tabID,
+                kind: .dirtyImagingTask,
+                owner: .user,
+                status: .running,
+                progress: 0.05,
+                title: "Dirty imaging",
+                detail: parameters.measurementSetPath,
+                logLines: ["Starting casars-imager dirty imaging task.", parameters.requestSummary],
+                lastEvent: "started"
+            )
+        )
         state.taskRun = TaskRun(
             runID: runID,
             state: .running,
@@ -719,22 +763,13 @@ public final class WorkbenchStore: ObservableObject {
 
         do {
             let execution = try dirtyImagingClient.startDirtyImaging(request: request) { [weak self] event in
-                self?.handleDirtyImagingEvent(event, runID: runID)
+                self?.handleDirtyImagingEvent(event, runID: runID, jobID: runID)
             }
-            if state.taskRun.runID == runID && state.taskRun.state == .running {
-                activeTaskExecution = execution
+            if state.jobs[runID]?.status == .running {
+                activeTaskExecutions[runID] = execution
             }
         } catch {
-            state.taskRun = TaskRun(
-                runID: runID,
-                state: .failed,
-                progress: 1.0,
-                logLines: ["Failed to start casars-imager."],
-                warnings: [],
-                products: [],
-                diagnostics: ["\(error)"],
-                requestSummary: parameters.requestSummary
-            )
+            failDirtyImagingJob(runID: runID, message: "Failed to start casars-imager.", diagnostics: ["\(error)"])
             state.lastErrors.append("Start dirty imaging: \(error)")
         }
     }
@@ -746,15 +781,11 @@ public final class WorkbenchStore: ObservableObject {
             return
         }
 
-        guard state.taskRun.state == .running else {
+        guard state.taskRun.state == .running, let runID = state.taskRun.runID else {
             state.lastErrors.append("No dirty imaging task is running")
             return
         }
-        activeTaskExecution?.cancel()
-        activeTaskExecution = nil
-        state.taskRun.state = .cancelled
-        state.taskRun.progress = 1.0
-        state.taskRun.logLines.append("Cancellation requested for dirty imaging task.")
+        cancelJob(runID, recordError: false)
         state.history.append(
             ProcessingHistoryEvent(
                 id: "hist-run-\(state.history.count + 1)",
@@ -798,6 +829,123 @@ public final class WorkbenchStore: ObservableObject {
         }
         let data = try encoder.encode(debugSnapshot())
         return String(decoding: data, as: UTF8.self)
+    }
+
+    public func cancelJob(_ jobID: String) {
+        cancelJob(jobID, recordError: true)
+    }
+
+    private func startJob(_ job: WorkbenchJob) {
+        if let existingJobID = state.activeJobIDsByTab[job.tabID] {
+            cancelJob(existingJobID, recordError: false)
+        }
+        state.jobs[job.id] = job
+        state.activeJobIDsByTab[job.tabID] = job.id
+    }
+
+    private func cancelJob(_ jobID: String, recordError: Bool) {
+        guard var job = state.jobs[jobID] else {
+            if recordError {
+                state.lastErrors.append("Unknown job \(jobID)")
+            }
+            return
+        }
+        guard job.status == .pending || job.status == .running else {
+            return
+        }
+
+        job.status = .cancelled
+        job.progress = 1.0
+        job.cancellationRequested = true
+        job.lastEvent = "cancelled"
+        job.logLines.append("Cancellation requested.")
+        state.jobs[jobID] = job
+        if state.activeJobIDsByTab[job.tabID] == jobID {
+            state.activeJobIDsByTab.removeValue(forKey: job.tabID)
+        }
+
+        switch job.kind {
+        case .measurementSetPlot:
+            if let datasetID = datasetIDForExplorerTabID(job.tabID),
+               var plotState = state.measurementSetPlots[datasetID] {
+                plotState.status = .idle
+                plotState.lastError = "Cancelled"
+                state.measurementSetPlots[datasetID] = plotState
+            }
+        case .dirtyImagingTask:
+            activeTaskExecutions[jobID]?.cancel()
+            activeTaskExecutions.removeValue(forKey: jobID)
+            if state.taskRun.runID == jobID || state.taskRun.state == .running {
+                state.taskRun.state = .cancelled
+                state.taskRun.progress = 1.0
+                state.taskRun.logLines.append("Cancellation requested for dirty imaging task.")
+            }
+        }
+    }
+
+    private func nextJobID(prefix: String) -> String {
+        "\(prefix)-\(state.jobs.count + 1)"
+    }
+
+    private func datasetIDForExplorerTabID(_ tabID: String) -> String? {
+        let prefix = "tab-explorer-"
+        guard tabID.hasPrefix(prefix) else { return nil }
+        return String(tabID.dropFirst(prefix.count))
+    }
+
+    private func finishMeasurementSetPlotJob(
+        jobID: String,
+        dataset: DatasetSummary,
+        plotState requestedPlotState: MeasurementSetExplorerPlotState,
+        result: MeasurementSetPlotResultSummary
+    ) {
+        guard var job = state.jobs[jobID], job.status != .cancelled else {
+            return
+        }
+        guard state.activeJobIDsByTab[job.tabID] == jobID else {
+            return
+        }
+
+        cacheMeasurementSetPlotResult(result, for: dataset, plotState: requestedPlotState)
+        var currentPlotState = measurementSetPlotState(for: dataset.id)
+        refreshMeasurementSetPlotStateFromCache(&currentPlotState, datasetID: dataset.id)
+        state.measurementSetPlots[dataset.id] = currentPlotState
+
+        job.status = .succeeded
+        job.progress = 1.0
+        job.resultSummary = result.summary
+        job.lastEvent = "succeeded"
+        job.logLines.append("Rendered \(result.renderedPointCount) points.")
+        state.jobs[jobID] = job
+        state.activeJobIDsByTab.removeValue(forKey: job.tabID)
+    }
+
+    private func failMeasurementSetPlotJob(
+        jobID: String,
+        datasetID: String,
+        datasetName: String,
+        error: String
+    ) {
+        guard var job = state.jobs[jobID], job.status != .cancelled else {
+            return
+        }
+        guard state.activeJobIDsByTab[job.tabID] == jobID else {
+            return
+        }
+
+        var plotState = measurementSetPlotState(for: datasetID)
+        plotState.status = .failed
+        plotState.lastError = error
+        state.measurementSetPlots[datasetID] = plotState
+
+        job.status = .failed
+        job.progress = 1.0
+        job.error = error
+        job.lastEvent = "failed"
+        job.logLines.append(error)
+        state.jobs[jobID] = job
+        state.activeJobIDsByTab.removeValue(forKey: job.tabID)
+        state.lastErrors.append("Render plot for \(datasetName): \(error)")
     }
 
     private func openExplorer(for dataset: DatasetSummary) {

--- a/apps/casars-mac/Sources/CasarsMacCore/WorkbenchStore.swift
+++ b/apps/casars-mac/Sources/CasarsMacCore/WorkbenchStore.swift
@@ -510,6 +510,12 @@ public final class WorkbenchStore: ObservableObject {
         updateDirtyImagingParameters(parameters)
     }
 
+    public func setDirtyImagingCorrelation(_ correlation: String?) {
+        guard var parameters = state.dirtyImagingTaskParameters else { return }
+        parameters.correlation = normalizedPickerValue(correlation)
+        updateDirtyImagingParameters(parameters)
+    }
+
     public func setDirtyImagingOutputPrefix(_ outputPrefix: String) {
         guard var parameters = state.dirtyImagingTaskParameters else { return }
         parameters.outputPrefix = outputPrefix
@@ -1053,7 +1059,7 @@ public final class WorkbenchStore: ObservableObject {
     }
 
     private func defaultDirtyImagingParameters(for dataset: DatasetSummary) -> DirtyImagingTaskParameters {
-        let firstField = dataset.fields.first
+        let firstField = defaultDirtyImagingField(for: dataset)
         let outputPrefix = defaultDirtyImagingOutputPrefix(for: dataset)
         return DirtyImagingTaskParameters(
             datasetID: dataset.id,
@@ -1061,9 +1067,56 @@ public final class WorkbenchStore: ObservableObject {
             outputPrefix: outputPrefix,
             selectedField: firstField,
             phaseCenterField: firstField,
-            selectedSpectralWindow: dataset.spectralWindows.first,
-            dataColumn: dataset.dataColumns.first ?? "DATA"
+            selectedSpectralWindow: defaultDirtyImagingSpectralWindow(for: dataset),
+            dataColumn: dataset.dataColumns.first ?? "DATA",
+            correlation: defaultDirtyImagingCorrelation(for: dataset)
         )
+    }
+
+    private func defaultDirtyImagingField(for dataset: DatasetSummary) -> String? {
+        if dataset.name == "mssel_test_small_multifield_spw.ms",
+           let sampleField = dataset.fields.first(where: { selectorToken($0) == "5" }) {
+            return sampleField
+        }
+        if let scienceLikeField = dataset.fields.first(where: { field in
+            let normalized = field.lowercased()
+            return normalized.contains("ngc") || normalized.contains("target")
+        }) {
+            return scienceLikeField
+        }
+        return dataset.fields.first
+    }
+
+    private func defaultDirtyImagingSpectralWindow(for dataset: DatasetSummary) -> String? {
+        if dataset.name == "mssel_test_small_multifield_spw.ms",
+           let sampleSpectralWindow = dataset.spectralWindows.first(where: { selectorToken($0) == "5" }) {
+            return sampleSpectralWindow
+        }
+        return dataset.spectralWindows.first(where: spectralWindowHasMultipleChannels) ?? dataset.spectralWindows.first
+    }
+
+    private func defaultDirtyImagingCorrelation(for dataset: DatasetSummary) -> String? {
+        let rawCorrelations = dataset.correlations.map { $0.uppercased() }
+        if rawCorrelations.count == 1,
+           ["XX", "YY", "RR", "LL"].contains(rawCorrelations[0]) {
+            return rawCorrelations[0]
+        }
+        return nil
+    }
+
+    private func spectralWindowHasMultipleChannels(_ spectralWindow: String) -> Bool {
+        guard let channelCount = spectralWindowChannelCount(spectralWindow) else {
+            return false
+        }
+        return channelCount > 1
+    }
+
+    private func spectralWindowChannelCount(_ spectralWindow: String) -> Int? {
+        guard let channelRange = spectralWindow.range(of: #"(\d+)\s+chan"#, options: .regularExpression) else {
+            return nil
+        }
+        let token = spectralWindow[channelRange].split(separator: " ").first
+        return token.flatMap { Int($0) }
     }
 
     private func blankDirtyImagingParameters() -> DirtyImagingTaskParameters {

--- a/apps/casars-mac/Sources/CasarsMacCore/WorkbenchStore.swift
+++ b/apps/casars-mac/Sources/CasarsMacCore/WorkbenchStore.swift
@@ -1061,6 +1061,7 @@ public final class WorkbenchStore: ObservableObject {
     private func defaultDirtyImagingParameters(for dataset: DatasetSummary) -> DirtyImagingTaskParameters {
         let firstField = defaultDirtyImagingField(for: dataset)
         let outputPrefix = defaultDirtyImagingOutputPrefix(for: dataset)
+        let isTutorialTWHya = isTWHyaTutorialDataset(dataset)
         return DirtyImagingTaskParameters(
             datasetID: dataset.id,
             measurementSetPath: dataset.path,
@@ -1069,11 +1070,17 @@ public final class WorkbenchStore: ObservableObject {
             phaseCenterField: firstField,
             selectedSpectralWindow: defaultDirtyImagingSpectralWindow(for: dataset),
             dataColumn: dataset.dataColumns.first ?? "DATA",
-            correlation: defaultDirtyImagingCorrelation(for: dataset)
+            correlation: defaultDirtyImagingCorrelation(for: dataset),
+            imageSize: isTutorialTWHya ? 250 : 512,
+            cellArcsec: isTutorialTWHya ? 0.1 : 1.0
         )
     }
 
     private func defaultDirtyImagingField(for dataset: DatasetSummary) -> String? {
+        if isTWHyaTutorialDataset(dataset),
+           let tutorialField = dataset.fields.first(where: { selectorToken($0) == "5" }) {
+            return tutorialField
+        }
         if dataset.name == "mssel_test_small_multifield_spw.ms",
            let sampleField = dataset.fields.first(where: { selectorToken($0) == "5" }) {
             return sampleField
@@ -1088,11 +1095,19 @@ public final class WorkbenchStore: ObservableObject {
     }
 
     private func defaultDirtyImagingSpectralWindow(for dataset: DatasetSummary) -> String? {
+        if isTWHyaTutorialDataset(dataset),
+           let tutorialSpectralWindow = dataset.spectralWindows.first(where: { selectorToken($0) == "0" }) {
+            return tutorialSpectralWindow
+        }
         if dataset.name == "mssel_test_small_multifield_spw.ms",
            let sampleSpectralWindow = dataset.spectralWindows.first(where: { selectorToken($0) == "5" }) {
             return sampleSpectralWindow
         }
         return dataset.spectralWindows.first(where: spectralWindowHasMultipleChannels) ?? dataset.spectralWindows.first
+    }
+
+    private func isTWHyaTutorialDataset(_ dataset: DatasetSummary) -> Bool {
+        dataset.name.lowercased().contains("twhya_calibrated.ms")
     }
 
     private func defaultDirtyImagingCorrelation(for dataset: DatasetSummary) -> String? {

--- a/apps/casars-mac/Sources/CasarsMacCore/WorkbenchStore.swift
+++ b/apps/casars-mac/Sources/CasarsMacCore/WorkbenchStore.swift
@@ -99,7 +99,7 @@ public final class WorkbenchStore: ObservableObject {
     private let probeClient: ProjectProbeClient
     private let plotClient: MeasurementSetPlotClient
     private let dirtyImagingClient: DirtyImagingTaskClient
-    private let plotQueue = DispatchQueue(label: "casars.mac.ms-plot-job", qos: .userInitiated)
+    private let plotQueue = DispatchQueue(label: "casars.mac.ms-plot-job", qos: .userInitiated, attributes: .concurrent)
     private var activeTaskExecutions: [String: DirtyImagingTaskExecution] = [:]
 
     public init(
@@ -875,7 +875,7 @@ public final class WorkbenchStore: ObservableObject {
         case .dirtyImagingTask:
             activeTaskExecutions[jobID]?.cancel()
             activeTaskExecutions.removeValue(forKey: jobID)
-            if state.taskRun.runID == jobID || state.taskRun.state == .running {
+            if state.taskRun.runID == jobID {
                 state.taskRun.state = .cancelled
                 state.taskRun.progress = 1.0
                 state.taskRun.logLines.append("Cancellation requested for dirty imaging task.")
@@ -891,6 +891,16 @@ public final class WorkbenchStore: ObservableObject {
         let prefix = "tab-explorer-"
         guard tabID.hasPrefix(prefix) else { return nil }
         return String(tabID.dropFirst(prefix.count))
+    }
+
+    private func activeTaskTabID(parameters: DirtyImagingTaskParameters) -> String {
+        if let activeTab = state.tabs.first(where: { $0.id == state.activeTabID && $0.kind == .task }) {
+            return activeTab.id
+        }
+        if !parameters.datasetID.isEmpty {
+            return "tab-dirty-imaging-\(parameters.datasetID)"
+        }
+        return "tab-dirty-imaging-unbound"
     }
 
     private func finishMeasurementSetPlotJob(
@@ -1099,39 +1109,99 @@ public final class WorkbenchStore: ObservableObject {
         }
     }
 
-    private func handleDirtyImagingEvent(_ event: DirtyImagingTaskEvent, runID: String) {
+    private func failDirtyImagingJob(runID: String, message: String, diagnostics: [String]) {
+        activeTaskExecutions.removeValue(forKey: runID)
+        if var job = state.jobs[runID], job.status != .cancelled {
+            job.status = .failed
+            job.progress = 1.0
+            job.error = message
+            job.lastEvent = "failed"
+            job.logLines.append(message)
+            job.logLines.append(contentsOf: diagnostics)
+            state.jobs[runID] = job
+            if state.activeJobIDsByTab[job.tabID] == runID {
+                state.activeJobIDsByTab.removeValue(forKey: job.tabID)
+            }
+        }
+
+        if state.taskRun.runID == runID {
+            state.taskRun = TaskRun(
+                runID: runID,
+                state: .failed,
+                progress: 1.0,
+                logLines: ["casars-imager dirty imaging failed.", message],
+                warnings: [],
+                products: [],
+                diagnostics: diagnostics,
+                requestSummary: state.dirtyImagingTaskParameters?.requestSummary
+            )
+        }
+    }
+
+    private func finishDirtyImagingJob(runID: String, result: DirtyImagingTaskResult) {
+        activeTaskExecutions.removeValue(forKey: runID)
+        if var job = state.jobs[runID], job.status != .cancelled {
+            job.status = .succeeded
+            job.progress = 1.0
+            job.resultSummary = result.report.summary
+            job.lastEvent = "succeeded"
+            job.logLines.append(result.report.summary)
+            job.logLines.append("Protocol: \(result.protocolSummary)")
+            state.jobs[runID] = job
+            if state.activeJobIDsByTab[job.tabID] == runID {
+                state.activeJobIDsByTab.removeValue(forKey: job.tabID)
+            }
+        }
+    }
+
+    private func cancelDirtyImagingJob(runID: String, failure: DirtyImagingTaskFailure) {
+        activeTaskExecutions.removeValue(forKey: runID)
+        if var job = state.jobs[runID] {
+            job.status = .cancelled
+            job.progress = 1.0
+            job.cancellationRequested = true
+            job.error = failure.message
+            job.lastEvent = "cancelled"
+            job.logLines.append(failure.message)
+            state.jobs[runID] = job
+            if state.activeJobIDsByTab[job.tabID] == runID {
+                state.activeJobIDsByTab.removeValue(forKey: job.tabID)
+            }
+        }
+    }
+
+    private func handleDirtyImagingEvent(_ event: DirtyImagingTaskEvent, runID: String, jobID: String) {
         guard Thread.isMainThread else {
             DispatchQueue.main.async { [weak self] in
-                self?.handleDirtyImagingEvent(event, runID: runID)
+                self?.handleDirtyImagingEvent(event, runID: runID, jobID: jobID)
             }
             return
         }
 
-        guard state.taskRun.runID == runID else {
+        guard state.jobs[jobID]?.status != .cancelled else {
             return
         }
 
         switch event {
         case .succeeded(let result):
-            guard state.taskRun.state != .cancelled else {
-                return
+            finishDirtyImagingJob(runID: jobID, result: result)
+            if state.taskRun.runID == runID {
+                state.taskRun = TaskRun(
+                    runID: runID,
+                    state: .succeeded,
+                    progress: 1.0,
+                    logLines: [
+                        "casars-imager completed dirty imaging.",
+                        result.report.summary,
+                        "Protocol: \(result.protocolSummary)"
+                    ],
+                    warnings: result.report.warnings,
+                    products: result.artifacts.map(\.path),
+                    diagnostics: result.diagnostics,
+                    outputPaths: result.outputPaths,
+                    requestSummary: result.request.parameters.requestSummary
+                )
             }
-            activeTaskExecution = nil
-            state.taskRun = TaskRun(
-                runID: runID,
-                state: .succeeded,
-                progress: 1.0,
-                logLines: [
-                    "casars-imager completed dirty imaging.",
-                    result.report.summary,
-                    "Protocol: \(result.protocolSummary)"
-                ],
-                warnings: result.report.warnings,
-                products: result.artifacts.map(\.path),
-                diagnostics: result.diagnostics,
-                outputPaths: result.outputPaths,
-                requestSummary: result.request.parameters.requestSummary
-            )
             appendProducedDatasets(from: result)
             state.history.append(
                 ProcessingHistoryEvent(
@@ -1145,23 +1215,15 @@ public final class WorkbenchStore: ObservableObject {
             )
 
         case .failed(let failure):
-            activeTaskExecution = nil
-            state.taskRun = TaskRun(
-                runID: runID,
-                state: .failed,
-                progress: 1.0,
-                logLines: ["casars-imager dirty imaging failed.", failure.message],
-                warnings: [],
-                products: [],
-                diagnostics: failure.diagnostics,
-                outputPaths: [failure.requestJSONPath, failure.stdoutPath, failure.stderrPath].compactMap { $0 },
-                requestSummary: state.dirtyImagingTaskParameters?.requestSummary
-            )
+            failDirtyImagingJob(runID: jobID, message: failure.message, diagnostics: failure.diagnostics)
+            if state.taskRun.runID == runID {
+                state.taskRun.outputPaths = [failure.requestJSONPath, failure.stdoutPath, failure.stderrPath].compactMap { $0 }
+            }
             state.lastErrors.append("Dirty imaging failed: \(failure.message)")
 
         case .cancelled(let failure):
-            activeTaskExecution = nil
-            if state.taskRun.state != .cancelled {
+            cancelDirtyImagingJob(runID: jobID, failure: failure)
+            if state.taskRun.runID == runID && state.taskRun.state != .cancelled {
                 state.taskRun.state = .cancelled
                 state.taskRun.progress = 1.0
                 state.taskRun.logLines.append(failure.message)

--- a/apps/casars-mac/Tests/CasarsMacCoreTests/WorkbenchStoreTests.swift
+++ b/apps/casars-mac/Tests/CasarsMacCoreTests/WorkbenchStoreTests.swift
@@ -534,6 +534,64 @@ final class WorkbenchStoreTests: XCTestCase {
         XCTAssertTrue(try XCTUnwrap(requestJSON).contains("\"correlation\" : \"YY\""))
     }
 
+    func testTWHyaTutorialDirtyImagingDefaultsUseKnownMFSParameters() throws {
+        let tutorial = DatasetSummary(
+            id: "/data/twhya_calibrated.ms",
+            name: "twhya_calibrated.ms",
+            path: "/data/twhya_calibrated.ms",
+            kind: .measurementSet,
+            size: "44772 selected rows, 1 spw",
+            units: "Jy, Hz, seconds",
+            fields: [
+                "0: J1037-295",
+                "1: Ceres",
+                "2: J1058+0133",
+                "3: J1107-4449",
+                "4: J1132-5606",
+                "5: TW Hya"
+            ],
+            spectralWindows: [
+                "spw 0: 384 chan, 372.533086 GHz center"
+            ],
+            correlations: ["XX", "YY"],
+            dataColumns: ["DATA"],
+            notes: "ALMA First Look TW Hya tutorial MeasurementSet."
+        )
+        let store = WorkbenchStore(
+            probeClient: StubProjectProbeClient(
+                result: ProjectFixtureProbe(
+                    project: ProjectFixture(
+                        name: "TW Hya Tutorial",
+                        rootPath: "/data",
+                        datasets: [tutorial],
+                        source: .probed
+                    ),
+                    diagnostics: []
+                )
+            )
+        )
+
+        store.openProject(path: "/data")
+        store.openDefaultTab(kind: .task)
+
+        let parameters = try XCTUnwrap(store.state.dirtyImagingTaskParameters)
+        XCTAssertEqual(parameters.selectedField, "5: TW Hya")
+        XCTAssertEqual(parameters.phaseCenterField, "5: TW Hya")
+        XCTAssertEqual(parameters.selectedSpectralWindow, "spw 0: 384 chan, 372.533086 GHz center")
+        XCTAssertNil(parameters.correlation)
+        XCTAssertEqual(parameters.imageSize, 250)
+        XCTAssertEqual(parameters.imageHeight, 250)
+        XCTAssertEqual(parameters.cellArcsec, 0.1)
+
+        let request = DirtyImagingTaskRequest(runID: "run-twhya", parameters: parameters)
+        let requestJSON = try XCTUnwrap(String(data: try request.encodedImagerJSON(), encoding: .utf8))
+        XCTAssertTrue(requestJSON.contains("\"field_ids\" : [\n      5\n    ]"))
+        XCTAssertTrue(requestJSON.contains("\"spw_selector\" : \"0\""))
+        XCTAssertTrue(requestJSON.contains("\"image_size\" : 250"))
+        XCTAssertTrue(requestJSON.contains("\"cell_arcsec\" : 0.1"))
+        XCTAssertFalse(requestJSON.contains("\"correlation\""))
+    }
+
     func testDirtyImagingValidationFailuresAreDebugVisible() {
         let probedDataset = DatasetSummary(
             id: "/data/probed.ms",

--- a/apps/casars-mac/Tests/CasarsMacCoreTests/WorkbenchStoreTests.swift
+++ b/apps/casars-mac/Tests/CasarsMacCoreTests/WorkbenchStoreTests.swift
@@ -632,6 +632,9 @@ final class WorkbenchStoreTests: XCTestCase {
 
         store.openProject(path: "/data")
         store.runMeasurementSetPlot(datasetID: probedDataset.id)
+        waitFor("plot job to finish") {
+            store.debugSnapshot().measurementSetPlots[probedDataset.id]?.status == .ready
+        }
 
         var snapshot = store.debugSnapshot()
         XCTAssertEqual(snapshot.measurementSetPlots[probedDataset.id]?.status, .ready)
@@ -653,6 +656,9 @@ final class WorkbenchStoreTests: XCTestCase {
         store.setMeasurementSetPlotField("0: Target", datasetID: probedDataset.id)
         store.setMeasurementSetPlotSpectralWindow("spw 0: 4 chan, 1.420000 GHz center", datasetID: probedDataset.id)
         store.runMeasurementSetPlot(datasetID: probedDataset.id)
+        waitFor("filtered plot job to finish") {
+            store.debugSnapshot().measurementSetPlots[probedDataset.id]?.resultPreset == .amplitudeVsUvDistance
+        }
 
         snapshot = store.debugSnapshot()
         XCTAssertEqual(snapshot.measurementSetPlots[probedDataset.id]?.preset, .amplitudeVsUvDistance)
@@ -675,6 +681,187 @@ final class WorkbenchStoreTests: XCTestCase {
         store.runMeasurementSetPlot(datasetID: probedDataset.id)
 
         XCTAssertEqual(plotClient.requests.count, 2)
+    }
+
+    func testMeasurementSetPlotJobDoesNotBlockUnrelatedWorkbenchActions() {
+        let msDataset = DatasetSummary(
+            id: "/data/probed.ms",
+            name: "probed.ms",
+            path: "/data/probed.ms",
+            kind: .measurementSet,
+            size: "12 rows, 1 fields, 1 spw, 2 antennas",
+            units: "Jy, Hz, seconds",
+            fields: ["0: Target"],
+            spectralWindows: ["spw 0: 4 chan, 1.420000 GHz center"],
+            dataColumns: ["DATA"],
+            notes: "Recognized by Rust probe."
+        )
+        let imageDataset = DatasetSummary(
+            id: "/data/output.image",
+            name: "output.image",
+            path: "/data/output.image",
+            kind: .imageCube,
+            size: "256 x 256",
+            units: "float32",
+            shape: [256, 256],
+            notes: "Produced image."
+        )
+        let plotClient = BlockingMeasurementSetPlotClient()
+        let store = WorkbenchStore(
+            probeClient: StubProjectProbeClient(
+                result: ProjectFixtureProbe(
+                    project: ProjectFixture(
+                        name: "Real Project",
+                        rootPath: "/data",
+                        datasets: [msDataset, imageDataset],
+                        source: .probed
+                    ),
+                    diagnostics: []
+                )
+            ),
+            plotClient: plotClient
+        )
+
+        store.openProject(path: "/data")
+        store.runMeasurementSetPlot(datasetID: msDataset.id)
+        XCTAssertEqual(plotClient.waitForStartedCount(1), .success)
+        XCTAssertEqual(store.debugSnapshot().measurementSetPlots[msDataset.id]?.status, .running)
+        XCTAssertEqual(store.debugSnapshot().runningJobCount, 1)
+
+        store.selectDataset(imageDataset.id)
+        store.openDatasetExplorer(imageDataset.id)
+        store.setInspectorCollapsed(true)
+        store.setCommandQuery("show inspector")
+        store.runCommandQuery()
+        store.activateTab(msDataset.explorerTabID)
+
+        XCTAssertEqual(store.state.selectedDatasetID, imageDataset.id)
+        XCTAssertEqual(store.state.tabs.first { $0.id == store.state.activeTabID }?.id, msDataset.explorerTabID)
+        XCTAssertFalse(store.debugSnapshot().inspectorCollapsed)
+        XCTAssertEqual(store.debugSnapshot().measurementSetPlots[msDataset.id]?.status, .running)
+
+        plotClient.releaseAll()
+        waitFor("blocked plot job to finish") {
+            store.debugSnapshot().measurementSetPlots[msDataset.id]?.status == .ready
+        }
+        XCTAssertEqual(store.debugSnapshot().jobs.first?.status, .succeeded)
+    }
+
+    func testTwoMeasurementSetTabsHoldIndependentPlotJobs() {
+        let first = DatasetSummary(
+            id: "/data/first.ms",
+            name: "first.ms",
+            path: "/data/first.ms",
+            kind: .measurementSet,
+            size: "12 rows, 1 fields, 1 spw, 2 antennas",
+            units: "Jy, Hz, seconds",
+            fields: ["0: First"],
+            spectralWindows: ["spw 0: 4 chan, 1.420000 GHz center"],
+            dataColumns: ["DATA"],
+            notes: "First MS."
+        )
+        let second = DatasetSummary(
+            id: "/data/second.ms",
+            name: "second.ms",
+            path: "/data/second.ms",
+            kind: .measurementSet,
+            size: "24 rows, 1 fields, 2 spw, 3 antennas",
+            units: "Jy, Hz, seconds",
+            fields: ["1: Second"],
+            spectralWindows: ["spw 1: 8 chan, 1.500000 GHz center"],
+            dataColumns: ["DATA"],
+            notes: "Second MS."
+        )
+        let plotClient = BlockingMeasurementSetPlotClient()
+        let store = WorkbenchStore(
+            probeClient: StubProjectProbeClient(
+                result: ProjectFixtureProbe(
+                    project: ProjectFixture(
+                        name: "Real Project",
+                        rootPath: "/data",
+                        datasets: [first, second],
+                        source: .probed
+                    ),
+                    diagnostics: []
+                )
+            ),
+            plotClient: plotClient
+        )
+
+        store.openProject(path: "/data")
+        store.runMeasurementSetPlot(datasetID: first.id)
+        XCTAssertEqual(plotClient.waitForStartedCount(1), .success)
+        store.openDatasetExplorer(second.id)
+        store.runMeasurementSetPlot(datasetID: second.id)
+        XCTAssertEqual(plotClient.waitForStartedCount(2), .success)
+
+        let snapshot = store.debugSnapshot()
+        XCTAssertEqual(snapshot.runningJobCount, 2)
+        XCTAssertEqual(snapshot.activeJobIDsByTab.keys.sorted(), [first.explorerTabID, second.explorerTabID])
+        XCTAssertEqual(snapshot.jobs.map(\.status), [.running, .running])
+
+        plotClient.releaseAll()
+        waitFor("both plot jobs to finish") {
+            let latest = store.debugSnapshot()
+            return latest.measurementSetPlots[first.id]?.status == .ready
+                && latest.measurementSetPlots[second.id]?.status == .ready
+        }
+        XCTAssertEqual(store.debugSnapshot().runningJobCount, 0)
+        XCTAssertEqual(store.debugSnapshot().jobs.map(\.status), [.succeeded, .succeeded])
+    }
+
+    func testCancellingDirtyImagingJobIsScopedToThatJob() {
+        let probedDataset = DatasetSummary(
+            id: "/data/probed.ms",
+            name: "probed.ms",
+            path: "/data/probed.ms",
+            kind: .measurementSet,
+            size: "12 rows, 1 fields, 1 spw, 2 antennas",
+            units: "Jy, Hz, seconds",
+            fields: ["0: Target"],
+            spectralWindows: ["spw 0: 4 chan, 1.420000 GHz center"],
+            dataColumns: ["DATA"],
+            notes: "Recognized by Rust probe."
+        )
+        let taskClient = HoldingDirtyImagingTaskClient()
+        let store = WorkbenchStore(
+            probeClient: StubProjectProbeClient(
+                result: ProjectFixtureProbe(
+                    project: ProjectFixture(
+                        name: "Real Project",
+                        rootPath: "/data",
+                        datasets: [probedDataset],
+                        source: .probed
+                    ),
+                    diagnostics: []
+                )
+            ),
+            dirtyImagingClient: taskClient
+        )
+
+        store.openProject(path: "/data")
+        store.openDefaultTab(kind: .task)
+        store.runTask()
+
+        let runID = tryUnwrap(store.state.taskRun.runID)
+        XCTAssertEqual(store.debugSnapshot().runningJobCount, 1)
+        XCTAssertEqual(store.debugSnapshot().jobs.first?.kind, .dirtyImagingTask)
+        XCTAssertEqual(store.debugSnapshot().jobs.first?.status, .running)
+
+        store.stopTask()
+
+        let snapshot = store.debugSnapshot()
+        XCTAssertEqual(taskClient.execution.didCancel, true)
+        XCTAssertEqual(snapshot.runningJobCount, 0)
+        XCTAssertEqual(snapshot.jobs.first?.id, runID)
+        XCTAssertEqual(snapshot.jobs.first?.status, .cancelled)
+        XCTAssertEqual(snapshot.jobs.first?.cancellationRequested, true)
+        XCTAssertEqual(snapshot.taskState, .cancelled)
+        XCTAssertTrue(snapshot.activeJobIDsByTab.isEmpty)
+
+        taskClient.emitSucceeded()
+        XCTAssertEqual(store.debugSnapshot().jobs.first?.status, .cancelled)
+        XCTAssertEqual(store.debugSnapshot().taskState, .cancelled)
     }
 
     func testInterfaceFontSizeIsAdjustableClampedAndPreservedAcrossFixtureOpen() {
@@ -747,10 +934,19 @@ private struct StubProjectProbeClient: ProjectProbeClient {
 }
 
 private final class StubMeasurementSetPlotClient: MeasurementSetPlotClient {
-    var requests: [MeasurementSetPlotBuildRequest] = []
+    private let lock = NSLock()
+    private var recordedRequests: [MeasurementSetPlotBuildRequest] = []
+
+    var requests: [MeasurementSetPlotBuildRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedRequests
+    }
 
     func buildPlot(request: MeasurementSetPlotBuildRequest) throws -> MeasurementSetPlotResultSummary {
-        requests.append(request)
+        lock.lock()
+        recordedRequests.append(request)
+        lock.unlock()
         return makePlotResult(
             preset: request.preset,
             presetLabel: request.preset.title,
@@ -761,6 +957,54 @@ private final class StubMeasurementSetPlotClient: MeasurementSetPlotClient {
             imageWidth: request.width,
             imageHeight: request.height
         )
+    }
+}
+
+private final class BlockingMeasurementSetPlotClient: MeasurementSetPlotClient {
+    private let lock = NSLock()
+    private let startedSemaphore = DispatchSemaphore(value: 0)
+    private let releaseSemaphore = DispatchSemaphore(value: 0)
+    private var startedCount = 0
+
+    func buildPlot(request: MeasurementSetPlotBuildRequest) throws -> MeasurementSetPlotResultSummary {
+        lock.lock()
+        startedCount += 1
+        lock.unlock()
+        startedSemaphore.signal()
+        releaseSemaphore.wait()
+        return makePlotResult(
+            preset: request.preset,
+            presetLabel: request.preset.title,
+            title: request.preset.title,
+            datasetPath: request.datasetPath,
+            dataColumn: request.dataColumn,
+            requestedMaxPoints: request.maxPlotPoints,
+            imageWidth: request.width,
+            imageHeight: request.height
+        )
+    }
+
+    func waitForStartedCount(_ count: Int) -> DispatchTimeoutResult {
+        while true {
+            lock.lock()
+            let current = startedCount
+            lock.unlock()
+            if current >= count {
+                return .success
+            }
+            if startedSemaphore.wait(timeout: .now() + 1) == .timedOut {
+                return .timedOut
+            }
+        }
+    }
+
+    func releaseAll() {
+        lock.lock()
+        let count = max(startedCount, 1)
+        lock.unlock()
+        for _ in 0..<count {
+            releaseSemaphore.signal()
+        }
     }
 }
 
@@ -837,6 +1081,64 @@ private final class StubDirtyImagingTaskClient: DirtyImagingTaskClient {
         eventHandler(event ?? .succeeded(result))
         return StubDirtyImagingExecution()
     }
+}
+
+private final class HoldingDirtyImagingTaskClient: DirtyImagingTaskClient {
+    var requests: [DirtyImagingTaskRequest] = []
+    var handler: ((DirtyImagingTaskEvent) -> Void)?
+    let execution = StubDirtyImagingExecution()
+
+    func startDirtyImaging(
+        request: DirtyImagingTaskRequest,
+        eventHandler: @escaping (DirtyImagingTaskEvent) -> Void
+    ) throws -> DirtyImagingTaskExecution {
+        requests.append(request)
+        handler = eventHandler
+        return execution
+    }
+
+    func emitSucceeded() {
+        guard let request = requests.last else { return }
+        handler?(.succeeded(DirtyImagingTaskResult(
+            request: request,
+            report: DirtyImagingRunReport(
+                warnings: [],
+                griddedSamples: 128,
+                majorCycles: 1,
+                minorIterations: 0,
+                channelCount: 1
+            ),
+            artifacts: [],
+            requestJSONPath: "/data/casa-rs-runs/output.casars-request.json",
+            stdoutPath: "/data/casa-rs-runs/output.casars-result.json",
+            stderrPath: "/data/casa-rs-runs/output.casars-stderr.log",
+            protocolSummary: #"{"protocol_name":"casars_imager_task"}"#,
+            diagnostics: []
+        )))
+    }
+}
+
+private func waitFor(
+    _ description: String,
+    timeout: TimeInterval = 2,
+    condition: () -> Bool
+) {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+        if condition() {
+            return
+        }
+        RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
+    }
+    XCTFail("Timed out waiting for \(description)")
+}
+
+private func tryUnwrap<T>(_ value: T?, file: StaticString = #filePath, line: UInt = #line) -> T {
+    guard let value else {
+        XCTFail("Expected non-nil value", file: file, line: line)
+        fatalError("Expected non-nil value")
+    }
+    return value
 }
 
 private final class StubDirtyImagingExecution: DirtyImagingTaskExecution {

--- a/apps/casars-mac/Tests/CasarsMacCoreTests/WorkbenchStoreTests.swift
+++ b/apps/casars-mac/Tests/CasarsMacCoreTests/WorkbenchStoreTests.swift
@@ -473,6 +473,67 @@ final class WorkbenchStoreTests: XCTestCase {
         XCTAssertEqual(store.state.tabs.first(where: { $0.kind == .task })?.title, "Dirty Image: second.ms")
     }
 
+    func testBundledSampleDirtyImagingDefaultsChooseLineTarget() throws {
+        let sample = DatasetSummary(
+            id: "/data/mssel_test_small_multifield_spw.ms",
+            name: "mssel_test_small_multifield_spw.ms",
+            path: "/data/mssel_test_small_multifield_spw.ms",
+            kind: .measurementSet,
+            size: "14985 rows, 9 fields, 6 spw, 10 antennas",
+            units: "Jy, Hz, seconds",
+            fields: [
+                "0: 3C273-F0",
+                "1: 2",
+                "2: NGC4826-F0",
+                "3: NGC4826-F1",
+                "4: 2000",
+                "5: NGC4826-F3",
+                "6: NGC4826-F4",
+                "7: NGC4826-F5",
+                "8: NGC4826-F6"
+            ],
+            spectralWindows: [
+                "spw 0: 1 chan, 115.138579 GHz center",
+                "spw 1: 1 chan, 115.217017 GHz center",
+                "spw 2: 64 chan, 114.999607 GHz center",
+                "spw 3: 64 chan, 115.089621 GHz center",
+                "spw 4: 64 chan, 115.179362 GHz center",
+                "spw 5: 64 chan, 115.269376 GHz center"
+            ],
+            correlations: ["YY"],
+            dataColumns: ["DATA"],
+            notes: "Bundled real sample MS."
+        )
+        let store = WorkbenchStore(
+            probeClient: StubProjectProbeClient(
+                result: ProjectFixtureProbe(
+                    project: ProjectFixture(
+                        name: "Sample Project",
+                        rootPath: "/data",
+                        datasets: [sample],
+                        source: .probed
+                    ),
+                    diagnostics: []
+                )
+            )
+        )
+
+        store.openProject(path: "/data")
+        store.openDefaultTab(kind: .task)
+
+        let parameters = try XCTUnwrap(store.state.dirtyImagingTaskParameters)
+        XCTAssertEqual(parameters.selectedField, "5: NGC4826-F3")
+        XCTAssertEqual(parameters.phaseCenterField, "5: NGC4826-F3")
+        XCTAssertEqual(parameters.selectedSpectralWindow, "spw 5: 64 chan, 115.269376 GHz center")
+        XCTAssertEqual(parameters.correlation, "YY")
+
+        let request = DirtyImagingTaskRequest(runID: "run-sample", parameters: parameters)
+        let requestJSON = String(data: try request.encodedImagerJSON(), encoding: .utf8)
+        XCTAssertTrue(try XCTUnwrap(requestJSON).contains("\"field_ids\" : [\n      5\n    ]"))
+        XCTAssertTrue(try XCTUnwrap(requestJSON).contains("\"spw_selector\" : \"5\""))
+        XCTAssertTrue(try XCTUnwrap(requestJSON).contains("\"correlation\" : \"YY\""))
+    }
+
     func testDirtyImagingValidationFailuresAreDebugVisible() {
         let probedDataset = DatasetSummary(
             id: "/data/probed.ms",

--- a/apps/casars-mac/script/build_and_run.sh
+++ b/apps/casars-mac/script/build_and_run.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 MODE="run"
 OPEN_PROJECT=""
+USE_TEMP_REAL_PROJECT="1"
 APP_NAME="casars-mac"
 BUNDLE_ID="org.casa-rs.casars-mac"
 MIN_SYSTEM_VERSION="14.0"
@@ -21,6 +22,8 @@ INFO_PLIST="$APP_CONTENTS/Info.plist"
 FRONTEND_DYLIB_NAME="libcasars_frontend_services.dylib"
 FRONTEND_DYLIB="$REPO_ROOT/target/debug/$FRONTEND_DYLIB_NAME"
 IMAGER_BINARY="$REPO_ROOT/target/debug/casars-imager"
+REAL_PROJECT_FIXTURE="$REPO_ROOT/crates/casa-ms/tests/fixtures/mssel_test_small_multifield_spw.ms.tgz"
+TEMP_REAL_PROJECT=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -34,16 +37,63 @@ while [[ $# -gt 0 ]]; do
         exit 2
       fi
       OPEN_PROJECT="$2"
+      USE_TEMP_REAL_PROJECT="0"
       shift 2
       ;;
+    --empty)
+      OPEN_PROJECT=""
+      USE_TEMP_REAL_PROJECT="0"
+      shift
+      ;;
     *)
-      echo "usage: $0 [run|--debug|--logs|--verify] [--project PATH]" >&2
+      echo "usage: $0 [run|--debug|--logs|--verify] [--project PATH|--empty]" >&2
       exit 2
       ;;
   esac
 done
 
+stage_temp_real_project() {
+  if [[ "$USE_TEMP_REAL_PROJECT" != "1" || -n "$OPEN_PROJECT" ]]; then
+    return
+  fi
+  if [[ ! -f "$REAL_PROJECT_FIXTURE" ]]; then
+    echo "warning: real demo fixture not found; opening empty workbench: $REAL_PROJECT_FIXTURE" >&2
+    return
+  fi
+
+  TEMP_REAL_PROJECT="$(mktemp -d "${TMPDIR:-/tmp}/casars-mac-real-project.XXXXXX")"
+  tar -xzf "$REAL_PROJECT_FIXTURE" -C "$TEMP_REAL_PROJECT"
+  OPEN_PROJECT="$TEMP_REAL_PROJECT"
+  echo "==> Opening temporary real-data project: $OPEN_PROJECT"
+  echo "==> Project will be removed after $APP_NAME exits."
+}
+
+cleanup_temp_real_project_now() {
+  if [[ -n "$TEMP_REAL_PROJECT" && -d "$TEMP_REAL_PROJECT" ]]; then
+    rm -rf "$TEMP_REAL_PROJECT"
+  fi
+}
+
+schedule_temp_real_project_cleanup() {
+  if [[ -z "$TEMP_REAL_PROJECT" || ! -d "$TEMP_REAL_PROJECT" ]]; then
+    return
+  fi
+
+  local app_pid="${1:-}"
+  if [[ -z "$app_pid" ]]; then
+    return
+  fi
+
+  (
+    while ps -p "$app_pid" >/dev/null 2>&1; do
+      sleep 2
+    done
+    rm -rf "$TEMP_REAL_PROJECT"
+  ) >/dev/null 2>&1 &
+}
+
 cd "$REPO_ROOT"
+stage_temp_real_project
 "$REPO_ROOT/scripts/generate-frontend-bindings.sh" "$REPO_ROOT/target/frontend-bindings"
 cargo build -p casars-imager
 
@@ -105,6 +155,10 @@ open_app() {
   fi
 }
 
+launched_app_pid() {
+  pgrep -n -x "$APP_NAME"
+}
+
 debug_app() {
   if [[ -n "$OPEN_PROJECT" ]]; then
     lldb -- "$APP_BINARY" --open-project "$OPEN_PROJECT"
@@ -116,21 +170,32 @@ debug_app() {
 case "$MODE" in
   run)
     open_app
+    sleep 1
+    if app_pid="$(launched_app_pid)"; then
+      schedule_temp_real_project_cleanup "$app_pid"
+    fi
     ;;
   --debug|debug)
     debug_app
+    cleanup_temp_real_project_now
     ;;
   --logs|logs)
     open_app
+    sleep 1
+    if app_pid="$(launched_app_pid)"; then
+      schedule_temp_real_project_cleanup "$app_pid"
+    fi
     /usr/bin/log stream --info --style compact --predicate "process == \"$APP_NAME\""
     ;;
   --verify|verify)
     open_app
     sleep 1
-    pgrep -x "$APP_NAME" >/dev/null
+    app_pid="$(launched_app_pid)"
+    [[ -n "$app_pid" ]]
+    schedule_temp_real_project_cleanup "$app_pid"
     ;;
   *)
-    echo "usage: $0 [run|--debug|--logs|--verify] [--project PATH]" >&2
+    echo "usage: $0 [run|--debug|--logs|--verify] [--project PATH|--empty]" >&2
     exit 2
     ;;
 esac

--- a/apps/casars-mac/script/build_and_run.sh
+++ b/apps/casars-mac/script/build_and_run.sh
@@ -22,8 +22,11 @@ INFO_PLIST="$APP_CONTENTS/Info.plist"
 FRONTEND_DYLIB_NAME="libcasars_frontend_services.dylib"
 FRONTEND_DYLIB="$REPO_ROOT/target/debug/$FRONTEND_DYLIB_NAME"
 IMAGER_BINARY="$REPO_ROOT/target/debug/casars-imager"
-REAL_PROJECT_FIXTURE="$REPO_ROOT/crates/casa-ms/tests/fixtures/mssel_test_small_multifield_spw.ms.tgz"
+TUTORIAL_DATA_ROOT="${CASA_RS_TUTORIAL_DATA_ROOT:-$HOME/SoftwareProjects/casa-tutorial-data}"
+TUTORIAL_DEMO_ARCHIVE="$TUTORIAL_DATA_ROOT/tutorial-parity/alma/first-look/twhya/twhya_calibrated.ms.tar"
+FALLBACK_REAL_PROJECT_FIXTURE="$REPO_ROOT/crates/casa-ms/tests/fixtures/mssel_test_small_multifield_spw.ms.tgz"
 TEMP_REAL_PROJECT=""
+TEMP_REAL_PROJECT_SOURCE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -56,16 +59,37 @@ stage_temp_real_project() {
   if [[ "$USE_TEMP_REAL_PROJECT" != "1" || -n "$OPEN_PROJECT" ]]; then
     return
   fi
-  if [[ ! -f "$REAL_PROJECT_FIXTURE" ]]; then
-    echo "warning: real demo fixture not found; opening empty workbench: $REAL_PROJECT_FIXTURE" >&2
+
+  local archive=""
+  local archive_kind=""
+  if [[ -f "$TUTORIAL_DEMO_ARCHIVE" ]]; then
+    archive="$TUTORIAL_DEMO_ARCHIVE"
+    archive_kind="tutorial TW Hya MeasurementSet"
+  elif [[ -f "$FALLBACK_REAL_PROJECT_FIXTURE" ]]; then
+    archive="$FALLBACK_REAL_PROJECT_FIXTURE"
+    archive_kind="bundled fallback MeasurementSet"
+  else
+    echo "warning: no real demo MeasurementSet found; opening empty workbench" >&2
+    echo "warning: checked $TUTORIAL_DEMO_ARCHIVE" >&2
+    echo "warning: checked $FALLBACK_REAL_PROJECT_FIXTURE" >&2
     return
   fi
 
   TEMP_REAL_PROJECT="$(mktemp -d "${TMPDIR:-/tmp}/casars-mac-real-project.XXXXXX")"
-  tar -xzf "$REAL_PROJECT_FIXTURE" -C "$TEMP_REAL_PROJECT"
+  TEMP_REAL_PROJECT_SOURCE="$archive"
+  case "$archive" in
+    *.tgz|*.tar.gz)
+      tar -xzf "$archive" -C "$TEMP_REAL_PROJECT"
+      ;;
+    *)
+      tar -xf "$archive" -C "$TEMP_REAL_PROJECT"
+      ;;
+  esac
   OPEN_PROJECT="$TEMP_REAL_PROJECT"
   echo "==> Opening temporary real-data project: $OPEN_PROJECT"
+  echo "==> Source: $archive_kind ($TEMP_REAL_PROJECT_SOURCE)"
   echo "==> Project will be removed after $APP_NAME exits."
+  trap cleanup_temp_real_project_now EXIT
 }
 
 cleanup_temp_real_project_now() {
@@ -84,12 +108,15 @@ schedule_temp_real_project_cleanup() {
     return
   fi
 
-  (
-    while ps -p "$app_pid" >/dev/null 2>&1; do
+  nohup /bin/sh -c '
+    app_pid="$1"
+    project="$2"
+    while kill -0 "$app_pid" 2>/dev/null; do
       sleep 2
     done
-    rm -rf "$TEMP_REAL_PROJECT"
-  ) >/dev/null 2>&1 &
+    rm -rf "$project"
+  ' sh "$app_pid" "$TEMP_REAL_PROJECT" >/dev/null 2>&1 &
+  trap - EXIT
 }
 
 cd "$REPO_ROOT"
@@ -148,10 +175,16 @@ codesign --force --sign - "$APP_BINARY" >/dev/null
 codesign --force --sign - "$APP_BUNDLE" >/dev/null
 
 open_app() {
+  local wait_for_exit="${1:-0}"
+  local open_flags=(-n)
+  if [[ "$wait_for_exit" == "1" ]]; then
+    open_flags=(-W -n)
+  fi
+
   if [[ -n "$OPEN_PROJECT" ]]; then
-    /usr/bin/open -n "$APP_BUNDLE" --args --open-project "$OPEN_PROJECT"
+    /usr/bin/open "${open_flags[@]}" "$APP_BUNDLE" --args --open-project "$OPEN_PROJECT"
   else
-    /usr/bin/open -n "$APP_BUNDLE"
+    /usr/bin/open "${open_flags[@]}" "$APP_BUNDLE"
   fi
 }
 
@@ -169,11 +202,8 @@ debug_app() {
 
 case "$MODE" in
   run)
-    open_app
-    sleep 1
-    if app_pid="$(launched_app_pid)"; then
-      schedule_temp_real_project_cleanup "$app_pid"
-    fi
+    open_app 1
+    cleanup_temp_real_project_now
     ;;
   --debug|debug)
     debug_app
@@ -192,7 +222,13 @@ case "$MODE" in
     sleep 1
     app_pid="$(launched_app_pid)"
     [[ -n "$app_pid" ]]
-    schedule_temp_real_project_cleanup "$app_pid"
+    if [[ -n "$TEMP_REAL_PROJECT" ]]; then
+      kill "$app_pid" >/dev/null 2>&1 || true
+      sleep 2
+      cleanup_temp_real_project_now
+    else
+      schedule_temp_real_project_cleanup "$app_pid"
+    fi
     ;;
   *)
     echo "usage: $0 [run|--debug|--logs|--verify] [--project PATH|--empty]" >&2

--- a/crates/casars-frontend-services/Cargo.toml
+++ b/crates/casars-frontend-services/Cargo.toml
@@ -15,16 +15,17 @@ crate-type = ["cdylib", "rlib", "staticlib"]
 anyhow = "1"
 camino = "1.2"
 cargo_metadata = "0.19"
+casa-coordinates = { path = "../casa-coordinates" }
 casa-images = { path = "../casa-images" }
 casa-ms = { path = "../casa-ms" }
 casa-tables = { path = "../casa-tables" }
+casa-types = { path = "../casa-types" }
 image = { version = "0.25", default-features = false, features = ["png"] }
 thiserror.workspace = true
 uniffi = "0.29.5"
 uniffi_bindgen = "0.29.5"
 
 [dev-dependencies]
-casa-types = { path = "../casa-types" }
 flate2 = "1"
 ndarray.workspace = true
 tar = "0.4"

--- a/crates/casars-frontend-services/src/lib.rs
+++ b/crates/casars-frontend-services/src/lib.rs
@@ -7,7 +7,8 @@ use std::io::Cursor;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use casa_images::{AnyPagedImage, ImagePixelType};
+use casa_coordinates::{CoordinateSystem, CoordinateType};
+use casa_images::{AnyPagedImage, ImageInfo, ImagePixelType};
 use casa_ms::{
     MeasurementSet, MeasurementSetPlotPayload, MeasurementSetPlotTheme,
     MeasurementSetSummaryOutputFormat, MsExploreSpec, MsPageExportRange, MsPlotPayload,
@@ -16,6 +17,10 @@ use casa_ms::{
     render_msexplore_plot_image,
 };
 use casa_tables::{Table, TableOptions};
+use casa_types::measures::direction::{
+    angular_increment_arcseconds, declination_increment_arcseconds, format_declination_labeled,
+    format_right_ascension_labeled,
+};
 use image::ImageFormat;
 use thiserror::Error;
 
@@ -773,8 +778,11 @@ fn probe_image(path: &Path, metadata: &fs::Metadata) -> Result<Option<DatasetPro
     let shape: Vec<u64> = image.shape().iter().map(|value| *value as u64).collect();
     let mask_names = image.mask_names();
     let region_names = image.region_names();
+    let brightness_unit = image_units(&image).to_string();
+    diagnostics.push(format!("Pixel type: {pixel_type}"));
+    diagnostics.extend(image_coordinate_diagnostics(&image));
     if let Some(default_mask) = image.default_mask_name() {
-        diagnostics.push(format!("default mask: {default_mask}"));
+        diagnostics.push(format!("Default mask: {default_mask}"));
     }
 
     Ok(Some(DatasetProbe {
@@ -786,7 +794,7 @@ fn probe_image(path: &Path, metadata: &fs::Metadata) -> Result<Option<DatasetPro
         modified_unix_seconds: modified_unix_seconds(metadata),
         probed_unix_seconds: now_unix_seconds(),
         logical_size: format_shape(&shape),
-        units: pixel_type.to_string(),
+        units: brightness_unit,
         fields: vec![],
         spectral_windows: vec![],
         scans: vec![],
@@ -803,6 +811,226 @@ fn probe_image(path: &Path, metadata: &fs::Metadata) -> Result<Option<DatasetPro
         ),
         diagnostics,
     }))
+}
+
+fn image_units(image: &AnyPagedImage) -> &str {
+    match image {
+        AnyPagedImage::Float32(image) => image.units(),
+        AnyPagedImage::Float64(image) => image.units(),
+        AnyPagedImage::Complex32(image) => image.units(),
+        AnyPagedImage::Complex64(image) => image.units(),
+    }
+}
+
+fn image_coordinates(image: &AnyPagedImage) -> &CoordinateSystem {
+    match image {
+        AnyPagedImage::Float32(image) => image.coordinates(),
+        AnyPagedImage::Float64(image) => image.coordinates(),
+        AnyPagedImage::Complex32(image) => image.coordinates(),
+        AnyPagedImage::Complex64(image) => image.coordinates(),
+    }
+}
+
+fn image_info(image: &AnyPagedImage) -> Result<ImageInfo, String> {
+    match image {
+        AnyPagedImage::Float32(image) => image.image_info(),
+        AnyPagedImage::Float64(image) => image.image_info(),
+        AnyPagedImage::Complex32(image) => image.image_info(),
+        AnyPagedImage::Complex64(image) => image.image_info(),
+    }
+    .map_err(|error| error.to_string())
+}
+
+fn image_coordinate_diagnostics(image: &AnyPagedImage) -> Vec<String> {
+    let coords = image_coordinates(image);
+    let shape = image.shape();
+    let mut diagnostics = Vec::new();
+    diagnostics.extend(image_direction_diagnostics(coords, shape));
+    diagnostics.extend(image_spectral_diagnostics(coords, shape));
+    match image_info(image) {
+        Ok(info) => diagnostics.extend(image_beam_diagnostics(&info)),
+        Err(error) => diagnostics.push(format!("Image info unavailable: {error}")),
+    }
+    diagnostics
+}
+
+fn image_direction_diagnostics(coords: &CoordinateSystem, shape: &[usize]) -> Vec<String> {
+    let mut diagnostics = Vec::new();
+    let mut pixel_offset = 0usize;
+    for index in 0..coords.n_coordinates() {
+        let coord = coords.coordinate(index);
+        let n_pixel_axes = coord.n_pixel_axes();
+        if coord.coordinate_type() == CoordinateType::Direction && n_pixel_axes >= 2 {
+            let increments = coord.increment();
+            if increments.len() >= 2 {
+                let ra_cell = angular_increment_arcseconds(increments[0]).value().abs();
+                let dec_cell = declination_increment_arcseconds(increments[1])
+                    .value()
+                    .abs();
+                diagnostics.push(format!(
+                    "Cell size: {} x {} arcsec",
+                    format_compact_float(ra_cell),
+                    format_compact_float(dec_cell)
+                ));
+            }
+
+            let Some(x_len) = shape.get(pixel_offset).copied() else {
+                break;
+            };
+            let Some(y_len) = shape.get(pixel_offset + 1).copied() else {
+                break;
+            };
+            let center_pixel = [
+                center_pixel_coordinate(x_len),
+                center_pixel_coordinate(y_len),
+            ];
+            if let Ok(world) = coord.to_world(&center_pixel) {
+                if world.len() >= 2 {
+                    diagnostics.push(format!(
+                        "Center: RA {} Dec {}",
+                        format_right_ascension_labeled(world[0], 3),
+                        format_declination_labeled(world[1], 2)
+                    ));
+                }
+            }
+            break;
+        }
+        pixel_offset += n_pixel_axes;
+    }
+    diagnostics
+}
+
+fn image_spectral_diagnostics(coords: &CoordinateSystem, shape: &[usize]) -> Vec<String> {
+    let mut diagnostics = Vec::new();
+    let mut pixel_offset = 0usize;
+    for index in 0..coords.n_coordinates() {
+        let coord = coords.coordinate(index);
+        let n_pixel_axes = coord.n_pixel_axes();
+        if coord.coordinate_type() == CoordinateType::Spectral && n_pixel_axes >= 1 {
+            let Some(channel_count) = shape.get(pixel_offset).copied() else {
+                break;
+            };
+            if channel_count == 0 {
+                break;
+            }
+            let center_pixel = [center_pixel_coordinate(channel_count)];
+            let unit = coord
+                .axis_units()
+                .first()
+                .cloned()
+                .unwrap_or_else(|| "Hz".to_string());
+            if let Ok(world) = coord.to_world(&center_pixel) {
+                if let Some(center) = world.first().copied() {
+                    diagnostics.push(format!(
+                        "Cube center frequency: {}",
+                        format_frequency_like_value(center, &unit)
+                    ));
+                }
+            }
+            let channel_separation = coord
+                .increment()
+                .first()
+                .copied()
+                .map(f64::abs)
+                .unwrap_or_default();
+            if channel_separation.is_finite() && channel_separation > 0.0 {
+                diagnostics.push(format!(
+                    "Total bandwidth: {}",
+                    format_frequency_like_value(channel_separation * channel_count as f64, &unit)
+                ));
+                diagnostics.push(format!(
+                    "Channel separation: {}",
+                    format_frequency_like_value(channel_separation, &unit)
+                ));
+            }
+            break;
+        }
+        pixel_offset += n_pixel_axes;
+    }
+    diagnostics
+}
+
+fn image_beam_diagnostics(info: &ImageInfo) -> Vec<String> {
+    let beam_set = &info.beam_set;
+    if let Some(beam) = beam_set.single_beam() {
+        if beam.is_null() {
+            return Vec::new();
+        }
+        return match (
+            beam.major_in("arcsec"),
+            beam.minor_in("arcsec"),
+            beam.position_angle_in("deg"),
+        ) {
+            (Ok(major), Ok(minor), Ok(pa)) => vec![format!(
+                "Beam: {} x {} arcsec, PA {} deg",
+                format_compact_float(major),
+                format_compact_float(minor),
+                format_compact_float(pa)
+            )],
+            _ => Vec::new(),
+        };
+    }
+    if beam_set.is_empty() {
+        return Vec::new();
+    }
+    let (channels, stokes) = beam_set.shape();
+    let mut diagnostics = vec![format!(
+        "Beam: {} per-plane beams ({} chan x {} stokes)",
+        beam_set.size(),
+        channels,
+        stokes
+    )];
+    if let Some(beam) = beam_set.median_area_beam() {
+        if !beam.is_null() {
+            if let (Ok(major), Ok(minor), Ok(pa)) = (
+                beam.major_in("arcsec"),
+                beam.minor_in("arcsec"),
+                beam.position_angle_in("deg"),
+            ) {
+                diagnostics.push(format!(
+                    "Median beam: {} x {} arcsec, PA {} deg",
+                    format_compact_float(major),
+                    format_compact_float(minor),
+                    format_compact_float(pa)
+                ));
+            }
+        }
+    }
+    diagnostics
+}
+
+fn center_pixel_coordinate(axis_len: usize) -> f64 {
+    axis_len.saturating_sub(1) as f64 / 2.0
+}
+
+fn format_frequency_like_value(value: f64, unit: &str) -> String {
+    if unit.eq_ignore_ascii_case("Hz") {
+        let abs_value = value.abs();
+        if abs_value >= 1.0e9 {
+            format!("{} GHz", format_compact_float(value / 1.0e9))
+        } else if abs_value >= 1.0e6 {
+            format!("{} MHz", format_compact_float(value / 1.0e6))
+        } else if abs_value >= 1.0e3 {
+            format!("{} kHz", format_compact_float(value / 1.0e3))
+        } else {
+            format!("{} Hz", format_compact_float(value))
+        }
+    } else if unit.is_empty() {
+        format_compact_float(value)
+    } else {
+        format!("{} {unit}", format_compact_float(value))
+    }
+}
+
+fn format_compact_float(value: f64) -> String {
+    let mut text = format!("{value:.6}");
+    while text.contains('.') && text.ends_with('0') {
+        text.pop();
+    }
+    if text.ends_with('.') {
+        text.pop();
+    }
+    if text == "-0" { "0".to_string() } else { text }
 }
 
 fn probe_table(path: &Path, metadata: &fs::Metadata) -> Result<Option<DatasetProbe>, String> {
@@ -997,7 +1225,14 @@ mod tests {
 
     use std::fs::File;
 
+    use casa_coordinates::{
+        CoordinateSystem, DirectionCoordinate, Projection, ProjectionType, SpectralCoordinate,
+    };
+    use casa_images::beam::{GaussianBeam, ImageBeamSet};
+    use casa_images::{ImageInfo, ImageType, PagedImage};
     use casa_tables::{ColumnSchema, TableInfo, TableSchema};
+    use casa_types::measures::direction::DirectionRef;
+    use casa_types::measures::frequency::FrequencyRef;
     use casa_types::{PrimitiveType, RecordField, RecordValue, ScalarValue, Value};
     use flate2::read::GzDecoder;
     use tempfile::TempDir;
@@ -1126,6 +1361,92 @@ mod tests {
                 .datasets
                 .iter()
                 .any(|dataset| dataset.name == "notes.txt")
+        );
+    }
+
+    #[test]
+    fn probe_image_reports_science_units_and_observing_metadata() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("restored.image");
+        let mut coords = CoordinateSystem::new();
+        let cell_rad = (0.1_f64 / 3600.0).to_radians();
+        coords.add_coordinate(Box::new(DirectionCoordinate::new(
+            DirectionRef::J2000,
+            Projection::new(ProjectionType::SIN),
+            [1.0, -0.5],
+            [-cell_rad, cell_rad],
+            [1.5, 1.5],
+        )));
+        coords.add_coordinate(Box::new(SpectralCoordinate::new(
+            FrequencyRef::LSRK,
+            100.0e9,
+            2.0e6,
+            2.0,
+            100.0e9,
+        )));
+        let mut image =
+            PagedImage::<f32>::create(vec![4, 4, 5], coords, &path).expect("create image");
+        image.set_units("Jy/beam").expect("set units");
+        image
+            .set_image_info(&ImageInfo {
+                image_type: ImageType::Intensity,
+                object_name: "TW Hya".to_string(),
+                beam_set: ImageBeamSet::new(GaussianBeam::new(
+                    (0.42_f64 / 3600.0).to_radians(),
+                    (0.31_f64 / 3600.0).to_radians(),
+                    12.0_f64.to_radians(),
+                )),
+            })
+            .expect("set image info");
+        image.save().expect("save image");
+
+        let probe = probe_path(path.display().to_string())
+            .expect("probe")
+            .expect("recognized");
+
+        assert_eq!(probe.kind, DatasetKind::Image);
+        assert_eq!(probe.units, "Jy/beam");
+        assert!(
+            probe
+                .diagnostics
+                .iter()
+                .any(|line| line == "Pixel type: float32")
+        );
+        assert!(
+            probe
+                .diagnostics
+                .iter()
+                .any(|line| line == "Cell size: 0.1 x 0.1 arcsec")
+        );
+        assert!(
+            probe
+                .diagnostics
+                .iter()
+                .any(|line| line.starts_with("Center: RA ") && line.contains(" Dec "))
+        );
+        assert!(
+            probe
+                .diagnostics
+                .iter()
+                .any(|line| line == "Cube center frequency: 100 GHz")
+        );
+        assert!(
+            probe
+                .diagnostics
+                .iter()
+                .any(|line| line == "Total bandwidth: 10 MHz")
+        );
+        assert!(
+            probe
+                .diagnostics
+                .iter()
+                .any(|line| line == "Channel separation: 2 MHz")
+        );
+        assert!(
+            probe
+                .diagnostics
+                .iter()
+                .any(|line| line == "Beam: 0.42 x 0.31 arcsec, PA 12 deg")
         );
     }
 

--- a/docs/mac-native-gui-spec.md
+++ b/docs/mac-native-gui-spec.md
@@ -102,6 +102,26 @@ The app should support multiple tabs or editor panes because users naturally
 compare an MS summary, a visibility plot, a task request, an image plane, and a
 Python plot while reducing data.
 
+### Workbench Job Runtime
+
+Slow work in a tab is represented as workbench jobs owned by the originating
+tab. Jobs expose a durable in-memory lifecycle for pending, running, succeeded,
+failed, and cancelled work, plus owner, progress, log lines, result summaries,
+errors, cancellation-request state, and last event text.
+
+The first implemented job kinds are MeasurementSet plot rendering and dirty
+imaging task execution. Plot rendering runs off the main thread through the
+Swift workbench and updates the visible plot state only if the originating job
+is still current for its tab. Dirty imaging remains a supervised short-lived
+`casars-imager --json-run` process, but its run state is now also keyed by job
+ID so cancellation and completion do not clear unrelated work.
+
+The first coordinator rule is one active job per tab: starting a new job for the
+same tab cancels or supersedes the previous active job for that tab, while other
+tabs keep their own active jobs. The coordinator is deliberately Swift-side and
+in-memory for this product slice. It is not a provider daemon, project-history
+storage format, or broad task scheduler.
+
 ## Core Panels
 
 ### Project Explorer


### PR DESCRIPTION
Wave issue: #194
Closes #194

Summary:
- Adds the Swift workbench job coordinator state for per-tab plot and dirty-imaging work.
- Runs MeasurementSet plot rendering off the main thread with per-tab job lifecycle, supersession, cancellation projection, and debug snapshot visibility.
- Keys dirty-imaging subprocess execution by job/run ID, with scoped success, failure, and cancellation cleanup.
- Documents the narrow Swift-side runtime decision in ARCHITECTURE.md and docs/mac-native-gui-spec.md.

Verification:
- swift test (apps/casars-mac): 25 tests passed
- just quick: passed
- just verify: passed, including Python package tests: 45 passed
- just docs-check: passed

Notes:
- Branch was rebased onto origin/main before PR creation to remove an unrelated local-only .gitignore base commit from the review diff.