### PR TITLE
ImPerformance Wave 1: imaging performance foundation

### DIFF
--- a/crates/casa-imaging/src/cube.rs
+++ b/crates/casa-imaging/src/cube.rs
@@ -794,6 +794,7 @@ fn run_clean_cube(request: &CubeImagingRequest) -> Result<CubeImagingResult, Ima
                                 &psf_state.psf,
                                 &scales,
                                 plane_request.small_scale_bias,
+                                plane_request.clean_mask.as_ref(),
                             )
                         });
                     let initial_peak =
@@ -1143,6 +1144,7 @@ fn run_clean_cube(request: &CubeImagingRequest) -> Result<CubeImagingResult, Ima
                     &plane.psf_state.psf,
                     &scales,
                     plane.request.small_scale_bias,
+                    plane.request.clean_mask.as_ref(),
                 ));
             }
             if plane.request.deconvolver == Deconvolver::Clark {

--- a/crates/casa-imaging/src/gridder.rs
+++ b/crates/casa-imaging/src/gridder.rs
@@ -59,7 +59,7 @@ pub(crate) struct StandardGridder {
 
 impl StandardGridder {
     pub(crate) fn new(geometry: ImageGeometry) -> Result<Self, ImagingError> {
-        Self::new_with_padding(geometry, padded_len)
+        Self::new_with_padding(geometry, casa_composite_padded_len)
     }
 
     pub(crate) fn new_unpadded(geometry: ImageGeometry) -> Result<Self, ImagingError> {
@@ -2282,6 +2282,16 @@ mod tests {
                 cpp_value.im
             );
         }
+    }
+
+    #[test]
+    fn standard_gridder_uses_casa_composite_grid_padding() {
+        let geometry = ImageGeometry {
+            image_shape: [512, 512],
+            cell_size_rad: [0.08 / 206_264.806_247, 0.08 / 206_264.806_247],
+        };
+        let gridder = StandardGridder::new(geometry).unwrap();
+        assert_eq!(gridder.grid_shape(), [640, 640]);
     }
 
     #[test]

--- a/crates/casa-imaging/src/lib.rs
+++ b/crates/casa-imaging/src/lib.rs
@@ -2379,7 +2379,13 @@ fn run_mosaic_image_domain_controller(
     }
     let mut multiscale_state = (request.deconvolver == Deconvolver::Multiscale).then(|| {
         let scales = effective_multiscale_scales(request);
-        build_multiscale_state(&residual, &psf_state.psf, &scales, request.small_scale_bias)
+        build_multiscale_state(
+            &residual,
+            &psf_state.psf,
+            &scales,
+            request.small_scale_bias,
+            request.clean_mask.as_ref(),
+        )
     });
     let clark_psf_patch = (request.deconvolver == Deconvolver::Clark).then(|| {
         build_clark_psf_patch(
@@ -2955,7 +2961,7 @@ fn run_multiscale_minor_cycle(
     nsigma_threshold_jy_per_beam: f32,
     stage_timings: &mut ImagingStageTimings,
 ) -> HogbomMinorCycleOutcome {
-    let Some(_cycle_candidate) =
+    let Some(cycle_candidate) =
         select_multiscale_candidate(multiscale_state, request.clean_mask.as_ref())
     else {
         return HogbomMinorCycleOutcome {
@@ -2971,7 +2977,7 @@ fn run_multiscale_minor_cycle(
         &multiscale_state.dirty_conv_scales[0],
         request.clean_mask.as_ref(),
     );
-    let initial_cycle_peak = cycle_peak;
+    let initial_cycle_component = cycle_candidate.strength.abs();
     if let Some(reason) = minor_cycle_stop_reason(
         cycle_peak,
         request.clean.threshold_jy_per_beam,
@@ -3000,12 +3006,9 @@ fn run_multiscale_minor_cycle(
             stop_reason = Some(CleanStopReason::NoCleanablePixels);
             break;
         };
-        let peak_abs = peak_abs_value_masked(
-            &multiscale_state.dirty_conv_scales[0],
-            request.clean_mask.as_ref(),
-        );
+        let component_abs = candidate.strength.abs();
         if let Some(reason) = minor_cycle_stop_reason(
-            peak_abs,
+            component_abs,
             request.clean.threshold_jy_per_beam,
             cycle_threshold_jy_per_beam,
             nsigma_threshold_jy_per_beam,
@@ -3013,7 +3016,7 @@ fn run_multiscale_minor_cycle(
             stop_reason = Some(reason);
             break;
         }
-        if cycle_component_updates > 0 && peak_abs > initial_cycle_peak * 1.5 {
+        if cycle_component_updates > 0 && component_abs > initial_cycle_component * 1.5 {
             stop_reason = Some(CleanStopReason::DivergenceDetected);
             break;
         }
@@ -3076,6 +3079,7 @@ struct MultiscaleState {
     psf_conv_scales: Vec<Vec<Array2<f32>>>,
     peak_psf_conv_scales: Vec<f32>,
     scale_bias: Vec<f32>,
+    scale_masks: Option<Vec<Array2<bool>>>,
 }
 
 fn refresh_multiscale_dirty_conv_scales(state: &mut MultiscaleState, residual: &Array2<f32>) {
@@ -3256,8 +3260,13 @@ fn run_multiscale_cotton_schwab(
     warnings: &mut Vec<String>,
 ) -> Result<CottonSchwabState, ImagingError> {
     let scales = effective_multiscale_scales(request);
-    let mut multiscale_state =
-        build_multiscale_state(&residual, &psf_state.psf, &scales, request.small_scale_bias);
+    let mut multiscale_state = build_multiscale_state(
+        &residual,
+        &psf_state.psf,
+        &scales,
+        request.small_scale_bias,
+        request.clean_mask.as_ref(),
+    );
     let mut minor_iterations = 0usize;
     let mut reported_minor_iterations = 0usize;
     let mut major_cycles = 0usize;
@@ -3287,7 +3296,6 @@ fn run_multiscale_cotton_schwab(
             &multiscale_state.dirty_conv_scales[0],
             request.clean_mask.as_ref(),
         );
-        let initial_cycle_peak = cycle_peak;
         let cycle_nsigma_threshold_jy_per_beam =
             nsigma_threshold_jy_per_beam(&residual, request.clean_mask.as_ref(), request.clean);
         if let Some(stop_reason) = tolerant_clean_stop_reason(
@@ -3309,8 +3317,10 @@ fn run_multiscale_cotton_schwab(
                 cycle_candidate.position.1,
             ]),
         };
+        let initial_cycle_component = cycle_candidate.strength.abs();
         let mut cycle_component_updates = 0usize;
         let mut updated_model = false;
+        let mut cycle_stop_reason = None::<CleanStopReason>;
         final_cycle_threshold_jy_per_beam =
             compute_cycle_threshold(cycle_peak, max_psf_sidelobe_level, request.clean);
         let minor_started = Instant::now();
@@ -3318,24 +3328,21 @@ fn run_multiscale_cotton_schwab(
             let Some(candidate) =
                 select_multiscale_candidate(&multiscale_state, request.clean_mask.as_ref())
             else {
-                clean_stop_reason = Some(CleanStopReason::NoCleanablePixels);
+                cycle_stop_reason = Some(CleanStopReason::NoCleanablePixels);
                 break;
             };
-            let peak_abs = peak_abs_value_masked(
-                &multiscale_state.dirty_conv_scales[0],
-                request.clean_mask.as_ref(),
-            );
+            let component_abs = candidate.strength.abs();
             if let Some(stop_reason) = minor_cycle_stop_reason(
-                peak_abs,
+                component_abs,
                 request.clean.threshold_jy_per_beam,
                 final_cycle_threshold_jy_per_beam,
                 cycle_nsigma_threshold_jy_per_beam,
             ) {
-                clean_stop_reason = Some(stop_reason);
+                cycle_stop_reason = Some(stop_reason);
                 break;
             }
-            if cycle_component_updates > 0 && peak_abs > initial_cycle_peak * 1.5 {
-                clean_stop_reason = Some(CleanStopReason::DivergenceDetected);
+            if cycle_component_updates > 0 && component_abs > initial_cycle_component * 1.5 {
+                cycle_stop_reason = Some(CleanStopReason::DivergenceDetected);
                 break;
             }
 
@@ -3362,7 +3369,7 @@ fn run_multiscale_cotton_schwab(
         let reported_updates = casa_multiscale_reported_updates(
             cycle_component_updates,
             cycle_reported_niter,
-            clean_stop_reason,
+            cycle_stop_reason,
             updated_model,
         );
         minor_cycle_traces.push(make_minor_cycle_trace(
@@ -3372,7 +3379,7 @@ fn run_multiscale_cotton_schwab(
                 updated_model,
                 actual_updates: cycle_component_updates,
                 reported_updates,
-                stop_reason: clean_stop_reason,
+                stop_reason: cycle_stop_reason,
                 final_cycle_threshold_jy_per_beam,
                 final_nsigma_threshold_jy_per_beam: cycle_nsigma_threshold_jy_per_beam,
             },
@@ -3383,6 +3390,7 @@ fn run_multiscale_cotton_schwab(
         ));
         reported_minor_iterations += reported_updates;
         if !updated_model {
+            clean_stop_reason = cycle_stop_reason;
             break;
         }
         residual = multiscale_state.dirty_conv_scales[0].clone();
@@ -3408,8 +3416,13 @@ fn run_multiscale_cotton_schwab(
             stage_timings,
         )?;
         stage_timings.major_cycle_refresh += refresh_started.elapsed();
-        multiscale_state =
-            build_multiscale_state(&residual, &psf_state.psf, &scales, request.small_scale_bias);
+        multiscale_state = build_multiscale_state(
+            &residual,
+            &psf_state.psf,
+            &scales,
+            request.small_scale_bias,
+            request.clean_mask.as_ref(),
+        );
         major_cycles += 1;
         residual_needs_refresh = false;
         let refreshed_peak = peak_abs_value_masked(&residual, request.clean_mask.as_ref());
@@ -3471,6 +3484,7 @@ fn build_multiscale_state(
     psf: &Array2<f32>,
     scales: &[f32],
     small_scale_bias: f32,
+    mask: Option<&Array2<bool>>,
 ) -> MultiscaleState {
     let scale_images = scales
         .iter()
@@ -3504,6 +3518,8 @@ fn build_multiscale_state(
     } else {
         vec![1.0; scales.len()]
     };
+    let scale_masks =
+        mask.map(|clean_mask| build_multiscale_scale_masks(clean_mask, &scale_images, scales));
 
     MultiscaleState {
         scales: scale_images,
@@ -3511,6 +3527,41 @@ fn build_multiscale_state(
         psf_conv_scales,
         peak_psf_conv_scales,
         scale_bias,
+        scale_masks,
+    }
+}
+
+fn build_multiscale_scale_masks(
+    mask: &Array2<bool>,
+    scale_images: &[Array2<f32>],
+    scale_sizes: &[f32],
+) -> Vec<Array2<bool>> {
+    let mask_values = mask.mapv(|cleanable| if cleanable { 1.0 } else { 0.0 });
+    scale_images
+        .iter()
+        .zip(scale_sizes.iter().copied())
+        .map(|(scale_image, scale_size)| {
+            let convolved = fft_convolve_real(&mask_values, scale_image);
+            let mut scale_mask = convolved.mapv(|value| value > 0.9);
+            apply_casa_multiscale_edge_mask(&mut scale_mask, scale_size);
+            scale_mask
+        })
+        .collect()
+}
+
+fn apply_casa_multiscale_edge_mask(mask: &mut Array2<bool>, scale_size: f32) {
+    let (nx, ny) = mask.dim();
+    let border = (scale_size * 1.5) as usize;
+    for x in 0..nx {
+        for y in 0..ny {
+            if x <= border
+                || y <= border
+                || x >= nx.saturating_sub(border + 1)
+                || y >= ny.saturating_sub(border + 1)
+            {
+                mask[(x, y)] = false;
+            }
+        }
     }
 }
 
@@ -3520,8 +3571,13 @@ fn select_multiscale_candidate(
 ) -> Option<MultiscaleCandidate> {
     let mut best = None::<(MultiscaleCandidate, f32)>;
     for scale_index in 0..state.dirty_conv_scales.len() {
+        let search_mask = state
+            .scale_masks
+            .as_ref()
+            .map(|scale_masks| &scale_masks[scale_index])
+            .or(mask);
         let Some((position, value)) =
-            peak_location_masked(&state.dirty_conv_scales[scale_index], mask)
+            peak_location_masked(&state.dirty_conv_scales[scale_index], search_mask)
         else {
             continue;
         };
@@ -4546,6 +4602,7 @@ fn run_mtmfs_multiscale_minor_cycle(
         &psf_terms[0],
         &scales,
         request.small_scale_bias,
+        request.clean_mask.as_ref(),
     );
     let Some(first_candidate) =
         select_multiscale_candidate(&multiscale_state, request.clean_mask.as_ref())
@@ -6450,7 +6507,7 @@ mod tests {
         PsfState, RestoringBeamMode, StandardGridder, StandardMfsModelPredictor, VisibilityBatch,
         VisibilityMetadataBatch, WProjectSkipReason, WTermMode, WeightDensityMode, WeightingMode,
         add_shifted_kernel, apply_chauvenet_clipping, apply_weighting, build_direct_components,
-        build_direct_pixel_coordinates, compute_cycle_threshold,
+        build_direct_pixel_coordinates, build_multiscale_scale_masks, compute_cycle_threshold,
         compute_dirty_psf_and_residual_standard, compute_psf, compute_psf_direct, compute_residual,
         compute_residual_direct, direct_predict_visibility, dirty_clean_config,
         make_multiscale_kernel, mean_stddev, minor_cycle_stop_reason,
@@ -9095,6 +9152,27 @@ mod tests {
             .filter(|value| value.abs() > 0.0)
             .count();
         assert_eq!(nonzero, 1);
+    }
+
+    #[test]
+    fn multiscale_clean_mask_uses_casa_scale_dependent_edges() {
+        let shape = (32, 32);
+        let mask = Array2::<bool>::from_elem(shape, true);
+        let scales = vec![0.0, 8.0];
+        let scale_images = scales
+            .iter()
+            .copied()
+            .map(|scale| make_multiscale_kernel(shape, scale))
+            .collect::<Vec<_>>();
+
+        let scale_masks = build_multiscale_scale_masks(&mask, &scale_images, &scales);
+
+        assert!(!scale_masks[0][(0, 16)]);
+        assert!(scale_masks[0][(1, 16)]);
+        assert!(!scale_masks[1][(12, 16)]);
+        assert!(scale_masks[1][(13, 16)]);
+        assert!(scale_masks[1][(18, 16)]);
+        assert!(!scale_masks[1][(19, 16)]);
     }
 
     #[test]

--- a/crates/casars-imager/examples/profile_imager.rs
+++ b/crates/casars-imager/examples/profile_imager.rs
@@ -457,6 +457,9 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Result<Options, String>
                 mask_image = Some(PathBuf::from(next_value(&mut args, "--mask-image")?))
             }
             "--wterm" => w_term_mode = parse_w_term_mode(&next_value(&mut args, "--wterm")?)?,
+            "--gridder" => {
+                w_term_mode = parse_gridder_w_term_mode(&next_value(&mut args, "--gridder")?)?
+            }
             "--wprojplanes" => w_project_planes = Some(parse_next(&mut args, "--wprojplanes")?),
             "--dirty-only" => dirty_only = true,
             "--repeats" => repeats = parse_next(&mut args, "--repeats")?,
@@ -560,6 +563,20 @@ fn parse_w_term_mode(text: &str) -> Result<WTermMode, String> {
         "wproject" => Ok(WTermMode::WProject),
         _ => Err(format!(
             "unsupported --wterm value {text:?}; expected none, direct, or wproject"
+        )),
+    }
+}
+
+fn parse_gridder_w_term_mode(text: &str) -> Result<WTermMode, String> {
+    match text.to_ascii_lowercase().as_str() {
+        "standard" | "gridft" | "ft" | "mosaic" => Ok(WTermMode::None),
+        "wproject" => Ok(WTermMode::WProject),
+        "widefield" | "awproject" | "awp2" | "awphpg" => Err(format!(
+            "gridder={text:?} is not implemented by casa-rs imager yet; \
+             supported gridder values are standard, wproject, and mosaic"
+        )),
+        _ => Err(format!(
+            "unsupported --gridder value {text:?}; expected standard, wproject, widefield, mosaic, awproject, awp2, or awphpg"
         )),
     }
 }
@@ -670,6 +687,7 @@ Options:
   --mask-box X0,Y0,X1,Y1
   --mask-image PATH
   --wterm none|direct|wproject
+  --gridder standard|mosaic|wproject
   --wprojplanes N
   --dirty-only
   --repeats N

--- a/crates/casars-imager/src/lib.rs
+++ b/crates/casars-imager/src/lib.rs
@@ -1050,6 +1050,7 @@ pub fn build_w_project_trace_from_config(
             config.imsize,
             &config.mask_boxes,
             config.mask_image.as_deref(),
+            config.use_mask == CleanMaskMode::User,
         )?,
         initial_model: None,
         w_term_mode: config.w_term_mode,
@@ -1115,6 +1116,7 @@ pub fn build_cube_channel_w_project_trace_from_config(
             config.imsize,
             &config.mask_boxes,
             config.mask_image.as_deref(),
+            config.use_mask == CleanMaskMode::User,
         )?,
         channel_clean_mask: None,
         auto_mask: None,
@@ -1434,6 +1436,7 @@ fn run_single_image_from_config_with_gridder_override(
                 config.imsize,
                 &config.mask_boxes,
                 config.mask_image.as_deref(),
+                config.use_mask == CleanMaskMode::User,
             )?;
             if config.deconvolver == Deconvolver::Mtmfs {
                 if config.use_mask == CleanMaskMode::AutoMultiThreshold {
@@ -1549,6 +1552,7 @@ fn run_single_image_from_config_with_gridder_override(
                 config.imsize,
                 &config.mask_boxes,
                 config.mask_image.as_deref(),
+                config.use_mask == CleanMaskMode::User,
             )?;
             let mut channel_clean_mask = None::<Array4<bool>>;
             let mut dirty_seed = None;
@@ -2782,6 +2786,7 @@ fn build_joint_outlier_clean_mask(
         config.imsize,
         &config.mask_boxes,
         config.mask_image.as_deref(),
+        config.use_mask == CleanMaskMode::User,
     )?;
     let Some(mask_text) = definition
         .and_then(|definition| definition.mask.as_deref())
@@ -3286,6 +3291,7 @@ pub fn trace_cube_channel_residual_refresh_from_config(
             config.imsize,
             &config.mask_boxes,
             config.mask_image.as_deref(),
+            config.use_mask == CleanMaskMode::User,
         )?,
         channel_clean_mask: None,
         auto_mask: None,
@@ -3350,6 +3356,7 @@ pub fn trace_cube_channel_residual_refresh_from_config_with_model_cube(
             config.imsize,
             &config.mask_boxes,
             config.mask_image.as_deref(),
+            config.use_mask == CleanMaskMode::User,
         )?,
         channel_clean_mask: None,
         auto_mask: None,
@@ -3417,6 +3424,7 @@ pub fn trace_cube_channel_residual_refresh_from_config_with_model_cube_model_cha
             config.imsize,
             &config.mask_boxes,
             config.mask_image.as_deref(),
+            config.use_mask == CleanMaskMode::User,
         )?,
         channel_clean_mask: None,
         auto_mask: None,
@@ -11800,9 +11808,10 @@ fn build_clean_mask(
     imsize: usize,
     mask_boxes: &[[usize; 4]],
     mask_image: Option<&Path>,
+    full_image_if_empty: bool,
 ) -> Result<Option<Array2<bool>>, String> {
     if mask_boxes.is_empty() && mask_image.is_none() {
-        return Ok(None);
+        return Ok(full_image_if_empty.then(|| Array2::<bool>::from_elem((imsize, imsize), true)));
     }
     let mut mask = Array2::<bool>::from_elem((imsize, imsize), false);
     for [x0, y0, x1, y1] in mask_boxes {
@@ -16164,23 +16173,25 @@ mod tests {
         assert_eq!(parse_mask_box("1, 2, 3, 4").unwrap(), [1, 2, 3, 4]);
         assert!(parse_mask_box("1,2,3").unwrap_err().contains("expects"));
 
-        let mask = build_clean_mask(6, &[[1, 2, 3, 4]], None)
+        let mask = build_clean_mask(6, &[[1, 2, 3, 4]], None, false)
             .unwrap()
             .expect("mask");
         assert!(mask[(1, 2)]);
         assert!(mask[(3, 4)]);
         assert!(!mask[(0, 0)]);
         assert!(
-            build_clean_mask(6, &[[4, 1, 3, 2]], None)
+            build_clean_mask(6, &[[4, 1, 3, 2]], None, false)
                 .unwrap_err()
                 .contains("x0 <= x1")
         );
         assert!(
-            build_clean_mask(6, &[[0, 0, 6, 1]], None)
+            build_clean_mask(6, &[[0, 0, 6, 1]], None, false)
                 .unwrap_err()
                 .contains("exceeds image bounds")
         );
-        assert!(build_clean_mask(6, &[], None).unwrap().is_none());
+        assert!(build_clean_mask(6, &[], None, false).unwrap().is_none());
+        let full_mask = build_clean_mask(6, &[], None, true).unwrap().expect("mask");
+        assert!(full_mask.iter().all(|cleanable| *cleanable));
     }
 
     #[test]
@@ -17577,8 +17588,8 @@ mod tests {
 
     #[test]
     fn clean_mask_rejects_invalid_boxes_and_mask_images() {
-        assert!(build_clean_mask(4, &[[2, 1, 1, 0]], None).is_err());
-        assert!(build_clean_mask(4, &[[0, 0, 4, 0]], None).is_err());
+        assert!(build_clean_mask(4, &[[2, 1, 1, 0]], None, false).is_err());
+        assert!(build_clean_mask(4, &[[0, 0, 4, 0]], None, false).is_err());
 
         let tmp = tempdir().unwrap();
         let path = tmp.path().join("mask.im");
@@ -17586,7 +17597,7 @@ mod tests {
         let mut image = PagedImage::<f32>::create(vec![2, 3, 1, 1], coords, &path).unwrap();
         image.save().unwrap();
 
-        let error = build_clean_mask(4, &[], Some(&path)).unwrap_err();
+        let error = build_clean_mask(4, &[], Some(&path), false).unwrap_err();
         assert!(error.contains("expected [4, 4]") || error.contains("expected [4, 4, 1, 1]"));
     }
 
@@ -17601,7 +17612,7 @@ mod tests {
         image.put_slice(&data.into_dyn(), &[0, 0, 0, 0]).unwrap();
         image.save().unwrap();
 
-        let mask = build_clean_mask(8, &[[1, 2, 2, 3], [4, 4, 4, 4]], Some(&path))
+        let mask = build_clean_mask(8, &[[1, 2, 2, 3], [4, 4, 4, 4]], Some(&path), false)
             .unwrap()
             .unwrap();
         assert!(mask[(1, 2)]);

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,8 @@ This directory holds stable project documentation.
   [`tutorial-parity/imperformance-wave-1-mode-selection.md`](tutorial-parity/imperformance-wave-1-mode-selection.md)
 - ImPerformance Wave 1 simulated dataset plan:
   [`tutorial-parity/imperformance-wave-1-datasets.md`](tutorial-parity/imperformance-wave-1-datasets.md)
+- ImPerformance Wave 1 benchmark harness:
+  [`tutorial-parity/imperformance-wave-1-benchmark-harness.md`](tutorial-parity/imperformance-wave-1-benchmark-harness.md)
 
 ## Planning And Program Reference
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,8 @@ This directory holds stable project documentation.
   [`tutorial-parity/imperformance-wave-1-datasets.md`](tutorial-parity/imperformance-wave-1-datasets.md)
 - ImPerformance Wave 1 benchmark harness:
   [`tutorial-parity/imperformance-wave-1-benchmark-harness.md`](tutorial-parity/imperformance-wave-1-benchmark-harness.md)
+- ImPerformance Wave 1 stage instrumentation:
+  [`tutorial-parity/imperformance-wave-1-stage-instrumentation.md`](tutorial-parity/imperformance-wave-1-stage-instrumentation.md)
 
 ## Planning And Program Reference
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,8 @@ This directory holds stable project documentation.
   [`tutorial-parity/tutorial-learning-packs.md`](tutorial-parity/tutorial-learning-packs.md)
 - ImPerformance Wave 1 mode selection:
   [`tutorial-parity/imperformance-wave-1-mode-selection.md`](tutorial-parity/imperformance-wave-1-mode-selection.md)
+- ImPerformance Wave 1 simulated dataset plan:
+  [`tutorial-parity/imperformance-wave-1-datasets.md`](tutorial-parity/imperformance-wave-1-datasets.md)
 
 ## Planning And Program Reference
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,8 @@ This directory holds stable project documentation.
   [`casa-vla-importvla-parity.md`](casa-vla-importvla-parity.md)
 - tutorial learning packs:
   [`tutorial-parity/tutorial-learning-packs.md`](tutorial-parity/tutorial-learning-packs.md)
+- ImPerformance Wave 1 mode selection:
+  [`tutorial-parity/imperformance-wave-1-mode-selection.md`](tutorial-parity/imperformance-wave-1-mode-selection.md)
 
 ## Planning And Program Reference
 

--- a/docs/tutorial-parity/README.md
+++ b/docs/tutorial-parity/README.md
@@ -44,6 +44,7 @@ functionality.
 ## ImPerformance Artifacts
 
 - [Wave 1 mode selection and target styles](imperformance-wave-1-mode-selection.md)
+- [Wave 1 simulated dataset plan](imperformance-wave-1-datasets.md)
 
 ## Source Pages
 

--- a/docs/tutorial-parity/README.md
+++ b/docs/tutorial-parity/README.md
@@ -41,6 +41,10 @@ functionality.
 - [Performance closeout](wave-7-performance-closeout.md)
 - [Ticket-level performance closeout](wave-7-ticket-closeout.md)
 
+## ImPerformance Artifacts
+
+- [Wave 1 mode selection and target styles](imperformance-wave-1-mode-selection.md)
+
 ## Source Pages
 
 - CASA Guides main page:

--- a/docs/tutorial-parity/imperformance-wave-1-benchmark-harness.md
+++ b/docs/tutorial-parity/imperformance-wave-1-benchmark-harness.md
@@ -1,0 +1,156 @@
+# ImPerformance Wave 1 Benchmark Harness
+
+Truth class: current descriptive
+Last reality check: 2026-05-15
+Verification: `python3 -m py_compile tools/perf/imager/run_workload.py tools/perf/imager/stage_wave1_datasets.py`; `bash -n scripts/bench-imager-vs-casa.sh`; `tools/perf/imager/run_workload.py --dry-run --output-dir target/imperformance-wave1/harness-dry-run wave1-standard-mfs-dirty-smoke`; `CASA_RS_TESTDATA_ROOT=/Users/brianglendenning/SoftwareProjects/casatestdata CASA_RS_CASA_PYTHON=/Users/brianglendenning/SoftwareProjects/casa-build/venv/bin/python tools/perf/imager/run_workload.py --repeats 1 --output-dir target/imperformance-wave1/harness-smoke wave1-standard-mfs-dirty-smoke`
+
+Wave issue: #246
+Child issue: #252
+
+This note records the reusable CASA C++ versus `casa-rs` imaging benchmark
+harness for ImPerformance Wave 1. The harness is intentionally manifest driven:
+the same workload JSON chooses the MeasurementSet, imaging mode, gridding mode,
+weighting, deconvolver, image geometry, channel selection, repeat count, and
+product comparison settings for both implementations.
+
+## Entry Point
+
+Run one workload manifest with:
+
+```sh
+tools/perf/imager/run_workload.py wave1-standard-mfs-dirty-smoke
+```
+
+The manifest can be a stable workload id under
+`tools/perf/imager/workloads/` or a generated JSON path from
+`tools/perf/imager/stage_wave1_datasets.py --materialize-workloads`.
+
+For real CASA C++ comparisons, set:
+
+```sh
+CASA_RS_TESTDATA_ROOT=/path/to/casatestdata
+CASA_RS_CASA_PYTHON=/path/to/casa-python
+```
+
+Wave 1 generated datasets should instead use `CASA_RS_IMPERF_DATA_ROOT` in the
+generated manifest.
+
+## Harness Contract
+
+`run_workload.py` performs the reusable outer harness work:
+
+- validates that the requested workload is inside the supported Wave 1 slice;
+- resolves datasets only through an explicit manifest path or root environment
+  variable plus relative path;
+- records git branch/commit, CASA Python path, benchmark script hash, command
+  argv, and delegated environment;
+- delegates to `scripts/bench-imager-vs-casa.sh` for the Rust CLI, Rust core
+  stage profiler, CASA `tclean`, and CASA `PySynthesisImager` stage probe;
+- preserves the final Rust and CASA product prefixes under the run output
+  directory;
+- compares configured image products with CASA `casatools.image`;
+- writes one machine-readable JSON result per run.
+
+The delegated shell script remains the only place that knows how to invoke the
+current `casars-imager` CLI and CASA `tclean` parameter sets. That keeps the
+manifest runner stable while the lower-level commands evolve.
+
+## Supported Slice
+
+The #252 harness slice supports:
+
+| Field | Supported values |
+|---|---|
+| `imaging.mode` | `dirty`, `clean` |
+| `imaging.specmode` | `mfs`, `cube` |
+| `imaging.gridder` | `standard`, `mosaic` |
+| `imaging.interpolation` | `nearest`, `linear` |
+| `imaging.wterm` | `none` |
+
+Unsupported W-projection and AW/widefield workloads fail before timing claims
+are written. Those modes remain deferred to their owning tickets.
+
+## Result JSON
+
+Each completed run records:
+
+- run identity, manifest path, selected workload, dataset path, storage label,
+  repeat count, and mode parameters;
+- exact delegated command and environment variables;
+- Rust CLI per-run wallclock and median;
+- CASA `tclean` per-run wallclock and median;
+- Rust and CASA stage medians when available;
+- preserved product root, Rust prefix, and CASA prefix;
+- product comparison metrics for configured suffixes.
+
+The default product comparison suffixes are:
+
+- `.image`
+- `.residual`
+- `.psf`
+
+Manifest authors can override them with:
+
+```json
+{
+  "comparison": {
+    "products": [".image", ".residual", ".psf"],
+    "max_elements_per_product": 1000000
+  }
+}
+```
+
+The product comparison reports shape, sampling stride, finite overlap count,
+Rust/CASA min/max/RMS, absolute-difference maximum, RMS difference,
+`diff_rms_over_casa_rms`, and `diff_abs_max_over_casa_peak`.
+
+For large products, `max_elements_per_product` bounds comparison cost by using
+CASA image chunk strides rather than forcing a full product read.
+
+## Smoke Evidence
+
+The local #252 smoke run used:
+
+```sh
+CASA_RS_TESTDATA_ROOT=/Users/brianglendenning/SoftwareProjects/casatestdata \
+CASA_RS_CASA_PYTHON=/Users/brianglendenning/SoftwareProjects/casa-build/venv/bin/python \
+tools/perf/imager/run_workload.py \
+  --repeats 1 \
+  --output-dir target/imperformance-wave1/harness-smoke \
+  wave1-standard-mfs-dirty-smoke
+```
+
+Result:
+
+- status: completed
+- Rust CLI median: `0.882409 s`
+- CASA `tclean` median: `0.137461 s`
+- `.image` comparison: `diff_rms_over_casa_rms = 0.0412297`,
+  `diff_abs_max_over_casa_peak = 0.00942697`
+- `.residual` comparison: same as `.image` for dirty imaging
+- `.psf` comparison: `diff_rms_over_casa_rms = 0.0258262`,
+  `diff_abs_max_over_casa_peak = 0.00257105`
+
+This is harness evidence, not a Wave 1 performance conclusion. The smoke
+dataset is a small existing testdata MeasurementSet, not one of the staged
+1 GiB / 32 GiB / 100 GiB simulated benchmark datasets.
+
+## Issue #252 Acceptance Mapping
+
+- Reusable manifest-driven runner: `tools/perf/imager/run_workload.py`.
+- Same manifest drives CASA C++ and `casa-rs`: `run_workload.py` translates
+  manifest fields into the delegated command environment used for both sides.
+- Command, inputs, products, wallclock, exit status, and stage timings:
+  recorded in each result JSON.
+- Product deltas: CASA-backed comparison of preserved `.image`, `.residual`,
+  and `.psf` products, with manifest-configurable product suffixes.
+- Dry-run support: `--dry-run` validates support and writes the planned command
+  without requiring CASA Python or a local MeasurementSet.
+- Unsupported modes: fail before timing claims are written.
+
+## Next Tickets
+
+#249 should move stage timing from the current script-parsed probe into a more
+complete structured stage/resource report. #251 should consume these result
+JSON files to build the baseline matrix and bottleneck ledger for the selected
+Wave 1 workloads.

--- a/docs/tutorial-parity/imperformance-wave-1-benchmark-harness.md
+++ b/docs/tutorial-parity/imperformance-wave-1-benchmark-harness.md
@@ -80,6 +80,7 @@ Each completed run records:
 - Rust CLI per-run wallclock and median;
 - CASA `tclean` per-run wallclock and median;
 - Rust and CASA stage medians when available;
+- normalized `stage_breakdown` categories for the Wave 1 bottleneck ledger;
 - preserved product root, Rust prefix, and CASA prefix;
 - product comparison metrics for configured suffixes.
 

--- a/docs/tutorial-parity/imperformance-wave-1-datasets.md
+++ b/docs/tutorial-parity/imperformance-wave-1-datasets.md
@@ -1,8 +1,8 @@
 # ImPerformance Wave 1 Simulated Dataset Plan
 
 Truth class: current descriptive
-Last reality check: 2026-05-14
-Verification: `tools/perf/imager/stage_wave1_datasets.py --dry-run --data-root /Volumes/GLENDENNING/casa-rs-imperformance --output-dir target/imperformance-wave1/dataset-dry-run`; `tools/perf/imager/stage_wave1_datasets.py --dry-run --data-root /tmp/casa-rs-imperformance --dataset wave1-vla-single-small --output-dir target/imperformance-wave1/dataset-small-dry-run`; `tools/perf/imager/stage_wave1_datasets.py --data-root /tmp/casa-rs-imperformance --dataset wave1-vla-single-small --materialize-models --materialize-workloads --output-dir target/imperformance-wave1/dataset-small-materialized`; `tools/perf/imager/run_workload.py --dry-run --output-dir target/imperformance-wave1/generated-workload-dry-run target/imperformance-wave1/dataset-small-materialized/workloads/wave1-vla-single-small-standard-mfs-dirty-control.json`; `just docs-check`; `just quick`
+Last reality check: 2026-05-16
+Verification: `python3 -m py_compile tools/perf/imager/stage_wave1_datasets.py tools/perf/imager/test_stage_wave1_datasets.py`; `python3 -m unittest tools/perf/imager/test_stage_wave1_datasets.py`; `tools/perf/imager/stage_wave1_datasets.py --dry-run --data-root /Volumes/GLENDENNING/casa-rs-imperformance --output-dir target/imperformance-wave1/dataset-dry-run`; `tools/perf/imager/stage_wave1_datasets.py --dry-run --data-root /tmp/casa-rs-imperformance --dataset wave1-vla-single-small --output-dir target/imperformance-wave1/dataset-small-dry-run`; `tools/perf/imager/stage_wave1_datasets.py --data-root /tmp/casa-rs-imperformance --dataset wave1-vla-single-small --materialize-models --materialize-workloads --output-dir target/imperformance-wave1/dataset-small-materialized`; `tools/perf/imager/stage_wave1_datasets.py --data-root /tmp/casa-rs-imperformance --dataset wave1-alma-shared-large --allow-non-external-large-root --materialize-workloads --output-dir target/imperformance-wave1/dataset-large-workloads`; `tools/perf/imager/run_workload.py --dry-run --output-dir target/imperformance-wave1/generated-workload-dry-run target/imperformance-wave1/dataset-small-materialized/workloads/wave1-vla-single-small-standard-mfs-dirty-control.json`; `just docs-check`; `just quick`
 
 Wave issue: #246
 Child issue: #248
@@ -24,7 +24,20 @@ The first performance wave uses three memory-pressure tiers:
 |---|---:|---|---|
 | small | `1 GiB` | much smaller than memory | may live under any explicit `CASA_RS_IMPERF_DATA_ROOT` |
 | medium | `32 GiB` | about memory on this workstation | stage under `/Volumes/GLENDENNING` unless explicitly overridden |
-| large | `100 GiB` | larger than memory on this workstation | stage under `/Volumes/GLENDENNING` unless explicitly overridden |
+| large | `100 GiB` total | larger than memory on this workstation | exactly one shared dataset, staged under `/Volumes/GLENDENNING` unless explicitly overridden |
+
+The large tier is intentionally **not** one 100 GiB dataset per mode. The
+external drive budget allows one large dataset, so the registry contains a
+single shared ALMA mosaic/cube superset:
+
+- dataset id: `wave1-alma-shared-large`;
+- instrument/family: ALMA shared-large mosaic/cube superset;
+- observing shape: 7 pointings, 256 channels, 24 h, 2 s integrations;
+- logical workloads select from this one MS:
+  - standard modes use field `0` with `gridder='standard'`;
+  - mosaic modes use all fields with `gridder='mosaic'`;
+  - bounded mosaic cube uses a 32-channel subset;
+  - MFS modes use the available channel range through `specmode='mfs'`.
 
 Generated MeasurementSets are not committed to git. The checked-in artifact is
 the registry and staging tool:
@@ -42,8 +55,8 @@ is the current path for all Wave 1 benchmark datasets.
 
 | Instrument | Single-field datasets | Mosaic datasets | Native `casa-rs` simulation status |
 |---|---:|---:|---|
-| VLA | small, medium, large | small, medium, large | VLA single-field single-plane is supported by the existing native `simobserve` path; native cube spectral structure and true mosaic generation are backlog |
-| ALMA | small, medium, large | small, medium, large | request-plan-only until ALMA simulation parity is checked |
+| VLA | small, medium | small, medium | VLA single-field single-plane is supported by the existing native `simobserve` path; native cube spectral structure and true mosaic generation are backlog |
+| ALMA | small, medium | small, medium, plus one shared large superset | request-plan-only until ALMA simulation parity is checked |
 
 The registry also includes both single-field and mosaic families:
 
@@ -51,6 +64,7 @@ The registry also includes both single-field and mosaic families:
 |---|---|---|
 | single | standard MFS dirty, standard MFS clean, standard cube, MT-MFS sentinel | CASA C++ generated datasets are usable now; native spectral cube model prediction is backlog #255 |
 | mosaic | mosaic MFS clean, mosaic cube bounded | CASA C++ generated datasets are usable now; native multi-field mosaic generation is backlog #254 |
+| shared-large | all selected Wave 1 modes | one ALMA large-tier superset backs all logical large workloads |
 
 The native blocked/request-plan statuses are intentional. They prevent the
 benchmark program from claiming native simulation capability while allowing the
@@ -154,10 +168,22 @@ tools/perf/imager/stage_wave1_datasets.py --dry-run
 
 Use `--allow-non-external-large-root` only for a deliberate one-off override.
 
+Generate logical workload manifests for the single shared large dataset without
+materializing the 100 GiB MeasurementSet:
+
+```sh
+tools/perf/imager/stage_wave1_datasets.py \
+  --data-root "$CASA_RS_IMPERF_DATA_ROOT" \
+  --dataset wave1-alma-shared-large \
+  --materialize-workloads
+```
+
 ## Issue #248 Acceptance Mapping
 
 - Deterministic generation path or registry entry for selected mode/tier
-  combinations: `wave1_dataset_registry.json` plus CASA C++ simulation plans.
+  combinations: `wave1_dataset_registry.json` plus CASA C++ simulation plans;
+  the large tier intentionally maps all selected modes to
+  `wave1-alma-shared-large`.
 - Metadata needed to reproduce benchmark workloads: generated dataset plan,
   source model files, spectral profile, and simulation request plans.
 - Provenance, size, checksum, path, and tier policy: this document plus the
@@ -166,8 +192,8 @@ Use `--allow-non-external-large-root` only for a deliberate one-off override.
   root outside `/Volumes/GLENDENNING`, and native simulation gaps are explicit
   statuses with follow-up issues.
 - Shared-data policy: explicit root only; no bulky generated data in git.
-- Performance tier intent: small, memory-sized, and larger-than-memory staged
-  datasets.
+- Performance tier intent: small, memory-sized, and one shared
+  larger-than-memory staged dataset.
 
 ## Stop Conditions Preserved
 

--- a/docs/tutorial-parity/imperformance-wave-1-datasets.md
+++ b/docs/tutorial-parity/imperformance-wave-1-datasets.md
@@ -1,0 +1,162 @@
+# ImPerformance Wave 1 Simulated Dataset Plan
+
+Truth class: current descriptive
+Last reality check: 2026-05-14
+Verification: `tools/perf/imager/stage_wave1_datasets.py --dry-run --data-root /Volumes/GLENDENNING/casa-rs-imperformance --output-dir target/imperformance-wave1/dataset-dry-run`; `tools/perf/imager/stage_wave1_datasets.py --dry-run --data-root /tmp/casa-rs-imperformance --dataset wave1-vla-single-small --output-dir target/imperformance-wave1/dataset-small-dry-run`; `tools/perf/imager/stage_wave1_datasets.py --data-root /tmp/casa-rs-imperformance --dataset wave1-vla-single-small --materialize-models --materialize-workloads --output-dir target/imperformance-wave1/dataset-small-materialized`; `tools/perf/imager/run_workload.py --dry-run --output-dir target/imperformance-wave1/generated-workload-dry-run target/imperformance-wave1/dataset-small-materialized/workloads/wave1-vla-single-small-standard-mfs-dirty-control.json`; `just docs-check`; `just quick`
+
+Wave issue: #246
+Child issue: #248
+
+This note defines the deterministic simulated data inputs for ImPerformance
+Wave 1. The goal is to benchmark imaging behavior, not calibration behavior.
+The datasets therefore use visually interesting deterministic sky models, a
+realistic but simple noise term, and explicit CASA C++ versus `casa-rs`
+simulation request plans.
+
+## Size Tiers
+
+The first performance wave uses three memory-pressure tiers:
+
+| Tier | Approximate staged MS size | Storage intent | Default policy |
+|---|---:|---|---|
+| small | `1 GiB` | much smaller than memory | may live under any explicit `CASA_RS_IMPERF_DATA_ROOT` |
+| medium | `32 GiB` | about memory on this workstation | stage under `/Volumes/GLENDENNING` unless explicitly overridden |
+| large | `100 GiB` | larger than memory on this workstation | stage under `/Volumes/GLENDENNING` unless explicitly overridden |
+
+Generated MeasurementSets are not committed to git. The checked-in artifact is
+the registry and staging tool:
+
+- registry: `tools/perf/imager/wave1_dataset_registry.json`
+- staging/preflight tool: `tools/perf/imager/stage_wave1_datasets.py`
+
+The staging root is always explicit. Set `CASA_RS_IMPERF_DATA_ROOT` or pass
+`--data-root`. The tool does not add a personal workstation fallback.
+
+## Instruments And Families
+
+The registry includes both VLA and ALMA simulated datasets:
+
+| Instrument | Single-field datasets | Mosaic datasets | Native `casa-rs` simulation status |
+|---|---:|---:|---|
+| VLA | small, medium, large | small, medium, large | VLA single-field is supported by the existing native `simobserve` path |
+| ALMA | small, medium, large | small, medium, large | request-plan-only until ALMA simulation parity is checked |
+
+The registry also includes both single-field and mosaic families:
+
+| Family | Wave 1 modes | Status |
+|---|---|---|
+| single | standard MFS dirty, standard MFS clean, standard cube, MT-MFS sentinel | usable first for VLA single-field; ALMA request plans are emitted for parity work |
+| mosaic | mosaic MFS clean, mosaic cube bounded | planned and preflighted; true multi-field native simulation is blocked by the current one-FIELD simulator |
+
+The blocked mosaic status is intentional. It prevents the benchmark program
+from claiming a generated mosaic dataset before either CASA-side staged mosaic
+generation or native multi-field MS generation exists.
+
+## Source Model
+
+The continuum model is deterministic and deliberately nontrivial:
+
+- bright compact core;
+- faint offset compact sources;
+- two extended spiral arms;
+- partial ring;
+- broad diffuse halo.
+
+The cube profile is also deterministic and includes frequency structure:
+
+- continuum baseline with spectral index;
+- central broad emission line;
+- offset narrow emission line;
+- absorption notch against the core;
+- weak velocity-gradient metadata for the extended arms.
+
+The current native simulator reads a single FITS plane. The staging tool
+therefore writes a continuum FITS model plus a spectral-profile JSON file. Cube
+benchmarks must record whether the spectral profile was applied by CASA
+simulation, by a future native cube-model predictor, or was unavailable.
+
+## Simulation Parity And Performance Checks
+
+Each staged dataset plan includes:
+
+- a `casars-simobserve.json` request for the native task protocol;
+- a `casa-simulation-plan.json` describing the matching CASA C++ simulation
+  work to run or mark blocked;
+- model/source provenance, shape, noise, storage, and selected-mode metadata.
+
+The simulation comparison is part of #248/#251 evidence because generated data
+becomes benchmark input. The comparison must record:
+
+- CASA C++ simulation status: ran, skipped, or blocked with reason;
+- `casa-rs` simulation status: ran, skipped, or blocked with reason;
+- simulation wallclock for each side when it ran;
+- row count, channel count, UVW/time/data sanity statistics;
+- model/source checksums.
+
+This is not a calibration benchmark. The noise term is simple deterministic
+complex visibility noise, tuned to make images realistic enough for repeated
+inspection without adding calibration-solver scope.
+
+## Commands
+
+Dry-run the full registry using the external drive root:
+
+```sh
+tools/perf/imager/stage_wave1_datasets.py \
+  --dry-run \
+  --data-root /Volumes/GLENDENNING/casa-rs-imperformance \
+  --output-dir target/imperformance-wave1/dataset-dry-run
+```
+
+Dry-run only the small VLA single-field dataset on a temporary root:
+
+```sh
+tools/perf/imager/stage_wave1_datasets.py \
+  --dry-run \
+  --data-root /tmp/casa-rs-imperformance \
+  --dataset wave1-vla-single-small \
+  --output-dir target/imperformance-wave1/dataset-small-dry-run
+```
+
+Materialize source models and generated benchmark workload manifests for one
+dataset:
+
+```sh
+tools/perf/imager/stage_wave1_datasets.py \
+  --data-root "$CASA_RS_IMPERF_DATA_ROOT" \
+  --dataset wave1-vla-single-small \
+  --materialize-models \
+  --materialize-workloads
+```
+
+Medium and large tiers require a root under `/Volumes/GLENDENNING` by default:
+
+```sh
+CASA_RS_IMPERF_DATA_ROOT=/Volumes/GLENDENNING/casa-rs-imperformance \
+tools/perf/imager/stage_wave1_datasets.py --dry-run
+```
+
+Use `--allow-non-external-large-root` only for a deliberate one-off override.
+
+## Issue #248 Acceptance Mapping
+
+- Deterministic generation path or registry entry for selected mode/tier
+  combinations: `wave1_dataset_registry.json`.
+- Metadata needed to reproduce benchmark workloads: generated dataset plan,
+  source model files, spectral profile, and simulation request plans.
+- Provenance, size, checksum, path, and tier policy: this document plus the
+  generated `wave1-dataset-plan.json`.
+- Clear preflight failures: missing `CASA_RS_IMPERF_DATA_ROOT`, medium/large
+  root outside `/Volumes/GLENDENNING`, and unsupported mosaic native simulation
+  are explicit statuses.
+- Shared-data policy: explicit root only; no bulky generated data in git.
+- Performance tier intent: small, memory-sized, and larger-than-memory staged
+  datasets.
+
+## Stop Conditions Preserved
+
+The current tool does not widen native simulation semantics. It records blocked
+status for true native mosaic generation and request-plan-only status for ALMA
+until those paths have CASA parity evidence. Implementing multi-field native
+simulation, CASA `simalma` parity, or a native cube-model predictor should be a
+separate approved scope change if the wave needs it before baseline timing.

--- a/docs/tutorial-parity/imperformance-wave-1-datasets.md
+++ b/docs/tutorial-parity/imperformance-wave-1-datasets.md
@@ -10,8 +10,11 @@ Child issue: #248
 This note defines the deterministic simulated data inputs for ImPerformance
 Wave 1. The goal is to benchmark imaging behavior, not calibration behavior.
 The datasets therefore use visually interesting deterministic sky models, a
-realistic but simple noise term, and explicit CASA C++ versus `casa-rs`
-simulation request plans.
+realistic but simple noise term, and explicit CASA C++ generation plans.
+
+For Wave 1, CASA C++ is allowed to be the dataset generator of record. Native
+`casa-rs` simulation gaps discovered by this plan are tracked as backlog issues
+instead of blocking benchmark dataset staging.
 
 ## Size Tiers
 
@@ -34,23 +37,24 @@ The staging root is always explicit. Set `CASA_RS_IMPERF_DATA_ROOT` or pass
 
 ## Instruments And Families
 
-The registry includes both VLA and ALMA simulated datasets:
+The registry includes both VLA and ALMA simulated datasets. CASA C++ generation
+is the current path for all Wave 1 benchmark datasets.
 
 | Instrument | Single-field datasets | Mosaic datasets | Native `casa-rs` simulation status |
 |---|---:|---:|---|
-| VLA | small, medium, large | small, medium, large | VLA single-field is supported by the existing native `simobserve` path |
+| VLA | small, medium, large | small, medium, large | VLA single-field single-plane is supported by the existing native `simobserve` path; native cube spectral structure and true mosaic generation are backlog |
 | ALMA | small, medium, large | small, medium, large | request-plan-only until ALMA simulation parity is checked |
 
 The registry also includes both single-field and mosaic families:
 
 | Family | Wave 1 modes | Status |
 |---|---|---|
-| single | standard MFS dirty, standard MFS clean, standard cube, MT-MFS sentinel | usable first for VLA single-field; ALMA request plans are emitted for parity work |
-| mosaic | mosaic MFS clean, mosaic cube bounded | planned and preflighted; true multi-field native simulation is blocked by the current one-FIELD simulator |
+| single | standard MFS dirty, standard MFS clean, standard cube, MT-MFS sentinel | CASA C++ generated datasets are usable now; native spectral cube model prediction is backlog #255 |
+| mosaic | mosaic MFS clean, mosaic cube bounded | CASA C++ generated datasets are usable now; native multi-field mosaic generation is backlog #254 |
 
-The blocked mosaic status is intentional. It prevents the benchmark program
-from claiming a generated mosaic dataset before either CASA-side staged mosaic
-generation or native multi-field MS generation exists.
+The native blocked/request-plan statuses are intentional. They prevent the
+benchmark program from claiming native simulation capability while allowing the
+performance wave to proceed from CASA C++ generated datasets.
 
 ## Source Model
 
@@ -71,17 +75,18 @@ The cube profile is also deterministic and includes frequency structure:
 - weak velocity-gradient metadata for the extended arms.
 
 The current native simulator reads a single FITS plane. The staging tool
-therefore writes a continuum FITS model plus a spectral-profile JSON file. Cube
-benchmarks must record whether the spectral profile was applied by CASA
-simulation, by a future native cube-model predictor, or was unavailable.
+therefore writes a continuum FITS model plus a spectral-profile JSON file.
+CASA C++ dataset generation must apply the spectral profile for cube benchmark
+datasets. Native use of the spectral profile is backlog #255.
 
 ## Simulation Parity And Performance Checks
 
 Each staged dataset plan includes:
 
-- a `casars-simobserve.json` request for the native task protocol;
-- a `casa-simulation-plan.json` describing the matching CASA C++ simulation
-  work to run or mark blocked;
+- a `casa-simulation-plan.json` describing the CASA C++ simulation work to run
+  for the Wave 1 benchmark dataset;
+- a `casars-simobserve.json` request for native capability comparison where
+  supported;
 - model/source provenance, shape, noise, storage, and selected-mode metadata.
 
 The simulation comparison is part of #248/#251 evidence because generated data
@@ -96,6 +101,17 @@ becomes benchmark input. The comparison must record:
 This is not a calibration benchmark. The noise term is simple deterministic
 complex visibility noise, tuned to make images realistic enough for repeated
 inspection without adding calibration-solver scope.
+
+## Native Simulation Follow-Ups
+
+Native simulation is not on the critical path for Wave 1 dataset generation.
+The missing capabilities are tracked separately:
+
+- #254: native multi-field mosaic simulation generation.
+- #255: native spectral cube model simulation.
+- #180: ALMA protoplanetary-disk simulation breadth.
+- #181: simalma workflow parity.
+- #182: ACA simulation parity.
 
 ## Commands
 
@@ -141,22 +157,21 @@ Use `--allow-non-external-large-root` only for a deliberate one-off override.
 ## Issue #248 Acceptance Mapping
 
 - Deterministic generation path or registry entry for selected mode/tier
-  combinations: `wave1_dataset_registry.json`.
+  combinations: `wave1_dataset_registry.json` plus CASA C++ simulation plans.
 - Metadata needed to reproduce benchmark workloads: generated dataset plan,
   source model files, spectral profile, and simulation request plans.
 - Provenance, size, checksum, path, and tier policy: this document plus the
   generated `wave1-dataset-plan.json`.
 - Clear preflight failures: missing `CASA_RS_IMPERF_DATA_ROOT`, medium/large
-  root outside `/Volumes/GLENDENNING`, and unsupported mosaic native simulation
-  are explicit statuses.
+  root outside `/Volumes/GLENDENNING`, and native simulation gaps are explicit
+  statuses with follow-up issues.
 - Shared-data policy: explicit root only; no bulky generated data in git.
 - Performance tier intent: small, memory-sized, and larger-than-memory staged
   datasets.
 
 ## Stop Conditions Preserved
 
-The current tool does not widen native simulation semantics. It records blocked
-status for true native mosaic generation and request-plan-only status for ALMA
-until those paths have CASA parity evidence. Implementing multi-field native
-simulation, CASA `simalma` parity, or a native cube-model predictor should be a
-separate approved scope change if the wave needs it before baseline timing.
+The current tool does not widen native simulation semantics. It records native
+gaps while allowing CASA C++ generation for Wave 1 datasets. Implementing
+multi-field native simulation, CASA `simalma` parity, ALMA/ACA native parity,
+or a native cube-model predictor should be separate approved scope.

--- a/docs/tutorial-parity/imperformance-wave-1-mode-selection.md
+++ b/docs/tutorial-parity/imperformance-wave-1-mode-selection.md
@@ -69,7 +69,7 @@ Interpretation:
 |---|---|---|---|
 | `standard-mfs-dirty-control` | `specmode='mfs'`, `gridder='standard'`, dirty-only | Fast control case for harness overhead, gridding, FFT, normalization, and product write cost. | Benchmark and keep near or faster than CASA C++. |
 | `standard-mfs-clean-current` | `specmode='mfs'`, `gridder='standard'`, `deconvolver='multiscale'`, optional `auto-multithresh` | Current single-field continuum practice; covers major/minor-cycle overhead without PB/mosaic cost. | Benchmark, correctness check, and stage budget. |
-| `standard-cube-line` | `specmode='cube'`, `gridder='standard'`, dirty and bounded clean variants | Current spectral-line practice; separates per-channel scaling from mosaic/PB overhead. | Benchmark and identify cube scaling budget without using #56 runtime controls. |
+| `standard-cube-line` | `specmode='cube'`, `gridder='standard'`, dirty and bounded clean variants | Current spectral-line practice; includes deconvolution coverage while separating per-channel scaling from mosaic/PB overhead. | Benchmark dirty and bounded-clean variants; identify cube scaling budget without using #56 runtime controls. |
 | `mosaic-mfs-clean-primary` | `specmode='mfs'`, `gridder='mosaic'`, multiscale clean, PB products | Common ALMA/VLA tutorial mode and current high-leverage slow area in `casa-rs`. | Primary follow-on optimization target. |
 | `mosaic-cube-bounded` | `specmode='cube'`, `gridder='mosaic'`, small channel count first | Exercises the expensive interaction between cube scaling, mosaic/PB work, and product generation. | Bounded benchmark and bottleneck ledger; large-cube controls stay with #56. |
 | `mtmfs-wideband-sentinel` | `specmode='mfs'`, `deconvolver='mtmfs'`, `nterms > 1` | Current wideband continuum algorithm family; useful to keep in view before backend planning hardens. | Baseline-only sentinel unless it becomes the dominant bottleneck. |
@@ -81,7 +81,7 @@ Interpretation:
 | W-projection speed work | Deferred | `casa-rs` exposes a W-term request path, but Wave 1 should not turn W-projection into the first optimization target without baseline evidence and a supported CASA comparison harness. |
 | AW/widefield gridder family | Deferred to #52 | Capability surface and CF-planning controls belong to #52. Wave 1 should leave hooks for future backend/resource planning but not implement AW. |
 | CASA-like `parallel` / `chanchunks` | Deferred to #56 | User-visible large-cube runtime controls already have an owner. Wave 1 can measure cube scaling but should not add these controls. |
-| GPU/Kokkos/CUDA execution | Deferred | LibRA shows that a backend/resource boundary is useful, but Wave 1 should not introduce GPU dependencies or runtime behavior. |
+| GPU/Kokkos/CUDA implementation | Not a mode; defer from #247 mode selection | LibRA suggests that a backend/resource boundary is useful, and Wave 1 should keep GPU-readiness in view. This ticket should not add GPU dependencies or runtime behavior before the benchmark modes and stage budgets exist. |
 | Distributed execution | Deferred | Not needed for first local CASA C++ versus `casa-rs` wallclock baselines. |
 
 ## Workload Shapes
@@ -93,7 +93,7 @@ owned by #252. These shapes define what those tickets must support.
 |---|---|---|---|---|---|
 | `standard-mfs-dirty-control` | small, medium, large | deterministic single-field continuum simulation | 512, 2048, and 4096 pixel images; one MFS plane | dirty-only, natural and Briggs variants | `.psf`, `.residual`, `.image`, timing JSON |
 | `standard-mfs-clean-current` | small, medium, large | deterministic single-field continuum with compact plus extended structure | 512, 2048, and 4096 pixel images | multiscale scales including zero; bounded `niter`; `auto-multithresh` on at least medium | `.psf`, `.residual`, `.model`, `.image`, `.sumwt`, timing JSON |
-| `standard-cube-line` | small, medium, large | deterministic spectral-line cube with known line structure | 16, 64, and 256 channels; 512 to 2048 pixel images | dirty-only plus bounded multiscale/automask clean | cube `.psf`, `.residual`, `.image`, optional `.model`, timing JSON |
+| `standard-cube-line` | small, medium, large | deterministic spectral-line cube with known line structure | 16, 64, and 256 channels; 512 to 2048 pixel images | dirty-only plus bounded multiscale/auto-multithresh clean | cube `.psf`, `.residual`, `.image`, `.model` for clean variants, timing JSON |
 | `mosaic-mfs-clean-primary` | small, medium, large | deterministic mosaic with overlapping pointings; include one real tutorial case | 512, 2048, and tutorial-scale images | multiscale clean; PB products enabled; Briggs weighting | `.psf`, `.residual`, `.model`, `.image`, `.image.pbcor`, `.pb`, timing JSON |
 | `mosaic-cube-bounded` | small, medium | deterministic line mosaic | 8 and 32 channels; 512 to 1024 pixel images | dirty-only plus short clean probe | cube products, PB products where supported, timing JSON |
 | `mtmfs-wideband-sentinel` | medium | wideband continuum simulation | 2048 pixel image; `nterms=2` initially | MT-MFS bounded clean; multiscale sentinel if already supported by path | Taylor-term products, alpha products, timing JSON |
@@ -107,7 +107,7 @@ wallclock. It should fail if it cannot produce trustworthy evidence.
 |---|---|---|
 | `standard-mfs-dirty-control` | median wallclock ratio, stage budget, correctness delta | 10x CASA C++ stretch target after backend/workspace work. |
 | `standard-mfs-clean-current` | median wallclock ratio, major/minor-cycle budget, correctness delta | 10x target for practical single-field continuum workflows. |
-| `standard-cube-line` | per-channel scaling, wallclock ratio, correctness delta | 10x target after cube dataflow and backend work; #56 owns user-visible chunk/parallel controls. |
+| `standard-cube-line` | dirty and bounded-clean per-channel scaling, wallclock ratio, correctness delta | 10x target after cube dataflow and backend work; #56 owns user-visible chunk/parallel controls. |
 | `mosaic-mfs-clean-primary` | primary bottleneck ledger plus CASA C++ ratio | First follow-on optimization target because previous evidence showed mosaic/CLEAN slower than CASA and the mode is current practice. |
 | `mosaic-cube-bounded` | bounded scaling and PB/product cost ledger | Decide whether the next ticket is mosaic gridding, PB/product writeback, or cube runtime controls. |
 | `mtmfs-wideband-sentinel` | baseline-only unless unexpectedly dominant | Keep wideband continuum visible before backend structure hardens. |
@@ -125,6 +125,10 @@ Rationale:
   CASA C++ while standard MFS dirty imaging was close to CASA.
 - The path is likely to exercise the same structural seams needed for later
   cube, PB, workspace residency, backend, and GPU work.
+
+The target is workload-level. The implementation path may be CPU dataflow
+repair, GPU/backend preparation, or both, depending on #251 stage evidence. Do
+not assume that CPU-only work can reach the long-term 10x target.
 
 If #251 shows that the dominant cost is MS/table preparation, image writing, or
 preview generation instead of imaging proper, split the follow-on target before

--- a/docs/tutorial-parity/imperformance-wave-1-mode-selection.md
+++ b/docs/tutorial-parity/imperformance-wave-1-mode-selection.md
@@ -1,0 +1,144 @@
+# ImPerformance Wave 1 Mode Selection
+
+Truth class: current descriptive
+Last reality check: 2026-05-14
+Verification: just docs-check; just quick
+
+Wave issue: #246
+Child issue: #247
+
+This note fixes the first benchmark targets for ImPerformance Wave 1. The goal
+is not to cover every CASA `tclean` mode. The goal is to pick a small set of
+current, real imaging use cases that can support reproducible CASA C++ versus
+`casa-rs` timing, correctness checks, and stage budgets before optimization
+work starts.
+
+## Current-Practice Signals
+
+The local RadioAstronomyOracle corpus does not provide a statistical survey of
+all current reductions. It does provide current 2024 tutorial and Synthesis
+Imaging Workshop signals about common practice:
+
+- ALMA pipeline material shows a standard imaging recipe that runs continuum
+  and line-imaging flows through `hifmakeimlist` / `hifmakeimages`, with
+  `specmode='mfs'` appearing early in the pipeline recipe. Citation:
+  `ALMA-Pipeline-tutorial-SISS2024.pdf, slide 15`.
+- ALMA manual tutorial material uses `tclean` with `specmode='mfs'`,
+  `gridder='standard'`, Briggs weighting, and Hogbom Clean for a compact
+  calibrator-style example. Citation: `ALMA-Manual-tutorial-SISS2024.pdf,
+  slide 137`.
+- The same 2024 ALMA tutorial uses standard-gridder MFS continuum imaging with
+  `deconvolver='multiscale'`, Briggs weighting, and large image sizes for
+  science-target continuum. Citation: `ALMA-Manual-tutorial-SISS2024.pdf,
+  slide 145`.
+- The ALMA line-imaging example uses `specmode='cube'`,
+  `deconvolver='multiscale'`, `restoringbeam='common'`,
+  `weighting='briggsbwtaper'`, and `perchanweightdensity=True`. Citation:
+  `ALMA-Manual-tutorial-SISS2024.pdf, slide 155`.
+- 2024 mosaicking material says that joint mosaic imaging uses
+  `gridder='mosaic'`, recommends `mosweight=True`, and recommends
+  `perchanwtdensity=True` plus `briggsbwtaper=True` for cubes. It also says
+  `gridder='mosaic'` is necessary for heterogeneous-array imaging in CASA
+  `tclean`. Citation: `Plunket-Mosaicking2024.pdf, slide 34`.
+- 2024 wideband material identifies CASA MT-MFS as one of the main wideband
+  deconvolution algorithms and notes compatibility with multiscale
+  deconvolution. Citation: `Marvil_Wideband2024.pdf, slide 19`.
+- 2024 ALMA tutorial material describes `auto-multithresh` as available in
+  `tclean` since CASA 5.1 and deployed in the ALMA Cycle 5 pipeline. Citation:
+  `ALMA-Manual-tutorial-SISS2024.pdf, slide 122`.
+
+Interpretation:
+
+- Single-field `standard` MFS remains a core control case.
+- Spectral-line cube imaging is a first-class current workload, not a corner
+  case.
+- `multiscale` and `auto-multithresh` should be treated as current-practice
+  clean workloads, not optional embellishments.
+- Mosaic imaging is common enough, and expensive enough in current `casa-rs`
+  evidence, to be a primary performance target.
+- MT-MFS is important for wideband continuum, but should be a Wave 1 sentinel
+  workload rather than the first optimization target unless baseline evidence
+  makes it dominant.
+- W-projection and AW/widefield imaging matter, but the existing #52 surface is
+  the right owner for AW/widefield capability. Wave 1 should avoid making #52 a
+  hidden prerequisite.
+
+## Selected Wave 1 Modes
+
+| ID | Mode | Why it is in Wave 1 | Target status |
+|---|---|---|---|
+| `standard-mfs-dirty-control` | `specmode='mfs'`, `gridder='standard'`, dirty-only | Fast control case for harness overhead, gridding, FFT, normalization, and product write cost. | Benchmark and keep near or faster than CASA C++. |
+| `standard-mfs-clean-current` | `specmode='mfs'`, `gridder='standard'`, `deconvolver='multiscale'`, optional `auto-multithresh` | Current single-field continuum practice; covers major/minor-cycle overhead without PB/mosaic cost. | Benchmark, correctness check, and stage budget. |
+| `standard-cube-line` | `specmode='cube'`, `gridder='standard'`, dirty and bounded clean variants | Current spectral-line practice; separates per-channel scaling from mosaic/PB overhead. | Benchmark and identify cube scaling budget without using #56 runtime controls. |
+| `mosaic-mfs-clean-primary` | `specmode='mfs'`, `gridder='mosaic'`, multiscale clean, PB products | Common ALMA/VLA tutorial mode and current high-leverage slow area in `casa-rs`. | Primary follow-on optimization target. |
+| `mosaic-cube-bounded` | `specmode='cube'`, `gridder='mosaic'`, small channel count first | Exercises the expensive interaction between cube scaling, mosaic/PB work, and product generation. | Bounded benchmark and bottleneck ledger; large-cube controls stay with #56. |
+| `mtmfs-wideband-sentinel` | `specmode='mfs'`, `deconvolver='mtmfs'`, `nterms > 1` | Current wideband continuum algorithm family; useful to keep in view before backend planning hardens. | Baseline-only sentinel unless it becomes the dominant bottleneck. |
+
+## Deferred Or Blocked Modes
+
+| Mode family | Status | Reason |
+|---|---|---|
+| W-projection speed work | Deferred | `casa-rs` exposes a W-term request path, but Wave 1 should not turn W-projection into the first optimization target without baseline evidence and a supported CASA comparison harness. |
+| AW/widefield gridder family | Deferred to #52 | Capability surface and CF-planning controls belong to #52. Wave 1 should leave hooks for future backend/resource planning but not implement AW. |
+| CASA-like `parallel` / `chanchunks` | Deferred to #56 | User-visible large-cube runtime controls already have an owner. Wave 1 can measure cube scaling but should not add these controls. |
+| GPU/Kokkos/CUDA execution | Deferred | LibRA shows that a backend/resource boundary is useful, but Wave 1 should not introduce GPU dependencies or runtime behavior. |
+| Distributed execution | Deferred | Not needed for first local CASA C++ versus `casa-rs` wallclock baselines. |
+
+## Workload Shapes
+
+Exact datasets will be created or wired by #248. Exact harness manifests will be
+owned by #252. These shapes define what those tickets must support.
+
+| Mode ID | Size tier | Dataset style | Image / channel shape | Clean settings | Expected products |
+|---|---|---|---|---|---|
+| `standard-mfs-dirty-control` | small, medium, large | deterministic single-field continuum simulation | 512, 2048, and 4096 pixel images; one MFS plane | dirty-only, natural and Briggs variants | `.psf`, `.residual`, `.image`, timing JSON |
+| `standard-mfs-clean-current` | small, medium, large | deterministic single-field continuum with compact plus extended structure | 512, 2048, and 4096 pixel images | multiscale scales including zero; bounded `niter`; `auto-multithresh` on at least medium | `.psf`, `.residual`, `.model`, `.image`, `.sumwt`, timing JSON |
+| `standard-cube-line` | small, medium, large | deterministic spectral-line cube with known line structure | 16, 64, and 256 channels; 512 to 2048 pixel images | dirty-only plus bounded multiscale/automask clean | cube `.psf`, `.residual`, `.image`, optional `.model`, timing JSON |
+| `mosaic-mfs-clean-primary` | small, medium, large | deterministic mosaic with overlapping pointings; include one real tutorial case | 512, 2048, and tutorial-scale images | multiscale clean; PB products enabled; Briggs weighting | `.psf`, `.residual`, `.model`, `.image`, `.image.pbcor`, `.pb`, timing JSON |
+| `mosaic-cube-bounded` | small, medium | deterministic line mosaic | 8 and 32 channels; 512 to 1024 pixel images | dirty-only plus short clean probe | cube products, PB products where supported, timing JSON |
+| `mtmfs-wideband-sentinel` | medium | wideband continuum simulation | 2048 pixel image; `nterms=2` initially | MT-MFS bounded clean; multiscale sentinel if already supported by path | Taylor-term products, alpha products, timing JSON |
+
+## Target Style
+
+Wave 1 should not fail because `casa-rs` has not yet reached 10x CASA C++
+wallclock. It should fail if it cannot produce trustworthy evidence.
+
+| Mode ID | Wave 1 target style | Long-term target direction |
+|---|---|---|
+| `standard-mfs-dirty-control` | median wallclock ratio, stage budget, correctness delta | 10x CASA C++ stretch target after backend/workspace work. |
+| `standard-mfs-clean-current` | median wallclock ratio, major/minor-cycle budget, correctness delta | 10x target for practical single-field continuum workflows. |
+| `standard-cube-line` | per-channel scaling, wallclock ratio, correctness delta | 10x target after cube dataflow and backend work; #56 owns user-visible chunk/parallel controls. |
+| `mosaic-mfs-clean-primary` | primary bottleneck ledger plus CASA C++ ratio | First follow-on optimization target because previous evidence showed mosaic/CLEAN slower than CASA and the mode is current practice. |
+| `mosaic-cube-bounded` | bounded scaling and PB/product cost ledger | Decide whether the next ticket is mosaic gridding, PB/product writeback, or cube runtime controls. |
+| `mtmfs-wideband-sentinel` | baseline-only unless unexpectedly dominant | Keep wideband continuum visible before backend structure hardens. |
+
+## First Follow-On Optimization Target
+
+The first optimization ticket after Wave 1 should target
+`mosaic-mfs-clean-primary` unless #251 produces contrary evidence.
+
+Rationale:
+
+- Current-practice sources make mosaic imaging a normal `tclean` workload, not
+  a niche path.
+- Existing Wave 7 evidence already showed mosaic/CLEAN workloads slower than
+  CASA C++ while standard MFS dirty imaging was close to CASA.
+- The path is likely to exercise the same structural seams needed for later
+  cube, PB, workspace residency, backend, and GPU work.
+
+If #251 shows that the dominant cost is MS/table preparation, image writing, or
+preview generation instead of imaging proper, split the follow-on target before
+optimizing.
+
+## Issue #247 Acceptance Mapping
+
+- Selected modes, excluded modes, and rationale: this document, sections
+  "Selected Wave 1 Modes" and "Deferred Or Blocked Modes".
+- Workload shapes: section "Workload Shapes".
+- Target styles: section "Target Style".
+- Blocked/deferred cases: section "Deferred Or Blocked Modes".
+- Existing surface mapping: the selected modes map to existing
+  `casars-imager` / `casa-imaging` surfaces except where marked as sentinel or
+  deferred.
+- First follow-on optimization target: section "First Follow-On Optimization
+  Target".

--- a/docs/tutorial-parity/imperformance-wave-1-mode-selection.md
+++ b/docs/tutorial-parity/imperformance-wave-1-mode-selection.md
@@ -87,16 +87,19 @@ Interpretation:
 ## Workload Shapes
 
 Exact datasets will be created or wired by #248. Exact harness manifests will be
-owned by #252. These shapes define what those tickets must support.
+owned by #252. These shapes define what those tickets must support. The large
+tier is a storage-constrained exception: all large logical workloads select
+from one shared ALMA mosaic/cube superset rather than from separate 100 GiB
+single-field and mosaic MeasurementSets.
 
 | Mode ID | Size tier | Dataset style | Image / channel shape | Clean settings | Expected products |
 |---|---|---|---|---|---|
-| `standard-mfs-dirty-control` | small, medium, large | deterministic single-field continuum simulation | 512, 2048, and 4096 pixel images; one MFS plane | dirty-only, natural and Briggs variants | `.psf`, `.residual`, `.image`, timing JSON |
-| `standard-mfs-clean-current` | small, medium, large | deterministic single-field continuum with compact plus extended structure | 512, 2048, and 4096 pixel images | multiscale scales including zero; bounded `niter`; `auto-multithresh` on at least medium | `.psf`, `.residual`, `.model`, `.image`, `.sumwt`, timing JSON |
-| `standard-cube-line` | small, medium, large | deterministic spectral-line cube with known line structure | 16, 64, and 256 channels; 512 to 2048 pixel images | dirty-only plus bounded multiscale/auto-multithresh clean | cube `.psf`, `.residual`, `.image`, `.model` for clean variants, timing JSON |
-| `mosaic-mfs-clean-primary` | small, medium, large | deterministic mosaic with overlapping pointings; include one real tutorial case | 512, 2048, and tutorial-scale images | multiscale clean; PB products enabled; Briggs weighting | `.psf`, `.residual`, `.model`, `.image`, `.image.pbcor`, `.pb`, timing JSON |
-| `mosaic-cube-bounded` | small, medium | deterministic line mosaic | 8 and 32 channels; 512 to 1024 pixel images | dirty-only plus short clean probe | cube products, PB products where supported, timing JSON |
-| `mtmfs-wideband-sentinel` | medium | wideband continuum simulation | 2048 pixel image; `nterms=2` initially | MT-MFS bounded clean; multiscale sentinel if already supported by path | Taylor-term products, alpha products, timing JSON |
+| `standard-mfs-dirty-control` | small, medium, large-shared | deterministic single-field continuum simulation; large selects field `0` from the shared ALMA superset | 512, 2048, and 4096 pixel images; MFS over the available channel range | dirty-only, natural and Briggs variants | `.psf`, `.residual`, `.image`, timing JSON |
+| `standard-mfs-clean-current` | small, medium, large-shared | deterministic single-field continuum with compact plus extended structure; large selects field `0` from the shared ALMA superset | 512, 2048, and 4096 pixel images | multiscale scales including zero; bounded `niter`; `auto-multithresh` on at least medium | `.psf`, `.residual`, `.model`, `.image`, `.sumwt`, timing JSON |
+| `standard-cube-line` | small, medium, large-shared | deterministic spectral-line cube with known line structure; large selects field `0` from the shared ALMA superset | 16, 64, and 256 channels; 512 to 4096 pixel images | dirty-only plus bounded multiscale/auto-multithresh clean | cube `.psf`, `.residual`, `.image`, `.model` for clean variants, timing JSON |
+| `mosaic-mfs-clean-primary` | small, medium, large-shared | deterministic mosaic with overlapping pointings; large uses all fields from the shared ALMA superset | 512, 2048, and 4096 pixel images | multiscale clean; PB products enabled; Briggs weighting | `.psf`, `.residual`, `.model`, `.image`, `.image.pbcor`, `.pb`, timing JSON |
+| `mosaic-cube-bounded` | small, medium, large-shared bounded subset | deterministic line mosaic; large uses all fields but a bounded channel slice from the shared ALMA superset | 8, 32, and 32 selected channels; 512 to 4096 pixel images | dirty-only plus short clean probe | cube products, PB products where supported, timing JSON |
+| `mtmfs-wideband-sentinel` | medium, large-shared sentinel | wideband continuum simulation; large selects from the shared ALMA superset | 2048 to 4096 pixel image; `nterms=2` initially | MT-MFS bounded clean; multiscale sentinel if already supported by path | Taylor-term products, alpha products, timing JSON |
 
 ## Target Style
 

--- a/docs/tutorial-parity/imperformance-wave-1-stage-instrumentation.md
+++ b/docs/tutorial-parity/imperformance-wave-1-stage-instrumentation.md
@@ -1,0 +1,115 @@
+# ImPerformance Wave 1 Stage Instrumentation
+
+Truth class: current descriptive
+Last reality check: 2026-05-15
+Verification: `python3 -m py_compile tools/perf/imager/run_workload.py tools/perf/imager/test_run_workload.py`; `python3 -m unittest tools/perf/imager/test_run_workload.py`; `tools/perf/imager/run_workload.py --dry-run --output-dir target/imperformance-wave1/stage-instrumentation-dry-run wave1-standard-mfs-dirty-smoke`; `CASA_RS_TESTDATA_ROOT=/Users/brianglendenning/SoftwareProjects/casatestdata CASA_RS_CASA_PYTHON=/Users/brianglendenning/SoftwareProjects/casa-build/venv/bin/python tools/perf/imager/run_workload.py --repeats 1 --output-dir target/imperformance-wave1/stage-instrumentation-smoke wave1-standard-mfs-dirty-smoke`
+
+Wave issue: #246
+Child issue: #249
+
+This note records the Wave 1 stage-level timing surface used by the benchmark
+harness. The implementation does not add public task-protocol fields or managed
+output schema fields. It normalizes the existing Rust profiler and CASA phase
+probe output into the local benchmark result JSON under
+`results.stage_breakdown`.
+
+## Contract Review
+
+The structured timing object is local benchmark evidence:
+
+- producer: `tools/perf/imager/run_workload.py`
+- consumer: Wave 1 benchmark summaries and the #251 bottleneck ledger
+- persisted public format: none
+- provider protocol change: none
+- managed-output contract change: none
+
+If these fields are later promoted into `casars-imager` JSON task output,
+managed output, or provider contracts, that will need a separate contract
+review.
+
+## Rust Categories
+
+The normalized Rust timing categories are:
+
+| Category | Source timing fields | Purpose |
+|---|---|---|
+| `frontend_ms_preparation` | `open_measurement_set`, `prepare_plane_input`, `extract_phase_center` | MS open, selection, row adaptation, and phase-center resolution. |
+| `visibility_adaptation_and_chunking` | `prepare_plane_input` | Visibility adaptation before pure imaging. |
+| `weighting_density_setup` | `weighting` | Imaging weights, density grids, and taper setup. |
+| `projection_pb_cf_preparation` | none yet | Explicit non-zero-free placeholder; projection/PB setup currently lives inside lower-level selected-mode paths. |
+| `gridding_degridding` | `psf_grid`, `residual_degrid_grid` | PSF gridding plus residual degrid/grid work. |
+| `fft` | `psf_fft`, `model_fft`, `residual_fft` | PSF, model, and residual FFT work. |
+| `normalization_pb_correction` | `psf_normalize`, `residual_normalize` | PSF and residual normalization; PB correction is included when the selected mode produces PB products. |
+| `deconvolution_minor_cycle` | `minor_cycle_solve` | Minor-cycle component selection and subtraction. |
+| `model_prediction_and_residual_refresh` | `major_cycle_refresh` | Major-cycle model prediction and residual refresh aggregate. |
+| `restore_and_beam_fit` | `beam_fit`, `restore` | Restoring-beam fit and restored-image generation. |
+| `coordinate_and_product_writeback` | `build_coordinate_system`, `write_products` | Output coordinate construction and image product writeback. |
+| `preview_sidecar_generation` | none in harness | Explicitly skipped because benchmark runs pass `--no-preview-pngs`. |
+| `frontend_total` | `frontend_total` | Total frontend wallclock from the Rust profiler. |
+| `core_total` | `total` | Total pure imaging-core wallclock from the Rust profiler. |
+
+Each category reports `status`, `reason`, `total_ms`, `components_ms`,
+`source_fields`, and a short description. Clean-only categories are marked
+`skipped` for dirty-only or `niter=0` workloads instead of publishing a
+misleading zero-cost stage.
+
+## CASA Categories
+
+The CASA side is a comparison probe, not the source of the `casa-rs`
+instrumentation contract. The normalized CASA categories are:
+
+- `setup_and_tool_construction`
+- `weighting_density_setup`
+- `psf_and_primary_beam`
+- `major_cycle_residual`
+- `deconvolution_minor_cycle`
+- `restore_and_cleanup`
+- `total`
+
+CASA cannot currently expose the same grid, FFT, normalization, and PB
+sub-stages through this probe, so the Rust categories are the canonical #249
+surface for choosing `casa-rs` optimization ownership.
+
+## Smoke Evidence
+
+The local one-repeat dirty-control smoke run completed with:
+
+- Rust CLI median: `0.926705 s`
+- CASA `tclean` median: `0.131690 s`
+- `results.stage_breakdown.schema_version`: `1`
+- Rust frontend/MS preparation: `38.485 ms`
+- Rust visibility adaptation/chunking: `37.356 ms`
+- Rust gridding/degridding: `0.600 ms`
+- Rust FFT: `0.424 ms`
+- Rust normalization/PB correction: `0.028 ms`
+- Rust coordinate/product writeback: `6.280 ms`
+- Rust deconvolution and model-prediction refresh: `skipped` for dirty-only
+- Preview sidecars: `skipped` because previews are disabled in benchmark runs
+
+This smoke workload is intentionally small and mostly measures harness shape.
+The 1 GiB / 32 GiB / 100 GiB simulated datasets will provide the Wave 1
+baseline matrix in #251.
+
+## Overhead Boundary
+
+The #249 implementation does not add timers to the hot imaging loops. It
+reuses timings already produced by `profile_imager` and `casa_phase_bench.py`,
+then performs a dictionary normalization pass in the Python harness after the
+benchmark process completes. Instrumentation overhead on imaging execution is
+therefore bounded to the existing profiler runs; the new category mapping is
+outside the measured imaging commands.
+
+## Issue #249 Acceptance Mapping
+
+- Structured `casa-rs` timing data: `results.stage_breakdown.rust`.
+- Frontend/MS preparation versus pure imaging core: separate frontend,
+  visibility-adaptation, and core categories plus `frontend_total` /
+  `core_total`.
+- Grid/degrid, FFT, normalization/PB correction, deconvolution, and writeback:
+  normalized Rust categories listed above.
+- Disabled/skipped paths: dirty-only clean stages and preview generation are
+  explicit `skipped` categories with reasons.
+- Contract impact: local benchmark JSON only; no provider protocol or
+  managed-output schema change.
+- Overhead: no new hot-loop timers; normalization happens after each benchmark
+  process completes.

--- a/scripts/bench-imager-vs-casa.sh
+++ b/scripts/bench-imager-vs-casa.sh
@@ -61,6 +61,7 @@ gain="${IMAGER_BENCH_GAIN:-0.1}"
 threshold_jy="${IMAGER_BENCH_THRESHOLD_JY:-0}"
 nsigma="${IMAGER_BENCH_NSIGMA:-0}"
 psfcutoff="${IMAGER_BENCH_PSFCUTOFF:-0.35}"
+keep_output_root="${IMAGER_BENCH_KEEP_OUTPUT_ROOT:-}"
 
 if [[ "$wterm" != "none" ]]; then
   echo "error: scripts/bench-imager-vs-casa.sh only supports IMAGER_BENCH_WTERM=none for Rust-vs-CASA comparisons" >&2
@@ -103,6 +104,31 @@ print(f"{statistics.median(values):.6f}")
 PY
 }
 
+run_timed_command() {
+  local stderr_file="$1"
+  shift
+  local start
+  local status
+  start="$(python3 - <<'PY'
+import time
+print(f"{time.perf_counter():.9f}")
+PY
+)"
+  "$@" >/dev/null 2>"$stderr_file"
+  status="$?"
+  python3 - "$start" "$stderr_file" <<'PY'
+import sys
+import time
+
+start = float(sys.argv[1])
+stderr_file = sys.argv[2]
+elapsed = time.perf_counter() - start
+with open(stderr_file, "a", encoding="utf-8") as handle:
+    handle.write(f"real {elapsed:.6f}\n")
+PY
+  return "$status"
+}
+
 echo "ms_path=$ms_path"
 echo "CASA_RS_CASA_PYTHON=$CASA_RS_CASA_PYTHON"
 echo "mode=$mode specmode=$specmode gridder=$gridder field=$field spw=$spw channel_start=$channel_start channel_count=$channel_count interpolation=$interpolation weighting=$weighting robust=$robust deconvolver=$deconvolver scales=$scales wterm=$wterm imsize=$imsize cell_arcsec=$cell_arcsec repeats=$repeats niter=$niter nsigma=$nsigma cycleniter=$minor_cycle_length cyclefactor=$cyclefactor minpsffraction=$min_psf_fraction maxpsffraction=$max_psf_fraction"
@@ -115,13 +141,26 @@ trap 'rm -rf "$tmpdir"' EXIT
 staged_ms_path="$tmpdir/benchmark.ms"
 cp -R "$ms_path" "$staged_ms_path"
 ms_path="$staged_ms_path"
+if [[ -n "$keep_output_root" ]]; then
+  mkdir -p "$keep_output_root/rust" "$keep_output_root/casa"
+  rust_keep_prefix="$keep_output_root/rust/rust"
+  casa_keep_prefix="$keep_output_root/casa/casa"
+else
+  rust_keep_prefix=""
+  casa_keep_prefix=""
+fi
 
 echo "Rust release CLI timings (seconds):"
 rust_cli_file="$tmpdir/rust-cli.txt"
 for run in $(seq 1 "$repeats"); do
-  prefix="$tmpdir/rust-run-$run"
+  if [[ -n "$rust_keep_prefix" && "$run" == "$repeats" ]]; then
+    prefix="$rust_keep_prefix"
+  else
+    prefix="$tmpdir/rust-run-$run"
+  fi
+  rust_stderr="$tmpdir/rust-$run.stderr"
   if [[ -n "$scales" ]]; then
-    /usr/bin/time -lp target/release/casars-imager \
+    if ! run_timed_command "$rust_stderr" target/release/casars-imager \
       --ms "$ms_path" \
       --imagename "$prefix" \
       --imsize "$imsize" \
@@ -149,10 +188,13 @@ for run in $(seq 1 "$repeats"); do
       --maxpsffraction "$max_psf_fraction" \
       --wterm "$wterm" \
       --no-preview-pngs \
-      $dirty_flag \
-      >/dev/null 2>"$tmpdir/rust-$run.stderr"
+      $dirty_flag; then
+      echo "error: Rust casars-imager run $run failed" >&2
+      cat "$rust_stderr" >&2
+      exit 1
+    fi
   else
-    /usr/bin/time -lp target/release/casars-imager \
+    if ! run_timed_command "$rust_stderr" target/release/casars-imager \
       --ms "$ms_path" \
       --imagename "$prefix" \
       --imsize "$imsize" \
@@ -179,14 +221,20 @@ for run in $(seq 1 "$repeats"); do
       --maxpsffraction "$max_psf_fraction" \
       --wterm "$wterm" \
       --no-preview-pngs \
-      $dirty_flag \
-      >/dev/null 2>"$tmpdir/rust-$run.stderr"
+      $dirty_flag; then
+      echo "error: Rust casars-imager run $run failed" >&2
+      cat "$rust_stderr" >&2
+      exit 1
+    fi
   fi
-  real_seconds="$(awk '/^real / {print $2}' "$tmpdir/rust-$run.stderr")"
+  real_seconds="$(awk '/^real / {print $2}' "$rust_stderr")"
   printf "  run=%s real=%s\n" "$run" "$real_seconds"
   printf "%s\n" "$real_seconds" >>"$rust_cli_file"
 done
 echo "  median=$(median_from_file "$rust_cli_file")"
+if [[ -n "$rust_keep_prefix" ]]; then
+  echo "  kept_rust_prefix=$rust_keep_prefix"
+fi
 echo
 
 echo "Rust stage medians (milliseconds):"
@@ -285,12 +333,18 @@ gridder = os.environ["CASA_RS_BENCH_GRIDDER"]
 scales = [] if os.environ["CASA_RS_BENCH_SCALES"] == "" else [int(float(v)) for v in os.environ["CASA_RS_BENCH_SCALES"].split(",")]
 specmode = os.environ["CASA_RS_BENCH_SPECMODE"]
 interpolation = os.environ["CASA_RS_BENCH_INTERPOLATION"]
+keep_output_root = os.environ.get("CASA_RS_BENCH_KEEP_OUTPUT_ROOT", "")
+casa_keep_prefix = os.path.join(keep_output_root, "casa", "casa") if keep_output_root else ""
 spw_selector = f"{spw}:{chan_start}" if chan_count == 1 else f"{spw}:{chan_start}~{chan_start + chan_count - 1}"
 times = []
 
 with tempfile.TemporaryDirectory() as td:
     for run in range(repeats):
-        prefix = os.path.join(td, f"run-{run}")
+        if casa_keep_prefix and run == repeats - 1:
+            os.makedirs(os.path.dirname(casa_keep_prefix), exist_ok=True)
+            prefix = casa_keep_prefix
+        else:
+            prefix = os.path.join(td, f"run-{run}")
         start = time.perf_counter()
         kwargs = dict(
             vis=vis,
@@ -342,6 +396,8 @@ with tempfile.TemporaryDirectory() as td:
         print(f"run={run + 1} real={elapsed:.6f}")
 
 print(f"median={statistics.median(times):.6f}")
+if casa_keep_prefix:
+    print(f"kept_casa_prefix={casa_keep_prefix}")
 PY
 
 echo "CASA tclean timings (seconds):"
@@ -369,8 +425,17 @@ CASA_RS_BENCH_CYCLEFACTOR="$cyclefactor" \
 CASA_RS_BENCH_MIN_PSFFRACTION="$min_psf_fraction" \
 CASA_RS_BENCH_MAX_PSFFRACTION="$max_psf_fraction" \
 CASA_RS_BENCH_INTERPOLATION="$interpolation" \
+CASA_RS_BENCH_KEEP_OUTPUT_ROOT="$keep_output_root" \
   "$CASA_RS_CASA_PYTHON" "$tmpdir/casa-imager-bench.py" | sed 's/^/  /'
 echo
+
+if [[ -n "$keep_output_root" ]]; then
+  echo "Kept benchmark products:"
+  echo "  product_root=$keep_output_root"
+  echo "  rust_prefix=$rust_keep_prefix"
+  echo "  casa_prefix=$casa_keep_prefix"
+  echo
+fi
 
 echo "CASA PySynthesisImager stage medians (milliseconds):"
 CASA_RS_BENCH_MS_PATH="$ms_path" \

--- a/scripts/bench-imager-vs-casa.sh
+++ b/scripts/bench-imager-vs-casa.sh
@@ -42,6 +42,7 @@ spw="${IMAGER_BENCH_SPW:-0}"
 channel_start="${IMAGER_BENCH_CHANNEL_START:-0}"
 channel_count="${IMAGER_BENCH_CHANNEL_COUNT:-1}"
 specmode="${IMAGER_BENCH_SPECMODE:-mfs}"
+gridder="${IMAGER_BENCH_GRIDDER:-standard}"
 interpolation="${IMAGER_BENCH_INTERPOLATION:-linear}"
 imsize="${IMAGER_BENCH_IMSIZE:-128}"
 cell_arcsec="${IMAGER_BENCH_CELL_ARCSEC:-30}"
@@ -68,6 +69,11 @@ fi
 
 if [[ "$specmode" != "mfs" && "$specmode" != "cube" ]]; then
   echo "error: IMAGER_BENCH_SPECMODE must be mfs or cube" >&2
+  exit 2
+fi
+
+if [[ "$gridder" != "standard" && "$gridder" != "mosaic" ]]; then
+  echo "error: IMAGER_BENCH_GRIDDER must be standard or mosaic" >&2
   exit 2
 fi
 
@@ -99,7 +105,7 @@ PY
 
 echo "ms_path=$ms_path"
 echo "CASA_RS_CASA_PYTHON=$CASA_RS_CASA_PYTHON"
-echo "mode=$mode specmode=$specmode field=$field spw=$spw channel_start=$channel_start channel_count=$channel_count interpolation=$interpolation weighting=$weighting robust=$robust deconvolver=$deconvolver scales=$scales wterm=$wterm imsize=$imsize cell_arcsec=$cell_arcsec repeats=$repeats niter=$niter nsigma=$nsigma cycleniter=$minor_cycle_length cyclefactor=$cyclefactor minpsffraction=$min_psf_fraction maxpsffraction=$max_psf_fraction"
+echo "mode=$mode specmode=$specmode gridder=$gridder field=$field spw=$spw channel_start=$channel_start channel_count=$channel_count interpolation=$interpolation weighting=$weighting robust=$robust deconvolver=$deconvolver scales=$scales wterm=$wterm imsize=$imsize cell_arcsec=$cell_arcsec repeats=$repeats niter=$niter nsigma=$nsigma cycleniter=$minor_cycle_length cyclefactor=$cyclefactor minpsffraction=$min_psf_fraction maxpsffraction=$max_psf_fraction"
 echo
 
 cargo build --release -p casars-imager --bin casars-imager --example profile_imager >/dev/null
@@ -125,6 +131,7 @@ for run in $(seq 1 "$repeats"); do
       --channel-start "$channel_start" \
       --channel-count "$channel_count" \
       --specmode "$specmode" \
+      --gridder "$gridder" \
       --interpolation "$interpolation" \
       --datacolumn DATA \
       --weighting "$weighting" \
@@ -155,6 +162,7 @@ for run in $(seq 1 "$repeats"); do
       --channel-start "$channel_start" \
       --channel-count "$channel_count" \
       --specmode "$specmode" \
+      --gridder "$gridder" \
       --interpolation "$interpolation" \
       --datacolumn DATA \
       --weighting "$weighting" \
@@ -190,6 +198,7 @@ if [[ -n "$scales" ]]; then
     --channel-start "$channel_start" \
     --channel-count "$channel_count" \
     --specmode "$specmode" \
+    --gridder "$gridder" \
     --interpolation "$interpolation" \
     --datacolumn DATA \
     --weighting "$weighting" \
@@ -220,6 +229,7 @@ else
     --channel-start "$channel_start" \
     --channel-count "$channel_count" \
     --specmode "$specmode" \
+    --gridder "$gridder" \
     --interpolation "$interpolation" \
     --datacolumn DATA \
     --weighting "$weighting" \
@@ -271,6 +281,7 @@ maxpsffraction = float(os.environ["CASA_RS_BENCH_MAX_PSFFRACTION"])
 weighting = os.environ["CASA_RS_BENCH_WEIGHTING"]
 robust = float(os.environ["CASA_RS_BENCH_ROBUST"])
 deconvolver = os.environ["CASA_RS_BENCH_DECONVOLVER"]
+gridder = os.environ["CASA_RS_BENCH_GRIDDER"]
 scales = [] if os.environ["CASA_RS_BENCH_SCALES"] == "" else [int(float(v)) for v in os.environ["CASA_RS_BENCH_SCALES"].split(",")]
 specmode = os.environ["CASA_RS_BENCH_SPECMODE"]
 interpolation = os.environ["CASA_RS_BENCH_INTERPOLATION"]
@@ -288,7 +299,7 @@ with tempfile.TemporaryDirectory() as td:
             field=field,
             stokes="I",
             specmode=specmode,
-            gridder="standard",
+            gridder=gridder,
             weighting=weighting,
             deconvolver=deconvolver,
             scales=scales,
@@ -341,6 +352,7 @@ CASA_RS_BENCH_SPW="$spw" \
 CASA_RS_BENCH_CHANNEL_START="$channel_start" \
 CASA_RS_BENCH_CHANNEL_COUNT="$channel_count" \
 CASA_RS_BENCH_SPECMODE="$specmode" \
+CASA_RS_BENCH_GRIDDER="$gridder" \
 CASA_RS_BENCH_IMSIZE="$imsize" \
 CASA_RS_BENCH_CELL_ARCSEC="$cell_arcsec" \
 CASA_RS_BENCH_WEIGHTING="$weighting" \
@@ -368,6 +380,7 @@ CASA_RS_BENCH_SPW="$spw" \
 CASA_RS_BENCH_CHANNEL_START="$channel_start" \
 CASA_RS_BENCH_CHANNEL_COUNT="$channel_count" \
 CASA_RS_BENCH_SPECMODE="$specmode" \
+CASA_RS_BENCH_GRIDDER="$gridder" \
 CASA_RS_BENCH_IMSIZE="$imsize" \
 CASA_RS_BENCH_CELL_ARCSEC="$cell_arcsec" \
 CASA_RS_BENCH_WEIGHTING="$weighting" \

--- a/tools/perf/README.md
+++ b/tools/perf/README.md
@@ -7,6 +7,11 @@ This directory holds reusable performance-analysis tooling for the repository.
 - `calibrate/`
   - `README.md`: apply-path tracing and analysis notes
   - `report.py`: JSONL-to-summary report script
+- `imager/`
+  - `README.md`: MeasurementSet-backed imaging benchmark notes
+  - `run_workload.py`: manifest-driven CASA C++ versus `casa-rs` benchmark
+    wrapper
+  - `workloads/`: checked-in workload manifests
 - `imexplore/`
   - `README.md`: feature-specific tracing and analysis notes
   - `report.py`: JSONL-to-summary report script

--- a/tools/perf/imager/README.md
+++ b/tools/perf/imager/README.md
@@ -5,6 +5,10 @@ imager.
 
 ## Entry points
 
+- `tools/perf/imager/run_workload.py`
+  - runs one JSON workload manifest, preflights support, delegates supported
+    workloads to `scripts/bench-imager-vs-casa.sh`, and writes a normalized
+    machine-readable result JSON
 - `crates/casars-imager/examples/profile_imager.rs`
   - runs repeated Rust imaging passes and reports median stage timings from the
     pure `casa-imaging` core
@@ -18,11 +22,32 @@ imager.
 scripts/bench-imager-vs-casa.sh
 ```
 
+To run the Wave 1 manifest harness in validation mode:
+
+```sh
+tools/perf/imager/run_workload.py --dry-run wave1-standard-mfs-dirty-smoke
+```
+
+The command writes a JSON plan under `target/imperformance-wave1/` without
+requiring CASA Python or a local MeasurementSet.
+
+To run the same workload for real:
+
+```sh
+CASA_RS_TESTDATA_ROOT=/path/to/casatestdata \
+CASA_RS_CASA_PYTHON=/path/to/casa-python \
+tools/perf/imager/run_workload.py wave1-standard-mfs-dirty-smoke
+```
+
 To force a different dataset:
 
 ```sh
 scripts/bench-imager-vs-casa.sh /path/to.ms
 ```
+
+The manifest runner intentionally resolves data only from an explicit manifest
+path or from the manifest's `dataset.root_env` plus `dataset.relative_path`.
+It does not add personal workstation data fallbacks.
 
 ## Environment variables
 
@@ -34,6 +59,10 @@ scripts/bench-imager-vs-casa.sh /path/to.ms
   - number of repeated Rust/CASA wall-clock runs
 - `IMAGER_BENCH_MODE`
   - `dirty` or `clean`
+- `IMAGER_BENCH_SPECMODE`
+  - `mfs` or `cube`
+- `IMAGER_BENCH_GRIDDER`
+  - `standard` or `mosaic`
 - `IMAGER_BENCH_INTERPOLATION`
   - cube spectral interpolation mode: `nearest` or `linear`
 - `IMAGER_BENCH_FIELD`
@@ -54,6 +83,43 @@ scripts/bench-imager-vs-casa.sh /path/to.ms
 - `IMAGER_BENCH_MINOR_CYCLE_LENGTH`
 - `IMAGER_BENCH_WTERM`
   - currently only `none` is supported in the Rust-vs-CASA benchmark script because the Rust-only `direct` mode has no matching `tclean` configuration in this harness
+
+## Manifest fields
+
+Workload manifests live in `tools/perf/imager/workloads/`. The first Wave 1
+manifest is `wave1-standard-mfs-dirty-smoke.json`.
+
+Required top-level fields:
+
+- `id`: stable workload id used in result filenames
+- `mode_id`: selected Wave 1 mode id, such as `standard-mfs-dirty-control`
+- `dataset`: `key`, plus either `path` or `root_env` and `relative_path`
+- `imaging`: CASA-like mode parameters
+
+Supported `imaging` values for the #252 harness slice:
+
+- `mode`: `dirty` or `clean`
+- `specmode`: `mfs` or `cube`
+- `gridder`: `standard` or `mosaic`
+- `interpolation`: `nearest` or `linear`
+- `wterm`: `none`
+
+Unsupported modes fail before timing claims are written. In particular,
+W-projection and AW/widefield manifests should be rejected by this ticket until
+their benchmark support is added or delegated to the owning follow-up.
+
+## Result JSON
+
+`run_workload.py` writes one JSON file per run with:
+
+- `run_id`, manifest path, git branch/commit, CASA Python path, benchmark script
+  hash, and the exact delegated command/env
+- dataset key/path, selected mode, image shape, channel count, weighting,
+  deconvolver, `niter`, run label, storage label, and repeat count
+- Rust CLI per-run wallclock and median wallclock
+- CASA `tclean` per-run wallclock and median wallclock when CASA ran
+- parsed Rust and CASA stage medians when present
+- a clear `dry_run`, `completed`, or `failed` status
 
 The active Wave 8 clean cube gate can now be reproduced directly through the
 same harness by setting, for example:

--- a/tools/perf/imager/README.md
+++ b/tools/perf/imager/README.md
@@ -9,6 +9,14 @@ imager.
   - runs one JSON workload manifest, preflights support, delegates supported
     workloads to `scripts/bench-imager-vs-casa.sh`, and writes a normalized
     machine-readable result JSON
+- `tools/perf/imager/stage_wave1_datasets.py`
+  - validates the ImPerformance Wave 1 simulated-dataset registry, enforces the
+    explicit data-root policy, and can materialize deterministic source models,
+    spectral profiles, simulation request plans, and generated workload
+    manifests
+- `tools/perf/imager/wave1_dataset_registry.json`
+  - records the VLA/ALMA, single-field/mosaic, small/medium/large simulated
+    dataset plan for #248
 - `crates/casars-imager/examples/profile_imager.rs`
   - runs repeated Rust imaging passes and reports median stage timings from the
     pure `casa-imaging` core
@@ -30,6 +38,18 @@ tools/perf/imager/run_workload.py --dry-run wave1-standard-mfs-dirty-smoke
 
 The command writes a JSON plan under `target/imperformance-wave1/` without
 requiring CASA Python or a local MeasurementSet.
+
+To validate the Wave 1 simulated-dataset plan:
+
+```sh
+tools/perf/imager/stage_wave1_datasets.py \
+  --dry-run \
+  --data-root /Volumes/GLENDENNING/casa-rs-imperformance
+```
+
+Medium and large datasets are expected to live on the external drive on this
+system. The staging tool requires those tiers under `/Volumes/GLENDENNING`
+unless `--allow-non-external-large-root` is passed explicitly.
 
 To run the same workload for real:
 

--- a/tools/perf/imager/README.md
+++ b/tools/perf/imager/README.md
@@ -51,6 +51,11 @@ Medium and large datasets are expected to live on the external drive on this
 system. The staging tool requires those tiers under `/Volumes/GLENDENNING`
 unless `--allow-non-external-large-root` is passed explicitly.
 
+For Wave 1, CASA C++ generation is the dataset source of truth. The staging
+tool also emits native `casa-rs` simulation request plans where useful, but
+native mosaic generation and native channel-varying cube source prediction are
+tracked as backlog work rather than Wave 1 blockers.
+
 To run the same workload for real:
 
 ```sh

--- a/tools/perf/imager/README.md
+++ b/tools/perf/imager/README.md
@@ -145,6 +145,10 @@ their benchmark support is added or delegated to the owning follow-up.
 - Rust CLI per-run wallclock and median wallclock
 - CASA `tclean` per-run wallclock and median wallclock when CASA ran
 - parsed Rust and CASA stage medians when present
+- normalized `stage_breakdown` categories that distinguish frontend/MS
+  preparation, visibility adaptation, weighting, gridding/degridding, FFT,
+  normalization/PB correction, deconvolution, model refresh, and product
+  writeback
 - preserved product prefixes when a real run is executed
 - CASA-backed product-comparison metrics for configured product suffixes
 - a clear `dry_run`, `completed`, or `failed` status

--- a/tools/perf/imager/README.md
+++ b/tools/perf/imager/README.md
@@ -22,7 +22,8 @@ imager.
     pure `casa-imaging` core
 - `scripts/bench-imager-vs-casa.sh`
   - compares Rust CLI wall-clock timings and Rust stage medians against CASA
-    `tclean` on the same MeasurementSet selection
+    `tclean` on the same MeasurementSet selection, and can preserve final-run
+    products for harness-level comparison
 
 ## Typical usage
 
@@ -144,6 +145,8 @@ their benchmark support is added or delegated to the owning follow-up.
 - Rust CLI per-run wallclock and median wallclock
 - CASA `tclean` per-run wallclock and median wallclock when CASA ran
 - parsed Rust and CASA stage medians when present
+- preserved product prefixes when a real run is executed
+- CASA-backed product-comparison metrics for configured product suffixes
 - a clear `dry_run`, `completed`, or `failed` status
 
 The active Wave 8 clean cube gate can now be reproduced directly through the

--- a/tools/perf/imager/README.md
+++ b/tools/perf/imager/README.md
@@ -15,8 +15,8 @@ imager.
     spectral profiles, simulation request plans, and generated workload
     manifests
 - `tools/perf/imager/wave1_dataset_registry.json`
-  - records the VLA/ALMA, single-field/mosaic, small/medium/large simulated
-    dataset plan for #248
+  - records the VLA/ALMA, single-field/mosaic, small/medium, and one shared
+    large simulated-dataset plan for #248
 - `crates/casars-imager/examples/profile_imager.rs`
   - runs repeated Rust imaging passes and reports median stage timings from the
     pure `casa-imaging` core
@@ -50,7 +50,10 @@ tools/perf/imager/stage_wave1_datasets.py \
 
 Medium and large datasets are expected to live on the external drive on this
 system. The staging tool requires those tiers under `/Volumes/GLENDENNING`
-unless `--allow-non-external-large-root` is passed explicitly.
+unless `--allow-non-external-large-root` is passed explicitly. The large tier
+is intentionally one shared `wave1-alma-shared-large` dataset; standard, cube,
+mosaic, and sentinel large workloads are generated as logical selections from
+that one staged MeasurementSet.
 
 For Wave 1, CASA C++ generation is the dataset source of truth. The staging
 tool also emits native `casa-rs` simulation request plans where useful, but

--- a/tools/perf/imager/casa_phase_bench.py
+++ b/tools/perf/imager/casa_phase_bench.py
@@ -52,6 +52,7 @@ def main() -> None:
     chan_start = env_int("CASA_RS_BENCH_CHANNEL_START")
     chan_count = env_int("CASA_RS_BENCH_CHANNEL_COUNT")
     specmode = env_str("CASA_RS_BENCH_SPECMODE")
+    gridder = env_str("CASA_RS_BENCH_GRIDDER")
     imsize = env_int("CASA_RS_BENCH_IMSIZE")
     cell_arcsec = env_str("CASA_RS_BENCH_CELL_ARCSEC")
     weighting = env_str("CASA_RS_BENCH_WEIGHTING")
@@ -124,7 +125,7 @@ def main() -> None:
                     projection="SIN",
                     specmode=specmode,
                     interpolation="nearest",
-                    gridder="standard",
+                    gridder=gridder,
                     restart=True,
                     weighting=weighting,
                     robust=robust,

--- a/tools/perf/imager/generate_wave1_casa_datasets.py
+++ b/tools/perf/imager/generate_wave1_casa_datasets.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env python3
+"""Generate CASA MeasurementSets and preview images for Wave 1 datasets.
+
+Run this with the CASA-capable Python listed in AGENTS.md, not with the
+default project Python.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import time
+from typing import Any
+
+import numpy as np
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("plan", type=pathlib.Path, help="wave1-dataset-plan.json")
+    parser.add_argument("--dataset", action="append", help="dataset id to generate")
+    parser.add_argument("--skip-existing", action="store_true", default=True)
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--preview-max-pixels", type=int, default=1024)
+    parser.add_argument("--no-preview", action="store_true")
+    args = parser.parse_args()
+
+    if args.overwrite:
+        args.skip_existing = False
+
+    plan = read_json(args.plan)
+    datasets = plan["datasets"]
+    if args.dataset:
+        wanted = set(args.dataset)
+        datasets = [dataset for dataset in datasets if dataset["id"] in wanted]
+        missing = wanted - {dataset["id"] for dataset in datasets}
+        if missing:
+            raise SystemExit(f"unknown dataset id(s): {', '.join(sorted(missing))}")
+
+    results = []
+    for dataset in datasets:
+        result = generate_dataset(
+            dataset,
+            skip_existing=args.skip_existing,
+            overwrite=args.overwrite,
+            preview=not args.no_preview,
+            preview_max_pixels=args.preview_max_pixels,
+        )
+        results.append(result)
+        print(json.dumps(result, sort_keys=True), flush=True)
+
+    summary_path = pathlib.Path(plan["data_root"]) / "wave1" / "generation-summary.json"
+    write_json(summary_path, {"generated_at": utc_now(), "datasets": results})
+    print(summary_path)
+
+
+def generate_dataset(
+    dataset: dict[str, Any],
+    *,
+    skip_existing: bool,
+    overwrite: bool,
+    preview: bool,
+    preview_max_pixels: int,
+) -> dict[str, Any]:
+    dataset_id = dataset["id"]
+    paths = dataset["paths"]
+    canonical_ms = pathlib.Path(paths["output_ms"])
+    dataset_dir = pathlib.Path(paths["dataset_dir"])
+    metadata_dir = dataset_dir / "metadata"
+    preview_dir = dataset_dir / "previews"
+    casa_dir = dataset_dir / "casa"
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+    preview_dir.mkdir(parents=True, exist_ok=True)
+    casa_dir.mkdir(parents=True, exist_ok=True)
+
+    if canonical_ms.exists() and skip_existing:
+        shape = inspect_ms(canonical_ms)
+        shape_path = metadata_dir / "ms-shape.json"
+        write_json(shape_path, shape)
+        preview_path = None
+        if preview and not (preview_dir / "dirty-mfs-panel.png").exists():
+            preview_path = make_preview(dataset, canonical_ms, preview_dir, preview_max_pixels)
+        return {
+            "dataset": dataset_id,
+            "status": "reused",
+            "ms": str(canonical_ms),
+            "shape": shape,
+            "shape_json": str(shape_path),
+            "preview_png": str(preview_path) if preview_path else None,
+        }
+
+    if canonical_ms.exists() and overwrite:
+        remove_path(canonical_ms)
+
+    model_image = create_model_image(dataset)
+    pointings = write_pointings(dataset, casa_dir)
+    project_name = dataset_id
+    project_dir = casa_dir / project_name
+    if project_dir.exists() and overwrite:
+        remove_path(project_dir)
+    project_dir.parent.mkdir(parents=True, exist_ok=True)
+
+    run_simobserve(dataset, model_image, pointings, project_dir)
+    produced_ms = find_single_ms(project_dir)
+    remove_duplicate_measurement_sets(project_dir, produced_ms)
+    canonical_ms.parent.mkdir(parents=True, exist_ok=True)
+    if canonical_ms.exists():
+        remove_path(canonical_ms)
+    os.symlink(produced_ms, canonical_ms, target_is_directory=True)
+
+    shape = inspect_ms(canonical_ms)
+    shape_path = metadata_dir / "ms-shape.json"
+    write_json(shape_path, shape)
+    preview_path = make_preview(dataset, canonical_ms, preview_dir, preview_max_pixels) if preview else None
+    return {
+        "dataset": dataset_id,
+        "status": "generated",
+        "project_dir": str(project_dir),
+        "produced_ms": str(produced_ms),
+        "ms": str(canonical_ms),
+        "shape": shape,
+        "shape_json": str(shape_path),
+        "preview_png": str(preview_path) if preview_path else None,
+    }
+
+
+def create_model_image(dataset: dict[str, Any]) -> pathlib.Path:
+    from casatools import coordsys, image
+
+    shape = dataset["shape"]
+    paths = dataset["paths"]
+    pixels = int(shape["model_pixels"])
+    channels = int(shape["channels"])
+    out = pathlib.Path(paths["continuum_model_fits"]).with_name(
+        f"structured-cube-{channels}ch.image"
+    )
+    if out.exists():
+        return out
+
+    base = structured_plane(pixels, dataset["family"])
+    profile = spectral_profile(channels)
+
+    cs = coordsys()
+    cs.newcoordsys(direction=True, stokes=["I"], spectral=True)
+    ia = image()
+    out.parent.mkdir(parents=True, exist_ok=True)
+    ia.fromshape(
+        outfile=str(out),
+        shape=[pixels, pixels, 1, channels],
+        csys=cs.torecord(),
+        overwrite=True,
+        type="f",
+    )
+    try:
+        for channel, scale in enumerate(profile):
+            plane = (base * scale)[:, :, np.newaxis, np.newaxis]
+            ia.putchunk(pixels=plane, blc=[0, 0, 0, channel])
+        ia.setbrightnessunit("Jy/pixel")
+    finally:
+        ia.close()
+    return out
+
+
+def structured_plane(pixels: int, family: str) -> np.ndarray:
+    coords = (np.arange(pixels, dtype=np.float32) + 0.5 - pixels / 2.0) / pixels
+    cx, cy = np.meshgrid(coords, coords, indexing="ij")
+    radius = np.hypot(cx, cy)
+    theta = np.arctan2(cy, cx)
+    core = gaussian_array(cx, cy, 0.0, 0.0, 0.018)
+    knot1 = 0.42 * gaussian_array(cx, cy, -0.14, 0.09, 0.028)
+    knot2 = 0.31 * gaussian_array(cx, cy, 0.18, -0.11, 0.022)
+    ring = 0.34 * np.exp(-((radius - 0.21) ** 2) / (2.0 * 0.018**2))
+    arm1 = 0.18 * np.exp(-((radius - (0.10 + 0.040 * theta)) ** 2) / (2.0 * 0.020**2))
+    arm2 = 0.14 * np.exp(-((radius - (0.18 - 0.035 * theta)) ** 2) / (2.0 * 0.024**2))
+    halo = 0.06 * np.exp(-(radius**2) / (2.0 * 0.26**2))
+    ripple = 0.015 * (1.0 + np.sin(37.0 * cx + 19.0 * cy))
+    if "mosaic" in family or family == "shared-large":
+        gradient = 1.0 + 0.10 * cx - 0.07 * cy
+    else:
+        gradient = 1.0
+    return np.maximum(
+        0.0,
+        (core + knot1 + knot2 + ring + arm1 + arm2 + halo + ripple) * gradient,
+    ).astype(np.float32)
+
+
+def source_pixel(cx: float, cy: float, family: str) -> float:
+    radius = math.hypot(cx, cy)
+    theta = math.atan2(cy, cx)
+    core = gaussian(cx, cy, 0.0, 0.0, 0.018)
+    knot1 = 0.42 * gaussian(cx, cy, -0.14, 0.09, 0.028)
+    knot2 = 0.31 * gaussian(cx, cy, 0.18, -0.11, 0.022)
+    ring = 0.34 * math.exp(-((radius - 0.21) ** 2) / (2.0 * 0.018**2))
+    arm1 = 0.18 * math.exp(-((radius - (0.10 + 0.040 * theta)) ** 2) / (2.0 * 0.020**2))
+    arm2 = 0.14 * math.exp(-((radius - (0.18 - 0.035 * theta)) ** 2) / (2.0 * 0.024**2))
+    halo = 0.06 * math.exp(-(radius**2) / (2.0 * 0.26**2))
+    ripple = 0.015 * (1.0 + math.sin(37.0 * cx + 19.0 * cy))
+    gradient = 1.0 + (0.10 * cx - 0.07 * cy if "mosaic" in family or family == "shared-large" else 0.0)
+    return max(0.0, (core + knot1 + knot2 + ring + arm1 + arm2 + halo + ripple) * gradient)
+
+
+def spectral_profile(channels: int) -> list[float]:
+    center = 0.5 * max(0, channels - 1)
+    values = []
+    for channel in range(channels):
+        x = 0.0 if channels == 1 else (channel - center) / max(1.0, center)
+        continuum = max(0.05, 1.0 + x) ** -0.7
+        broad_line = 0.45 * math.exp(-0.5 * ((x - 0.05) / 0.22) ** 2)
+        narrow_line = 0.22 * math.exp(-0.5 * ((x + 0.38) / 0.08) ** 2)
+        absorption = -0.18 * math.exp(-0.5 * ((x - 0.32) / 0.06) ** 2)
+        values.append(max(0.05, continuum + broad_line + narrow_line + absorption))
+    return values
+
+
+def write_pointings(dataset: dict[str, Any], casa_dir: pathlib.Path) -> pathlib.Path:
+    count = int(dataset["shape"]["pointing_count"])
+    spacing_arcsec = 24.0 if dataset["instrument"] == "alma" else 120.0
+    offsets = [(0.0, 0.0)]
+    if count > 1:
+        for index in range(6):
+            angle = math.tau * index / 6.0
+            offsets.append((spacing_arcsec * math.cos(angle), spacing_arcsec * math.sin(angle)))
+    out = casa_dir / f"{dataset['id']}.ptg.txt"
+    lines = []
+    for dra_arcsec, ddec_arcsec in offsets[:count]:
+        lines.append(format_direction(270.000129 + dra_arcsec / 3600.0, -22.999889 + ddec_arcsec / 3600.0))
+    out.write_text("\n".join(lines) + "\n", encoding="ascii")
+    return out
+
+
+def format_direction(ra_deg: float, dec_deg: float) -> str:
+    ra_hours = ra_deg / 15.0
+    hh = int(ra_hours)
+    mm_float = (ra_hours - hh) * 60.0
+    mm = int(mm_float)
+    ss = (mm_float - mm) * 60.0
+    sign = "-" if dec_deg < 0 else "+"
+    dec_abs = abs(dec_deg)
+    dd = int(dec_abs)
+    dm_float = (dec_abs - dd) * 60.0
+    dm = int(dm_float)
+    ds = (dm_float - dm) * 60.0
+    return f"J2000 {hh:02d}h{mm:02d}m{ss:08.5f}s {sign}{dd:02d}d{dm:02d}m{ds:07.4f}s 10.0"
+
+
+def run_simobserve(
+    dataset: dict[str, Any],
+    model_image: pathlib.Path,
+    pointings: pathlib.Path,
+    project_dir: pathlib.Path,
+) -> None:
+    from casatasks import simobserve
+
+    shape = dataset["shape"]
+    project_dir.parent.mkdir(parents=True, exist_ok=True)
+    old_cwd = pathlib.Path.cwd()
+    try:
+        os.chdir(project_dir.parent)
+        simobserve(
+            project=project_dir.name,
+            skymodel=str(model_image),
+            indirection="J2000 18h00m00.03096s -22d59m59.6004s",
+            incell=f"{cell_arcsec(dataset['instrument'])}arcsec",
+            incenter=f"{start_frequency_hz(dataset['instrument'])}Hz",
+            inwidth=f"{channel_width_hz(dataset['instrument'])}Hz",
+            setpointings=False,
+            ptgfile=str(pointings),
+            integration=f"{shape['integration_seconds']}s",
+            totaltime=f"{shape['duration_seconds']}s",
+            antennalist=antenna_list(dataset["instrument"]),
+            thermalnoise="tsys-atm",
+            seed=stable_seed(dataset["id"]),
+            graphics="none",
+            verbose=False,
+            overwrite=True,
+        )
+    finally:
+        os.chdir(old_cwd)
+
+
+def make_preview(
+    dataset: dict[str, Any],
+    ms: pathlib.Path,
+    preview_dir: pathlib.Path,
+    preview_max_pixels: int,
+) -> pathlib.Path:
+    from casatasks import tclean
+    from casatools import image
+
+    imsize = min(int(dataset["shape"]["image_pixels"]), preview_max_pixels)
+    imagename = preview_dir / "dirty-mfs"
+    cleanup_image_products(imagename)
+    tclean(
+        vis=str(ms),
+        imagename=str(imagename),
+        datacolumn="data",
+        field="" if dataset["family"] in {"mosaic", "shared-large"} else "0",
+        spw=preview_spw(dataset),
+        stokes="I",
+        specmode="mfs",
+        gridder="mosaic" if dataset["family"] in {"mosaic", "shared-large"} else "standard",
+        weighting="natural",
+        imsize=imsize,
+        cell=f"{cell_arcsec(dataset['instrument'])}arcsec",
+        niter=0,
+        interactive=False,
+        parallel=False,
+    )
+    image_path = pathlib.Path(str(imagename) + ".image")
+    png_path = preview_dir / "dirty-mfs-panel.png"
+    ia = image()
+    ia.open(str(image_path))
+    pixels = np.squeeze(ia.getchunk())
+    ia.close()
+    write_panel_png(dataset, pixels, png_path)
+    return png_path
+
+
+def write_panel_png(dataset: dict[str, Any], dirty: np.ndarray, out: pathlib.Path) -> None:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    model = structured_plane(min(dirty.shape), dataset["family"])
+    if model.shape != dirty.shape:
+        model = model[: dirty.shape[0], : dirty.shape[1]]
+    diff_scale = max(float(np.nanmax(np.abs(dirty))), 1e-12)
+    fig, axes = plt.subplots(1, 3, figsize=(12, 4), constrained_layout=True)
+    panels = [
+        ("model", model, None),
+        ("dirty MFS", dirty, None),
+        ("dirty / peak", dirty / diff_scale, (-1.0, 1.0)),
+    ]
+    for axis, (title, data, limits) in zip(axes, panels, strict=True):
+        kwargs = {"origin": "lower", "cmap": "magma"}
+        if limits:
+            kwargs.update({"vmin": limits[0], "vmax": limits[1], "cmap": "coolwarm"})
+        image = axis.imshow(np.asarray(data).T, **kwargs)
+        axis.set_title(title)
+        axis.set_xticks([])
+        axis.set_yticks([])
+        fig.colorbar(image, ax=axis, fraction=0.046)
+    fig.suptitle(dataset["id"])
+    out.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out, dpi=150)
+    plt.close(fig)
+
+
+def inspect_ms(ms: pathlib.Path) -> dict[str, Any]:
+    from casatools import table
+
+    tb = table()
+    tb.open(str(ms))
+    nrows = int(tb.nrows())
+    data_shape = list(tb.getcell("DATA", 0).shape) if nrows else []
+    tb.close()
+    result = {
+        "path": str(ms),
+        "size_bytes": du_bytes(ms),
+        "main_rows": nrows,
+        "data_cell_shape": data_shape,
+    }
+    for subtable in ["ANTENNA", "FIELD", "SPECTRAL_WINDOW", "DATA_DESCRIPTION"]:
+        sub = ms / subtable
+        if sub.exists():
+            tb.open(str(sub))
+            result[subtable.lower() + "_rows"] = int(tb.nrows())
+            tb.close()
+    return result
+
+
+def find_single_ms(project_dir: pathlib.Path) -> pathlib.Path:
+    matches = sorted(project_dir.glob("*.ms"))
+    noisy = [path for path in matches if path.name.endswith(".noisy.ms")]
+    if len(noisy) == 1:
+        return noisy[0]
+    if len(matches) != 1:
+        raise RuntimeError(f"expected one MS under {project_dir}, found {matches}")
+    return matches[0]
+
+
+def remove_duplicate_measurement_sets(project_dir: pathlib.Path, keep: pathlib.Path) -> None:
+    for path in project_dir.glob("*.ms"):
+        if path != keep:
+            remove_path(path)
+
+
+def preview_spw(dataset: dict[str, Any]) -> str:
+    channels = int(dataset["shape"]["channels"])
+    if dataset["tier"] == "large" and channels > 64:
+        return "0:0~63"
+    return "0"
+
+
+def cleanup_image_products(prefix: pathlib.Path) -> None:
+    for path in prefix.parent.glob(prefix.name + ".*"):
+        remove_path(path)
+
+
+def remove_path(path: pathlib.Path) -> None:
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+    elif path.is_dir():
+        shutil.rmtree(path)
+
+
+def du_bytes(path: pathlib.Path) -> int:
+    output = subprocess.check_output(["du", "-sk", str(path.resolve())], text=True)
+    return int(output.split()[0]) * 1024
+
+
+def antenna_list(instrument: str) -> str:
+    return "alma.cycle8.5.cfg" if instrument == "alma" else "vla.d.cfg"
+
+
+def cell_arcsec(instrument: str) -> float:
+    return 0.08 if instrument == "alma" else 0.35
+
+
+def start_frequency_hz(instrument: str) -> float:
+    return 230.0e9 if instrument == "alma" else 44.0e9
+
+
+def channel_width_hz(instrument: str) -> float:
+    return 2.0e6 if instrument == "alma" else 128.0e6
+
+
+def stable_seed(text: str) -> int:
+    import hashlib
+
+    return int(hashlib.sha256(text.encode("utf-8")).hexdigest()[:8], 16)
+
+
+def gaussian(x: float, y: float, x0: float, y0: float, sigma: float) -> float:
+    return math.exp(-(((x - x0) ** 2 + (y - y0) ** 2) / (2.0 * sigma**2)))
+
+
+def gaussian_array(
+    x: np.ndarray, y: np.ndarray, x0: float, y0: float, sigma: float
+) -> np.ndarray:
+    return np.exp(-(((x - x0) ** 2 + (y - y0) ** 2) / (2.0 * sigma**2)))
+
+
+def read_json(path: pathlib.Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: pathlib.Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def utc_now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/perf/imager/run_workload.py
+++ b/tools/perf/imager/run_workload.py
@@ -23,6 +23,7 @@ SUPPORTED_GRIDDER_VALUES = {"mosaic", "standard"}
 SUPPORTED_SPEC_MODES = {"mfs", "cube"}
 SUPPORTED_BENCH_MODES = {"dirty", "clean"}
 SUPPORTED_INTERPOLATION = {"nearest", "linear"}
+DEFAULT_COMPARISON_PRODUCTS = [".image", ".residual", ".psf"]
 
 
 class HarnessError(Exception):
@@ -74,6 +75,7 @@ def main() -> None:
         )
         output_dir = args.output_dir.resolve()
         output_dir.mkdir(parents=True, exist_ok=True)
+        attach_output_paths(plan, output_dir, dry_run=args.dry_run)
         result_path = output_dir / f"{plan['run_id']}.json"
         log_path = output_dir / f"{plan['run_id']}.log"
 
@@ -134,6 +136,7 @@ def build_plan(
     dataset = required_object(manifest, "dataset")
     imaging = required_object(manifest, "imaging")
     run = object_value(manifest, "run")
+    comparison = object_value(manifest, "comparison")
 
     specmode = enum_value(imaging, "specmode", SUPPORTED_SPEC_MODES)
     gridder = enum_value(imaging, "gridder", SUPPORTED_GRIDDER_VALUES)
@@ -221,12 +224,29 @@ def build_plan(
             "storage_label": storage_label_override
             or str_value(run, "storage_label", "script-staged-tempdir"),
         },
+        "comparison": {
+            "products": product_suffixes_value(comparison),
+            "max_elements_per_product": int_value(
+                comparison, "max_elements_per_product", 1_000_000
+            ),
+        },
         "command": {
             "argv": command,
             "env": env,
         },
         "environment": collect_environment(casa_python),
     }
+
+
+def attach_output_paths(plan: dict[str, Any], output_dir: pathlib.Path, *, dry_run: bool) -> None:
+    product_root = output_dir / "products" / plan["run_id"]
+    plan["products"] = {
+        "root": None if dry_run else str(product_root),
+        "rust_prefix": None if dry_run else str(product_root / "rust" / "rust"),
+        "casa_prefix": None if dry_run else str(product_root / "casa" / "casa"),
+    }
+    if not dry_run:
+        plan["command"]["env"]["IMAGER_BENCH_KEEP_OUTPUT_ROOT"] = str(product_root)
 
 
 def run_plan(plan: dict[str, Any], log_path: pathlib.Path) -> dict[str, Any]:
@@ -258,6 +278,8 @@ def run_plan(plan: dict[str, Any], log_path: pathlib.Path) -> dict[str, Any]:
         }
 
     parsed = parse_benchmark_log(completed.stdout)
+    comparison = compare_products(plan, parsed, log_path)
+    parsed["product_comparison"] = comparison
     return {
         "schema_version": 1,
         "status": "completed",
@@ -278,6 +300,8 @@ def empty_results(*, casa_status: str, reason: str) -> dict[str, Any]:
             "timings_seconds": {"runs": [], "median": None},
         },
         "stage_medians_ms": {"rust": {}, "casa": {}},
+        "product_paths": {},
+        "product_comparison": {"status": "skipped", "reason": reason, "products": {}},
     }
 
 
@@ -297,7 +321,79 @@ def parse_benchmark_log(text: str) -> dict[str, Any]:
             "timings_seconds": {"runs": casa_runs, "median": casa_median},
         },
         "stage_medians_ms": {"rust": rust_stages, "casa": casa_stages},
+        "product_paths": parse_product_paths(text),
     }
+
+
+def parse_product_paths(text: str) -> dict[str, str]:
+    paths = {}
+    for key in ("product_root", "rust_prefix", "casa_prefix"):
+        match = re.search(rf"^\s*{key}=(.+)$", text, flags=re.MULTILINE)
+        if match:
+            paths[key] = match.group(1).strip()
+    return paths
+
+
+def compare_products(
+    plan: dict[str, Any], parsed: dict[str, Any], log_path: pathlib.Path
+) -> dict[str, Any]:
+    product_paths = parsed.get("product_paths", {})
+    rust_prefix = product_paths.get("rust_prefix") or plan.get("products", {}).get("rust_prefix")
+    casa_prefix = product_paths.get("casa_prefix") or plan.get("products", {}).get("casa_prefix")
+    casa_python = plan.get("environment", {}).get("casa_python")
+    if not rust_prefix or not casa_prefix:
+        return {
+            "status": "skipped",
+            "reason": "benchmark did not preserve product prefixes",
+            "products": {},
+        }
+    if not casa_python:
+        return {
+            "status": "skipped",
+            "reason": "CASA Python is required for CASA image product comparison",
+            "products": {},
+        }
+
+    request = {
+        "rust_prefix": rust_prefix,
+        "casa_prefix": casa_prefix,
+        "products": plan["comparison"]["products"],
+        "max_elements_per_product": plan["comparison"]["max_elements_per_product"],
+    }
+    request_path = log_path.with_suffix(".comparison-input.json")
+    output_path = log_path.with_suffix(".comparison.json")
+    script_path = log_path.with_suffix(".compare-products.py")
+    request_path.write_text(json.dumps(request, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    script_path.write_text(PRODUCT_COMPARISON_SCRIPT, encoding="utf-8")
+    completed = subprocess.run(
+        [casa_python, str(script_path), str(request_path), str(output_path)],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    comparison_log_path = log_path.with_suffix(".comparison.log")
+    comparison_log_path.write_text(completed.stdout, encoding="utf-8")
+    if completed.returncode != 0:
+        return {
+            "status": "failed",
+            "reason": f"product comparison exited {completed.returncode}",
+            "log": str(comparison_log_path),
+            "products": {},
+        }
+    try:
+        comparison = json.loads(output_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        return {
+            "status": "failed",
+            "reason": f"read product comparison output: {error}",
+            "log": str(comparison_log_path),
+            "products": {},
+        }
+    comparison["log"] = str(comparison_log_path)
+    comparison["input"] = str(request_path)
+    return comparison
 
 
 def parse_timing_section(text: str, heading: str) -> tuple[list[float], float | None]:
@@ -469,6 +565,163 @@ def scales_value(imaging: dict[str, Any]) -> str:
     if not isinstance(value, list) or not all(isinstance(item, int) for item in value):
         raise HarnessError("'scales' must be a list of integers")
     return ",".join(str(item) for item in value)
+
+
+def product_suffixes_value(comparison: dict[str, Any]) -> list[str]:
+    value = comparison.get("products", DEFAULT_COMPARISON_PRODUCTS)
+    if not isinstance(value, list) or not value:
+        raise HarnessError("'comparison.products' must be a non-empty list")
+    result = []
+    for item in value:
+        if not isinstance(item, str) or not item.startswith("."):
+            raise HarnessError("'comparison.products' values must be suffix strings")
+        result.append(item)
+    return result
+
+
+PRODUCT_COMPARISON_SCRIPT = r'''#!/usr/bin/env python3
+import json
+import math
+import os
+import sys
+
+import numpy as np
+from casatools import image
+
+
+def main():
+    with open(sys.argv[1], "r", encoding="utf-8") as handle:
+        request = json.load(handle)
+    products = {}
+    for suffix in request["products"]:
+        rust_path = request["rust_prefix"] + suffix
+        casa_path = request["casa_prefix"] + suffix
+        products[suffix] = compare_one(
+            rust_path,
+            casa_path,
+            int(request["max_elements_per_product"]),
+        )
+    output = {"status": "completed", "products": products}
+    with open(sys.argv[2], "w", encoding="utf-8") as handle:
+        json.dump(output, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def compare_one(rust_path, casa_path, max_elements):
+    if not os.path.isdir(rust_path) or not os.path.isdir(casa_path):
+        return {
+            "status": "missing",
+            "rust_path": rust_path,
+            "casa_path": casa_path,
+            "rust_exists": os.path.isdir(rust_path),
+            "casa_exists": os.path.isdir(casa_path),
+        }
+    rust = load_image(rust_path, max_elements)
+    casa = load_image(casa_path, max_elements)
+    if rust["shape"] != casa["shape"]:
+        return {
+            "status": "shape_mismatch",
+            "rust_path": rust_path,
+            "casa_path": casa_path,
+            "rust_shape": rust["shape"],
+            "casa_shape": casa["shape"],
+        }
+    rust_data = rust["data"]
+    casa_data = casa["data"]
+    mask = np.isfinite(rust_data) & np.isfinite(casa_data)
+    valid_count = int(np.count_nonzero(mask))
+    if valid_count == 0:
+        return {
+            "status": "no_finite_overlap",
+            "rust_path": rust_path,
+            "casa_path": casa_path,
+            "shape": rust["shape"],
+            "sample_stride": rust["sample_stride"],
+            "sampled_elements": int(rust_data.size),
+        }
+    rust_valid = rust_data[mask]
+    casa_valid = casa_data[mask]
+    diff = rust_valid - casa_valid
+    casa_peak = max(abs(float(np.nanmin(casa_valid))), abs(float(np.nanmax(casa_valid))))
+    casa_rms = rms(casa_valid)
+    diff_rms = rms(diff)
+    diff_abs_max = float(np.nanmax(np.abs(diff)))
+    return {
+        "status": "compared",
+        "rust_path": rust_path,
+        "casa_path": casa_path,
+        "shape": rust["shape"],
+        "sample_stride": rust["sample_stride"],
+        "sampled_elements": int(rust_data.size),
+        "finite_overlap": valid_count,
+        "rust_min": finite_float(np.nanmin(rust_valid)),
+        "rust_max": finite_float(np.nanmax(rust_valid)),
+        "rust_rms": finite_float(rms(rust_valid)),
+        "casa_min": finite_float(np.nanmin(casa_valid)),
+        "casa_max": finite_float(np.nanmax(casa_valid)),
+        "casa_rms": finite_float(casa_rms),
+        "diff_abs_max": finite_float(diff_abs_max),
+        "diff_rms": finite_float(diff_rms),
+        "diff_rms_over_casa_rms": finite_float(diff_rms / abs(casa_rms)) if casa_rms else None,
+        "diff_abs_max_over_casa_peak": finite_float(diff_abs_max / casa_peak) if casa_peak else None,
+    }
+
+
+def load_image(path, max_elements):
+    tool = image()
+    try:
+        tool.open(path)
+        shape = [int(v) for v in tool.shape()]
+        stride = stride_for(shape, max_elements)
+        trc = [max(0, v - 1) for v in shape]
+        data = tool.getchunk(
+            blc=[0] * len(shape),
+            trc=trc,
+            inc=stride,
+            dropdeg=False,
+            getmask=False,
+        )
+    finally:
+        tool.close()
+    return {
+        "shape": shape,
+        "sample_stride": stride,
+        "data": np.asarray(data, dtype=np.float64),
+    }
+
+
+def stride_for(shape, max_elements):
+    if max_elements < 1:
+        raise ValueError("max_elements_per_product must be >= 1")
+    stride = [1] * len(shape)
+    sampled = product(shape)
+    index = 0
+    while sampled > max_elements:
+        stride[index % len(stride)] += 1
+        sampled = product(math.ceil(size / step) for size, step in zip(shape, stride))
+        index += 1
+    return stride
+
+
+def product(values):
+    result = 1
+    for value in values:
+        result *= int(value)
+    return result
+
+
+def rms(values):
+    return float(np.sqrt(np.nanmean(values * values)))
+
+
+def finite_float(value):
+    value = float(value)
+    return value if math.isfinite(value) else None
+
+
+if __name__ == "__main__":
+    main()
+'''
 
 
 if __name__ == "__main__":

--- a/tools/perf/imager/run_workload.py
+++ b/tools/perf/imager/run_workload.py
@@ -278,6 +278,7 @@ def run_plan(plan: dict[str, Any], log_path: pathlib.Path) -> dict[str, Any]:
         }
 
     parsed = parse_benchmark_log(completed.stdout)
+    attach_stage_breakdown(plan, parsed)
     comparison = compare_products(plan, parsed, log_path)
     parsed["product_comparison"] = comparison
     return {
@@ -300,6 +301,7 @@ def empty_results(*, casa_status: str, reason: str) -> dict[str, Any]:
             "timings_seconds": {"runs": [], "median": None},
         },
         "stage_medians_ms": {"rust": {}, "casa": {}},
+        "stage_breakdown": empty_stage_breakdown(reason),
         "product_paths": {},
         "product_comparison": {"status": "skipped", "reason": reason, "products": {}},
     }
@@ -322,6 +324,215 @@ def parse_benchmark_log(text: str) -> dict[str, Any]:
         },
         "stage_medians_ms": {"rust": rust_stages, "casa": casa_stages},
         "product_paths": parse_product_paths(text),
+    }
+
+
+def attach_stage_breakdown(plan: dict[str, Any], parsed: dict[str, Any]) -> None:
+    medians = parsed.get("stage_medians_ms", {})
+    parsed["stage_breakdown"] = {
+        "schema_version": 1,
+        "units": "milliseconds",
+        "instrumentation_scope": "benchmark-harness",
+        "contract_review": (
+            "local benchmark result JSON only; no provider protocol or managed-output "
+            "schema change"
+        ),
+        "rust": build_rust_stage_breakdown(plan, medians.get("rust", {})),
+        "casa": build_casa_stage_breakdown(medians.get("casa", {})),
+    }
+
+
+def empty_stage_breakdown(reason: str) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "units": "milliseconds",
+        "instrumentation_scope": "benchmark-harness",
+        "rust": {"status": "skipped", "reason": reason, "categories": {}},
+        "casa": {"status": "skipped", "reason": reason, "categories": {}},
+    }
+
+
+def build_rust_stage_breakdown(plan: dict[str, Any], stages: dict[str, float]) -> dict[str, Any]:
+    dirty_only = plan["mode"]["bench_mode"] == "dirty" or plan["mode"]["niter"] == 0
+    categories = {
+        "frontend_ms_preparation": stage_category(
+            stages,
+            ["open_measurement_set", "prepare_plane_input", "extract_phase_center"],
+            "MS open, selection, row adaptation, and phase-center resolution.",
+        ),
+        "visibility_adaptation_and_chunking": stage_category(
+            stages,
+            ["prepare_plane_input"],
+            "Visibility adaptation before entering the imaging core.",
+        ),
+        "weighting_density_setup": stage_category(
+            stages,
+            ["weighting"],
+            "Imaging weights, density grids, and taper setup.",
+        ),
+        "projection_pb_cf_preparation": stage_category(
+            stages,
+            [],
+            "No dedicated Wave 1 casa-rs timing field yet; projection/PB setup is included in the gridding/PB product paths where applicable.",
+            skipped=True,
+        ),
+        "gridding_degridding": stage_category(
+            stages,
+            ["psf_grid", "residual_degrid_grid"],
+            "PSF gridding plus residual degrid/grid work.",
+        ),
+        "fft": stage_category(
+            stages,
+            ["psf_fft", "model_fft", "residual_fft"],
+            "PSF, model, and residual FFT work.",
+        ),
+        "normalization_pb_correction": stage_category(
+            stages,
+            ["psf_normalize", "residual_normalize"],
+            "PSF and residual normalization; PB correction is included when the selected mode produces PB products.",
+        ),
+        "deconvolution_minor_cycle": stage_category(
+            stages,
+            ["minor_cycle_solve"],
+            "Minor-cycle component selection and subtraction.",
+            skipped=dirty_only,
+            skip_reason="dirty-only or niter=0 workload",
+        ),
+        "model_prediction_and_residual_refresh": stage_category(
+            stages,
+            ["major_cycle_refresh"],
+            "Major-cycle model prediction and residual refresh aggregate.",
+            skipped=dirty_only,
+            skip_reason="dirty-only or niter=0 workload",
+        ),
+        "restore_and_beam_fit": stage_category(
+            stages,
+            ["beam_fit", "restore"],
+            "Restoring-beam fit and restored-image generation.",
+            skipped=dirty_only,
+            skip_reason="dirty-only or niter=0 workload",
+        ),
+        "coordinate_and_product_writeback": stage_category(
+            stages,
+            ["build_coordinate_system", "write_products"],
+            "Output coordinate construction and image product writeback.",
+        ),
+        "preview_sidecar_generation": stage_category(
+            stages,
+            [],
+            "The benchmark script passes --no-preview-pngs, so preview sidecars are disabled.",
+            skipped=True,
+            skip_reason="disabled by benchmark harness",
+        ),
+        "frontend_total": stage_category(
+            stages,
+            ["frontend_total"],
+            "Total frontend wallclock from the Rust profiler.",
+        ),
+        "core_total": stage_category(
+            stages,
+            ["total"],
+            "Total pure imaging-core wallclock from the Rust profiler.",
+        ),
+    }
+    return {"status": "reported" if stages else "missing", "categories": categories}
+
+
+def build_casa_stage_breakdown(stages: dict[str, float]) -> dict[str, Any]:
+    categories = {
+        "setup_and_tool_construction": stage_category(
+            stages,
+            [
+                "parameter_setup",
+                "construct_imager",
+                "initialize_imagers",
+                "initialize_normalizers",
+                "initialize_deconvolvers",
+                "initialize_iteration_control",
+                "estimate_memory",
+            ],
+            "CASA PySynthesisImager setup, construction, and initialization.",
+        ),
+        "weighting_density_setup": stage_category(
+            stages,
+            ["set_weighting"],
+            "CASA weighting setup.",
+        ),
+        "psf_and_primary_beam": stage_category(
+            stages,
+            ["make_psf", "make_pb"],
+            "CASA PSF and PB construction.",
+        ),
+        "major_cycle_residual": stage_category(
+            stages,
+            ["calcres_major_cycle", "clean_major_cycle"],
+            "CASA residual major-cycle and clean major-cycle work.",
+        ),
+        "deconvolution_minor_cycle": stage_category(
+            stages,
+            ["minor_cycle", "update_mask", "has_converged"],
+            "CASA minor-cycle, mask update, and convergence checks.",
+        ),
+        "restore_and_cleanup": stage_category(
+            stages,
+            ["restore_images", "delete_tools"],
+            "CASA restore and tool cleanup.",
+        ),
+        "total": stage_category(stages, ["total"], "CASA phase probe total."),
+    }
+    return {"status": "reported" if stages else "missing", "categories": categories}
+
+
+def stage_category(
+    stages: dict[str, float],
+    fields: list[str],
+    description: str,
+    *,
+    skipped: bool = False,
+    skip_reason: str | None = None,
+) -> dict[str, Any]:
+    components = {field: stages[field] for field in fields if field in stages}
+    if skipped and not components:
+        return {
+            "status": "skipped",
+            "reason": skip_reason or description,
+            "total_ms": None,
+            "components_ms": {},
+            "source_fields": fields,
+            "description": description,
+        }
+    if not fields:
+        return {
+            "status": "not_reported",
+            "reason": description,
+            "total_ms": None,
+            "components_ms": {},
+            "source_fields": [],
+            "description": description,
+        }
+    missing = [field for field in fields if field not in stages]
+    if components:
+        total = sum(components.values())
+        status = "measured" if total > 0 else "measured_zero"
+        if skipped and total == 0:
+            status = "skipped"
+        return {
+            "status": status,
+            "reason": skip_reason if status == "skipped" else None,
+            "total_ms": total,
+            "components_ms": components,
+            "source_fields": fields,
+            "missing_fields": missing,
+            "description": description,
+        }
+    return {
+        "status": "missing",
+        "reason": f"no source timing fields found: {', '.join(fields)}",
+        "total_ms": None,
+        "components_ms": {},
+        "source_fields": fields,
+        "missing_fields": missing,
+        "description": description,
     }
 
 

--- a/tools/perf/imager/run_workload.py
+++ b/tools/perf/imager/run_workload.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+"""Run manifest-driven CASA C++ versus casa-rs imaging benchmarks."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import pathlib
+import re
+import statistics
+import subprocess
+import sys
+import uuid
+from typing import Any
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+WORKLOAD_DIR = pathlib.Path(__file__).resolve().parent / "workloads"
+BENCH_SCRIPT = REPO_ROOT / "scripts" / "bench-imager-vs-casa.sh"
+SUPPORTED_GRIDDER_VALUES = {"mosaic", "standard"}
+SUPPORTED_SPEC_MODES = {"mfs", "cube"}
+SUPPORTED_BENCH_MODES = {"dirty", "clean"}
+SUPPORTED_INTERPOLATION = {"nearest", "linear"}
+
+
+class HarnessError(Exception):
+    """Error that should be shown without a Python traceback."""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("workload", help="workload manifest id or JSON path")
+    parser.add_argument(
+        "--output-dir",
+        type=pathlib.Path,
+        default=pathlib.Path("target/imperformance-wave1"),
+        help="directory for result JSON and benchmark log",
+    )
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        default=None,
+        help="override manifest run.repeats",
+    )
+    parser.add_argument(
+        "--run-label",
+        default=None,
+        help="override manifest run.run_label, for example cold, warm, or fresh-open",
+    )
+    parser.add_argument(
+        "--storage-label",
+        default=None,
+        help="override manifest run.storage_label",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="validate manifest support and write the planned command without running",
+    )
+    args = parser.parse_args()
+
+    try:
+        manifest_path = resolve_workload(args.workload)
+        manifest = load_manifest(manifest_path)
+        plan = build_plan(
+            manifest_path=manifest_path,
+            manifest=manifest,
+            repeats_override=args.repeats,
+            run_label_override=args.run_label,
+            storage_label_override=args.storage_label,
+            dry_run=args.dry_run,
+        )
+        output_dir = args.output_dir.resolve()
+        output_dir.mkdir(parents=True, exist_ok=True)
+        result_path = output_dir / f"{plan['run_id']}.json"
+        log_path = output_dir / f"{plan['run_id']}.log"
+
+        if args.dry_run:
+            result = {
+                "schema_version": 1,
+                "status": "dry_run",
+                **plan,
+                "logs": {"benchmark_log": None},
+                "results": empty_results(casa_status="not_run", reason="dry run"),
+            }
+            write_json(result_path, result)
+            print(result_path)
+            return
+
+        result = run_plan(plan, log_path)
+        result["logs"] = {"benchmark_log": str(log_path)}
+        write_json(result_path, result)
+        print(result_path)
+    except HarnessError as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(2) from None
+
+
+def resolve_workload(value: str) -> pathlib.Path:
+    candidate = pathlib.Path(value)
+    if candidate.exists():
+        return candidate.resolve()
+    if candidate.suffix != ".json":
+        candidate = WORKLOAD_DIR / f"{value}.json"
+    if candidate.exists():
+        return candidate.resolve()
+    raise HarnessError(f"workload manifest not found: {value}")
+
+
+def load_manifest(path: pathlib.Path) -> dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            value = json.load(handle)
+    except json.JSONDecodeError as error:
+        raise HarnessError(f"parse {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise HarnessError(f"{path} must contain a JSON object")
+    return value
+
+
+def build_plan(
+    *,
+    manifest_path: pathlib.Path,
+    manifest: dict[str, Any],
+    repeats_override: int | None,
+    run_label_override: str | None,
+    storage_label_override: str | None,
+    dry_run: bool,
+) -> dict[str, Any]:
+    workload_id = required_str(manifest, "id")
+    mode_id = required_str(manifest, "mode_id")
+    dataset = required_object(manifest, "dataset")
+    imaging = required_object(manifest, "imaging")
+    run = object_value(manifest, "run")
+
+    specmode = enum_value(imaging, "specmode", SUPPORTED_SPEC_MODES)
+    gridder = enum_value(imaging, "gridder", SUPPORTED_GRIDDER_VALUES)
+    bench_mode = enum_value(imaging, "mode", SUPPORTED_BENCH_MODES)
+    interpolation = enum_value_default(imaging, "interpolation", "linear", SUPPORTED_INTERPOLATION)
+    wterm = str_value(imaging, "wterm", "none")
+    if wterm != "none":
+        raise HarnessError(
+            f"{workload_id}: wterm={wterm!r} is not supported by this harness yet"
+        )
+    repeats = repeats_override if repeats_override is not None else int_value(run, "repeats", 5)
+    if repeats < 1:
+        raise HarnessError("repeats must be >= 1")
+
+    dataset_path = resolve_dataset_path(dataset, dry_run=dry_run)
+    casa_python = os.environ.get("CASA_RS_CASA_PYTHON")
+    if not dry_run and not casa_python:
+        raise HarnessError("CASA_RS_CASA_PYTHON is required for a benchmark run")
+    if not dry_run and casa_python and not pathlib.Path(casa_python).is_file():
+        raise HarnessError(f"CASA_RS_CASA_PYTHON does not exist: {casa_python}")
+
+    env = {
+        "BENCH_REPEATS": str(repeats),
+        "IMAGER_BENCH_MODE": bench_mode,
+        "IMAGER_BENCH_SPECMODE": specmode,
+        "IMAGER_BENCH_GRIDDER": gridder,
+        "IMAGER_BENCH_INTERPOLATION": interpolation,
+        "IMAGER_BENCH_FIELD": str_value(imaging, "field", "0"),
+        "IMAGER_BENCH_SPW": str_value(imaging, "spw", "0"),
+        "IMAGER_BENCH_CHANNEL_START": str(int_value(imaging, "channel_start", 0)),
+        "IMAGER_BENCH_CHANNEL_COUNT": str(int_value(imaging, "channel_count", 1)),
+        "IMAGER_BENCH_IMSIZE": str(int_value(imaging, "imsize", 128)),
+        "IMAGER_BENCH_CELL_ARCSEC": str(float_value(imaging, "cell_arcsec", 30.0)),
+        "IMAGER_BENCH_WEIGHTING": str_value(imaging, "weighting", "natural"),
+        "IMAGER_BENCH_ROBUST": str(float_value(imaging, "robust", 0.5)),
+        "IMAGER_BENCH_DECONVOLVER": str_value(imaging, "deconvolver", "hogbom"),
+        "IMAGER_BENCH_SCALES": scales_value(imaging),
+        "IMAGER_BENCH_WTERM": wterm,
+        "IMAGER_BENCH_NITER": str(int_value(imaging, "niter", 4)),
+        "IMAGER_BENCH_GAIN": str(float_value(imaging, "gain", 0.1)),
+        "IMAGER_BENCH_THRESHOLD_JY": str(float_value(imaging, "threshold_jy", 0.0)),
+        "IMAGER_BENCH_NSIGMA": str(float_value(imaging, "nsigma", 0.0)),
+        "IMAGER_BENCH_PSFCUTOFF": str(float_value(imaging, "psfcutoff", 0.35)),
+        "IMAGER_BENCH_MINOR_CYCLE_LENGTH": str(
+            int_value(imaging, "minor_cycle_length", 2)
+        ),
+        "IMAGER_BENCH_CYCLEFACTOR": str(float_value(imaging, "cyclefactor", 1.0)),
+        "IMAGER_BENCH_MIN_PSFFRACTION": str(
+            float_value(imaging, "min_psf_fraction", 0.05)
+        ),
+        "IMAGER_BENCH_MAX_PSFFRACTION": str(
+            float_value(imaging, "max_psf_fraction", 0.8)
+        ),
+    }
+
+    command = [str(BENCH_SCRIPT), str(dataset_path)]
+    return {
+        "run_id": f"{utc_stamp()}-{workload_id}-{uuid.uuid4().hex[:8]}",
+        "created_at": utc_now(),
+        "manifest_path": str(manifest_path),
+        "workload": {
+            "id": workload_id,
+            "mode_id": mode_id,
+            "description": str_value(manifest, "description", ""),
+        },
+        "dataset": {
+            "key": required_str(dataset, "key"),
+            "path": str(dataset_path),
+            "relative_path": dataset.get("relative_path"),
+            "root_env": dataset.get("root_env"),
+        },
+        "mode": {
+            "specmode": specmode,
+            "gridder": gridder,
+            "bench_mode": bench_mode,
+            "image_shape": [int_value(imaging, "imsize", 128), int_value(imaging, "imsize", 128)],
+            "channel_count": int_value(imaging, "channel_count", 1),
+            "weighting": str_value(imaging, "weighting", "natural"),
+            "deconvolver": str_value(imaging, "deconvolver", "hogbom"),
+            "niter": int_value(imaging, "niter", 4),
+        },
+        "run": {
+            "repeats": repeats,
+            "run_label": run_label_override or str_value(run, "run_label", "warm"),
+            "storage_label": storage_label_override
+            or str_value(run, "storage_label", "script-staged-tempdir"),
+        },
+        "command": {
+            "argv": command,
+            "env": env,
+        },
+        "environment": collect_environment(casa_python),
+    }
+
+
+def run_plan(plan: dict[str, Any], log_path: pathlib.Path) -> dict[str, Any]:
+    env = os.environ.copy()
+    env.update(plan["command"]["env"])
+    started = utc_now()
+    completed = subprocess.run(
+        plan["command"]["argv"],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    log_path.write_text(completed.stdout, encoding="utf-8")
+    if completed.returncode != 0:
+        return {
+            "schema_version": 1,
+            "status": "failed",
+            **plan,
+            "started_at": started,
+            "completed_at": utc_now(),
+            "exit_code": completed.returncode,
+            "results": empty_results(
+                casa_status="blocked",
+                reason=f"benchmark command exited {completed.returncode}",
+            ),
+        }
+
+    parsed = parse_benchmark_log(completed.stdout)
+    return {
+        "schema_version": 1,
+        "status": "completed",
+        **plan,
+        "started_at": started,
+        "completed_at": utc_now(),
+        "exit_code": completed.returncode,
+        "results": parsed,
+    }
+
+
+def empty_results(*, casa_status: str, reason: str) -> dict[str, Any]:
+    return {
+        "rust": {"status": "not_run", "timings_seconds": {"runs": [], "median": None}},
+        "casa": {
+            "status": casa_status,
+            "reason": reason,
+            "timings_seconds": {"runs": [], "median": None},
+        },
+        "stage_medians_ms": {"rust": {}, "casa": {}},
+    }
+
+
+def parse_benchmark_log(text: str) -> dict[str, Any]:
+    rust_runs, rust_median = parse_timing_section(text, "Rust release CLI timings")
+    casa_runs, casa_median = parse_timing_section(text, "CASA tclean timings")
+    rust_stages = parse_stage_section(text, "Rust stage medians")
+    casa_stages = parse_stage_section(text, "CASA PySynthesisImager stage medians")
+    return {
+        "rust": {
+            "status": "ran",
+            "timings_seconds": {"runs": rust_runs, "median": rust_median},
+        },
+        "casa": {
+            "status": "ran",
+            "reason": None,
+            "timings_seconds": {"runs": casa_runs, "median": casa_median},
+        },
+        "stage_medians_ms": {"rust": rust_stages, "casa": casa_stages},
+    }
+
+
+def parse_timing_section(text: str, heading: str) -> tuple[list[float], float | None]:
+    lines = section_lines(text, f"{heading} ")
+    runs = []
+    median_value = None
+    for line in lines:
+        run_match = re.search(r"\brun=\d+\s+real=([0-9.]+)", line)
+        if run_match:
+            runs.append(float(run_match.group(1)))
+        median_match = re.search(r"\bmedian=([0-9.]+)", line)
+        if median_match:
+            median_value = float(median_match.group(1))
+    if median_value is None and runs:
+        median_value = statistics.median(runs)
+    return runs, median_value
+
+
+def parse_stage_section(text: str, heading: str) -> dict[str, float]:
+    lines = section_lines(text, f"{heading} ")
+    stages: dict[str, float] = {}
+    for line in lines:
+        for name, value in re.findall(r"([A-Za-z0-9_]+)=([0-9.]+)", line):
+            if name != "run":
+                stages[name] = float(value)
+    return stages
+
+
+def section_lines(text: str, heading_prefix: str) -> list[str]:
+    lines = text.splitlines()
+    result = []
+    collecting = False
+    for line in lines:
+        if line.startswith(heading_prefix):
+            collecting = True
+            continue
+        if collecting and line.strip() == "":
+            break
+        if collecting:
+            result.append(line.strip())
+    return result
+
+
+def resolve_dataset_path(dataset: dict[str, Any], *, dry_run: bool) -> pathlib.Path:
+    if "path" in dataset:
+        path = pathlib.Path(os.path.expanduser(required_str(dataset, "path")))
+    else:
+        root_env = str_value(dataset, "root_env", "CASA_RS_TESTDATA_ROOT")
+        root = os.environ.get(root_env)
+        if not root:
+            if dry_run:
+                root = f"${root_env}"
+            else:
+                raise HarnessError(f"{root_env} is required for dataset {dataset.get('key')!r}")
+        path = pathlib.Path(root) / required_str(dataset, "relative_path")
+    if not dry_run and not path.is_dir():
+        raise HarnessError(f"dataset path does not exist: {path}")
+    return path
+
+
+def collect_environment(casa_python: str | None) -> dict[str, Any]:
+    return {
+        "repo_root": str(REPO_ROOT),
+        "git_commit": git_value(["rev-parse", "HEAD"]),
+        "git_branch": git_value(["branch", "--show-current"]),
+        "python": sys.version.split()[0],
+        "casa_python": casa_python,
+        "bench_script": str(BENCH_SCRIPT),
+        "bench_script_sha256": file_sha256(BENCH_SCRIPT),
+    }
+
+
+def git_value(args: list[str]) -> str | None:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.strip()
+
+
+def file_sha256(path: pathlib.Path) -> str:
+    import hashlib
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def utc_stamp() -> str:
+    return dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def write_json(path: pathlib.Path, value: dict[str, Any]) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def required_object(obj: dict[str, Any], key: str) -> dict[str, Any]:
+    value = obj.get(key)
+    if not isinstance(value, dict):
+        raise HarnessError(f"missing object field {key!r}")
+    return value
+
+
+def object_value(obj: dict[str, Any], key: str) -> dict[str, Any]:
+    value = obj.get(key, {})
+    if not isinstance(value, dict):
+        raise HarnessError(f"{key!r} must be an object")
+    return value
+
+
+def required_str(obj: dict[str, Any], key: str) -> str:
+    value = obj.get(key)
+    if not isinstance(value, str) or not value:
+        raise HarnessError(f"missing string field {key!r}")
+    return value
+
+
+def str_value(obj: dict[str, Any], key: str, default: str) -> str:
+    value = obj.get(key, default)
+    if not isinstance(value, str):
+        raise HarnessError(f"{key!r} must be a string")
+    return value
+
+
+def int_value(obj: dict[str, Any], key: str, default: int) -> int:
+    value = obj.get(key, default)
+    if not isinstance(value, int):
+        raise HarnessError(f"{key!r} must be an integer")
+    return value
+
+
+def float_value(obj: dict[str, Any], key: str, default: float) -> float:
+    value = obj.get(key, default)
+    if not isinstance(value, (int, float)):
+        raise HarnessError(f"{key!r} must be numeric")
+    return float(value)
+
+
+def enum_value(obj: dict[str, Any], key: str, allowed: set[str]) -> str:
+    return enum_value_default(obj, key, None, allowed)
+
+
+def enum_value_default(
+    obj: dict[str, Any], key: str, default: str | None, allowed: set[str]
+) -> str:
+    value = obj.get(key, default)
+    if not isinstance(value, str) or value not in allowed:
+        allowed_text = ", ".join(sorted(allowed))
+        raise HarnessError(f"{key!r} must be one of: {allowed_text}")
+    return value
+
+
+def scales_value(imaging: dict[str, Any]) -> str:
+    value = imaging.get("scales", "")
+    if value == "":
+        return ""
+    if not isinstance(value, list) or not all(isinstance(item, int) for item in value):
+        raise HarnessError("'scales' must be a list of integers")
+    return ",".join(str(item) for item in value)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/perf/imager/stage_wave1_datasets.py
+++ b/tools/perf/imager/stage_wave1_datasets.py
@@ -1,0 +1,601 @@
+#!/usr/bin/env python3
+"""Prepare deterministic ImPerformance Wave 1 simulated dataset inputs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import pathlib
+import struct
+import sys
+import time
+from typing import Any
+
+
+TOOL_DIR = pathlib.Path(__file__).resolve().parent
+REGISTRY_PATH = TOOL_DIR / "wave1_dataset_registry.json"
+DEFAULT_OUTPUT_DIR = pathlib.Path("target/imperformance-wave1/datasets")
+EXTERNAL_PREFIX = pathlib.Path("/Volumes/GLENDENNING")
+
+
+class DatasetError(Exception):
+    """Error that should be reported without a traceback."""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--registry",
+        type=pathlib.Path,
+        default=REGISTRY_PATH,
+        help="dataset registry JSON",
+    )
+    parser.add_argument("--dataset", action="append", help="dataset id to include")
+    parser.add_argument("--tier", action="append", help="tier to include")
+    parser.add_argument("--instrument", action="append", help="instrument to include")
+    parser.add_argument(
+        "--output-dir",
+        type=pathlib.Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help="directory for generated plan JSON",
+    )
+    parser.add_argument(
+        "--data-root",
+        type=pathlib.Path,
+        default=None,
+        help="explicit staging root; otherwise the registry root_env must be set",
+    )
+    parser.add_argument(
+        "--materialize-models",
+        action="store_true",
+        help="write continuum model FITS files and spectral-profile JSON files",
+    )
+    parser.add_argument(
+        "--materialize-workloads",
+        action="store_true",
+        help="write benchmark workload manifests for each planned dataset",
+    )
+    parser.add_argument(
+        "--allow-non-external-large-root",
+        action="store_true",
+        help="allow medium/large tiers outside /Volumes/GLENDENNING",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="validate and write the staging plan without materializing files",
+    )
+    args = parser.parse_args()
+
+    try:
+        registry = read_json(args.registry)
+        specs = select_datasets(
+            registry,
+            dataset_ids=args.dataset,
+            tiers=args.tier,
+            instruments=args.instrument,
+        )
+        data_root = resolve_data_root(registry, args.data_root)
+        plan = build_plan(registry, specs, data_root, args.allow_non_external_large_root)
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        plan_path = args.output_dir / "wave1-dataset-plan.json"
+        if args.materialize_models and not args.dry_run:
+            materialize_models(plan)
+        if args.materialize_workloads and not args.dry_run:
+            materialize_workloads(plan, args.output_dir / "workloads")
+        write_json(plan_path, plan)
+        print(plan_path)
+    except DatasetError as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(2) from None
+
+
+def read_json(path: pathlib.Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as error:
+        raise DatasetError(f"read {path}: {error}") from error
+    except json.JSONDecodeError as error:
+        raise DatasetError(f"parse {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise DatasetError(f"{path} must contain a JSON object")
+    return value
+
+
+def select_datasets(
+    registry: dict[str, Any],
+    *,
+    dataset_ids: list[str] | None,
+    tiers: list[str] | None,
+    instruments: list[str] | None,
+) -> list[dict[str, Any]]:
+    datasets = registry.get("datasets")
+    if not isinstance(datasets, list):
+        raise DatasetError("registry missing datasets array")
+    selected = []
+    wanted_ids = set(dataset_ids or [])
+    wanted_tiers = set(tiers or [])
+    wanted_instruments = set(instruments or [])
+    for item in datasets:
+        if not isinstance(item, dict):
+            raise DatasetError("dataset entries must be objects")
+        dataset_id = required_str(item, "id")
+        if wanted_ids and dataset_id not in wanted_ids:
+            continue
+        if wanted_tiers and required_str(item, "tier") not in wanted_tiers:
+            continue
+        if wanted_instruments and required_str(item, "instrument") not in wanted_instruments:
+            continue
+        selected.append(item)
+    if wanted_ids:
+        found = {required_str(item, "id") for item in selected}
+        missing = sorted(wanted_ids - found)
+        if missing:
+            raise DatasetError(f"unknown dataset id(s): {', '.join(missing)}")
+    if not selected:
+        raise DatasetError("no datasets selected")
+    return selected
+
+
+def resolve_data_root(registry: dict[str, Any], explicit: pathlib.Path | None) -> pathlib.Path:
+    if explicit is not None:
+        return explicit.expanduser().resolve()
+    root_env = required_str(registry, "root_env")
+    value = os.environ.get(root_env)
+    if not value:
+        hint = registry.get("external_root_hint", "<set explicit data root>")
+        raise DatasetError(f"{root_env} is required; for this system use {hint}")
+    return pathlib.Path(value).expanduser().resolve()
+
+
+def build_plan(
+    registry: dict[str, Any],
+    specs: list[dict[str, Any]],
+    data_root: pathlib.Path,
+    allow_non_external_large_root: bool,
+) -> dict[str, Any]:
+    tiers = required_object(registry, "tiers")
+    instruments = required_object(registry, "instruments")
+    families = required_object(registry, "families")
+    planned = []
+    for spec in specs:
+        tier_name = required_str(spec, "tier")
+        tier = required_object(tiers, tier_name)
+        instrument_name = required_str(spec, "instrument")
+        instrument = required_object(instruments, instrument_name)
+        family_name = required_str(spec, "family")
+        family = required_object(families, family_name)
+        if bool(tier.get("external_root_required")) and not allow_non_external_large_root:
+            try:
+                data_root.relative_to(EXTERNAL_PREFIX)
+            except ValueError as error:
+                raise DatasetError(
+                    f"{required_str(spec, 'id')} is a {tier_name} tier dataset; "
+                    f"stage it under {EXTERNAL_PREFIX} or pass "
+                    "--allow-non-external-large-root"
+                ) from error
+
+        dataset_dir = data_root / "wave1" / instrument_name / family_name / tier_name
+        continuum_model = dataset_dir / "models" / "structured-continuum.fits"
+        spectral_profile = dataset_dir / "models" / "spectral-profile.json"
+        casars_request = dataset_dir / "requests" / "casars-simobserve.json"
+        casa_request = dataset_dir / "requests" / "casa-simulation-plan.json"
+        output_ms = dataset_dir / "ms" / f"{required_str(spec, 'id')}.ms"
+        selected_modes = family.get("selected_modes", [])
+        if not isinstance(selected_modes, list):
+            raise DatasetError(f"family {family_name} selected_modes must be an array")
+        native_status = native_status_for(spec, instrument, family)
+        planned.append(
+            {
+                "id": required_str(spec, "id"),
+                "instrument": instrument_name,
+                "family": family_name,
+                "tier": tier_name,
+                "target_size_bytes": int_value(tier, "target_size_bytes"),
+                "storage_label": required_str(tier, "storage_label"),
+                "selected_modes": selected_modes,
+                "paths": {
+                    "dataset_dir": str(dataset_dir),
+                    "continuum_model_fits": str(continuum_model),
+                    "spectral_profile_json": str(spectral_profile),
+                    "casars_simobserve_request": str(casars_request),
+                    "casa_simulation_plan": str(casa_request),
+                    "output_ms": str(output_ms),
+                },
+                "shape": {
+                    "model_pixels": int_value(spec, "model_pixels"),
+                    "image_pixels": int_value(spec, "image_pixels"),
+                    "channels": int_value(spec, "channels"),
+                    "pointing_count": int_value(family, "pointing_count"),
+                    "duration_seconds": float_value(spec, "duration_seconds"),
+                    "integration_seconds": float_value(spec, "integration_seconds"),
+                    "estimated_main_rows": estimated_main_rows(spec, family),
+                },
+                "source_model": {
+                    "continuum": registry["source_model"]["continuum_components"],
+                    "cube": registry["source_model"]["cube_components"],
+                    "noise_model": registry["source_model"]["noise_model"],
+                    "noise_simplenoise_jy": float_value(spec, "noise_simplenoise_jy"),
+                },
+                "support": native_status,
+                "provenance": {
+                    "registry": str(REGISTRY_PATH),
+                    "generated_by": str(pathlib.Path(__file__).resolve()),
+                    "generated_at": utc_now(),
+                },
+            }
+        )
+    return {
+        "schema_version": 1,
+        "root_env": required_str(registry, "root_env"),
+        "data_root": str(data_root),
+        "external_root_hint": registry.get("external_root_hint"),
+        "datasets": planned,
+    }
+
+
+def native_status_for(
+    spec: dict[str, Any], instrument: dict[str, Any], family: dict[str, Any]
+) -> dict[str, str]:
+    instrument_status = required_str(instrument, "native_casars_status")
+    family_name = required_str(spec, "family")
+    if family_name == "mosaic":
+        return {
+            "casars_simulation": "blocked",
+            "casa_simulation": "planned",
+            "reason": "current native simulator writes one FIELD; true mosaic staging requires multi-field generation or CASA simulation",
+        }
+    if required_str(spec, "instrument") != "vla":
+        return {
+            "casars_simulation": "request-plan-only",
+            "casa_simulation": "planned",
+            "reason": instrument_status,
+        }
+    return {
+        "casars_simulation": "supported",
+        "casa_simulation": "planned",
+        "reason": "native VLA single-field simobserve parity path exists; CASA side is retained for simulation performance/parity checks",
+    }
+
+
+def materialize_models(plan: dict[str, Any]) -> None:
+    for dataset in plan["datasets"]:
+        paths = dataset["paths"]
+        model_path = pathlib.Path(paths["continuum_model_fits"])
+        profile_path = pathlib.Path(paths["spectral_profile_json"])
+        request_path = pathlib.Path(paths["casars_simobserve_request"])
+        casa_plan_path = pathlib.Path(paths["casa_simulation_plan"])
+        model_path.parent.mkdir(parents=True, exist_ok=True)
+        profile_path.parent.mkdir(parents=True, exist_ok=True)
+        request_path.parent.mkdir(parents=True, exist_ok=True)
+        write_structured_fits(
+            model_path,
+            pixels=int(dataset["shape"]["model_pixels"]),
+            instrument=dataset["instrument"],
+            family=dataset["family"],
+        )
+        spectral_profile = build_spectral_profile(dataset)
+        write_json(profile_path, spectral_profile)
+        write_json(request_path, build_casars_simobserve_request(dataset))
+        write_json(casa_plan_path, build_casa_simulation_plan(dataset))
+        dataset["artifacts"] = {
+            "continuum_model_sha256": sha256_file(model_path),
+            "spectral_profile_sha256": sha256_file(profile_path),
+            "casars_request_sha256": sha256_file(request_path),
+            "casa_plan_sha256": sha256_file(casa_plan_path),
+        }
+
+
+def materialize_workloads(plan: dict[str, Any], output_dir: pathlib.Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for dataset in plan["datasets"]:
+        for mode_id in dataset["selected_modes"]:
+            workload = build_workload_manifest(dataset, mode_id)
+            write_json(output_dir / f"{dataset['id']}-{mode_id}.json", workload)
+
+
+def build_workload_manifest(dataset: dict[str, Any], mode_id: str) -> dict[str, Any]:
+    family = dataset["family"]
+    specmode = "cube" if "cube" in mode_id else "mfs"
+    gridder = "mosaic" if family == "mosaic" else "standard"
+    is_clean = "clean" in mode_id or mode_id.startswith("mtmfs")
+    deconvolver = "multiscale" if is_clean else "hogbom"
+    channels = dataset["shape"]["channels"] if specmode == "cube" else 1
+    if dataset["tier"] == "small":
+        niter = 25 if is_clean else 0
+    elif dataset["tier"] == "medium":
+        niter = 100 if is_clean else 0
+    else:
+        niter = 250 if is_clean else 0
+    return {
+        "id": f"{dataset['id']}-{mode_id}",
+        "mode_id": mode_id,
+        "description": f"{dataset['id']} {mode_id} generated from ImPerformance Wave 1 dataset plan.",
+        "dataset": {
+            "key": dataset["id"],
+            "root_env": "CASA_RS_IMPERF_DATA_ROOT",
+            "relative_path": relative_to_wave_root(dataset["paths"]["output_ms"]),
+        },
+        "imaging": {
+            "mode": "clean" if is_clean else "dirty",
+            "specmode": specmode,
+            "gridder": gridder,
+            "field": "0",
+            "spw": "0",
+            "channel_start": 0,
+            "channel_count": channels,
+            "imsize": int(dataset["shape"]["image_pixels"]),
+            "cell_arcsec": 0.1 if dataset["instrument"] == "alma" else 0.5,
+            "weighting": "briggs" if is_clean else "natural",
+            "robust": 0.5,
+            "deconvolver": deconvolver,
+            "scales": [0, 5, 15] if deconvolver == "multiscale" else "",
+            "niter": niter,
+            "wterm": "none",
+        },
+        "run": {
+            "repeats": 3,
+            "run_label": "warm",
+            "storage_label": dataset["storage_label"],
+        },
+    }
+
+
+def relative_to_wave_root(path_text: str) -> str:
+    parts = pathlib.Path(path_text).parts
+    if "wave1" in parts:
+        return str(pathlib.Path(*parts[parts.index("wave1") :]))
+    return path_text
+
+
+def build_casars_simobserve_request(dataset: dict[str, Any]) -> dict[str, Any]:
+    request: dict[str, Any] = {
+        "kind": "run",
+        "request": {
+            "model_image": dataset["paths"]["continuum_model_fits"],
+            "model_peak_jy_per_pixel": 0.003,
+            "output_ms": dataset["paths"]["output_ms"],
+            "overwrite": True,
+            "duration_seconds": dataset["shape"]["duration_seconds"],
+            "integration_seconds": dataset["shape"]["integration_seconds"],
+            "spectral_setup": {
+                "name": "wave1",
+                "start_frequency_hz": start_frequency_hz(dataset["instrument"]),
+                "channel_width_hz": channel_width_hz(dataset["instrument"]),
+                "channel_count": dataset["shape"]["channels"],
+            },
+            "predict_model": True,
+            "corruption": {
+                "seed": stable_seed(dataset["id"]),
+                "noise": {
+                    "mode": "simplenoise",
+                    "simplenoise_jy": dataset["source_model"]["noise_simplenoise_jy"],
+                },
+            },
+        },
+    }
+    if dataset["instrument"] == "alma":
+        request["request"]["antennas"] = alma_antennas()
+    return request
+
+
+def build_casa_simulation_plan(dataset: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "status": dataset["support"]["casa_simulation"],
+        "dataset": dataset["id"],
+        "purpose": "CASA C++ simulation parity and performance check for the same source model and observing shape.",
+        "model_image": dataset["paths"]["continuum_model_fits"],
+        "spectral_profile": dataset["paths"]["spectral_profile_json"],
+        "output_ms": dataset["paths"]["output_ms"].replace(".ms", ".casa.ms"),
+        "instrument": dataset["instrument"],
+        "family": dataset["family"],
+        "tier": dataset["tier"],
+        "shape": dataset["shape"],
+        "noise_simplenoise_jy": dataset["source_model"]["noise_simplenoise_jy"],
+        "notes": [
+            "Use CASA simobserve/simalma where available for the instrument and family.",
+            "Record CASA ran, skipped, or blocked with reason before claiming simulation parity or performance.",
+            "Do not use this plan as a calibration test; the intended corruption is simple deterministic visibility noise.",
+        ],
+    }
+
+
+def write_structured_fits(
+    path: pathlib.Path, *, pixels: int, instrument: str, family: str
+) -> None:
+    if pixels < 8:
+        raise DatasetError("model FITS must be at least 8x8 pixels")
+    cards = [
+        ("SIMPLE", "T"),
+        ("BITPIX", "-32"),
+        ("NAXIS", "2"),
+        ("NAXIS1", str(pixels)),
+        ("NAXIS2", str(pixels)),
+        ("CTYPE1", "'RA---SIN'"),
+        ("CTYPE2", "'DEC--SIN'"),
+        ("CUNIT1", "'deg'"),
+        ("CUNIT2", "'deg'"),
+        ("CRPIX1", f"{pixels / 2 + 0.5:.6f}"),
+        ("CRPIX2", f"{pixels / 2 + 0.5:.6f}"),
+        ("CRVAL1", "270.000129"),
+        ("CRVAL2", "-22.999889"),
+        ("CDELT1", f"{-cell_deg(instrument):.12g}"),
+        ("CDELT2", f"{cell_deg(instrument):.12g}"),
+        ("BUNIT", "'Jy/pixel'"),
+        ("OBJECT", f"'{instrument.upper()} WAVE1 {family.upper()}'"),
+    ]
+    header = "".join(format_card(key, value) for key, value in cards)
+    header += "END".ljust(80)
+    header = pad_block(header.encode("ascii"))
+    with path.open("wb") as handle:
+        handle.write(header)
+        for y in range(pixels):
+            row = bytearray()
+            for x in range(pixels):
+                row.extend(struct.pack(">f", source_pixel(x, y, pixels, family)))
+            handle.write(row)
+        pad = (-pixels * pixels * 4) % 2880
+        if pad:
+            handle.write(b"\0" * pad)
+
+
+def source_pixel(x: int, y: int, pixels: int, family: str) -> float:
+    cx = (x + 0.5 - pixels / 2.0) / pixels
+    cy = (y + 0.5 - pixels / 2.0) / pixels
+    radius = math.hypot(cx, cy)
+    theta = math.atan2(cy, cx)
+    core = gaussian(cx, cy, 0.0, 0.0, 0.018)
+    knot1 = 0.42 * gaussian(cx, cy, -0.14, 0.09, 0.028)
+    knot2 = 0.31 * gaussian(cx, cy, 0.18, -0.11, 0.022)
+    ring = 0.34 * math.exp(-((radius - 0.21) ** 2) / (2.0 * 0.018**2))
+    arm1 = 0.18 * math.exp(-((radius - (0.10 + 0.040 * theta)) ** 2) / (2.0 * 0.020**2))
+    arm2 = 0.14 * math.exp(
+        -((radius - (0.18 - 0.035 * theta)) ** 2) / (2.0 * 0.024**2)
+    )
+    halo = 0.06 * math.exp(-(radius**2) / (2.0 * 0.26**2))
+    ripple = 0.015 * (1.0 + math.sin(37.0 * cx + 19.0 * cy))
+    mosaic_gradient = 1.0 + (0.10 * cx - 0.07 * cy if family == "mosaic" else 0.0)
+    value = (core + knot1 + knot2 + ring + arm1 + arm2 + halo + ripple) * mosaic_gradient
+    return max(0.0, float(value))
+
+
+def build_spectral_profile(dataset: dict[str, Any]) -> dict[str, Any]:
+    channels = int(dataset["shape"]["channels"])
+    profile = []
+    center = 0.5 * max(0, channels - 1)
+    for channel in range(channels):
+        x = 0.0 if channels == 1 else (channel - center) / max(1.0, center)
+        continuum = max(0.05, 1.0 + x) ** -0.7
+        broad_line = 0.45 * math.exp(-0.5 * ((x - 0.05) / 0.22) ** 2)
+        narrow_line = 0.22 * math.exp(-0.5 * ((x + 0.38) / 0.08) ** 2)
+        absorption = -0.18 * math.exp(-0.5 * ((x - 0.32) / 0.06) ** 2)
+        profile.append(
+            {
+                "channel": channel,
+                "relative_frequency_offset": x,
+                "continuum_scale": continuum,
+                "line_scale": broad_line + narrow_line + absorption,
+                "total_scale": max(0.05, continuum + broad_line + narrow_line + absorption),
+            }
+        )
+    return {
+        "schema_version": 1,
+        "dataset": dataset["id"],
+        "description": "Deterministic cube spectral structure for detecting channel ordering and interpolation regressions.",
+        "channels": channels,
+        "components": dataset["source_model"]["cube"],
+        "profile": profile,
+    }
+
+
+def estimated_main_rows(spec: dict[str, Any], family: dict[str, Any]) -> int:
+    antenna_count = 27 if required_str(spec, "instrument") == "vla" else 43
+    baseline_count = antenna_count * (antenna_count - 1) // 2
+    samples = math.ceil(float_value(spec, "duration_seconds") / float_value(spec, "integration_seconds"))
+    return baseline_count * samples * int_value(family, "pointing_count")
+
+
+def alma_antennas() -> list[dict[str, Any]]:
+    center = [-2_225_035.0, -5_441_197.0, -2_481_630.0]
+    antennas = []
+    for index in range(43):
+        arm = index % 3
+        radius = 18.0 + 14.0 * index
+        angle = (2.0 * math.pi * arm / 3.0) + index * 0.37
+        x_offset = radius * math.cos(angle)
+        y_offset = radius * math.sin(angle)
+        z_offset = 0.08 * radius * math.sin(angle * 0.5)
+        antennas.append(
+            {
+                "name": f"DA{index + 1:02d}",
+                "station": f"A{index + 1:03d}",
+                "position_m": [
+                    center[0] + x_offset,
+                    center[1] + y_offset,
+                    center[2] + z_offset,
+                ],
+                "dish_diameter_m": 12.0,
+            }
+        )
+    return antennas
+
+
+def format_card(key: str, value: str) -> str:
+    return f"{key:<8}= {value:>20}".ljust(80)
+
+
+def pad_block(data: bytes) -> bytes:
+    return data + b" " * ((-len(data)) % 2880)
+
+
+def gaussian(x: float, y: float, x0: float, y0: float, sigma: float) -> float:
+    return math.exp(-(((x - x0) ** 2 + (y - y0) ** 2) / (2.0 * sigma**2)))
+
+
+def cell_deg(instrument: str) -> float:
+    return (0.08 if instrument == "alma" else 0.35) / 3600.0
+
+
+def start_frequency_hz(instrument: str) -> float:
+    return 230.0e9 if instrument == "alma" else 44.0e9
+
+
+def channel_width_hz(instrument: str) -> float:
+    return 2.0e6 if instrument == "alma" else 128.0e6
+
+
+def stable_seed(text: str) -> int:
+    return int(hashlib.sha256(text.encode("utf-8")).hexdigest()[:12], 16)
+
+
+def sha256_file(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def utc_now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def write_json(path: pathlib.Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def required_object(obj: dict[str, Any], key: str) -> dict[str, Any]:
+    value = obj.get(key)
+    if not isinstance(value, dict):
+        raise DatasetError(f"missing object field {key!r}")
+    return value
+
+
+def required_str(obj: dict[str, Any], key: str) -> str:
+    value = obj.get(key)
+    if not isinstance(value, str) or value == "":
+        raise DatasetError(f"missing string field {key!r}")
+    return value
+
+
+def int_value(obj: dict[str, Any], key: str) -> int:
+    value = obj.get(key)
+    if not isinstance(value, int):
+        raise DatasetError(f"{key!r} must be an integer")
+    return value
+
+
+def float_value(obj: dict[str, Any], key: str) -> float:
+    value = obj.get(key)
+    if not isinstance(value, (int, float)):
+        raise DatasetError(f"{key!r} must be numeric")
+    return float(value)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/perf/imager/stage_wave1_datasets.py
+++ b/tools/perf/imager/stage_wave1_datasets.py
@@ -245,18 +245,27 @@ def native_status_for(
     if family_name == "mosaic":
         return {
             "casars_simulation": "blocked",
-            "casa_simulation": "planned",
+            "casa_simulation": "generation-path",
+            "native_backlog_issue": "#254",
             "reason": "current native simulator writes one FIELD; true mosaic staging requires multi-field generation or CASA simulation",
         }
     if required_str(spec, "instrument") != "vla":
         return {
             "casars_simulation": "request-plan-only",
-            "casa_simulation": "planned",
+            "casa_simulation": "generation-path",
+            "native_backlog_issue": "#180/#181/#182",
             "reason": instrument_status,
+        }
+    if int_value(spec, "channels") > 1:
+        return {
+            "casars_simulation": "supported-single-plane",
+            "casa_simulation": "generation-path",
+            "native_backlog_issue": "#255",
+            "reason": "native VLA single-field simobserve can write a multi-channel MS from one 2D model plane; CASA generation is required for deterministic channel-varying source structure",
         }
     return {
         "casars_simulation": "supported",
-        "casa_simulation": "planned",
+        "casa_simulation": "generation-path",
         "reason": "native VLA single-field simobserve parity path exists; CASA side is retained for simulation performance/parity checks",
     }
 

--- a/tools/perf/imager/stage_wave1_datasets.py
+++ b/tools/perf/imager/stage_wave1_datasets.py
@@ -546,7 +546,7 @@ def estimated_main_rows(spec: dict[str, Any], family: dict[str, Any]) -> int:
     antenna_count = 27 if required_str(spec, "instrument") == "vla" else 43
     baseline_count = antenna_count * (antenna_count - 1) // 2
     samples = math.ceil(float_value(spec, "duration_seconds") / float_value(spec, "integration_seconds"))
-    return baseline_count * samples * int_value(family, "pointing_count")
+    return baseline_count * samples
 
 
 def alma_antennas() -> list[dict[str, Any]]:

--- a/tools/perf/imager/stage_wave1_datasets.py
+++ b/tools/perf/imager/stage_wave1_datasets.py
@@ -160,6 +160,7 @@ def build_plan(
     tiers = required_object(registry, "tiers")
     instruments = required_object(registry, "instruments")
     families = required_object(registry, "families")
+    validate_large_tier_policy(registry, specs)
     planned = []
     for spec in specs:
         tier_name = required_str(spec, "tier")
@@ -184,9 +185,9 @@ def build_plan(
         casars_request = dataset_dir / "requests" / "casars-simobserve.json"
         casa_request = dataset_dir / "requests" / "casa-simulation-plan.json"
         output_ms = dataset_dir / "ms" / f"{required_str(spec, 'id')}.ms"
-        selected_modes = family.get("selected_modes", [])
+        selected_modes = spec.get("selected_modes", family.get("selected_modes", []))
         if not isinstance(selected_modes, list):
-            raise DatasetError(f"family {family_name} selected_modes must be an array")
+            raise DatasetError(f"{required_str(spec, 'id')} selected_modes must be an array")
         native_status = native_status_for(spec, instrument, family)
         planned.append(
             {
@@ -233,8 +234,33 @@ def build_plan(
         "root_env": required_str(registry, "root_env"),
         "data_root": str(data_root),
         "external_root_hint": registry.get("external_root_hint"),
+        "large_tier_policy": registry.get("large_tier_policy"),
         "datasets": planned,
     }
+
+
+def validate_large_tier_policy(registry: dict[str, Any], specs: list[dict[str, Any]]) -> None:
+    policy = registry.get("large_tier_policy")
+    if not isinstance(policy, dict):
+        return
+    expected_count = policy.get("dataset_count")
+    expected_id = policy.get("dataset_id")
+    large_specs = [spec for spec in specs if required_str(spec, "tier") == "large"]
+    if not large_specs:
+        return
+    if not isinstance(expected_count, int):
+        raise DatasetError("large_tier_policy.dataset_count must be an integer")
+    if expected_count != len(large_specs):
+        raise DatasetError(
+            "large tier policy expects "
+            f"{expected_count} dataset(s), selected {len(large_specs)}"
+        )
+    if isinstance(expected_id, str):
+        large_ids = {required_str(spec, "id") for spec in large_specs}
+        if expected_id not in large_ids:
+            raise DatasetError(
+                f"large tier policy requires shared dataset {expected_id!r}"
+            )
 
 
 def native_status_for(
@@ -242,6 +268,13 @@ def native_status_for(
 ) -> dict[str, str]:
     instrument_status = required_str(instrument, "native_casars_status")
     family_name = required_str(spec, "family")
+    if family_name == "shared-large":
+        return {
+            "casars_simulation": "blocked",
+            "casa_simulation": "generation-path",
+            "native_backlog_issue": "#254/#255/#180/#181/#182",
+            "reason": "shared large ALMA mosaic/cube superset requires CASA generation until native ALMA, multi-field mosaic, and channel-varying cube simulation exist",
+        }
     if family_name == "mosaic":
         return {
             "casars_simulation": "blocked",
@@ -307,12 +340,11 @@ def materialize_workloads(plan: dict[str, Any], output_dir: pathlib.Path) -> Non
 
 
 def build_workload_manifest(dataset: dict[str, Any], mode_id: str) -> dict[str, Any]:
-    family = dataset["family"]
     specmode = "cube" if "cube" in mode_id else "mfs"
-    gridder = "mosaic" if family == "mosaic" else "standard"
+    gridder = "mosaic" if mode_id.startswith("mosaic") else "standard"
     is_clean = "clean" in mode_id or mode_id.startswith("mtmfs")
     deconvolver = "multiscale" if is_clean else "hogbom"
-    channels = dataset["shape"]["channels"] if specmode == "cube" else 1
+    channels = workload_channel_count(dataset, mode_id, specmode)
     if dataset["tier"] == "small":
         niter = 25 if is_clean else 0
     elif dataset["tier"] == "medium":
@@ -332,7 +364,7 @@ def build_workload_manifest(dataset: dict[str, Any], mode_id: str) -> dict[str, 
             "mode": "clean" if is_clean else "dirty",
             "specmode": specmode,
             "gridder": gridder,
-            "field": "0",
+            "field": "" if gridder == "mosaic" else "0",
             "spw": "0",
             "channel_start": 0,
             "channel_count": channels,
@@ -351,6 +383,15 @@ def build_workload_manifest(dataset: dict[str, Any], mode_id: str) -> dict[str, 
             "storage_label": dataset["storage_label"],
         },
     }
+
+
+def workload_channel_count(dataset: dict[str, Any], mode_id: str, specmode: str) -> int:
+    channels = int(dataset["shape"]["channels"])
+    if specmode != "cube":
+        return channels
+    if "bounded" in mode_id:
+        return min(channels, 32)
+    return channels
 
 
 def relative_to_wave_root(path_text: str) -> str:

--- a/tools/perf/imager/test_run_workload.py
+++ b/tools/perf/imager/test_run_workload.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Focused tests for the Wave 1 imager workload harness helpers."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import run_workload
+
+
+class StageBreakdownTests(unittest.TestCase):
+    def test_dirty_workload_marks_clean_only_categories_skipped(self) -> None:
+        plan = {
+            "mode": {
+                "bench_mode": "dirty",
+                "niter": 0,
+            }
+        }
+        stages = {
+            "open_measurement_set": 1.0,
+            "prepare_plane_input": 2.0,
+            "extract_phase_center": 3.0,
+            "weighting": 4.0,
+            "psf_grid": 5.0,
+            "psf_fft": 6.0,
+            "psf_normalize": 7.0,
+            "residual_degrid_grid": 8.0,
+            "residual_fft": 9.0,
+            "residual_normalize": 10.0,
+            "minor_cycle_solve": 0.0,
+            "major_cycle_refresh": 0.0,
+            "beam_fit": 0.0,
+            "restore": 0.0,
+            "build_coordinate_system": 11.0,
+            "write_products": 12.0,
+            "frontend_total": 30.0,
+            "total": 40.0,
+        }
+
+        breakdown = run_workload.build_rust_stage_breakdown(plan, stages)
+        categories = breakdown["categories"]
+
+        self.assertEqual(
+            categories["frontend_ms_preparation"]["total_ms"],
+            6.0,
+        )
+        self.assertEqual(categories["gridding_degridding"]["total_ms"], 13.0)
+        self.assertEqual(categories["fft"]["total_ms"], 15.0)
+        self.assertEqual(categories["normalization_pb_correction"]["total_ms"], 17.0)
+        self.assertEqual(categories["deconvolution_minor_cycle"]["status"], "skipped")
+        self.assertEqual(
+            categories["model_prediction_and_residual_refresh"]["status"],
+            "skipped",
+        )
+        self.assertEqual(categories["preview_sidecar_generation"]["status"], "skipped")
+
+    def test_clean_workload_reports_clean_categories_when_measured(self) -> None:
+        plan = {
+            "mode": {
+                "bench_mode": "clean",
+                "niter": 25,
+            }
+        }
+        stages = {
+            "minor_cycle_solve": 3.5,
+            "major_cycle_refresh": 8.0,
+            "beam_fit": 1.0,
+            "restore": 2.0,
+        }
+
+        breakdown = run_workload.build_rust_stage_breakdown(plan, stages)
+        categories = breakdown["categories"]
+
+        self.assertEqual(categories["deconvolution_minor_cycle"]["status"], "measured")
+        self.assertEqual(categories["deconvolution_minor_cycle"]["total_ms"], 3.5)
+        self.assertEqual(
+            categories["model_prediction_and_residual_refresh"]["status"],
+            "measured",
+        )
+        self.assertEqual(categories["restore_and_beam_fit"]["total_ms"], 3.0)
+
+    def test_attach_stage_breakdown_does_not_require_casa_stage_data(self) -> None:
+        plan = {
+            "mode": {
+                "bench_mode": "dirty",
+                "niter": 0,
+            }
+        }
+        parsed = {
+            "stage_medians_ms": {
+                "rust": {"psf_grid": 1.0},
+                "casa": {},
+            }
+        }
+
+        run_workload.attach_stage_breakdown(plan, parsed)
+
+        self.assertEqual(parsed["stage_breakdown"]["schema_version"], 1)
+        self.assertEqual(parsed["stage_breakdown"]["rust"]["status"], "reported")
+        self.assertEqual(parsed["stage_breakdown"]["casa"]["status"], "missing")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/perf/imager/test_stage_wave1_datasets.py
+++ b/tools/perf/imager/test_stage_wave1_datasets.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Tests for Wave 1 dataset staging policy."""
+
+from __future__ import annotations
+
+import copy
+import pathlib
+import sys
+import unittest
+
+
+TOOL_DIR = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(TOOL_DIR))
+
+import stage_wave1_datasets as stage  # noqa: E402
+
+
+class StageWave1DatasetsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.registry = stage.read_json(stage.REGISTRY_PATH)
+        self.data_root = pathlib.Path("/Volumes/GLENDENNING/casa-rs-imperformance")
+
+    def test_full_plan_uses_one_shared_large_dataset(self) -> None:
+        specs = stage.select_datasets(
+            self.registry,
+            dataset_ids=None,
+            tiers=None,
+            instruments=None,
+        )
+
+        plan = stage.build_plan(
+            self.registry,
+            specs,
+            self.data_root,
+            allow_non_external_large_root=False,
+        )
+
+        large = [dataset for dataset in plan["datasets"] if dataset["tier"] == "large"]
+        self.assertEqual(["wave1-alma-shared-large"], [dataset["id"] for dataset in large])
+        self.assertEqual(
+            [
+                "standard-mfs-dirty-control",
+                "standard-mfs-clean-current",
+                "standard-cube-line",
+                "mosaic-mfs-clean-primary",
+                "mosaic-cube-bounded",
+                "mtmfs-wideband-sentinel",
+            ],
+            large[0]["selected_modes"],
+        )
+
+    def test_shared_large_workloads_select_standard_or_mosaic_gridder(self) -> None:
+        spec = stage.select_datasets(
+            self.registry,
+            dataset_ids=["wave1-alma-shared-large"],
+            tiers=None,
+            instruments=None,
+        )
+        dataset = stage.build_plan(
+            self.registry,
+            spec,
+            self.data_root,
+            allow_non_external_large_root=False,
+        )["datasets"][0]
+
+        standard = stage.build_workload_manifest(dataset, "standard-cube-line")
+        mfs = stage.build_workload_manifest(dataset, "standard-mfs-dirty-control")
+        mosaic = stage.build_workload_manifest(dataset, "mosaic-cube-bounded")
+
+        self.assertEqual("standard", standard["imaging"]["gridder"])
+        self.assertEqual("0", standard["imaging"]["field"])
+        self.assertEqual(256, standard["imaging"]["channel_count"])
+        self.assertEqual("mfs", mfs["imaging"]["specmode"])
+        self.assertEqual(256, mfs["imaging"]["channel_count"])
+        self.assertEqual("mosaic", mosaic["imaging"]["gridder"])
+        self.assertEqual("", mosaic["imaging"]["field"])
+        self.assertEqual(32, mosaic["imaging"]["channel_count"])
+
+    def test_large_tier_policy_rejects_multiple_large_datasets(self) -> None:
+        registry = copy.deepcopy(self.registry)
+        duplicate = copy.deepcopy(registry["datasets"][-1])
+        duplicate["id"] = "wave1-extra-large"
+        registry["datasets"].append(duplicate)
+        specs = stage.select_datasets(
+            registry,
+            dataset_ids=None,
+            tiers=["large"],
+            instruments=None,
+        )
+
+        with self.assertRaisesRegex(stage.DatasetError, "large tier policy expects 1"):
+            stage.build_plan(
+                registry,
+                specs,
+                self.data_root,
+                allow_non_external_large_root=False,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/perf/imager/wave1_dataset_registry.json
+++ b/tools/perf/imager/wave1_dataset_registry.json
@@ -98,8 +98,8 @@
       "model_pixels": 512,
       "image_pixels": 512,
       "channels": 16,
-      "duration_seconds": 192,
-      "integration_seconds": 2,
+      "duration_seconds": 1200,
+      "integration_seconds": 10,
       "noise_simplenoise_jy": 0.001
     },
     {
@@ -110,8 +110,8 @@
       "model_pixels": 2048,
       "image_pixels": 2048,
       "channels": 64,
-      "duration_seconds": 2160,
-      "integration_seconds": 2,
+      "duration_seconds": 28800,
+      "integration_seconds": 10,
       "noise_simplenoise_jy": 0.001
     },
     {
@@ -122,8 +122,8 @@
       "model_pixels": 512,
       "image_pixels": 512,
       "channels": 8,
-      "duration_seconds": 128,
-      "integration_seconds": 2,
+      "duration_seconds": 600,
+      "integration_seconds": 10,
       "noise_simplenoise_jy": 0.0012
     },
     {
@@ -134,8 +134,8 @@
       "model_pixels": 2048,
       "image_pixels": 2048,
       "channels": 32,
-      "duration_seconds": 2160,
-      "integration_seconds": 2,
+      "duration_seconds": 7200,
+      "integration_seconds": 10,
       "noise_simplenoise_jy": 0.0012
     },
     {
@@ -146,8 +146,8 @@
       "model_pixels": 512,
       "image_pixels": 512,
       "channels": 16,
-      "duration_seconds": 192,
-      "integration_seconds": 2,
+      "duration_seconds": 600,
+      "integration_seconds": 10,
       "noise_simplenoise_jy": 0.0007
     },
     {
@@ -158,8 +158,8 @@
       "model_pixels": 2048,
       "image_pixels": 2048,
       "channels": 64,
-      "duration_seconds": 2160,
-      "integration_seconds": 2,
+      "duration_seconds": 10800,
+      "integration_seconds": 10,
       "noise_simplenoise_jy": 0.0007
     },
     {
@@ -170,8 +170,8 @@
       "model_pixels": 512,
       "image_pixels": 512,
       "channels": 8,
-      "duration_seconds": 128,
-      "integration_seconds": 2,
+      "duration_seconds": 300,
+      "integration_seconds": 10,
       "noise_simplenoise_jy": 0.0008
     },
     {
@@ -182,8 +182,8 @@
       "model_pixels": 2048,
       "image_pixels": 2048,
       "channels": 32,
-      "duration_seconds": 2160,
-      "integration_seconds": 2,
+      "duration_seconds": 2700,
+      "integration_seconds": 10,
       "noise_simplenoise_jy": 0.0008
     },
     {
@@ -191,11 +191,11 @@
       "instrument": "alma",
       "family": "shared-large",
       "tier": "large",
-      "model_pixels": 4096,
+      "model_pixels": 2048,
       "image_pixels": 4096,
-      "channels": 256,
-      "duration_seconds": 86400,
-      "integration_seconds": 2,
+      "channels": 128,
+      "duration_seconds": 57600,
+      "integration_seconds": 10,
       "noise_simplenoise_jy": 0.0008
     }
   ]

--- a/tools/perf/imager/wave1_dataset_registry.json
+++ b/tools/perf/imager/wave1_dataset_registry.json
@@ -3,6 +3,11 @@
   "root_env": "CASA_RS_IMPERF_DATA_ROOT",
   "external_root_hint": "/Volumes/GLENDENNING/casa-rs-imperformance",
   "description": "Deterministic simulated imaging datasets for ImPerformance Wave 1.",
+  "large_tier_policy": {
+    "dataset_count": 1,
+    "dataset_id": "wave1-alma-shared-large",
+    "reason": "The external drive budget allows one approximately 100 GiB dataset. The large tier is therefore a shared ALMA mosaic/cube superset, and benchmark manifests select fields, channels, and gridders from that one MeasurementSet."
+  },
   "tiers": {
     "small": {
       "target_size_bytes": 1073741824,
@@ -52,6 +57,18 @@
         "mosaic-cube-bounded"
       ],
       "pointing_count": 7
+    },
+    "shared-large": {
+      "display_name": "shared large ALMA mosaic/cube superset",
+      "selected_modes": [
+        "standard-mfs-dirty-control",
+        "standard-mfs-clean-current",
+        "standard-cube-line",
+        "mosaic-mfs-clean-primary",
+        "mosaic-cube-bounded",
+        "mtmfs-wideband-sentinel"
+      ],
+      "pointing_count": 7
     }
   },
   "source_model": {
@@ -98,18 +115,6 @@
       "noise_simplenoise_jy": 0.001
     },
     {
-      "id": "wave1-vla-single-large",
-      "instrument": "vla",
-      "family": "single",
-      "tier": "large",
-      "model_pixels": 4096,
-      "image_pixels": 4096,
-      "channels": 256,
-      "duration_seconds": 5760,
-      "integration_seconds": 2,
-      "noise_simplenoise_jy": 0.001
-    },
-    {
       "id": "wave1-vla-mosaic-small",
       "instrument": "vla",
       "family": "mosaic",
@@ -130,18 +135,6 @@
       "image_pixels": 2048,
       "channels": 32,
       "duration_seconds": 2160,
-      "integration_seconds": 2,
-      "noise_simplenoise_jy": 0.0012
-    },
-    {
-      "id": "wave1-vla-mosaic-large",
-      "instrument": "vla",
-      "family": "mosaic",
-      "tier": "large",
-      "model_pixels": 4096,
-      "image_pixels": 4096,
-      "channels": 96,
-      "duration_seconds": 5760,
       "integration_seconds": 2,
       "noise_simplenoise_jy": 0.0012
     },
@@ -170,18 +163,6 @@
       "noise_simplenoise_jy": 0.0007
     },
     {
-      "id": "wave1-alma-single-large",
-      "instrument": "alma",
-      "family": "single",
-      "tier": "large",
-      "model_pixels": 4096,
-      "image_pixels": 4096,
-      "channels": 256,
-      "duration_seconds": 5760,
-      "integration_seconds": 2,
-      "noise_simplenoise_jy": 0.0007
-    },
-    {
       "id": "wave1-alma-mosaic-small",
       "instrument": "alma",
       "family": "mosaic",
@@ -206,14 +187,14 @@
       "noise_simplenoise_jy": 0.0008
     },
     {
-      "id": "wave1-alma-mosaic-large",
+      "id": "wave1-alma-shared-large",
       "instrument": "alma",
-      "family": "mosaic",
+      "family": "shared-large",
       "tier": "large",
       "model_pixels": 4096,
       "image_pixels": 4096,
-      "channels": 96,
-      "duration_seconds": 5760,
+      "channels": 256,
+      "duration_seconds": 86400,
       "integration_seconds": 2,
       "noise_simplenoise_jy": 0.0008
     }

--- a/tools/perf/imager/wave1_dataset_registry.json
+++ b/tools/perf/imager/wave1_dataset_registry.json
@@ -1,0 +1,221 @@
+{
+  "schema_version": 1,
+  "root_env": "CASA_RS_IMPERF_DATA_ROOT",
+  "external_root_hint": "/Volumes/GLENDENNING/casa-rs-imperformance",
+  "description": "Deterministic simulated imaging datasets for ImPerformance Wave 1.",
+  "tiers": {
+    "small": {
+      "target_size_bytes": 1073741824,
+      "storage_label": "well-below-memory",
+      "external_root_required": false
+    },
+    "medium": {
+      "target_size_bytes": 34359738368,
+      "storage_label": "about-memory",
+      "external_root_required": true
+    },
+    "large": {
+      "target_size_bytes": 107374182400,
+      "storage_label": "larger-than-memory",
+      "external_root_required": true
+    }
+  },
+  "instruments": {
+    "vla": {
+      "display_name": "VLA",
+      "array_configuration": "synthetic VLA A-like",
+      "dish_diameter_m": 25.0,
+      "native_casars_status": "supported"
+    },
+    "alma": {
+      "display_name": "ALMA",
+      "array_configuration": "synthetic compact 12m-like",
+      "dish_diameter_m": 12.0,
+      "native_casars_status": "request-plan-only until ALMA parity is checked"
+    }
+  },
+  "families": {
+    "single": {
+      "display_name": "single-field standard-gridder",
+      "selected_modes": [
+        "standard-mfs-dirty-control",
+        "standard-mfs-clean-current",
+        "standard-cube-line",
+        "mtmfs-wideband-sentinel"
+      ],
+      "pointing_count": 1
+    },
+    "mosaic": {
+      "display_name": "overlapping-field mosaic",
+      "selected_modes": [
+        "mosaic-mfs-clean-primary",
+        "mosaic-cube-bounded"
+      ],
+      "pointing_count": 7
+    }
+  },
+  "source_model": {
+    "name": "structured star-forming field",
+    "continuum_components": [
+      "bright compact core",
+      "faint offset compact sources",
+      "two extended spiral arms",
+      "partial ring",
+      "broad diffuse halo"
+    ],
+    "cube_components": [
+      "continuum baseline with spectral index",
+      "central broad emission line",
+      "offset narrow emission line",
+      "absorption notch against the core",
+      "weak velocity gradient across the extended arms"
+    ],
+    "noise_model": "deterministic simple complex visibility noise"
+  },
+  "datasets": [
+    {
+      "id": "wave1-vla-single-small",
+      "instrument": "vla",
+      "family": "single",
+      "tier": "small",
+      "model_pixels": 512,
+      "image_pixels": 512,
+      "channels": 16,
+      "duration_seconds": 192,
+      "integration_seconds": 2,
+      "noise_simplenoise_jy": 0.001
+    },
+    {
+      "id": "wave1-vla-single-medium",
+      "instrument": "vla",
+      "family": "single",
+      "tier": "medium",
+      "model_pixels": 2048,
+      "image_pixels": 2048,
+      "channels": 64,
+      "duration_seconds": 2160,
+      "integration_seconds": 2,
+      "noise_simplenoise_jy": 0.001
+    },
+    {
+      "id": "wave1-vla-single-large",
+      "instrument": "vla",
+      "family": "single",
+      "tier": "large",
+      "model_pixels": 4096,
+      "image_pixels": 4096,
+      "channels": 256,
+      "duration_seconds": 5760,
+      "integration_seconds": 2,
+      "noise_simplenoise_jy": 0.001
+    },
+    {
+      "id": "wave1-vla-mosaic-small",
+      "instrument": "vla",
+      "family": "mosaic",
+      "tier": "small",
+      "model_pixels": 512,
+      "image_pixels": 512,
+      "channels": 8,
+      "duration_seconds": 128,
+      "integration_seconds": 2,
+      "noise_simplenoise_jy": 0.0012
+    },
+    {
+      "id": "wave1-vla-mosaic-medium",
+      "instrument": "vla",
+      "family": "mosaic",
+      "tier": "medium",
+      "model_pixels": 2048,
+      "image_pixels": 2048,
+      "channels": 32,
+      "duration_seconds": 2160,
+      "integration_seconds": 2,
+      "noise_simplenoise_jy": 0.0012
+    },
+    {
+      "id": "wave1-vla-mosaic-large",
+      "instrument": "vla",
+      "family": "mosaic",
+      "tier": "large",
+      "model_pixels": 4096,
+      "image_pixels": 4096,
+      "channels": 96,
+      "duration_seconds": 5760,
+      "integration_seconds": 2,
+      "noise_simplenoise_jy": 0.0012
+    },
+    {
+      "id": "wave1-alma-single-small",
+      "instrument": "alma",
+      "family": "single",
+      "tier": "small",
+      "model_pixels": 512,
+      "image_pixels": 512,
+      "channels": 16,
+      "duration_seconds": 192,
+      "integration_seconds": 2,
+      "noise_simplenoise_jy": 0.0007
+    },
+    {
+      "id": "wave1-alma-single-medium",
+      "instrument": "alma",
+      "family": "single",
+      "tier": "medium",
+      "model_pixels": 2048,
+      "image_pixels": 2048,
+      "channels": 64,
+      "duration_seconds": 2160,
+      "integration_seconds": 2,
+      "noise_simplenoise_jy": 0.0007
+    },
+    {
+      "id": "wave1-alma-single-large",
+      "instrument": "alma",
+      "family": "single",
+      "tier": "large",
+      "model_pixels": 4096,
+      "image_pixels": 4096,
+      "channels": 256,
+      "duration_seconds": 5760,
+      "integration_seconds": 2,
+      "noise_simplenoise_jy": 0.0007
+    },
+    {
+      "id": "wave1-alma-mosaic-small",
+      "instrument": "alma",
+      "family": "mosaic",
+      "tier": "small",
+      "model_pixels": 512,
+      "image_pixels": 512,
+      "channels": 8,
+      "duration_seconds": 128,
+      "integration_seconds": 2,
+      "noise_simplenoise_jy": 0.0008
+    },
+    {
+      "id": "wave1-alma-mosaic-medium",
+      "instrument": "alma",
+      "family": "mosaic",
+      "tier": "medium",
+      "model_pixels": 2048,
+      "image_pixels": 2048,
+      "channels": 32,
+      "duration_seconds": 2160,
+      "integration_seconds": 2,
+      "noise_simplenoise_jy": 0.0008
+    },
+    {
+      "id": "wave1-alma-mosaic-large",
+      "instrument": "alma",
+      "family": "mosaic",
+      "tier": "large",
+      "model_pixels": 4096,
+      "image_pixels": 4096,
+      "channels": 96,
+      "duration_seconds": 5760,
+      "integration_seconds": 2,
+      "noise_simplenoise_jy": 0.0008
+    }
+  ]
+}

--- a/tools/perf/imager/workloads/wave1-standard-mfs-dirty-smoke.json
+++ b/tools/perf/imager/workloads/wave1-standard-mfs-dirty-smoke.json
@@ -1,0 +1,31 @@
+{
+  "id": "wave1-standard-mfs-dirty-smoke",
+  "mode_id": "standard-mfs-dirty-control",
+  "description": "Small standard-gridder MFS dirty control workload for ImPerformance Wave 1 harness validation.",
+  "dataset": {
+    "key": "ngc5921-testdata",
+    "root_env": "CASA_RS_TESTDATA_ROOT",
+    "relative_path": "measurementset/vla/ngc5921.ms"
+  },
+  "imaging": {
+    "mode": "dirty",
+    "specmode": "mfs",
+    "gridder": "standard",
+    "field": "0",
+    "spw": "0",
+    "channel_start": 0,
+    "channel_count": 1,
+    "imsize": 128,
+    "cell_arcsec": 30.0,
+    "weighting": "natural",
+    "robust": 0.5,
+    "deconvolver": "hogbom",
+    "niter": 0,
+    "wterm": "none"
+  },
+  "run": {
+    "repeats": 3,
+    "run_label": "warm",
+    "storage_label": "script-staged-tempdir"
+  }
+}


### PR DESCRIPTION
Wave issue: #246

Draft wave PR for ImPerformance Wave 1. This PR is the single wave vessel and should stay open until the approved #246 scope is complete.

Current scope landed:

- #247 selected Wave 1 imaging modes: standard MFS dirty, standard MFS clean, standard cube dirty, standard cube clean, mosaic MFS dirty, mosaic MFS clean, W-projection/AW readiness only.
- #252 added a reusable manifest-driven CASA C++ versus casa-rs imaging benchmark harness with normalized JSON output and a Wave 1 smoke workload.
- #248 added the deterministic simulated dataset registry/staging plan for VLA and ALMA, single-field and mosaic families, small/medium/large tiers, explicit external-drive policy, source-model generation, spectral-profile metadata, CASA C++ simulation plans, native simulation request plans where useful, and generated benchmark workload manifests.
- #248 now treats CASA C++ as the Wave 1 benchmark dataset generator of record; native simulation gaps are tracked separately as #254, #255, and the existing ALMA/simalma/ACA issues #180/#181/#182.

Remaining wave work before review/merge:

- #251 benchmark execution/collection for selected Wave 1 modes.
- #249 profiling/instrumentation from imaging stages to structural hotspots.
- #250 Wave 1 refactor and optimization plan.

Verification so far:

- `just docs-check`
- `just quick`
- `bash -n scripts/bench-imager-vs-casa.sh`
- `python3 -m py_compile tools/perf/imager/run_workload.py tools/perf/imager/casa_phase_bench.py`
- `cargo check -p casars-imager --example profile_imager`
- `tools/perf/imager/run_workload.py --dry-run --output-dir target/imperformance-wave1/check wave1-standard-mfs-dirty-smoke`
- `python3 -m py_compile tools/perf/imager/stage_wave1_datasets.py tools/perf/imager/run_workload.py`
- `python3 -m json.tool tools/perf/imager/wave1_dataset_registry.json`
- `tools/perf/imager/stage_wave1_datasets.py --dry-run --data-root /Volumes/GLENDENNING/casa-rs-imperformance --output-dir target/imperformance-wave1/dataset-dry-run`
- `tools/perf/imager/stage_wave1_datasets.py --dry-run --data-root /tmp/casa-rs-imperformance --dataset wave1-vla-single-small --output-dir target/imperformance-wave1/dataset-small-dry-run`
- `tools/perf/imager/stage_wave1_datasets.py --data-root /tmp/casa-rs-imperformance --dataset wave1-vla-single-small --materialize-models --materialize-workloads --output-dir target/imperformance-wave1/dataset-small-materialized`
- `tools/perf/imager/run_workload.py --dry-run --output-dir target/imperformance-wave1/generated-workload-dry-run target/imperformance-wave1/dataset-small-materialized/workloads/wave1-vla-single-small-standard-mfs-dirty-control.json`
- `python3 -m py_compile tools/perf/imager/stage_wave1_datasets.py`
- `tools/perf/imager/stage_wave1_datasets.py --dry-run --data-root /Volumes/GLENDENNING/casa-rs-imperformance --output-dir target/imperformance-wave1/dataset-casa-generation-dry-run`
- `python3 -m json.tool target/imperformance-wave1/dataset-casa-generation-dry-run/wave1-dataset-plan.json | rg -n "generation-path|native_backlog_issue|supported-single-plane|blocked|request-plan-only"`

Contract notes:

- No public API, persisted format, provider-contract, dependency, runtime, concurrency, or major imaging algorithm change is intended in the landed scope.
- Default verification stays light; heavy benchmark runs remain explicit performance evidence.
- #248 records CASA C++ generation as the Wave 1 dataset path and records native mosaic, native spectral cube, and ALMA/simalma/ACA simulation gaps as backlog/follow-up issues rather than widening native simulation capability in this wave.