### PR TITLE
GUI-Wave-5: Native explorer spine and product routing

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -73,6 +73,11 @@ pending/running/succeeded/failed/cancelled state, cancellation projection, logs,
 results/errors, and debug-snapshot visibility. The coordinator is intentionally
 local to `apps/casars-mac`; it does not introduce a provider daemon, durable
 project-history format, or repo-wide async runtime contract.
+GUI-Wave-5 keeps that runtime shape and adds the native explorer spine: real
+MeasurementSet, CASA image, and table probes are routed into typed Swift
+explorer tabs, and dirty-imaging artifacts are grouped under their originating
+in-memory run state so generated products can be reopened without adding a
+project-history persistence format or background service.
 
 ## Persistence / external systems
 

--- a/apps/casars-mac/Sources/CasarsMacApp/CentralWorkspaceView.swift
+++ b/apps/casars-mac/Sources/CasarsMacApp/CentralWorkspaceView.swift
@@ -230,29 +230,90 @@ struct DatasetExplorerPanel: View {
 
     @ViewBuilder
     private func realExplorerContent(for dataset: DatasetSummary) -> some View {
-        if dataset.kind == .measurementSet {
+        switch dataset.kind {
+        case .measurementSet:
             MeasurementSetPlotPanel(store: store, dataset: dataset)
-        } else {
+        case .imageCube:
+            imageExplorerContent(for: dataset)
+        case .calibrationTable, .table:
+            tableExplorerContent(for: dataset)
+        case .runProduct:
+            productExplorerContent(for: dataset)
+        }
+    }
+
+    private func imageExplorerContent(for dataset: DatasetSummary) -> some View {
+        VStack(alignment: .leading, spacing: 18) {
             HStack(alignment: .top, spacing: 16) {
                 SummaryBox(
-                    title: "Overview",
+                    title: "Image",
                     values: [
                         dataset.size,
+                        "Units: \(dataset.units.isEmpty ? "Unknown" : dataset.units)",
                         "Bytes: \(byteCount(dataset.sizeBytes))",
                         "Shape: \(formatShape(dataset.shape))"
                     ]
                 )
-                SummaryBox(title: "Fields", values: dataset.fields)
-                SummaryBox(title: "Spectral Windows", values: dataset.spectralWindows)
+                SummaryBox(title: "WCS and Beam", values: dataset.diagnostics.filter(isImageGeometryDiagnostic))
+                SummaryBox(title: "Masks and Regions", values: imageMaskRegionValues(for: dataset))
             }
 
-            SummaryBox(
-                title: "Explorer Status",
-                values: ["A real summary is available. A specialized \(dataset.kind.explorerName) is not implemented yet."]
-            )
+            ImagePreviewPlaceholder(dataset: dataset)
 
             SummaryBox(title: "Probe Notes", values: [dataset.notes] + dataset.diagnostics)
         }
+    }
+
+    private func tableExplorerContent(for dataset: DatasetSummary) -> some View {
+        VStack(alignment: .leading, spacing: 18) {
+            HStack(alignment: .top, spacing: 16) {
+                SummaryBox(
+                    title: "Table",
+                    values: [
+                        dataset.size,
+                        "Type: \(dataset.units.isEmpty ? "casacore table" : dataset.units)",
+                        "Rows: \(dataset.shape.first.map(String.init) ?? "Unknown")",
+                        "Bytes: \(byteCount(dataset.sizeBytes))"
+                    ]
+                )
+                SummaryBox(title: "Columns", values: dataset.columns)
+                SummaryBox(title: "Subtables", values: dataset.subtables)
+            }
+
+            TablePreviewSummary(dataset: dataset)
+            SummaryBox(title: "Probe Notes", values: [dataset.notes] + dataset.diagnostics)
+        }
+    }
+
+    private func productExplorerContent(for dataset: DatasetSummary) -> some View {
+        VStack(alignment: .leading, spacing: 18) {
+            SummaryBox(
+                title: "Product",
+                values: [
+                    dataset.size,
+                    dataset.units,
+                    dataset.path
+                ]
+            )
+            SummaryBox(title: "Product Metadata", values: [dataset.notes] + dataset.diagnostics)
+        }
+    }
+
+    private func isImageGeometryDiagnostic(_ value: String) -> Bool {
+        value.hasPrefix("Cell size:")
+            || value.hasPrefix("Center:")
+            || value.hasPrefix("Cube center frequency:")
+            || value.hasPrefix("Total bandwidth:")
+            || value.hasPrefix("Channel separation:")
+            || value.hasPrefix("Beam:")
+            || value.hasPrefix("Median beam:")
+    }
+
+    private func imageMaskRegionValues(for dataset: DatasetSummary) -> [String] {
+        let values = dataset.diagnostics.filter {
+            $0.hasPrefix("Default mask:") || $0.lowercased().contains("mask") || $0.lowercased().contains("region")
+        }
+        return values.isEmpty ? ["No mask or region metadata reported"] : values
     }
 
     private func primarySummaryTitle(for dataset: DatasetSummary) -> String {
@@ -746,6 +807,7 @@ struct DirtyImagingTaskPanel: View {
                         imagingBlock(parameters: parameters)
                         outputBlock(parameters: parameters)
                         runBlock
+                        runProductsBlock
                     } else {
                         PanelHeader(title: "Dirty Imaging", subtitle: "Select a MeasurementSet before opening this task")
                     }
@@ -1085,6 +1147,58 @@ struct DirtyImagingTaskPanel: View {
         .accessibilityIdentifier("task.runState")
     }
 
+    @ViewBuilder
+    private var runProductsBlock: some View {
+        if let group = activeRunProductGroup {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Generated Products")
+                    .workbenchFont(.headline)
+                Text(group.runID)
+                    .workbenchFont(.caption, design: .monospaced)
+                    .foregroundStyle(.secondary)
+
+                ForEach(group.products) { product in
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(product.label)
+                                .workbenchFont(.subheadline, weight: .semibold)
+                            Text(product.path)
+                                .workbenchFont(.caption, design: .monospaced)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                            if product.previewPngExists, let preview = product.previewPngPath {
+                                Text("Preview: \(preview)")
+                                    .workbenchFont(.caption, design: .monospaced)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                            }
+                        }
+
+                        Spacer()
+
+                        Button {
+                            store.openRunProduct(runID: group.runID, productID: product.id)
+                        } label: {
+                            Label("Open", systemImage: "arrow.up.right.square")
+                        }
+                        .disabled(product.datasetID == nil)
+                        .accessibilityIdentifier("task.product.open.\(product.id)")
+                    }
+                    .padding(.vertical, 3)
+                }
+            }
+            .taskCard()
+            .accessibilityIdentifier("task.generatedProducts")
+        }
+    }
+
+    private var activeRunProductGroup: RunProductGroup? {
+        guard let runID = store.state.taskRun.runID else {
+            return nil
+        }
+        return store.state.runProductGroups.first { $0.runID == runID }
+    }
+
     private func valueList(_ title: String, values: [String]) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             Text(title)
