### PR TITLE
Implement Wave 7 performance fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target-clippy/
 dist/
 site/
 .DS_Store
+.obsidian/
 crates/casa-test-support/tAipsIO_tmp.*
 tarpaulin-ci/
 casa-*.log

--- a/crates/casa-calibration/src/execute.rs
+++ b/crates/casa-calibration/src/execute.rs
@@ -727,13 +727,12 @@ fn execute_apply_plan(
         .iter()
         .map(|row| row.row_index)
         .collect::<BTreeSet<_>>();
-    let created_corrected_data_column =
-        ensure_corrected_data_column(ms, Some(&selected_row_indices)).map_err(|source| {
-            ApplyExecutionError::CreateCorrectedData {
-                path: ms_path.clone(),
-                source,
-            }
+    let corrected_data_creation = ensure_corrected_data_column(ms, Some(&selected_row_indices))
+        .map_err(|source| ApplyExecutionError::CreateCorrectedData {
+            path: ms_path.clone(),
+            source,
         })?;
+    let created_corrected_data_column = corrected_data_creation.created;
     let ensure_corrected_data_ns = ensure_corrected_data_started_at.elapsed().as_nanos() as u64;
 
     let correlation_lookup_started_at = Instant::now();
@@ -1116,7 +1115,14 @@ fn execute_apply_plan(
     if use_partial_main_save {
         let changed_row_indices: Vec<usize> =
             plan.selected_rows.iter().map(|row| row.row_index).collect();
-        if created_corrected_data_column {
+        if corrected_data_creation.cloned_from_data {
+            ms.main_table()
+                .save_selected_rows_in_place_assuming_valid(&changed_columns, &changed_row_indices)
+                .map_err(|source| ApplyExecutionError::MutateMeasurementSet {
+                    path: ms_path.clone(),
+                    source: MsError::from(source),
+                })?;
+        } else if created_corrected_data_column {
             ms.main_table_mut()
                 .save_added_tiled_shape_column_in_place_assuming_valid(
                     VisibilityDataColumn::CorrectedData.name(),
@@ -4459,16 +4465,25 @@ fn cal_spw_reference_frequency_hz(cal_spw: &crate::plan::SpectralWindowPlan) -> 
         .unwrap_or(cal_spw.ref_frequency_hz)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CorrectedDataCreation {
+    created: bool,
+    cloned_from_data: bool,
+}
+
 fn ensure_corrected_data_column(
     ms: &mut MeasurementSet,
     _rows_overwritten_by_apply: Option<&BTreeSet<usize>>,
-) -> Result<bool, TableError> {
+) -> Result<CorrectedDataCreation, TableError> {
     if ms
         .main_table()
         .schema()
         .is_some_and(|schema| schema.contains_column(VisibilityDataColumn::CorrectedData.name()))
     {
-        return Ok(false);
+        return Ok(CorrectedDataCreation {
+            created: false,
+            cloned_from_data: false,
+        });
     }
 
     let column_def = *VisibilityDataColumn::CorrectedData
@@ -4480,6 +4495,30 @@ fn ensure_corrected_data_column(
         .expect("corrected data column present")
         .clone();
     ms.main_table_mut().add_column(column, None)?;
+    if let Some(data_keywords) = ms
+        .main_table()
+        .column_keywords(VisibilityDataColumn::Data.name())
+        .cloned()
+    {
+        ms.main_table_mut()
+            .set_column_keywords(VisibilityDataColumn::CorrectedData.name(), data_keywords);
+    }
+
+    if ms
+        .main_table_mut()
+        .save_added_tiled_column_clone_in_place_assuming_valid(
+            VisibilityDataColumn::Data.name(),
+            VisibilityDataColumn::CorrectedData.name(),
+            "TiledCorrected",
+        )
+        .is_ok()
+    {
+        return Ok(CorrectedDataCreation {
+            created: true,
+            cloned_from_data: true,
+        });
+    }
+
     let row_indices = (0..ms.main_table().row_count()).collect::<Vec<_>>();
     let data_values = ms
         .main_table()
@@ -4495,7 +4534,10 @@ fn ensure_corrected_data_column(
         )?;
     }
 
-    Ok(true)
+    Ok(CorrectedDataCreation {
+        created: true,
+        cloned_from_data: false,
+    })
 }
 
 #[derive(Clone, Copy, Default)]
@@ -5806,7 +5848,13 @@ mod tests {
             .add_row(RecordValue::new(fields))
             .unwrap();
 
-        assert!(ensure_corrected_data_column(&mut ms, None).unwrap());
+        assert_eq!(
+            ensure_corrected_data_column(&mut ms, None).unwrap(),
+            CorrectedDataCreation {
+                created: true,
+                cloned_from_data: false
+            }
+        );
         assert!(
             ms.main_table()
                 .schema()
@@ -5821,7 +5869,13 @@ mod tests {
                 .get(VisibilityDataColumn::CorrectedData.name())
                 .is_some()
         );
-        assert!(!ensure_corrected_data_column(&mut ms, None).unwrap());
+        assert_eq!(
+            ensure_corrected_data_column(&mut ms, None).unwrap(),
+            CorrectedDataCreation {
+                created: false,
+                cloned_from_data: false
+            }
+        );
         assert_eq!(display_ms_path(&ms), "<in-memory>");
     }
 }

--- a/crates/casa-imaging/src/gridder.rs
+++ b/crates/casa-imaging/src/gridder.rs
@@ -981,6 +981,28 @@ impl ScreenProjector {
         plan: &ScreenProjectSamplePlan,
         value: Complex64,
     ) {
+        if let Some(storage) = grid.as_slice_memory_order_mut() {
+            let grid_stride = self.grid_shape[1];
+            for iy in plan.min_iy..=plan.max_iy {
+                let kernel_y = (self.kernel_center as isize
+                    + iy * self.sampling as isize
+                    + plan.off_y) as usize;
+                let grid_y = (plan.loc_y + iy) as usize;
+                for ix in plan.min_ix..=plan.max_ix {
+                    let signed_x = ix * self.sampling as isize + plan.off_x;
+                    let signed_y = iy * self.sampling as isize + plan.off_y;
+                    let kernel_x = (self.kernel_center as isize + signed_x) as usize;
+                    let phase = signed_x as f64 * self.phase_gradient_rad_per_sample[0]
+                        + signed_y as f64 * self.phase_gradient_rad_per_sample[1];
+                    let phasor = Complex64::new(phase.cos(), phase.sin());
+                    let kernel = self.kernel_weights[(kernel_x, kernel_y)];
+                    let cwt = Complex64::new(kernel.re as f64, kernel.im as f64) * phasor;
+                    let grid_x = (plan.loc_x + ix) as usize;
+                    storage[grid_x * grid_stride + grid_y] += value * cwt;
+                }
+            }
+            return;
+        }
         for iy in plan.min_iy..=plan.max_iy {
             let kernel_y =
                 (self.kernel_center as isize + iy * self.sampling as isize + plan.off_y) as usize;
@@ -1003,6 +1025,28 @@ impl ScreenProjector {
         grid: &Array2<Complex32>,
         plan: &ScreenProjectSamplePlan,
     ) -> Complex32 {
+        if let Some(storage) = grid.as_slice_memory_order() {
+            let grid_stride = self.grid_shape[1];
+            let mut value = Complex32::new(0.0, 0.0);
+            for iy in plan.min_iy..=plan.max_iy {
+                let kernel_y = (self.kernel_center as isize
+                    + iy * self.sampling as isize
+                    + plan.off_y) as usize;
+                let grid_y = (plan.loc_y + iy) as usize;
+                for ix in plan.min_ix..=plan.max_ix {
+                    let signed_x = ix * self.sampling as isize + plan.off_x;
+                    let signed_y = iy * self.sampling as isize + plan.off_y;
+                    let kernel_x = (self.kernel_center as isize + signed_x) as usize;
+                    let phase = signed_x as f64 * self.phase_gradient_rad_per_sample[0]
+                        + signed_y as f64 * self.phase_gradient_rad_per_sample[1];
+                    let phasor = Complex32::new(phase.cos() as f32, phase.sin() as f32);
+                    let cwt = self.kernel_weights[(kernel_x, kernel_y)] * phasor;
+                    let grid_x = (plan.loc_x + ix) as usize;
+                    value += storage[grid_x * grid_stride + grid_y] * cwt;
+                }
+            }
+            return value;
+        }
         let mut value = Complex32::new(0.0, 0.0);
         for iy in plan.min_iy..=plan.max_iy {
             let kernel_y =

--- a/crates/casa-imaging/src/gridder.rs
+++ b/crates/casa-imaging/src/gridder.rs
@@ -705,6 +705,7 @@ pub(crate) struct ScreenProjector {
     support: usize,
     kernel_center: usize,
     kernel_weights: Array2<Complex32>,
+    phased_kernel_weights: Array2<Complex32>,
     normalization_sum: Complex32,
     phase_gradient_rad_per_sample: [f64; 2],
 }
@@ -828,6 +829,7 @@ impl ScreenProjector {
             sampling,
             support,
             kernel_center,
+            phased_kernel_weights: kernel_weights.clone(),
             kernel_weights,
             normalization_sum: kernel_sum,
             phase_gradient_rad_per_sample: [0.0, 0.0],
@@ -897,6 +899,7 @@ impl ScreenProjector {
             support,
             kernel_center,
             normalization_sum: Complex32::new(imaging_norm, 0.0),
+            phased_kernel_weights: kernel_weights.clone(),
             kernel_weights,
             phase_gradient_rad_per_sample: [0.0, 0.0],
         })
@@ -904,6 +907,15 @@ impl ScreenProjector {
 
     pub(crate) fn with_phase_gradient(mut self, phase_gradient_rad_per_sample: [f64; 2]) -> Self {
         self.phase_gradient_rad_per_sample = phase_gradient_rad_per_sample;
+        self.phased_kernel_weights = self.kernel_weights.clone();
+        let center = self.kernel_center as isize;
+        for ((kernel_x, kernel_y), weight) in self.phased_kernel_weights.indexed_iter_mut() {
+            let signed_x = kernel_x as isize - center;
+            let signed_y = kernel_y as isize - center;
+            let phase = signed_x as f64 * phase_gradient_rad_per_sample[0]
+                + signed_y as f64 * phase_gradient_rad_per_sample[1];
+            *weight *= Complex32::new(phase.cos() as f32, phase.sin() as f32);
+        }
         self
     }
 
@@ -964,12 +976,8 @@ impl ScreenProjector {
                 (self.kernel_center as isize + iy * self.sampling as isize + plan.off_y) as usize;
             for ix in plan.min_ix..=plan.max_ix {
                 let signed_x = ix * self.sampling as isize + plan.off_x;
-                let signed_y = iy * self.sampling as isize + plan.off_y;
                 let kernel_x = (self.kernel_center as isize + signed_x) as usize;
-                let phase = signed_x as f64 * self.phase_gradient_rad_per_sample[0]
-                    + signed_y as f64 * self.phase_gradient_rad_per_sample[1];
-                let phasor = Complex32::new(phase.cos() as f32, phase.sin() as f32);
-                let cwt = self.kernel_weights[(kernel_x, kernel_y)] * phasor;
+                let cwt = self.phased_kernel_weights[(kernel_x, kernel_y)];
                 grid[((plan.loc_x + ix) as usize, (plan.loc_y + iy) as usize)] += value * cwt;
             }
         }
@@ -990,13 +998,9 @@ impl ScreenProjector {
                 let grid_y = (plan.loc_y + iy) as usize;
                 for ix in plan.min_ix..=plan.max_ix {
                     let signed_x = ix * self.sampling as isize + plan.off_x;
-                    let signed_y = iy * self.sampling as isize + plan.off_y;
                     let kernel_x = (self.kernel_center as isize + signed_x) as usize;
-                    let phase = signed_x as f64 * self.phase_gradient_rad_per_sample[0]
-                        + signed_y as f64 * self.phase_gradient_rad_per_sample[1];
-                    let phasor = Complex64::new(phase.cos(), phase.sin());
-                    let kernel = self.kernel_weights[(kernel_x, kernel_y)];
-                    let cwt = Complex64::new(kernel.re as f64, kernel.im as f64) * phasor;
+                    let kernel = self.phased_kernel_weights[(kernel_x, kernel_y)];
+                    let cwt = Complex64::new(kernel.re as f64, kernel.im as f64);
                     let grid_x = (plan.loc_x + ix) as usize;
                     storage[grid_x * grid_stride + grid_y] += value * cwt;
                 }
@@ -1008,13 +1012,9 @@ impl ScreenProjector {
                 (self.kernel_center as isize + iy * self.sampling as isize + plan.off_y) as usize;
             for ix in plan.min_ix..=plan.max_ix {
                 let signed_x = ix * self.sampling as isize + plan.off_x;
-                let signed_y = iy * self.sampling as isize + plan.off_y;
                 let kernel_x = (self.kernel_center as isize + signed_x) as usize;
-                let phase = signed_x as f64 * self.phase_gradient_rad_per_sample[0]
-                    + signed_y as f64 * self.phase_gradient_rad_per_sample[1];
-                let phasor = Complex64::new(phase.cos(), phase.sin());
-                let kernel = self.kernel_weights[(kernel_x, kernel_y)];
-                let cwt = Complex64::new(kernel.re as f64, kernel.im as f64) * phasor;
+                let kernel = self.phased_kernel_weights[(kernel_x, kernel_y)];
+                let cwt = Complex64::new(kernel.re as f64, kernel.im as f64);
                 grid[((plan.loc_x + ix) as usize, (plan.loc_y + iy) as usize)] += value * cwt;
             }
         }
@@ -1035,14 +1035,10 @@ impl ScreenProjector {
                 let grid_y = (plan.loc_y + iy) as usize;
                 for ix in plan.min_ix..=plan.max_ix {
                     let signed_x = ix * self.sampling as isize + plan.off_x;
-                    let signed_y = iy * self.sampling as isize + plan.off_y;
                     let kernel_x = (self.kernel_center as isize + signed_x) as usize;
-                    let phase = signed_x as f64 * self.phase_gradient_rad_per_sample[0]
-                        + signed_y as f64 * self.phase_gradient_rad_per_sample[1];
-                    let phasor = Complex32::new(phase.cos() as f32, phase.sin() as f32);
-                    let cwt = self.kernel_weights[(kernel_x, kernel_y)] * phasor;
+                    let cwt = self.phased_kernel_weights[(kernel_x, kernel_y)];
                     let grid_x = (plan.loc_x + ix) as usize;
-                    value += storage[grid_x * grid_stride + grid_y] * cwt;
+                    value += cwt.conj() * storage[grid_x * grid_stride + grid_y];
                 }
             }
             return value;
@@ -1053,12 +1049,8 @@ impl ScreenProjector {
                 (self.kernel_center as isize + iy * self.sampling as isize + plan.off_y) as usize;
             for ix in plan.min_ix..=plan.max_ix {
                 let signed_x = ix * self.sampling as isize + plan.off_x;
-                let signed_y = iy * self.sampling as isize + plan.off_y;
                 let kernel_x = (self.kernel_center as isize + signed_x) as usize;
-                let phase = signed_x as f64 * self.phase_gradient_rad_per_sample[0]
-                    + signed_y as f64 * self.phase_gradient_rad_per_sample[1];
-                let phasor = Complex32::new(phase.cos() as f32, phase.sin() as f32);
-                let cwt = self.kernel_weights[(kernel_x, kernel_y)] * phasor;
+                let cwt = self.phased_kernel_weights[(kernel_x, kernel_y)];
                 value +=
                     cwt.conj() * grid[((plan.loc_x + ix) as usize, (plan.loc_y + iy) as usize)];
             }
@@ -1081,12 +1073,8 @@ impl ScreenProjector {
             .ok()?;
             for ix in plan.min_ix..=plan.max_ix {
                 let signed_x = ix * self.sampling as isize + plan.off_x;
-                let signed_y = iy * self.sampling as isize + plan.off_y;
                 let kernel_x = usize::try_from(self.kernel_center as isize + signed_x).ok()?;
-                let phase = signed_x as f64 * self.phase_gradient_rad_per_sample[0]
-                    + signed_y as f64 * self.phase_gradient_rad_per_sample[1];
-                let phasor = Complex32::new(phase.cos() as f32, phase.sin() as f32);
-                let tap = *self.kernel_weights.get((kernel_x, kernel_y))? * phasor;
+                let tap = *self.phased_kernel_weights.get((kernel_x, kernel_y))?;
                 sum += tap;
                 if ix == 0 && iy == 0 {
                     center = tap;
@@ -1112,15 +1100,11 @@ impl ScreenProjector {
             .ok()?;
             for ix in plan.min_ix..=plan.max_ix {
                 let signed_x = ix * self.sampling as isize + plan.off_x;
-                let signed_y = iy * self.sampling as isize + plan.off_y;
                 let kernel_x = usize::try_from(self.kernel_center as isize + signed_x).ok()?;
-                let phase = signed_x as f64 * self.phase_gradient_rad_per_sample[0]
-                    + signed_y as f64 * self.phase_gradient_rad_per_sample[1];
-                let phasor = Complex32::new(phase.cos() as f32, phase.sin() as f32);
                 taps.push((
                     ix,
                     iy,
-                    *self.kernel_weights.get((kernel_x, kernel_y))? * phasor,
+                    *self.phased_kernel_weights.get((kernel_x, kernel_y))?,
                 ));
             }
         }
@@ -1140,14 +1124,10 @@ impl ScreenProjector {
             usize::try_from(self.kernel_center as isize + iy * self.sampling as isize + plan.off_y)
                 .ok()?;
         let signed_x = ix * self.sampling as isize + plan.off_x;
-        let signed_y = iy * self.sampling as isize + plan.off_y;
         let kernel_x = usize::try_from(self.kernel_center as isize + signed_x).ok()?;
-        let phase = signed_x as f64 * self.phase_gradient_rad_per_sample[0]
-            + signed_y as f64 * self.phase_gradient_rad_per_sample[1];
-        let phasor = Complex32::new(phase.cos() as f32, phase.sin() as f32);
-        self.kernel_weights
+        self.phased_kernel_weights
             .get((kernel_x, kernel_y))
-            .map(|kernel| *kernel * phasor)
+            .copied()
     }
 
     fn sample_normalization(
@@ -1166,12 +1146,8 @@ impl ScreenProjector {
                     .ok()?;
             for ix in min_ix..=max_ix {
                 let signed_x = ix * self.sampling as isize + off_x;
-                let signed_y = iy * self.sampling as isize + off_y;
                 let kernel_x = usize::try_from(self.kernel_center as isize + signed_x).ok()?;
-                let phase = signed_x as f64 * self.phase_gradient_rad_per_sample[0]
-                    + signed_y as f64 * self.phase_gradient_rad_per_sample[1];
-                let phasor = Complex32::new(phase.cos() as f32, phase.sin() as f32);
-                let value = *self.kernel_weights.get((kernel_x, kernel_y))? * phasor;
+                let value = *self.phased_kernel_weights.get((kernel_x, kernel_y))?;
                 normalization += value;
             }
         }

--- a/crates/casa-imaging/src/lib.rs
+++ b/crates/casa-imaging/src/lib.rs
@@ -763,6 +763,7 @@ fn run_mosaic_dirty_imaging(
         let mut trace_group_weight_sum = 0.0f64;
         let mut trace_group_sample_count = 0usize;
         let mut trace_group_center_count = 0usize;
+        let mut group_weight_grid_sum = 0.0f64;
         for sample_index in 0..group.batch.len() {
             if !group.batch.gridable[sample_index] {
                 skipped_samples += 1;
@@ -899,11 +900,7 @@ fn run_mosaic_dirty_imaging(
                 &plan,
                 Complex64::new(visibility.re as f64, visibility.im as f64) * grid_weight64,
             );
-            weight_projector.grid_sample_planned_f64(
-                &mut group_weight_grid,
-                &weight_plan,
-                Complex64::new(grid_weight64, 0.0),
-            );
+            group_weight_grid_sum += grid_weight64;
             let reported = f64::from(grid_weight);
             if plan.center_in_bounds {
                 normalization_sumwt += reported;
@@ -911,6 +908,13 @@ fn run_mosaic_dirty_imaging(
                 trace_group_center_count += 1;
             }
             gridded_samples += 1;
+        }
+        if group_weight_grid_sum > 0.0 {
+            weight_projector.grid_sample_planned_f64(
+                &mut group_weight_grid,
+                &weight_plan,
+                Complex64::new(group_weight_grid_sum, 0.0),
+            );
         }
         if let Some(residual_grid) = accumulated_residual_grid.as_mut() {
             Zip::from(residual_grid)

--- a/crates/casa-tables/src/storage/tiled_stman.rs
+++ b/crates/casa-tables/src/storage/tiled_stman.rs
@@ -2169,6 +2169,43 @@ fn tsm_data_path(table_path: &Path, dm_seq_nr: u32, file_seq_nr: u32) -> std::pa
     table_path.join(format!("table.f{dm_seq_nr}_TSM{file_seq_nr}"))
 }
 
+/// Clone an existing tiled storage manager's header and payload files to a new
+/// data-manager sequence number.
+///
+/// This mirrors the storage-side part of casacore `TableCopy::cloneColumn*`
+/// for the common single-column tiled MeasurementSet data-column case. The
+/// caller is responsible for updating `table.dat` to bind the new column to
+/// `target_dm_seq_nr`.
+pub(crate) fn clone_tiled_manager_files(
+    table_path: &Path,
+    source_dm_seq_nr: u32,
+    target_dm_seq_nr: u32,
+    target_dm_name: &str,
+) -> Result<(), StorageError> {
+    let source_header_path = table_path.join(format!("table.f{source_dm_seq_nr}"));
+    let target_header_path = table_path.join(format!("table.f{target_dm_seq_nr}"));
+    let (variant, mut header) = read_tiled_header(&source_header_path)?;
+
+    if header.col_data_types.len() != 1 {
+        return Err(StorageError::UnsupportedDataManager(format!(
+            "tiled data manager {source_dm_seq_nr} has {} columns; clone_tiled_manager_files supports single-column managers",
+            header.col_data_types.len()
+        )));
+    }
+
+    for file_info in header.files.iter().flatten() {
+        let source_data_path = tsm_data_path(table_path, source_dm_seq_nr, file_info.seq_nr);
+        let target_data_path = tsm_data_path(table_path, target_dm_seq_nr, file_info.seq_nr);
+        std::fs::copy(&source_data_path, &target_data_path)?;
+    }
+
+    header.seq_nr = target_dm_seq_nr;
+    header.hypercolumn_name = target_dm_name.to_string();
+    write_tiled_header(&target_header_path, &variant, &header)?;
+    invalidate_shared_tile_cache_for_table(table_path);
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Save interface (write columns with tiled DM)
 // ---------------------------------------------------------------------------

--- a/crates/casa-tables/src/table/io.rs
+++ b/crates/casa-tables/src/table/io.rs
@@ -742,6 +742,193 @@ impl Table {
         Ok(())
     }
 
+    /// Persists a newly-added array column by cloning an existing single-column
+    /// tiled data manager and binding the clone to `target_column`.
+    ///
+    /// This is the storage-layout clone used by casacore
+    /// `TableCopy::cloneColumnTyped` + `TableCopy::copyColumnData` for
+    /// MeasurementSet scratch columns: the target starts as a byte-for-byte copy
+    /// of the source tiled payload, then callers can sparsely patch rows.
+    ///
+    /// Callers must ensure that `target_column` already exists in the in-memory
+    /// schema, is not yet present on disk, and has the same primitive array
+    /// type as `source_column`.
+    pub fn save_added_tiled_column_clone_in_place_assuming_valid(
+        &mut self,
+        source_column: &str,
+        target_column: &str,
+        target_data_manager_name: &str,
+    ) -> Result<(), TableError> {
+        if self.kind != TableKind::Plain {
+            return Err(TableError::Storage(
+                "cloning a tiled column in place requires a plain disk-backed table".to_string(),
+            ));
+        }
+        if !self.virtual_columns.is_empty() || !self.virtual_bindings.is_empty() {
+            return Err(TableError::Storage(
+                "cloning a tiled column in place does not support virtual columns".to_string(),
+            ));
+        }
+
+        let source_path = self
+            .source_path
+            .as_ref()
+            .ok_or_else(|| TableError::Storage("table has no source path".to_string()))?
+            .clone();
+        let target_schema_column = self
+            .inner
+            .schema()
+            .and_then(|schema| schema.column(target_column))
+            .cloned()
+            .ok_or_else(|| TableError::SchemaColumnUnknown {
+                column: target_column.to_string(),
+            })?;
+
+        let auto_unlock = self.begin_write_operation("save_added_tiled_column_clone")?;
+        let result = (|| {
+            let control_path = source_path.join(crate::storage::TABLE_CONTROL_FILE);
+            let mut table_dat =
+                match crate::storage::table_control::read_table_dat_dispatch(&control_path)? {
+                    crate::storage::table_control::TableDatResult::Plain(table_dat) => table_dat,
+                    _ => {
+                        return Err(TableError::Storage(
+                            "cloning a tiled column in place only supports plain tables"
+                                .to_string(),
+                        ));
+                    }
+                };
+
+            if table_dat
+                .table_desc
+                .columns
+                .iter()
+                .any(|desc| desc.col_name == target_column)
+            {
+                return Err(TableError::Storage(format!(
+                    "column \"{target_column}\" already exists on disk"
+                )));
+            }
+
+            let source_desc = table_dat
+                .table_desc
+                .columns
+                .iter()
+                .find(|desc| desc.col_name == source_column)
+                .cloned()
+                .ok_or_else(|| TableError::SchemaColumnUnknown {
+                    column: source_column.to_string(),
+                })?;
+            let source_plain_column = table_dat
+                .column_set
+                .columns
+                .iter()
+                .find(|entry| entry.original_name == source_column)
+                .cloned()
+                .ok_or_else(|| {
+                    TableError::Storage(format!(
+                        "column \"{source_column}\" is not bound to an on-disk data manager"
+                    ))
+                })?;
+            let source_dm = table_dat
+                .column_set
+                .data_managers
+                .iter()
+                .find(|entry| entry.seq_nr == source_plain_column.dm_seq_nr)
+                .cloned()
+                .ok_or_else(|| {
+                    TableError::Storage(format!(
+                        "data manager {} for column \"{source_column}\" is missing",
+                        source_plain_column.dm_seq_nr
+                    ))
+                })?;
+            if !matches!(
+                source_dm.type_name.as_str(),
+                "TiledColumnStMan" | "TiledShapeStMan" | "TiledCellStMan" | "TiledDataStMan"
+            ) {
+                return Err(TableError::Storage(format!(
+                    "column \"{source_column}\" is stored in {}, not a tiled data manager",
+                    source_dm.type_name
+                )));
+            }
+            let source_group_columns = table_dat
+                .column_set
+                .columns
+                .iter()
+                .filter(|entry| entry.dm_seq_nr == source_plain_column.dm_seq_nr)
+                .count();
+            if source_group_columns != 1 {
+                return Err(TableError::Storage(format!(
+                    "column \"{source_column}\" shares data manager {} with {source_group_columns} columns; clone currently supports single-column tiled managers",
+                    source_plain_column.dm_seq_nr
+                )));
+            }
+
+            let mut target_desc =
+                crate::storage::table_control::ColumnDescContents::from_column_schema(
+                    &target_schema_column,
+                );
+            if source_desc.require_primitive_type()? != target_desc.require_primitive_type()? {
+                return Err(TableError::Storage(format!(
+                    "cannot clone \"{source_column}\" into \"{target_column}\" with a different primitive type"
+                )));
+            }
+            target_desc.data_manager_type = source_dm.type_name.clone();
+            target_desc.data_manager_group = target_data_manager_name.to_string();
+            if let Some(keywords) = self.inner.column_keywords(target_column) {
+                target_desc.keywords = keywords.clone();
+            } else {
+                target_desc.keywords = source_desc.keywords.clone();
+            }
+
+            let target_seq_nr = table_dat
+                .column_set
+                .data_managers
+                .iter()
+                .map(|dm| dm.seq_nr)
+                .max()
+                .map_or(0, |seq| seq + 1);
+            crate::storage::tiled_stman::clone_tiled_manager_files(
+                &source_path,
+                source_plain_column.dm_seq_nr,
+                target_seq_nr,
+                target_data_manager_name,
+            )?;
+
+            table_dat.table_desc.columns.push(target_desc);
+            table_dat
+                .column_set
+                .columns
+                .push(crate::storage::table_control::PlainColumnEntry {
+                    original_name: target_column.to_string(),
+                    dm_seq_nr: target_seq_nr,
+                    is_array: true,
+                });
+            table_dat.column_set.data_managers.push(
+                crate::storage::table_control::DataManagerEntry {
+                    type_name: source_dm.type_name.clone(),
+                    seq_nr: target_seq_nr,
+                    data: source_dm.data.clone(),
+                },
+            );
+            table_dat.column_set.seq_count = table_dat
+                .column_set
+                .data_managers
+                .iter()
+                .map(|dm| dm.seq_nr + 1)
+                .max()
+                .unwrap_or(1);
+            crate::storage::table_control::write_table_dat(&control_path, &table_dat)?;
+            crate::storage::tiled_stman::invalidate_shared_tile_cache_for_table(&source_path);
+            self.dm_info.push(crate::storage::DataManagerInfo {
+                dm_type: source_dm.type_name,
+                seq_nr: target_seq_nr,
+                columns: vec![target_column.to_string()],
+            });
+            Ok(())
+        })();
+        self.finish_write_operation(auto_unlock, result)
+    }
+
     /// Persists a newly-added variable-shape array column as a standalone
     /// `TiledShapeStMan` data manager without rewriting existing managers.
     ///

--- a/crates/casa-tables/src/table/tests.rs
+++ b/crates/casa-tables/src/table/tests.rs
@@ -3684,6 +3684,111 @@ fn add_variable_shape_tiled_column_in_place_persists_defined_rows_only() {
 }
 
 #[test]
+fn clone_tiled_array_column_in_place_preserves_source_values_and_allows_sparse_patch() {
+    let schema = TableSchema::new(vec![ColumnSchema::array_variable(
+        "DATA",
+        PrimitiveType::Complex32,
+        Some(2),
+    )])
+    .expect("schema");
+    let mut table = Table::with_schema(schema);
+    for row_idx in 0..4 {
+        table
+            .add_row(RecordValue::new(vec![RecordField::new(
+                "DATA",
+                Value::Array(ArrayValue::Complex32(
+                    ArrayD::from_shape_vec(
+                        vec![2, 2],
+                        vec![
+                            casa_types::Complex32::new(row_idx as f32, 0.0),
+                            casa_types::Complex32::new(row_idx as f32, 1.0),
+                            casa_types::Complex32::new(row_idx as f32, 2.0),
+                            casa_types::Complex32::new(row_idx as f32, 3.0),
+                        ],
+                    )
+                    .expect("shape DATA"),
+                )),
+            )]))
+            .expect("add row");
+    }
+
+    let root = unique_test_dir("clone_tiled_array_column");
+    std::fs::create_dir_all(&root).expect("mkdir");
+    table
+        .save(TableOptions::new(&root).with_data_manager(DataManagerKind::TiledShapeStMan))
+        .expect("save source table");
+
+    let mut reopened = Table::open(TableOptions::new(&root)).expect("open source table");
+    reopened
+        .add_column(
+            ColumnSchema::array_variable("CORRECTED_DATA", PrimitiveType::Complex32, Some(2)),
+            None,
+        )
+        .expect("add corrected column");
+    reopened
+        .save_added_tiled_column_clone_in_place_assuming_valid(
+            "DATA",
+            "CORRECTED_DATA",
+            "TiledCorrected",
+        )
+        .expect("clone DATA to CORRECTED_DATA");
+    table_set_cell(
+        &mut reopened,
+        2,
+        "CORRECTED_DATA",
+        Value::Array(ArrayValue::Complex32(
+            ArrayD::from_shape_vec(
+                vec![2, 2],
+                vec![
+                    casa_types::Complex32::new(20.0, 0.0),
+                    casa_types::Complex32::new(20.0, 1.0),
+                    casa_types::Complex32::new(20.0, 2.0),
+                    casa_types::Complex32::new(20.0, 3.0),
+                ],
+            )
+            .expect("shape corrected"),
+        )),
+    )
+    .expect("patch row");
+    reopened
+        .save_selected_rows_in_place_assuming_valid(&["CORRECTED_DATA"], &[2])
+        .expect("sparse patch corrected");
+
+    let patched = Table::open(TableOptions::new(&root)).expect("reopen patched table");
+    assert_eq!(
+        table_array(&patched, 1, "CORRECTED_DATA"),
+        table_array(&patched, 1, "DATA")
+    );
+    assert_ne!(
+        table_array(&patched, 2, "CORRECTED_DATA"),
+        table_array(&patched, 2, "DATA")
+    );
+    assert_eq!(
+        table_array(&patched, 2, "CORRECTED_DATA"),
+        Ok(&ArrayValue::Complex32(
+            ArrayD::from_shape_vec(
+                vec![2, 2],
+                vec![
+                    casa_types::Complex32::new(20.0, 0.0),
+                    casa_types::Complex32::new(20.0, 1.0),
+                    casa_types::Complex32::new(20.0, 2.0),
+                    casa_types::Complex32::new(20.0, 3.0),
+                ],
+            )
+            .unwrap()
+        ))
+    );
+    assert!(
+        patched
+            .data_manager_info()
+            .iter()
+            .any(|dm| dm.dm_type == "TiledShapeStMan" && dm.columns == ["CORRECTED_DATA"])
+    );
+
+    std::fs::remove_dir_all(&root).expect("cleanup");
+}
+
+#[test]
 fn from_rows_with_schema_persists_missing_undefined_scalar_cells() {
     use crate::schema::ColumnOptions;
 

--- a/docs/tutorial-parity/README.md
+++ b/docs/tutorial-parity/README.md
@@ -35,6 +35,10 @@ functionality.
 - [Issue 163 M100 Band 3 Combine evidence](wave-6-issue-163-m100-band3-combine.md)
 - [Issue 169 VLA 3C391 evidence](wave-6-issue-169-3c391.md)
 
+## Wave 7 Artifacts
+
+- [Performance closeout](wave-7-performance-closeout.md)
+
 ## Source Pages
 
 - CASA Guides main page:

--- a/docs/tutorial-parity/README.md
+++ b/docs/tutorial-parity/README.md
@@ -38,6 +38,7 @@ functionality.
 ## Wave 7 Artifacts
 
 - [Performance closeout](wave-7-performance-closeout.md)
+- [Ticket-level performance closeout](wave-7-ticket-closeout.md)
 
 ## Source Pages
 

--- a/docs/tutorial-parity/wave-7-performance-closeout.md
+++ b/docs/tutorial-parity/wave-7-performance-closeout.md
@@ -1,0 +1,85 @@
+# Wave 7 Performance Closeout
+
+Truth class: current descriptive
+Last reality check: 2026-05-05
+Verification: `bash -n scripts/run-wave7-performance-closeout.sh`; `just docs-check`
+
+Wave issue: #144
+Child issue: #130
+
+Wave 7 consolidates tutorial-program performance evidence and splits remaining
+performance work into subsystem tickets. It does not change imaging,
+calibration, plotting, table, or simulation algorithms.
+
+## Measurement Policy
+
+- Compare CASA 6.7.5-9 / CASA C++ and casa-rs on the same staged tutorial
+  inputs before claiming match/exceed status.
+- Record whether a timing is cold path, fresh-open, reused-open, or warm
+  in-process. If that distinction is missing, treat the number as evidence for
+  follow-up shaping rather than a final performance claim.
+- Use the shared tutorial-data registry or shared fixture resolver for new
+  timing runs. Do not use personal workstation paths as implicit script
+  fallbacks.
+- Severe regressions block closeout only when the workload and outputs are
+  already equivalent enough for the comparison to be meaningful.
+- Non-severe gaps become follow-up tickets with reproduction commands, dataset
+  keys, suspected subsystem, and acceptance criteria.
+
+## Current Baseline
+
+| Vertical / capability | Evidence | CASA timing | casa-rs timing | Status |
+|---|---|---:|---:|---|
+| Wave 3 #117 TW Hydra dirty MFS imaging | `docs/tutorial-parity/wave-3-issue-117-mfs-foundation.md` | `5.246 s` wall | `4.777 s` internal after #95 | Meets current target for this standard-MFS dirty case. |
+| Wave 3 #118 TW Hydra self-cal loop | `docs/tutorial-parity/wave-3-issue-118-selfcal-parity.md` | `175.962 s` total | `176.736 s` total | End-to-end runtime is within roughly 2%, but calibration/apply/export is still slower. |
+| Wave 3 #120 image analysis | `docs/tutorial-parity/wave-3-issue-120-image-analysis.md` | `0.001977-0.020663 s` warm medians | `0.000206-0.006461 s` warm medians | casa-rs is faster on the measured warm in-process operations. |
+| Wave 5 #125 VLA protoplanetary disk imaging / plotting | `docs/tutorial-parity/wave-5-simulation-parity.md` | `2.146 s` `tclean`; `0.209 s` headless plot fallback | `2.897 s` imager; `6.284 s` `msexplore` | Imaging is close after the MFS frequency-cache fix; plot timing needs a fair `plotms` comparison. |
+| Wave 5 #126 simulation corruptions | `docs/tutorial-parity/wave-5-simulation-parity.md` | `0.114 s` noise+gain corruption | native corruption timings recorded in JSON artifacts | Direct CASA comparison is limited by simulator feature availability. |
+| Wave 6 #161 Antennae Band 7 mosaic | `docs/tutorial-parity/wave-6-issue-161-antennae-band7.md` | `42.026 s` continuum runner; `3.124 s` two-channel cube probe | `193.242 s` continuum runner; `2.395 s` two-channel cube probe | Continuum mosaic/CLEAN is 4.60x CASA and needs imaging-performance follow-up. |
+| Wave 6 #163 M100 data combination | `docs/tutorial-parity/wave-6-issue-163-m100-band3-combine.md` | Same-input CASA products recorded; full comparable CASA timing not yet recorded for the 70-channel scale-up | `33.757 s` two-channel release probe; `552.409 s` 70-channel release scale-up | Needs a same-shape CASA timing and cube-scaling breakdown before optimization claims. |
+| Wave 6 #169 VLA 3C391 mosaic | `docs/tutorial-parity/wave-6-issue-169-3c391.md` | `75.489 s` | `257.494 s` | Mosaic/CLEAN is 3.41x CASA and belongs with the imaging-performance follow-up. |
+
+## Follow-Up Split
+
+The current evidence supports these subsystem splits:
+
+| Area | Reason | Follow-up |
+|---|---|---|
+| Imaging mosaic / CLEAN throughput | Wave 6 #161 and #169 are 3.41x-4.60x CASA on same-input mosaic products, and #163 shows large cube scale-up cost. | #197 serial mosaic/PB/CLEAN throughput triage before broader runtime-model changes. |
+| Calibration/apply/export overhead | Wave 3 #118 matches total runtime, but calibration/apply/export is `37.347 s` in casa-rs versus `9.513 s` in CASA. | #198 isolate calibration apply, split/export, and caltable I/O overhead in the self-cal loop. |
+| Plot export / `msexplore` timing | Wave 5 #125 shows `msexplore` plot output at `6.284 s`, but the CASA side was a matplotlib fallback because `plotms` was unavailable without `DISPLAY`. | #199 run fair `plotms` versus `msexplore` export timing with a display-capable CASA path or equivalent exported-data oracle. |
+| Large cube runtime controls | Existing #56 already covers CASA-like `parallel` and `chanchunks` controls. | Keep #56 separate from the serial-throughput triage unless profiling shows the fix requires runtime/concurrency changes. |
+
+## Rerun Harness
+
+Use:
+
+```bash
+scripts/run-wave7-performance-closeout.sh
+```
+
+By default the script runs shared dataset preflight checks and writes a closeout
+run directory under `target/wave7-performance-closeout/` without running heavy
+benchmarks. M100-heavy reruns from this workstation should set the tutorial
+root explicitly because the full M100 archives are staged on the external
+mirror, not under the default home tutorial root:
+
+```bash
+CASA_RS_TUTORIAL_DATA_ROOT=/Volumes/GLENDENNING/casa-rs/tutorial-data \
+  scripts/run-wave7-performance-closeout.sh
+```
+
+Use:
+
+```bash
+WAVE7_RUN_BENCHES=1 scripts/run-wave7-performance-closeout.sh
+```
+
+to also run the existing shared benchmark scripts and capture their logs.
+
+## Closeout Decision
+
+Wave 7 closeout created #197, #198, and #199 as follow-up tickets. The wave
+should not attempt to fix imaging throughput directly; any algorithm,
+concurrency, or runtime-model change must happen under the shaped follow-up
+issue and the stop-and-ask rules in `AGENTS.md`.

--- a/docs/tutorial-parity/wave-7-performance-closeout.md
+++ b/docs/tutorial-parity/wave-7-performance-closeout.md
@@ -2,7 +2,7 @@
 
 Truth class: current descriptive
 Last reality check: 2026-05-05
-Verification: `bash -n scripts/run-wave7-performance-closeout.sh`; `just docs-check`
+Verification: `bash -n scripts/run-wave7-performance-closeout.sh`; `bash -n scripts/run-wave7-ticket-closeout.sh`; `just docs-check`; `just quick`; `just verify`
 
 Wave issue: #144
 Child issue: #130
@@ -83,3 +83,9 @@ Wave 7 closeout created #197, #198, and #199 as follow-up tickets. The wave
 should not attempt to fix imaging throughput directly; any algorithm,
 concurrency, or runtime-model change must happen under the shaped follow-up
 issue and the stop-and-ask rules in `AGENTS.md`.
+
+The ticket-level closeout is recorded in
+`docs/tutorial-parity/wave-7-ticket-closeout.md`. It created #204 for serial
+mosaic grid/degrid optimization and #205 for TW Hydra applycal persistence
+overhead; the direct #199 `plotms` run did not confirm a Rust plotting
+regression.

--- a/docs/tutorial-parity/wave-7-ticket-closeout.md
+++ b/docs/tutorial-parity/wave-7-ticket-closeout.md
@@ -45,24 +45,26 @@ bottleneck to serial gridding/degridding:
 | Antennae North continuum clean | `134.19 s` | `132.804 s` | `7.299 s` | `125.471 s` | `psf_grid=80.775 s`, `residual_degrid_grid=43.334 s` |
 | VLA 3C391 multiscale mosaic | `547.93 s` | `547.390 s` | `46.314 s` | `501.041 s` | `psf_grid=184.120 s`, `residual_degrid_grid=307.836 s`, `weighting=6.465 s` |
 
-#204 now has two local mosaic hot-path fixes:
+#204 now has three local mosaic hot-path fixes:
 
 - the centered per-group mosaic weight kernel is gridded once from the group
   weight sum instead of once per accepted visibility sample;
 - mosaic screen-projector grid/degrid loops use contiguous grid slices instead
-  of per-tap `ndarray` indexing.
+  of per-tap `ndarray` indexing;
+- mosaic screen-projector phase-gradient kernels are precomputed once per
+  pointing instead of recomputing trigonometric phasors for every tap of every
+  visibility sample.
 
 Updated same-input casa-rs evidence:
 
 | Current profile after #204 fixes | Wall | Frontend total | prepare | run_imaging | Dominant core stages |
 |---|---:|---:|---:|---:|---|
-| Antennae North continuum clean | `51.92 s` | `51.916 s` | `2.750 s` | `49.138 s` | `psf_grid=22.991 s`, `residual_degrid_grid=25.598 s` |
-| VLA 3C391 multiscale mosaic | `309.84 s` | `309.843 s` | `36.460 s` | `273.356 s` | `psf_grid=102.227 s`, `residual_degrid_grid=163.906 s`, `weighting=4.808 s` |
+| Antennae North continuum clean | `11.53 s` | `11.529 s` | `2.662 s` | `8.844 s` | `psf_grid=4.162 s`, `residual_degrid_grid=4.147 s` |
+| VLA 3C391 multiscale mosaic | `69.06 s` | `69.057 s` | `24.503 s` | `44.524 s` | `psf_grid=12.842 s`, `residual_degrid_grid=27.205 s`, `weighting=2.861 s` |
 
 This moves the Antennae tutorial case from `3.19x` the current CASA C++ run
-to `1.24x`, and the 3C391 tutorial case from `7.26x` to `4.10x`, using the
-current CASA C++ timings above. The remaining #204 work is the serial mosaic
-residual-refresh path; parallel/chanchunks work remains owned by #56.
+to `0.27x`, and the 3C391 tutorial case from `7.26x` to `0.91x`, using the
+current CASA C++ timings above.
 
 ## #198 Calibration Apply/Export
 

--- a/docs/tutorial-parity/wave-7-ticket-closeout.md
+++ b/docs/tutorial-parity/wave-7-ticket-closeout.md
@@ -1,0 +1,117 @@
+# Wave 7 Ticket Closeout
+
+Truth class: current evidence
+Last reality check: 2026-05-05
+Verification: `bash -n scripts/run-wave7-ticket-closeout.sh`; `WAVE7_TICKET_OUTDIR=target/wave7-ticket-closeout/current WAVE7_RUN_ISSUE197=1 WAVE7_RUN_ISSUE198=0 WAVE7_RUN_ISSUE199=0 WAVE7_TICKET_REPEATS=1 scripts/run-wave7-ticket-closeout.sh`; `WAVE7_TICKET_OUTDIR=target/wave7-ticket-closeout/current WAVE7_RUN_TARGETED_BENCHES=1 WAVE7_TICKET_REPEATS=1 scripts/run-wave7-ticket-closeout.sh`; `just quick`; `just verify`
+
+Wave issue: #144
+Wave child: #130
+Ticket closeouts: #197, #198, #199
+Follow-up implementation tickets: #204, #205
+
+This document records the Wave 7 ticket-level performance triage after the
+initial closeout split. The ticket work stayed inside measurement, evidence,
+and follow-up shaping; it did not change imaging, calibration, plotting, table,
+or runtime algorithms.
+
+The current rerun artifacts are under:
+
+```text
+target/wave7-ticket-closeout/current/
+```
+
+## #197 Imaging Throughput
+
+Existing same-input tutorial wall-clock evidence already showed the serial
+mosaic/CLEAN gap:
+
+| Workload | CASA C++ | casa-rs | Prior status |
+|---|---:|---:|---|
+| Wave 6 #161 Antennae Band 7 continuum runner | `42.026 s` | `193.242 s` | `4.60x CASA` |
+| Wave 6 #169 VLA 3C391 multiscale mosaic runner | `75.489 s` | `257.494 s` | `3.41x CASA` |
+| Wave 6 #163 M100 70-channel raw combine | comparable CASA wall-clock not preserved | `552.409 s` | casa-rs `run_imaging=479.390 s`, `prepare_plane_input=67.155 s` |
+
+The #163 blocker is now explicit: the same-input CASA products and comparison
+panels exist in the Wave 6 evidence trail, but a comparable 70-channel CASA
+wall-clock timing sidecar was not preserved in the current branch. The raw M100
+archives are staged under the explicit external tutorial root
+`/Volumes/GLENDENNING/casa-rs/tutorial-data`; `/Volumes/home/casatestdata` is
+not needed for this tutorial data.
+
+Current casa-rs managed-output profiles localize the confirmed #161/#169
+bottleneck to serial gridding/degridding:
+
+| Current profile | Wall | Frontend total | prepare | run_imaging | Dominant core stages |
+|---|---:|---:|---:|---:|---|
+| Antennae North continuum clean | `134.19 s` | `132.804 s` | `7.299 s` | `125.471 s` | `psf_grid=80.775 s`, `residual_degrid_grid=43.334 s` |
+| VLA 3C391 multiscale mosaic | `547.93 s` | `547.390 s` | `46.314 s` | `501.041 s` | `psf_grid=184.120 s`, `residual_degrid_grid=307.836 s`, `weighting=6.465 s` |
+
+The first implementation follow-up is #204. It targets the serial mosaic
+PSF/residual grid-degrid hot path and explicitly excludes parallel/chanchunks
+work, which remains owned by #56.
+
+## #198 Calibration Apply/Export
+
+The targeted TW Hydra applycal benchmark used the staged `twhya_selfcal.ms`
+archive extracted under the run directory, with `field=5`, `spw=0`,
+`refant=DV22`, and `applymode=calflag`.
+
+| Runtime | Wall median |
+|---|---:|
+| CASA `applycal` | `0.893 s` |
+| casa-rs `calibrate apply` | `2.510 s` |
+| Ratio | `2.81x CASA` |
+
+casa-rs internal timing:
+
+| Stage | Time |
+|---|---:|
+| report total | `2.460 s` |
+| save | `1.733 s` |
+| ensure corrected data | `0.337 s` |
+| row loop | `0.281 s` |
+| row compute | `0.167 s` |
+| row read/fetch | `0.098 s` |
+| planning | `0.064 s` |
+| calibration load | `0.001 s` |
+
+The dominant bottleneck is save/persistence after apply, not caltable loading
+or calibration row math. The implementation follow-up is #205.
+
+## #199 Plot Export
+
+Direct `plotms` timing now works on this local CASA path. The repeated run in
+`issue199-plotms-msexplore-bench.log` used the same `ngc5921.ms`, amplitude vs
+time, `spw=0`, `iteraxis=scan`, `gridcols=2`, correlation coloring, and
+`1600x900` PNG export.
+
+| Runtime | Median |
+|---|---:|
+| CASA `plotms` PNG export | `4.141 s` |
+| casa-rs `msexplore` CLI PNG export | `3.200 s` |
+| casa-rs in-process fresh pipeline | `3.107 s` |
+| casa-rs in-process reused-open pipeline | `2.330 s` |
+
+The Rust path is not slower than direct `plotms` in this measured scenario.
+The dominant Rust in-process cost is rendering (`2.809 s` median), followed by
+fresh payload build (`1.891 s` median). Since no direct plotms regression is
+confirmed, #199 does not need a performance implementation follow-up from this
+wave.
+
+## Rerun Harness
+
+Use:
+
+```bash
+scripts/run-wave7-ticket-closeout.sh
+```
+
+By default the script runs data preflight only. To rerun one slice:
+
+```bash
+WAVE7_RUN_ISSUE197=1 scripts/run-wave7-ticket-closeout.sh
+WAVE7_RUN_ISSUE198=1 scripts/run-wave7-ticket-closeout.sh
+WAVE7_RUN_ISSUE199=1 scripts/run-wave7-ticket-closeout.sh
+```
+
+Set `WAVE7_RUN_TARGETED_BENCHES=1` to run all three targeted slices.

--- a/docs/tutorial-parity/wave-7-ticket-closeout.md
+++ b/docs/tutorial-parity/wave-7-ticket-closeout.md
@@ -10,9 +10,8 @@ Ticket closeouts: #197, #198, #199
 Follow-up implementation tickets: #204, #205
 
 This document records the Wave 7 ticket-level performance triage after the
-initial closeout split. The ticket work stayed inside measurement, evidence,
-and follow-up shaping; it did not change imaging, calibration, plotting, table,
-or runtime algorithms.
+initial closeout split plus the first implementation repairs for the confirmed
+imaging and calibration hotspots.
 
 The current rerun artifacts are under:
 
@@ -46,9 +45,24 @@ bottleneck to serial gridding/degridding:
 | Antennae North continuum clean | `134.19 s` | `132.804 s` | `7.299 s` | `125.471 s` | `psf_grid=80.775 s`, `residual_degrid_grid=43.334 s` |
 | VLA 3C391 multiscale mosaic | `547.93 s` | `547.390 s` | `46.314 s` | `501.041 s` | `psf_grid=184.120 s`, `residual_degrid_grid=307.836 s`, `weighting=6.465 s` |
 
-The first implementation follow-up is #204. It targets the serial mosaic
-PSF/residual grid-degrid hot path and explicitly excludes parallel/chanchunks
-work, which remains owned by #56.
+#204 now has two local mosaic hot-path fixes:
+
+- the centered per-group mosaic weight kernel is gridded once from the group
+  weight sum instead of once per accepted visibility sample;
+- mosaic screen-projector grid/degrid loops use contiguous grid slices instead
+  of per-tap `ndarray` indexing.
+
+Updated same-input casa-rs evidence:
+
+| Current profile after #204 fixes | Wall | Frontend total | prepare | run_imaging | Dominant core stages |
+|---|---:|---:|---:|---:|---|
+| Antennae North continuum clean | `51.92 s` | `51.916 s` | `2.750 s` | `49.138 s` | `psf_grid=22.991 s`, `residual_degrid_grid=25.598 s` |
+| VLA 3C391 multiscale mosaic | `309.84 s` | `309.843 s` | `36.460 s` | `273.356 s` | `psf_grid=102.227 s`, `residual_degrid_grid=163.906 s`, `weighting=4.808 s` |
+
+This moves the Antennae tutorial case from `3.19x` the current CASA C++ run
+to `1.24x`, and the 3C391 tutorial case from `7.26x` to `4.10x`, using the
+current CASA C++ timings above. The remaining #204 work is the serial mosaic
+residual-refresh path; parallel/chanchunks work remains owned by #56.
 
 ## #198 Calibration Apply/Export
 
@@ -75,8 +89,39 @@ casa-rs internal timing:
 | planning | `0.064 s` |
 | calibration load | `0.001 s` |
 
-The dominant bottleneck is save/persistence after apply, not caltable loading
-or calibration row math. The implementation follow-up is #205.
+The dominant bottleneck was save/persistence after apply, not caltable loading
+or calibration row math. #205 now has the CASA/C++ source finding: uncompressed
+`CORRECTED_DATA` creation uses `TableCopy::cloneColumnTyped<Complex>` plus
+`TableCopy::copyColumnData(..., preserveTileShape=true)` from `DATA` or
+`FLOAT_DATA`, then sparse apply writes patch selected rows.
+
+The Rust fix added the same storage-layout path for single-column tiled
+MeasurementSet data columns, then retained the existing selected-row patch
+save. One-repeat local evidence on the same TW Hydra slice:
+
+| Runtime | Wall / total |
+|---|---:|
+| CASA `applycal` | `0.808 s` |
+| casa-rs `calibrate apply` | `0.937 s` |
+| Ratio | `1.16x CASA` |
+
+Updated casa-rs internal timing:
+
+| Stage | Time |
+|---|---:|
+| report total | `0.937 s` |
+| execute apply plan | `0.871 s` |
+| save | `0.573 s` |
+| ensure corrected data | `0.001 s` |
+| row loop | `0.295 s` |
+| row read/fetch | `0.193 s` |
+| row compute | `0.093 s` |
+| row writeback | `0.005 s` |
+| planning | `0.048 s` |
+
+CASA/casatools reopened the Rust output: a selected field-5 row had
+`DATA != CORRECTED_DATA`, while an unselected row had
+`DATA == CORRECTED_DATA`, preserving CASA scratch-column semantics.
 
 ## #199 Plot Export
 

--- a/scripts/run-wave7-performance-closeout.sh
+++ b/scripts/run-wave7-performance-closeout.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+outdir="${WAVE7_OUTDIR:-target/wave7-performance-closeout/$stamp}"
+run_benches="${WAVE7_RUN_BENCHES:-0}"
+bench_repeats="${WAVE7_BENCH_REPEATS:-3}"
+
+mkdir -p "$outdir"
+log_file="$outdir/wave7-performance-closeout.log"
+
+if [[ -z "${CASA_RS_CASA_PYTHON:-}" && -x "$HOME/SoftwareProjects/casa-build/venv/bin/python" ]]; then
+  export CASA_RS_CASA_PYTHON="$HOME/SoftwareProjects/casa-build/venv/bin/python"
+fi
+
+if [[ -z "${CASA_RS_TUTORIAL_DATA_ROOT:-}" && -d "$HOME/SoftwareProjects/casa-tutorial-data" ]]; then
+  export CASA_RS_TUTORIAL_DATA_ROOT="$HOME/SoftwareProjects/casa-tutorial-data"
+fi
+
+if [[ -z "${CASA_RS_TESTDATA_ROOT:-}" && -d "$HOME/SoftwareProjects/casatestdata" ]]; then
+  export CASA_RS_TESTDATA_ROOT="$HOME/SoftwareProjects/casatestdata"
+fi
+
+require_tutorial_key() {
+  local key="$1"
+  cargo run -q -p casa-test-support --bin casatestdata-preflight -- \
+    --tier tutorial-parity \
+    --require-registry-key "$key"
+}
+
+check_tutorial_key() {
+  local key="$1"
+  if ! require_tutorial_key "$key"; then
+    echo "wave7 preflight warning: missing tutorial registry key $key"
+    if [[ -n "${CASA_RS_TUTORIAL_DATA_ROOT:-}" ]]; then
+      echo "wave7 preflight hint: selected tutorial root may not contain this staged key"
+    else
+      echo "wave7 preflight hint: set CASA_RS_TUTORIAL_DATA_ROOT to the staged tutorial mirror for one-off local data"
+    fi
+  fi
+}
+
+main() {
+  echo "wave7_performance_closeout_stamp=$stamp"
+  echo "outdir=$outdir"
+  echo "run_benches=$run_benches"
+  echo "bench_repeats=$bench_repeats"
+  echo "CASA_RS_CASA_PYTHON=${CASA_RS_CASA_PYTHON:-}"
+  echo "CASA_RS_TUTORIAL_DATA_ROOT=${CASA_RS_TUTORIAL_DATA_ROOT:-}"
+  echo "CASA_RS_TESTDATA_ROOT=${CASA_RS_TESTDATA_ROOT:-}"
+  echo
+
+  echo "==> Tutorial dataset preflight"
+  check_tutorial_key alma/first-look/twhya/calibrated-ms
+  check_tutorial_key alma/first-look/twhya/continuum-image
+  check_tutorial_key alma/first-look/twhya/n2hp-image
+  check_tutorial_key simulation/vla-ppdisk/model-fits
+  check_tutorial_key alma/antennae/band7/calibrated-data
+  check_tutorial_key alma/antennae/band7/reference-images
+  check_tutorial_key alma/m100/band3-combine/aca-reference-images
+  check_tutorial_key alma/m100/band3-combine/reference-images
+  check_tutorial_key vla/3c391/final-calibrated-mosaic-ms
+  echo
+
+  cat >"$outdir/README.md" <<EOF
+# Wave 7 Performance Closeout Run
+
+Stamp: \`$stamp\`
+
+This directory records a Wave 7 performance closeout harness run.
+
+- \`wave7-performance-closeout.log\`: preflight and benchmark output
+- \`bench-imager-vs-casa.log\`: optional imaging benchmark log
+- \`bench-msexplore-vs-casa.log\`: optional plotting benchmark log
+- \`bench-calibrate-vs-casa.log\`: optional calibration benchmark log
+
+Set \`WAVE7_RUN_BENCHES=1\` to run the optional benchmark logs.
+EOF
+
+  if [[ "$run_benches" != "1" ]]; then
+    echo "==> Skipping heavy benchmark runs; set WAVE7_RUN_BENCHES=1 to run them"
+    return 0
+  fi
+
+  echo "==> Shared fixture preflight for benchmark scripts"
+  cargo run -q -p casa-test-support --bin casatestdata-preflight -- --tier default-fixture
+  echo
+
+  echo "==> Running imaging benchmark"
+  BENCH_REPEATS="$bench_repeats" scripts/bench-imager-vs-casa.sh \
+    >"$outdir/bench-imager-vs-casa.log" 2>&1
+  tail -40 "$outdir/bench-imager-vs-casa.log"
+  echo
+
+  echo "==> Running msexplore benchmark"
+  BENCH_REPEATS="$bench_repeats" scripts/bench-msexplore-vs-casa.sh \
+    >"$outdir/bench-msexplore-vs-casa.log" 2>&1
+  tail -40 "$outdir/bench-msexplore-vs-casa.log"
+  echo
+
+  echo "==> Running calibration benchmark"
+  CAL_BENCH_REPEATS="$bench_repeats" scripts/bench-calibrate-vs-casa.sh \
+    >"$outdir/bench-calibrate-vs-casa.log" 2>&1
+  tail -40 "$outdir/bench-calibrate-vs-casa.log"
+}
+
+main "$@" 2>&1 | tee "$log_file"

--- a/scripts/run-wave7-ticket-closeout.sh
+++ b/scripts/run-wave7-ticket-closeout.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+outdir="${WAVE7_TICKET_OUTDIR:-target/wave7-ticket-closeout/$stamp}"
+run_benches="${WAVE7_RUN_TARGETED_BENCHES:-0}"
+run_issue197="${WAVE7_RUN_ISSUE197:-$run_benches}"
+run_issue198="${WAVE7_RUN_ISSUE198:-$run_benches}"
+run_issue199="${WAVE7_RUN_ISSUE199:-$run_benches}"
+repeats="${WAVE7_TICKET_REPEATS:-1}"
+
+mkdir -p "$outdir"
+log_file="$outdir/wave7-ticket-closeout.log"
+
+if [[ -z "${CASA_RS_CASA_PYTHON:-}" && -x "$HOME/SoftwareProjects/casa-build/venv/bin/python" ]]; then
+  export CASA_RS_CASA_PYTHON="$HOME/SoftwareProjects/casa-build/venv/bin/python"
+fi
+
+if [[ -z "${CASA_RS_TUTORIAL_DATA_ROOT:-}" && -d "$HOME/SoftwareProjects/casa-tutorial-data" ]]; then
+  export CASA_RS_TUTORIAL_DATA_ROOT="$HOME/SoftwareProjects/casa-tutorial-data"
+fi
+
+if [[ -z "${CASA_RS_TESTDATA_ROOT:-}" && -d "$HOME/SoftwareProjects/casatestdata" ]]; then
+  export CASA_RS_TESTDATA_ROOT="$HOME/SoftwareProjects/casatestdata"
+fi
+
+require_tutorial_key() {
+  local key="$1"
+  cargo run -q -p casa-test-support --bin casatestdata-preflight -- \
+    --tier tutorial-parity \
+    --require-registry-key "$key"
+}
+
+run_optional() {
+  local label="$1"
+  shift
+  echo "==> $label"
+  if "$@"; then
+    echo "status=passed label=$label"
+  else
+    local status=$?
+    echo "status=failed label=$label exit=$status"
+    return 0
+  fi
+  echo
+}
+
+extract_twhya_selfcal() {
+  local dest_root="$outdir/twhya"
+  local ms_path="$dest_root/twhya_selfcal.ms"
+  local archive="${CASA_RS_TUTORIAL_DATA_ROOT:-}/tutorial-parity/alma/first-look/twhya/twhya_selfcal.ms.tgz"
+  if [[ -d "$ms_path" ]]; then
+    printf "%s\n" "$ms_path"
+    return 0
+  fi
+  if [[ ! -f "$archive" ]]; then
+    echo "error: missing TW Hydra selfcal archive: $archive" >&2
+    return 2
+  fi
+  mkdir -p "$dest_root"
+  tar -xf "$archive" -C "$dest_root"
+  printf "%s\n" "$ms_path"
+}
+
+run_imager_profiles() {
+  local antennae_ms="${CASA_RS_TUTORIAL_DATA_ROOT:-}/tutorial-parity/alma/antennae/band7/Antennae_Band7_CalibratedData/Antennae_North.cal.ms"
+  local vla_ms="${CASA_RS_TUTORIAL_DATA_ROOT:-}/tutorial-parity/vla/3c391/EVLA_3C391_FinalCalibratedMosaicMS/3c391_ctm_mosaic_spw0.ms"
+
+  cargo build --release -p casars-imager --bin casars-imager >/dev/null
+
+  if ! /usr/bin/time -lp target/release/casars-imager \
+    --ms "$antennae_ms" \
+    --imagename "$outdir/issue197-antennae-rust" \
+    --managed-output true \
+    --no-preview-pngs \
+    --phasecenter-field 12 \
+    --spw "0:1~50;120~164" \
+    --datacolumn DATA \
+    --deconvolver hogbom \
+    --imsize 500 \
+    --cell-arcsec 0.13 \
+    --niter 32 \
+    --minor-cycle-length 32 \
+    --casa-hogbom-iterations \
+    --gain 0.1 \
+    --threshold-jy 0.0004 \
+    >"$outdir/issue197-antennae-managed-output.json" \
+    2>"$outdir/issue197-antennae-timing.stderr"; then
+    cat "$outdir/issue197-antennae-timing.stderr"
+    return 1
+  fi
+
+  summarize_imager_json "$outdir/issue197-antennae-managed-output.json"
+  cat "$outdir/issue197-antennae-timing.stderr"
+  echo
+
+  if ! /usr/bin/time -lp target/release/casars-imager \
+    --ms "$vla_ms" \
+    --imagename "$outdir/issue197-3c391-rust" \
+    --managed-output true \
+    --no-preview-pngs \
+    --phasecenter-field 0 \
+    --deconvolver multiscale \
+    --scales 0,5,15,45 \
+    --smallscalebias 0.9 \
+    --weighting briggs \
+    --robust 0.5 \
+    --imsize 480 \
+    --cell-arcsec 2.5 \
+    --niter 500 \
+    --gain 0.1 \
+    --threshold-jy 0.001 \
+    --minor-cycle-length 500 \
+    >"$outdir/issue197-3c391-managed-output.json" \
+    2>"$outdir/issue197-3c391-timing.stderr"; then
+    cat "$outdir/issue197-3c391-timing.stderr"
+    return 1
+  fi
+
+  summarize_imager_json "$outdir/issue197-3c391-managed-output.json"
+  cat "$outdir/issue197-3c391-timing.stderr"
+}
+
+summarize_imager_json() {
+  local path="$1"
+  python3 - "$path" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as handle:
+    obj = json.load(handle)
+run = obj["run"]
+frontend = {name: value / 1.0e9 for name, value in run["frontend_timings"]["values_ns"]}
+core = {name: value / 1.0e9 for name, value in run["stage_timings"]["values_ns"]}
+print(f"managed_output={path}")
+print(f"  gridded_samples={run['gridded_samples']} major_cycles={run['major_cycles']} minor_iterations={run['minor_iterations']}")
+print("  frontend_seconds:")
+for name in ["open_measurement_set", "prepare_plane_input", "run_imaging", "write_products", "total"]:
+    if name in frontend:
+        print(f"    {name}={frontend[name]:.6f}")
+print("  core_seconds:")
+for name in [
+    "controller_overhead",
+    "weighting",
+    "psf_grid",
+    "psf_fft",
+    "residual_degrid_grid",
+    "residual_fft",
+    "residual_normalize",
+    "minor_cycle",
+    "major_cycle_refresh",
+    "restore",
+    "total",
+]:
+    if name in core:
+        print(f"    {name}={core[name]:.6f}")
+PY
+}
+
+run_calibration_apply_bench() {
+  local twhya_ms
+  twhya_ms="$(extract_twhya_selfcal)"
+  CAL_BENCH_REPEATS="$repeats" \
+  CAL_BENCH_FIELD="${WAVE7_TWHY_CAL_FIELD:-5}" \
+  CAL_BENCH_SPW="${WAVE7_TWHY_CAL_SPW:-0}" \
+  CAL_BENCH_REFANT="${WAVE7_TWHY_CAL_REFANT:-DV22}" \
+  CAL_BENCH_JSON_OUT="$outdir/issue198-twhya-applycal-bench.json" \
+    scripts/bench-calibrate-vs-casa.sh "$twhya_ms" \
+    >"$outdir/issue198-twhya-applycal-bench.log" 2>&1
+  tail -60 "$outdir/issue198-twhya-applycal-bench.log"
+}
+
+run_plot_bench() {
+  BENCH_REPEATS="$repeats" \
+    scripts/bench-msexplore-vs-casa.sh \
+    >"$outdir/issue199-plotms-msexplore-bench.log" 2>&1
+  tail -60 "$outdir/issue199-plotms-msexplore-bench.log"
+}
+
+main() {
+  echo "wave7_ticket_closeout_stamp=$stamp"
+  echo "outdir=$outdir"
+  echo "run_benches=$run_benches"
+  echo "run_issue197=$run_issue197"
+  echo "run_issue198=$run_issue198"
+  echo "run_issue199=$run_issue199"
+  echo "repeats=$repeats"
+  echo "CASA_RS_CASA_PYTHON=${CASA_RS_CASA_PYTHON:-}"
+  echo "CASA_RS_TUTORIAL_DATA_ROOT=${CASA_RS_TUTORIAL_DATA_ROOT:-}"
+  echo "CASA_RS_TESTDATA_ROOT=${CASA_RS_TESTDATA_ROOT:-}"
+  echo
+
+  echo "==> Tutorial dataset preflight"
+  require_tutorial_key alma/antennae/band7/calibrated-data
+  require_tutorial_key vla/3c391/final-calibrated-mosaic-ms
+  require_tutorial_key alma/first-look/twhya/selfcal-ms
+  echo
+
+  cat >"$outdir/README.md" <<EOF
+# Wave 7 Ticket Closeout Run
+
+Stamp: \`$stamp\`
+
+This directory records targeted Wave 7 ticket closeout evidence.
+
+- \`issue197-antennae-managed-output.json\`: casa-rs stage profile for #197 Antennae.
+- \`issue197-antennae-timing.stderr\`: wall-clock timing for #197 Antennae.
+- \`issue197-3c391-managed-output.json\`: casa-rs stage profile for #197 3C391.
+- \`issue197-3c391-timing.stderr\`: wall-clock timing for #197 3C391.
+- \`issue198-twhya-applycal-bench.log\`: TW Hydra applycal benchmark for #198.
+- \`issue198-twhya-applycal-bench.json\`: machine-readable #198 benchmark summary.
+- \`issue199-plotms-msexplore-bench.log\`: direct plotms versus msexplore timing for #199, or the exact plotms blocker.
+
+Set \`WAVE7_RUN_TARGETED_BENCHES=1\` to run all targeted benchmarks, or set
+\`WAVE7_RUN_ISSUE197=1\`, \`WAVE7_RUN_ISSUE198=1\`, or \`WAVE7_RUN_ISSUE199=1\`
+to run one ticket slice.
+EOF
+
+  if [[ "$run_issue197" != "1" && "$run_issue198" != "1" && "$run_issue199" != "1" ]]; then
+    echo "==> Skipping targeted benchmark runs; set WAVE7_RUN_TARGETED_BENCHES=1 to run them"
+    return 0
+  fi
+
+  if [[ "$run_issue197" == "1" ]]; then
+    run_optional "issue #197 imaging stage profiles" run_imager_profiles
+  fi
+  if [[ "$run_issue198" == "1" ]]; then
+    run_optional "issue #198 TW Hydra applycal benchmark" run_calibration_apply_bench
+  fi
+  if [[ "$run_issue199" == "1" ]]; then
+    run_optional "issue #199 plotms versus msexplore benchmark" run_plot_bench
+  fi
+}
+
+main "$@" 2>&1 | tee "$log_file"


### PR DESCRIPTION
Wave issue: #144

Closes #130
Closes #144
Closes #197
Closes #198
Closes #199
Closes #204
Closes #205

## Summary
- implement CASA-style `DATA -> CORRECTED_DATA` tiled-column cloning for applycal scratch-column creation, then sparse-patch selected rows
- reduce mosaic imaging hot-path cost by collapsing centered per-group weight-kernel gridding to one write per group, using contiguous grid slices in screen-projector grid/degrid loops, and precomputing phase-gradient-adjusted kernels per pointing
- update Wave 7 ticket closeout evidence with post-fix CASA-vs-casa-rs timings and ticket comments for #204/#205

## Performance Evidence
- TW Hydra applycal: casa-rs `0.937 s` vs CASA `0.808 s`, now `1.16x CASA` instead of `2.81x CASA`
- Antennae North continuum clean: casa-rs `11.53 s` vs preserved CASA `42.026 s`, now `0.27x CASA` instead of current-profile `134.19 s`
- VLA 3C391 multiscale mosaic: casa-rs `69.06 s` vs preserved CASA `75.489 s`, now `0.91x CASA` instead of current-profile `547.93 s`
- #199 did not confirm a Rust plotting regression: direct plotms median `4.141 s`; msexplore CLI median `3.200 s`

## Verification
- `bash -n scripts/run-wave7-performance-closeout.sh`
- `bash -n scripts/run-wave7-ticket-closeout.sh`
- `scripts/run-wave7-ticket-closeout.sh`
- `WAVE7_TICKET_OUTDIR=target/wave7-ticket-closeout/current WAVE7_RUN_TARGETED_BENCHES=1 WAVE7_TICKET_REPEATS=1 scripts/run-wave7-ticket-closeout.sh`
- `cargo test -p casa-tables clone_tiled_array_column_in_place_preserves_source_values_and_allows_sparse_patch -- --nocapture`
- `cargo test -p casa-calibration sample_bpoly_row_and_corrected_data_column_cover_remaining_helpers -- --nocapture`
- `cargo test -p casa-calibration --test apply_execute -- --nocapture`
- `cargo test -p casa-imaging screen_projector -- --nocapture`
- `cargo test -p casa-imaging mosaic_clean_reduces_residual_peak_and_tracks_pb_weight_image -- --nocapture`
- `just quick`
- `just verify` (network-enabled rerun for Python package build dependency fetch)

## Notes
- /Volumes/GLENDENNING/casa-rs/tutorial-data contains the M100 tutorial archives used for the heavy M100 reruns; it is intentionally only used when selected explicitly with CASA_RS_TUTORIAL_DATA_ROOT.
- /Volumes/home/casatestdata is not needed for the M100 tutorial data.