@@ -1263,6 +1377,72 @@ struct SummaryBox: View {
         }
         .frame(maxWidth: .infinity, minHeight: 110, alignment: .topLeading)
         .padding()
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+struct ImagePreviewPlaceholder: View {
+    let dataset: DatasetSummary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Preview")
+                .workbenchFont(.headline)
+            ZStack {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Color(nsColor: .windowBackgroundColor))
+                    .overlay(RoundedRectangle(cornerRadius: 6).stroke(Color.secondary.opacity(0.20)))
+                VStack(spacing: 8) {
+                    Image(systemName: "photo")
+                        .workbenchFont(.largeTitle)
+                        .foregroundStyle(.secondary)
+                    Text(previewText)
+                        .workbenchFont(.caption)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                .padding()
+            }
+            .frame(minHeight: 180)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var previewText: String {
+        if let preview = dataset.diagnostics.first(where: { $0.hasPrefix("preview:") }) {
+            return preview
+        }
+        return "Image metadata is loaded. Raster plane preview is deferred to GUI-Wave-6."
+    }
+}
+
+struct TablePreviewSummary: View {
+    let dataset: DatasetSummary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Column Preview")
+                .workbenchFont(.headline)
+            if dataset.columns.isEmpty {
+                Text("No columns reported by the table schema.")
+                    .workbenchFont(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 160), spacing: 8)], alignment: .leading, spacing: 8) {
+                    ForEach(dataset.columns, id: \.self) { column in
+                        Label(column, systemImage: "tablecells")
+                            .lineLimit(1)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 5)
+                            .background(Color(nsColor: .controlBackgroundColor))
+                            .clipShape(RoundedRectangle(cornerRadius: 6))
+                    }
+                }
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
         .background(.regularMaterial)
         .clipShape(RoundedRectangle(cornerRadius: 8))
     }

--- a/apps/casars-mac/Sources/CasarsMacCore/WorkbenchModels.swift
+++ b/apps/casars-mac/Sources/CasarsMacCore/WorkbenchModels.swift
@@ -320,6 +320,65 @@ public struct TaskRun: Codable, Equatable {
     }
 }
 
+public struct RunProductReference: Identifiable, Codable, Equatable {
+    public let id: String
+    public var artifactKind: String
+    public var label: String
+    public var path: String
+    public var datasetID: String?
+    public var exists: Bool
+    public var previewPngPath: String?
+    public var previewPngExists: Bool
+
+    public init(
+        id: String,
+        artifactKind: String,
+        label: String,
+        path: String,
+        datasetID: String?,
+        exists: Bool,
+        previewPngPath: String?,
+        previewPngExists: Bool
+    ) {
+        self.id = id
+        self.artifactKind = artifactKind
+        self.label = label
+        self.path = path
+        self.datasetID = datasetID
+        self.exists = exists
+        self.previewPngPath = previewPngPath
+        self.previewPngExists = previewPngExists
+    }
+}
+
+public struct RunProductGroup: Identifiable, Codable, Equatable {
+    public let id: String
+    public var runID: String
+    public var title: String
+    public var sourceDatasetID: String
+    public var sourcePath: String
+    public var products: [RunProductReference]
+    public var diagnostics: [String]
+
+    public init(
+        id: String,
+        runID: String,
+        title: String,
+        sourceDatasetID: String,
+        sourcePath: String,
+        products: [RunProductReference],
+        diagnostics: [String]
+    ) {
+        self.id = id
+        self.runID = runID
+        self.title = title
+        self.sourceDatasetID = sourceDatasetID
+        self.sourcePath = sourcePath
+        self.products = products
+        self.diagnostics = diagnostics
+    }
+}
+
 public enum AIProposalState: String, Codable, Equatable {
     case pending
     case applied
@@ -637,6 +696,7 @@ public struct WorkbenchState: Codable, Equatable {
     public var measurementSetPlotResultCache: [String: MeasurementSetPlotResultSummary]
     public var jobs: [String: WorkbenchJob]
     public var activeJobIDsByTab: [String: String]
+    public var runProductGroups: [RunProductGroup]
     public var history: [ProcessingHistoryEvent]
     public var commandQuery: String
     public var lastErrors: [String]
@@ -661,6 +721,7 @@ public struct WorkbenchState: Codable, Equatable {
         measurementSetPlotResultCache: [String: MeasurementSetPlotResultSummary] = [:],
         jobs: [String: WorkbenchJob] = [:],
         activeJobIDsByTab: [String: String] = [:],
+        runProductGroups: [RunProductGroup] = [],
         history: [ProcessingHistoryEvent],
         commandQuery: String,
         lastErrors: [String],
@@ -684,6 +745,7 @@ public struct WorkbenchState: Codable, Equatable {
         self.measurementSetPlotResultCache = measurementSetPlotResultCache
         self.jobs = jobs
         self.activeJobIDsByTab = activeJobIDsByTab
+        self.runProductGroups = runProductGroups
         self.history = history
         self.commandQuery = commandQuery
         self.lastErrors = lastErrors
@@ -758,6 +820,7 @@ public struct DebugStateSnapshot: Codable, Equatable {
     public var probeDiagnostics: [String]
     public var inspectorCollapsed: Bool
     public var openTabs: [String]
+    public var explorerTabs: [DebugExplorerTabSnapshot]
     public var activeTab: String
     public var taskState: TaskRunState
     public var taskRequest: DirtyImagingTaskParameters?
@@ -769,6 +832,7 @@ public struct DebugStateSnapshot: Codable, Equatable {
     public var jobs: [DebugWorkbenchJobSnapshot]
     public var activeJobIDsByTab: [String: String]
     public var runningJobCount: Int
+    public var runProductGroups: [DebugRunProductGroupSnapshot]
     public var processingHistoryEvents: [String]
     public var commandQuery: String
     public var lastErrors: [String]
@@ -786,6 +850,9 @@ public struct DebugStateSnapshot: Codable, Equatable {
         probeDiagnostics = state.probeDiagnostics
         inspectorCollapsed = state.inspectorCollapsed
         openTabs = state.tabs.map(\.title)
+        explorerTabs = state.tabs
+            .filter { $0.kind == .datasetExplorer }
+            .map { DebugExplorerTabSnapshot(tab: $0, state: state) }
         activeTab = state.tabs.first { $0.id == state.activeTabID }?.title ?? state.activeTabID
         taskState = state.taskRun.state
         taskRequest = state.dirtyImagingTaskParameters
@@ -805,10 +872,72 @@ public struct DebugStateSnapshot: Codable, Equatable {
             .map(DebugWorkbenchJobSnapshot.init(job:))
         activeJobIDsByTab = state.activeJobIDsByTab
         runningJobCount = state.jobs.values.filter { $0.status == .running || $0.status == .pending }.count
+        runProductGroups = state.runProductGroups.map(DebugRunProductGroupSnapshot.init(group:))
         processingHistoryEvents = state.history.map(\.title)
         commandQuery = state.commandQuery
         lastErrors = state.lastErrors
         interfaceFontSize = state.interfaceFontSize
+    }
+}
+
+public struct DebugExplorerTabSnapshot: Codable, Equatable {
+    public var id: String
+    public var title: String
+    public var datasetID: String?
+    public var datasetName: String?
+    public var datasetKind: DatasetKind?
+    public var path: String?
+
+    public init(tab: WorkbenchTab, state: WorkbenchState) {
+        id = tab.id
+        title = tab.title
+        datasetID = tab.datasetID
+        let dataset = tab.datasetID.flatMap { datasetID in
+            state.project.datasets.first { $0.id == datasetID }
+        }
+        datasetName = dataset?.name
+        datasetKind = dataset?.kind
+        path = dataset?.path
+    }
+}
+
+public struct DebugRunProductGroupSnapshot: Codable, Equatable {
+    public var runID: String
+    public var title: String
+    public var sourceDatasetID: String
+    public var sourcePath: String
+    public var products: [DebugRunProductReferenceSnapshot]
+    public var diagnostics: [String]
+
+    public init(group: RunProductGroup) {
+        runID = group.runID
+        title = group.title
+        sourceDatasetID = group.sourceDatasetID
+        sourcePath = group.sourcePath
+        products = group.products.map(DebugRunProductReferenceSnapshot.init(product:))
+        diagnostics = group.diagnostics
+    }
+}
+
+public struct DebugRunProductReferenceSnapshot: Codable, Equatable {
+    public var id: String
+    public var artifactKind: String
+    public var label: String
+    public var path: String
+    public var datasetID: String?
+    public var exists: Bool
+    public var previewPngPath: String?
+    public var previewPngExists: Bool
+
+    public init(product: RunProductReference) {
+        id = product.id
+        artifactKind = product.artifactKind
+        label = product.label
+        path = product.path
+        datasetID = product.datasetID
+        exists = product.exists
+        previewPngPath = product.previewPngPath
+        previewPngExists = product.previewPngExists
     }
 }
 

--- a/apps/casars-mac/Sources/CasarsMacCore/WorkbenchStore.swift
+++ b/apps/casars-mac/Sources/CasarsMacCore/WorkbenchStore.swift
@@ -207,6 +207,23 @@ public final class WorkbenchStore: ObservableObject {
         openExplorer(for: dataset)
     }
 
+    public func openRunProduct(runID: String, productID: String) {
+        guard let group = state.runProductGroups.first(where: { $0.runID == runID }) else {
+            state.lastErrors.append("Unknown run \(runID)")
+            return
+        }
+        guard let product = group.products.first(where: { $0.id == productID }) else {
+            state.lastErrors.append("Unknown product \(productID)")
+            return
+        }
+        guard let datasetID = product.datasetID else {
+            state.lastErrors.append("Product \(product.label) is not a recognized dataset")
+            return
+        }
+
+        openDatasetExplorer(datasetID)
+    }
+
     public func setMeasurementSetPlotPreset(_ preset: MeasurementSetExplorerPlotPreset, datasetID: String) {
         var plotState = measurementSetPlotState(for: datasetID)
         plotState.preset = preset
@@ -1270,7 +1287,8 @@ public final class WorkbenchStore: ObservableObject {
                     requestSummary: result.request.parameters.requestSummary
                 )
             }
-            appendProducedDatasets(from: result)
+            let products = appendProducedDatasets(from: result)
+            recordRunProductGroup(from: result, products: products)
             state.history.append(
                 ProcessingHistoryEvent(
                     id: "hist-run-\(state.history.count + 1)",
@@ -1310,30 +1328,87 @@ public final class WorkbenchStore: ObservableObject {
         }
     }
 
-    private func appendProducedDatasets(from result: DirtyImagingTaskResult) {
+    private func appendProducedDatasets(from result: DirtyImagingTaskResult) -> [RunProductReference] {
+        var products: [RunProductReference] = []
         for artifact in result.artifacts where artifact.exists {
-            guard !state.project.datasets.contains(where: { $0.path == artifact.path }) else {
+            if let existing = state.project.datasets.first(where: { $0.path == artifact.path }) {
+                products.append(runProductReference(artifact: artifact, datasetID: existing.id))
                 continue
             }
             if let probed = try? probeClient.probePath(path: artifact.path) {
                 state.project.datasets.append(probed)
+                products.append(runProductReference(artifact: artifact, datasetID: probed.id))
                 continue
             }
-            state.project.datasets.append(
-                DatasetSummary(
-                    id: artifact.path,
-                    name: URL(fileURLWithPath: artifact.path).lastPathComponent,
-                    path: artifact.path,
-                    kind: .imageCube,
-                    size: "Unprobed image product",
-                    units: "CASA image",
-                    notes: "Produced by \(result.request.runID) from \(result.request.parameters.measurementSetPath).",
-                    diagnostics: artifact.previewPngExists
-                        ? ["preview: \(artifact.previewPngPath ?? "")"]
-                        : []
-                )
+            let fallback = DatasetSummary(
+                id: artifact.path,
+                name: URL(fileURLWithPath: artifact.path).lastPathComponent,
+                path: artifact.path,
+                kind: fallbackDatasetKind(for: artifact),
+                size: "Unprobed \(artifact.kind) product",
+                units: fallbackDatasetUnits(for: artifact),
+                notes: "Produced by \(result.request.runID) from \(result.request.parameters.measurementSetPath).",
+                diagnostics: artifact.previewPngExists
+                    ? ["preview: \(artifact.previewPngPath ?? "")"]
+                    : []
             )
+            state.project.datasets.append(fallback)
+            products.append(runProductReference(artifact: artifact, datasetID: fallback.id))
         }
+        return products
+    }
+
+    private func recordRunProductGroup(from result: DirtyImagingTaskResult, products: [RunProductReference]) {
+        let parameters = result.request.parameters
+        let group = RunProductGroup(
+            id: "products-\(result.request.runID)",
+            runID: result.request.runID,
+            title: "Dirty imaging products",
+            sourceDatasetID: parameters.datasetID,
+            sourcePath: parameters.measurementSetPath,
+            products: products,
+            diagnostics: result.diagnostics
+        )
+        if let index = state.runProductGroups.firstIndex(where: { $0.runID == result.request.runID }) {
+            state.runProductGroups[index] = group
+        } else {
+            state.runProductGroups.append(group)
+        }
+    }
+
+    private func runProductReference(artifact: DirtyImagingArtifact, datasetID: String?) -> RunProductReference {
+        RunProductReference(
+            id: artifact.path,
+            artifactKind: artifact.kind,
+            label: artifact.label,
+            path: artifact.path,
+            datasetID: datasetID,
+            exists: artifact.exists,
+            previewPngPath: artifact.previewPngPath,
+            previewPngExists: artifact.previewPngExists
+        )
+    }
+
+    private func fallbackDatasetKind(for artifact: DirtyImagingArtifact) -> DatasetKind {
+        let kind = artifact.kind.lowercased()
+        if kind.contains("table") {
+            return .table
+        }
+        if kind.contains("ms") || kind.contains("measurement") {
+            return .measurementSet
+        }
+        return .imageCube
+    }
+
+    private func fallbackDatasetUnits(for artifact: DirtyImagingArtifact) -> String {
+        let kind = artifact.kind.lowercased()
+        if kind.contains("image") {
+            return "CASA image"
+        }
+        if kind.contains("table") {
+            return "CASA table"
+        }
+        return artifact.kind
     }
 
     private func currentTimestamp() -> String {

--- a/apps/casars-mac/Tests/CasarsMacCoreTests/WorkbenchStoreTests.swift
+++ b/apps/casars-mac/Tests/CasarsMacCoreTests/WorkbenchStoreTests.swift
@@ -221,6 +221,76 @@ final class WorkbenchStoreTests: XCTestCase {
         XCTAssertEqual(store.state.tabs.first { $0.id == store.state.activeTabID }?.title, "MS: probed.ms")
     }
 
+    func testExplorerTabsExposeTypedRealDatasetRoutesInDebugSnapshot() {
+        let msDataset = DatasetSummary(
+            id: "/data/probed.ms",
+            name: "probed.ms",
+            path: "/data/probed.ms",
+            kind: .measurementSet,
+            size: "12 rows, 1 fields, 1 spw, 2 antennas",
+            units: "Jy, Hz, seconds",
+            fields: ["0: Target"],
+            spectralWindows: ["spw 0: 4 chan, 1.420000 GHz center"],
+            dataColumns: ["DATA"],
+            notes: "Recognized by Rust probe."
+        )
+        let imageDataset = DatasetSummary(
+            id: "/data/restored.image",
+            name: "restored.image",
+            path: "/data/restored.image",
+            kind: .imageCube,
+            size: "256 x 256 x 8",
+            units: "Jy/beam",
+            columns: ["map"],
+            shape: [256, 256, 8],
+            notes: "Recognized by Rust image probe.",
+            diagnostics: [
+                "Pixel type: float32",
+                "Cell size: 0.1 x 0.1 arcsec",
+                "Center: RA 10:00:00.000 Dec -30.00.00.00",
+                "Cube center frequency: 372.533 GHz",
+                "Total bandwidth: 384 MHz",
+                "Channel separation: 1 MHz",
+                "Beam: 0.42 x 0.31 arcsec, PA 12 deg"
+            ]
+        )
+        let tableDataset = DatasetSummary(
+            id: "/data/G.cal",
+            name: "G.cal",
+            path: "/data/G.cal",
+            kind: .table,
+            size: "3 rows, 4 columns",
+            units: "Calibration Table",
+            columns: ["ANTENNA1", "FIELD_ID", "CPARAM", "FLAG"],
+            shape: [3],
+            notes: "Recognized by Rust table probe."
+        )
+        let store = WorkbenchStore(
+            probeClient: StubProjectProbeClient(
+                result: ProjectFixtureProbe(
+                    project: ProjectFixture(
+                        name: "Real Project",
+                        rootPath: "/data",
+                        datasets: [msDataset, imageDataset, tableDataset],
+                        source: .probed
+                    ),
+                    diagnostics: []
+                )
+            )
+        )
+
+        store.openProject(path: "/data")
+        store.openDatasetExplorer(imageDataset.id)
+        store.openDatasetExplorer(tableDataset.id)
+
+        let snapshot = store.debugSnapshot()
+        XCTAssertEqual(snapshot.openTabs, ["MS: probed.ms", "Image: restored.image", "Table: G.cal"])
+        XCTAssertEqual(snapshot.explorerTabs.map(\.datasetKind), [.measurementSet, .imageCube, .table])
+        XCTAssertEqual(snapshot.explorerTabs.map(\.path), [msDataset.path, imageDataset.path, tableDataset.path])
+        XCTAssertEqual(snapshot.selectedDatasetSummary?.kind, .table)
+        XCTAssertEqual(snapshot.selectedDatasetSummary?.columns, ["ANTENNA1", "FIELD_ID", "CPARAM", "FLAG"])
+    }
+
     func testFakeExecutionTabsAreGatedOutsideDemoProjectButRealImagingTaskOpens() {
         let probedDataset = DatasetSummary(
             id: "/data/probed.ms",
@@ -412,6 +482,17 @@ final class WorkbenchStoreTests: XCTestCase {
         XCTAssertEqual(producedDataset?.size, "256 x 256")
         XCTAssertEqual(producedDataset?.units, "float32")
         XCTAssertEqual(producedDataset?.shape, [256, 256])
+        let runID = try XCTUnwrap(store.state.taskRun.runID)
+        XCTAssertEqual(snapshot.runProductGroups.count, 1)
+        XCTAssertEqual(snapshot.runProductGroups.first?.runID, runID)
+        XCTAssertEqual(snapshot.runProductGroups.first?.sourceDatasetID, probedDataset.id)
+        XCTAssertEqual(snapshot.runProductGroups.first?.products.first?.label, "Dirty Image")
+        XCTAssertEqual(snapshot.runProductGroups.first?.products.first?.datasetID, producedDataset?.id)
+
+        let productID = try XCTUnwrap(store.state.runProductGroups.first?.products.first?.id)
+        store.openRunProduct(runID: runID, productID: productID)
+        XCTAssertEqual(store.state.selectedDatasetID, producedDataset?.id)
+        XCTAssertEqual(store.state.tabs.first { $0.id == store.state.activeTabID }?.title, "Image: output.image")
         XCTAssertNoThrow(try store.debugJSON())
     }
 

--- a/docs/mac-native-gui-spec.md
+++ b/docs/mac-native-gui-spec.md
@@ -122,6 +122,13 @@ tabs keep their own active jobs. The coordinator is deliberately Swift-side and
 in-memory for this product slice. It is not a provider daemon, project-history
 storage format, or broad task scheduler.
 
+GUI-Wave-5 keeps generated-product relationships in the same in-memory
+workbench state. A dirty-imaging completion creates a run-product group keyed by
+the run ID, links each recognized artifact to the probed `DatasetSummary`, and
+routes product opens through the normal type-aware explorer tab path. This is a
+debuggable GUI state model, not a persisted run manifest; a durable project
+history/cache remains future work.
+
 ## Core Panels
 
 ### Project Explorer
@@ -580,8 +587,12 @@ adds a first real MeasurementSet plot API through the same frontend-service
 boundary. GUI-Wave-4 adds the first real task run by supervising a short-lived
 `casars-imager --json-run` dirty-imaging process from the Swift workbench,
 recording request/result/log artifacts in processing history, and surfacing run
-state through debug JSON. Image exploration, Python execution, and AI behavior
-remain stubbed unless separately approved.
+state through debug JSON. GUI-Wave-5 adds the first native explorer spine for
+real MeasurementSets, CASA images, and CASA tables: Rust/frontend-service probes
+remain the source of scientific metadata, while Swift routes datasets and
+generated products into typed tabs and projects shallow summaries. Deep image
+viewing, table cell browsing, Python execution, and AI behavior remain future
+work unless separately approved.
 
 ## Testability And Debuggability
 
@@ -615,10 +626,12 @@ should include:
 - selected dataset
 - inspector collapsed/expanded state
 - open central tabs
+- typed explorer tabs and their dataset paths
 - active central tab
 - command/search query state when present
 - task run states
 - current task request, diagnostics, logs, and output paths
+- generated product groups keyed by task run
 - AI chat messages and proposal states
 - Python terminal ownership state
 - processing-history events


### PR DESCRIPTION
Wave issue: #200
Closes #200

Summary:
- Add in-memory dirty-imaging run product groups and openable generated-product routing.
- Route real MeasurementSet, image, and table datasets through typed native explorer tabs with debug snapshot visibility.
- Replace generic real-dataset placeholders with shallow image/table explorer summaries and document the durable in-memory runtime decision.

Verification:
- cargo test -p casars-frontend-services
- cargo build -p casars-imager
- swift test (apps/casars-mac)
- CASARS_IMAGER_BIN=/Users/brianglendenning/.codex/worktrees/e7c9/casa-rs/target/debug/casars-imager swift run casars-mac --dump-debug-state --simulate-main-flow --open-project /private/tmp/casa-rs-gui200.qyEEWj/mssel_test_small_multifield_spw.ms
- just quick
- just verify (rerun with escalation after sandboxed pip DNS failure)