### PR TITLE
ImPerformance wave 1: harden native simobserve

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,9 @@ Use `Closes #N` only for issues that should auto-close on merge.
 - Before implementing behavior that exists in CASA/casacore C++, inspect the
   relevant upstream task/tool/library path first and preserve its semantics
   unless there is an explicit reason to diverge.
+- When investigating parity or correctness differences against CASA/casacore
+  C++, favor targeted instrumentation of both implementations over blind
+  parameter experiments or speculative fixes.
 - Use the shared least-squares helper and its well-exercised linear algebra
   backend for polynomial or linear least-squares solves; do not add ad hoc
   normal-equation or Gaussian-elimination solvers.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,6 +652,7 @@ dependencies = [
  "casa-types",
  "flate2",
  "image 0.25.10",
+ "libm",
  "nalgebra",
  "ndarray",
  "num-complex",

--- a/crates/casa-coordinates/src/fits/coordinate_util.rs
+++ b/crates/casa-coordinates/src/fits/coordinate_util.rs
@@ -523,22 +523,25 @@ fn parse_direction(
         .ok_or_else(|| CoordinateError::UnsupportedProjection(proj_code.to_string()))?;
     let proj = Projection::new(proj_type);
 
-    // CRVAL (degrees -> radians)
+    let lon_scale = celestial_unit_scale_to_rad(h, a1)?;
+    let lat_scale = celestial_unit_scale_to_rad(h, a2)?;
+
+    // CRVAL (FITS celestial units -> radians; default is degrees)
     let crval_lon = h
         .get_float(&format!("CRVAL{a1}"))
         .ok_or_else(|| CoordinateError::InvalidRecord(format!("missing CRVAL{a1}")))?
-        * DEG_TO_RAD;
+        * lon_scale;
     let crval_lat = h
         .get_float(&format!("CRVAL{a2}"))
         .ok_or_else(|| CoordinateError::InvalidRecord(format!("missing CRVAL{a2}")))?
-        * DEG_TO_RAD;
+        * lat_scale;
 
     // CRPIX (1-based -> 0-based)
     let crpix_lon = h.get_float(&format!("CRPIX{a1}")).unwrap_or(1.0) - 1.0;
     let crpix_lat = h.get_float(&format!("CRPIX{a2}")).unwrap_or(1.0) - 1.0;
 
-    // CDELT (degrees -> radians) — check for CD matrix first
-    let (cdelt_lon, cdelt_lat, pc) = read_linear_transform_2d(h, a1, a2)?;
+    // CDELT/CD (FITS celestial units -> radians) with PC/CD/CROTA2 support.
+    let (cdelt_lon, cdelt_lat, pc) = read_linear_transform_2d(h, a1, a2, lon_scale, lat_scale)?;
 
     // Direction reference from RADESYS
     let dir_ref = if let Some(radesys) = h.get_string("RADESYS") {
@@ -584,6 +587,8 @@ fn read_linear_transform_2d(
     h: &FitsHeader,
     a1: usize,
     a2: usize,
+    lon_scale: f64,
+    lat_scale: f64,
 ) -> Result<(f64, f64, ndarray::Array2<f64>), CoordinateError> {
     // Check for CD matrix first
     let cd11 = h.get_float(&format!("CD{a1}_{a1}"));
@@ -618,8 +623,7 @@ fn read_linear_transform_2d(
         )
         .unwrap();
 
-        // Convert degrees to radians
-        Ok((cdelt1 * DEG_TO_RAD, cdelt2 * DEG_TO_RAD, pc))
+        Ok((cdelt1 * lon_scale, cdelt2 * lat_scale, pc))
     } else {
         // PC matrix or CROTA2
         let cdelt1 = h
@@ -645,8 +649,22 @@ fn read_linear_transform_2d(
             ndarray::Array2::eye(2)
         };
 
-        // Convert degrees to radians
-        Ok((cdelt1 * DEG_TO_RAD, cdelt2 * DEG_TO_RAD, pc))
+        Ok((cdelt1 * lon_scale, cdelt2 * lat_scale, pc))
+    }
+}
+
+fn celestial_unit_scale_to_rad(h: &FitsHeader, axis: usize) -> Result<f64, CoordinateError> {
+    let unit = h
+        .get_string(&format!("CUNIT{axis}"))
+        .unwrap_or("deg")
+        .trim()
+        .to_ascii_lowercase();
+    match unit.as_str() {
+        "" | "deg" | "degree" | "degrees" => Ok(DEG_TO_RAD),
+        "rad" | "radian" | "radians" => Ok(1.0),
+        other => Err(CoordinateError::InvalidRecord(format!(
+            "unsupported celestial CUNIT{axis}={other:?}; expected deg or rad"
+        ))),
     }
 }
 
@@ -1047,6 +1065,34 @@ mod tests {
             world1[1],
             world2[1]
         );
+    }
+
+    #[test]
+    fn parses_direction_units_in_radians() {
+        let cards = [
+            "NAXIS   =                    2",
+            "NAXIS1  =                   32",
+            "NAXIS2  =                   32",
+            "CTYPE1  = 'RA---SIN'",
+            "CRVAL1  =   1.230000000000000E+00",
+            "CRPIX1  =   1.700000000000000E+01",
+            "CDELT1  =  -1.000000000000000E-06",
+            "CUNIT1  = 'rad     '",
+            "CTYPE2  = 'DEC--SIN'",
+            "CRVAL2  =  -4.500000000000000E-01",
+            "CRPIX2  =   1.700000000000000E+01",
+            "CDELT2  =   1.000000000000000E-06",
+            "CUNIT2  = 'rad     '",
+        ];
+
+        let header = FitsHeader::from_cards(&cards);
+        let cs = from_fits_header(&header, &[32, 32]).unwrap();
+        let dir = cs.coordinate(cs.find_coordinate(CoordinateType::Direction).unwrap());
+
+        assert!((dir.reference_value()[0] - 1.23).abs() < 1e-12);
+        assert!((dir.reference_value()[1] + 0.45).abs() < 1e-12);
+        assert!((dir.increment()[0] + 1e-6).abs() < 1e-18);
+        assert!((dir.increment()[1] - 1e-6).abs() < 1e-18);
     }
 
     #[test]

--- a/crates/casa-imaging/src/cube.rs
+++ b/crates/casa-imaging/src/cube.rs
@@ -794,6 +794,7 @@ fn run_clean_cube(request: &CubeImagingRequest) -> Result<CubeImagingResult, Ima
                                 &psf_state.psf,
                                 &scales,
                                 plane_request.small_scale_bias,
+                                plane_request.clean_mask.as_ref(),
                             )
                         });
                     let initial_peak =
@@ -1143,6 +1144,7 @@ fn run_clean_cube(request: &CubeImagingRequest) -> Result<CubeImagingResult, Ima
                     &plane.psf_state.psf,
                     &scales,
                     plane.request.small_scale_bias,
+                    plane.request.clean_mask.as_ref(),
                 ));
             }
             if plane.request.deconvolver == Deconvolver::Clark {

--- a/crates/casa-imaging/src/gridder.rs
+++ b/crates/casa-imaging/src/gridder.rs
@@ -59,7 +59,7 @@ pub(crate) struct StandardGridder {
 
 impl StandardGridder {
     pub(crate) fn new(geometry: ImageGeometry) -> Result<Self, ImagingError> {
-        Self::new_with_padding(geometry, padded_len)
+        Self::new_with_padding(geometry, casa_composite_padded_len)
     }
 
     pub(crate) fn new_unpadded(geometry: ImageGeometry) -> Result<Self, ImagingError> {
@@ -2282,6 +2282,16 @@ mod tests {
                 cpp_value.im
             );
         }
+    }
+
+    #[test]
+    fn standard_gridder_uses_casa_composite_grid_padding() {
+        let geometry = ImageGeometry {
+            image_shape: [512, 512],
+            cell_size_rad: [0.08 / 206_264.806_247, 0.08 / 206_264.806_247],
+        };
+        let gridder = StandardGridder::new(geometry).unwrap();
+        assert_eq!(gridder.grid_shape(), [640, 640]);
     }
 
     #[test]

--- a/crates/casa-imaging/src/lib.rs
+++ b/crates/casa-imaging/src/lib.rs
@@ -2087,10 +2087,10 @@ fn airy_voltage_pattern(
     {
         return 0.0;
     }
-    let radius_arcmin_ghz = radius_rad.to_degrees() * 60.0 * (frequency_hz / 1.0e9);
-    let support_arcsec_at_100ghz =
-        airy_max_radius_arcsec_at_100ghz(dish_diameter_m, blockage_diameter_m);
-    let maximum_radius_arcmin_ghz = support_arcsec_at_100ghz / 60.0 * 100.0;
+    // CASA PBMath1D stores per-pixel radius terms as Float before looking up
+    // the tabulated voltage pattern.
+    let radius_arcmin_ghz = (radius_rad.to_degrees() * 60.0 * (frequency_hz / 1.0e9)) as f32 as f64;
+    let maximum_radius_arcmin_ghz = casa_airy_max_radius_arcmin_ghz();
     if radius_arcmin_ghz > maximum_radius_arcmin_ghz {
         return 0.0;
     }
@@ -2128,11 +2128,12 @@ fn primary_beam_max_radius_arcsec_at_100ghz(primary_beam_model: PrimaryBeamModel
 }
 
 fn airy_max_radius_arcsec_at_100ghz(dish_diameter_m: f64, blockage_diameter_m: f64) -> f64 {
-    if dish_diameter_m <= 7.0 && blockage_diameter_m > 0.0 {
-        300.0
-    } else {
-        150.0
-    }
+    let _ = (dish_diameter_m, blockage_diameter_m);
+    casa_airy_max_radius_arcmin_ghz() * 60.0 / 100.0
+}
+
+fn casa_airy_max_radius_arcmin_ghz() -> f64 {
+    1.784 * 60.0
 }
 
 fn evla_common_voltage_pattern(radius_rad: f64, frequency_hz: f64) -> f32 {
@@ -6542,16 +6543,17 @@ mod tests {
     }
 
     #[test]
-    fn alma_aca_airy_voltage_uses_wide_casa_support() {
-        let radius_between_12m_and_7m_support = (220.0_f64 / 3600.0).to_radians();
+    fn alma_aca_airy_voltage_uses_casa_common_pb_radius() {
+        let inside_casa_support = (60.0_f64 / 3600.0).to_radians();
+        let outside_casa_support = (70.0_f64 / 3600.0).to_radians();
 
-        assert_eq!(
+        assert_ne!(
             super::primary_beam_voltage_pattern(
                 PrimaryBeamModel::Airy {
                     dish_diameter_m: 10.7,
                     blockage_diameter_m: 0.75,
                 },
-                radius_between_12m_and_7m_support,
+                inside_casa_support,
                 100.0e9,
             ),
             0.0
@@ -6562,7 +6564,29 @@ mod tests {
                     dish_diameter_m: 6.25,
                     blockage_diameter_m: 0.75,
                 },
-                radius_between_12m_and_7m_support,
+                inside_casa_support,
+                100.0e9,
+            ),
+            0.0
+        );
+        assert_eq!(
+            super::primary_beam_voltage_pattern(
+                PrimaryBeamModel::Airy {
+                    dish_diameter_m: 10.7,
+                    blockage_diameter_m: 0.75,
+                },
+                outside_casa_support,
+                100.0e9,
+            ),
+            0.0
+        );
+        assert_eq!(
+            super::primary_beam_voltage_pattern(
+                PrimaryBeamModel::Airy {
+                    dish_diameter_m: 6.25,
+                    blockage_diameter_m: 0.75,
+                },
+                outside_casa_support,
                 100.0e9,
             ),
             0.0

--- a/crates/casa-imaging/src/lib.rs
+++ b/crates/casa-imaging/src/lib.rs
@@ -2379,7 +2379,13 @@ fn run_mosaic_image_domain_controller(
     }
     let mut multiscale_state = (request.deconvolver == Deconvolver::Multiscale).then(|| {
         let scales = effective_multiscale_scales(request);
-        build_multiscale_state(&residual, &psf_state.psf, &scales, request.small_scale_bias)
+        build_multiscale_state(
+            &residual,
+            &psf_state.psf,
+            &scales,
+            request.small_scale_bias,
+            request.clean_mask.as_ref(),
+        )
     });
     let clark_psf_patch = (request.deconvolver == Deconvolver::Clark).then(|| {
         build_clark_psf_patch(
@@ -2955,7 +2961,7 @@ fn run_multiscale_minor_cycle(
     nsigma_threshold_jy_per_beam: f32,
     stage_timings: &mut ImagingStageTimings,
 ) -> HogbomMinorCycleOutcome {
-    let Some(_cycle_candidate) =
+    let Some(cycle_candidate) =
         select_multiscale_candidate(multiscale_state, request.clean_mask.as_ref())
     else {
         return HogbomMinorCycleOutcome {
@@ -2971,7 +2977,7 @@ fn run_multiscale_minor_cycle(
         &multiscale_state.dirty_conv_scales[0],
         request.clean_mask.as_ref(),
     );
-    let initial_cycle_peak = cycle_peak;
+    let initial_cycle_component = cycle_candidate.strength.abs();
     if let Some(reason) = minor_cycle_stop_reason(
         cycle_peak,
         request.clean.threshold_jy_per_beam,
@@ -3000,12 +3006,9 @@ fn run_multiscale_minor_cycle(
             stop_reason = Some(CleanStopReason::NoCleanablePixels);
             break;
         };
-        let peak_abs = peak_abs_value_masked(
-            &multiscale_state.dirty_conv_scales[0],
-            request.clean_mask.as_ref(),
-        );
+        let component_abs = candidate.strength.abs();
         if let Some(reason) = minor_cycle_stop_reason(
-            peak_abs,
+            component_abs,
             request.clean.threshold_jy_per_beam,
             cycle_threshold_jy_per_beam,
             nsigma_threshold_jy_per_beam,
@@ -3013,7 +3016,7 @@ fn run_multiscale_minor_cycle(
             stop_reason = Some(reason);
             break;
         }
-        if cycle_component_updates > 0 && peak_abs > initial_cycle_peak * 1.5 {
+        if cycle_component_updates > 0 && component_abs > initial_cycle_component * 1.5 {
             stop_reason = Some(CleanStopReason::DivergenceDetected);
             break;
         }
@@ -3076,6 +3079,7 @@ struct MultiscaleState {
     psf_conv_scales: Vec<Vec<Array2<f32>>>,
     peak_psf_conv_scales: Vec<f32>,
     scale_bias: Vec<f32>,
+    scale_masks: Option<Vec<Array2<bool>>>,
 }
 
 fn refresh_multiscale_dirty_conv_scales(state: &mut MultiscaleState, residual: &Array2<f32>) {
@@ -3256,8 +3260,13 @@ fn run_multiscale_cotton_schwab(
     warnings: &mut Vec<String>,
 ) -> Result<CottonSchwabState, ImagingError> {
     let scales = effective_multiscale_scales(request);
-    let mut multiscale_state =
-        build_multiscale_state(&residual, &psf_state.psf, &scales, request.small_scale_bias);
+    let mut multiscale_state = build_multiscale_state(
+        &residual,
+        &psf_state.psf,
+        &scales,
+        request.small_scale_bias,
+        request.clean_mask.as_ref(),
+    );
     let mut minor_iterations = 0usize;
     let mut reported_minor_iterations = 0usize;
     let mut major_cycles = 0usize;
@@ -3287,7 +3296,6 @@ fn run_multiscale_cotton_schwab(
             &multiscale_state.dirty_conv_scales[0],
             request.clean_mask.as_ref(),
         );
-        let initial_cycle_peak = cycle_peak;
         let cycle_nsigma_threshold_jy_per_beam =
             nsigma_threshold_jy_per_beam(&residual, request.clean_mask.as_ref(), request.clean);
         if let Some(stop_reason) = tolerant_clean_stop_reason(
@@ -3309,8 +3317,10 @@ fn run_multiscale_cotton_schwab(
                 cycle_candidate.position.1,
             ]),
         };
+        let initial_cycle_component = cycle_candidate.strength.abs();
         let mut cycle_component_updates = 0usize;
         let mut updated_model = false;
+        let mut cycle_stop_reason = None::<CleanStopReason>;
         final_cycle_threshold_jy_per_beam =
             compute_cycle_threshold(cycle_peak, max_psf_sidelobe_level, request.clean);
         let minor_started = Instant::now();
@@ -3318,24 +3328,21 @@ fn run_multiscale_cotton_schwab(
             let Some(candidate) =
                 select_multiscale_candidate(&multiscale_state, request.clean_mask.as_ref())
             else {
-                clean_stop_reason = Some(CleanStopReason::NoCleanablePixels);
+                cycle_stop_reason = Some(CleanStopReason::NoCleanablePixels);
                 break;
             };
-            let peak_abs = peak_abs_value_masked(
-                &multiscale_state.dirty_conv_scales[0],
-                request.clean_mask.as_ref(),
-            );
+            let component_abs = candidate.strength.abs();
             if let Some(stop_reason) = minor_cycle_stop_reason(
-                peak_abs,
+                component_abs,
                 request.clean.threshold_jy_per_beam,
                 final_cycle_threshold_jy_per_beam,
                 cycle_nsigma_threshold_jy_per_beam,
             ) {
-                clean_stop_reason = Some(stop_reason);
+                cycle_stop_reason = Some(stop_reason);
                 break;
             }
-            if cycle_component_updates > 0 && peak_abs > initial_cycle_peak * 1.5 {
-                clean_stop_reason = Some(CleanStopReason::DivergenceDetected);
+            if cycle_component_updates > 0 && component_abs > initial_cycle_component * 1.5 {
+                cycle_stop_reason = Some(CleanStopReason::DivergenceDetected);
                 break;
             }
 
@@ -3362,7 +3369,7 @@ fn run_multiscale_cotton_schwab(
         let reported_updates = casa_multiscale_reported_updates(
             cycle_component_updates,
             cycle_reported_niter,
-            clean_stop_reason,
+            cycle_stop_reason,
             updated_model,
         );
         minor_cycle_traces.push(make_minor_cycle_trace(
@@ -3372,7 +3379,7 @@ fn run_multiscale_cotton_schwab(
                 updated_model,
                 actual_updates: cycle_component_updates,
                 reported_updates,
-                stop_reason: clean_stop_reason,
+                stop_reason: cycle_stop_reason,
                 final_cycle_threshold_jy_per_beam,
                 final_nsigma_threshold_jy_per_beam: cycle_nsigma_threshold_jy_per_beam,
             },
@@ -3383,6 +3390,7 @@ fn run_multiscale_cotton_schwab(
         ));
         reported_minor_iterations += reported_updates;
         if !updated_model {
+            clean_stop_reason = cycle_stop_reason;
             break;
         }
         residual = multiscale_state.dirty_conv_scales[0].clone();
@@ -3408,8 +3416,13 @@ fn run_multiscale_cotton_schwab(
             stage_timings,
         )?;
         stage_timings.major_cycle_refresh += refresh_started.elapsed();
-        multiscale_state =
-            build_multiscale_state(&residual, &psf_state.psf, &scales, request.small_scale_bias);
+        multiscale_state = build_multiscale_state(
+            &residual,
+            &psf_state.psf,
+            &scales,
+            request.small_scale_bias,
+            request.clean_mask.as_ref(),
+        );
         major_cycles += 1;
         residual_needs_refresh = false;
         let refreshed_peak = peak_abs_value_masked(&residual, request.clean_mask.as_ref());
@@ -3471,6 +3484,7 @@ fn build_multiscale_state(
     psf: &Array2<f32>,
     scales: &[f32],
     small_scale_bias: f32,
+    mask: Option<&Array2<bool>>,
 ) -> MultiscaleState {
     let scale_images = scales
         .iter()
@@ -3504,6 +3518,8 @@ fn build_multiscale_state(
     } else {
         vec![1.0; scales.len()]
     };
+    let scale_masks =
+        mask.map(|clean_mask| build_multiscale_scale_masks(clean_mask, &scale_images, scales));
 
     MultiscaleState {
         scales: scale_images,
@@ -3511,6 +3527,41 @@ fn build_multiscale_state(
         psf_conv_scales,
         peak_psf_conv_scales,
         scale_bias,
+        scale_masks,
+    }
+}
+
+fn build_multiscale_scale_masks(
+    mask: &Array2<bool>,
+    scale_images: &[Array2<f32>],
+    scale_sizes: &[f32],
+) -> Vec<Array2<bool>> {
+    let mask_values = mask.mapv(|cleanable| if cleanable { 1.0 } else { 0.0 });
+    scale_images
+        .iter()
+        .zip(scale_sizes.iter().copied())
+        .map(|(scale_image, scale_size)| {
+            let convolved = fft_convolve_real(&mask_values, scale_image);
+            let mut scale_mask = convolved.mapv(|value| value > 0.9);
+            apply_casa_multiscale_edge_mask(&mut scale_mask, scale_size);
+            scale_mask
+        })
+        .collect()
+}
+
+fn apply_casa_multiscale_edge_mask(mask: &mut Array2<bool>, scale_size: f32) {
+    let (nx, ny) = mask.dim();
+    let border = (scale_size * 1.5) as usize;
+    for x in 0..nx {
+        for y in 0..ny {
+            if x <= border
+                || y <= border
+                || x >= nx.saturating_sub(border + 1)
+                || y >= ny.saturating_sub(border + 1)
+            {
+                mask[(x, y)] = false;
+            }
+        }
     }
 }
 
@@ -3520,8 +3571,13 @@ fn select_multiscale_candidate(
 ) -> Option<MultiscaleCandidate> {
     let mut best = None::<(MultiscaleCandidate, f32)>;
     for scale_index in 0..state.dirty_conv_scales.len() {
+        let search_mask = state
+            .scale_masks
+            .as_ref()
+            .map(|scale_masks| &scale_masks[scale_index])
+            .or(mask);
         let Some((position, value)) =
-            peak_location_masked(&state.dirty_conv_scales[scale_index], mask)
+            peak_location_masked(&state.dirty_conv_scales[scale_index], search_mask)
         else {
             continue;
         };
@@ -4546,6 +4602,7 @@ fn run_mtmfs_multiscale_minor_cycle(
         &psf_terms[0],
         &scales,
         request.small_scale_bias,
+        request.clean_mask.as_ref(),
     );
     let Some(first_candidate) =
         select_multiscale_candidate(&multiscale_state, request.clean_mask.as_ref())
@@ -6450,7 +6507,7 @@ mod tests {
         PsfState, RestoringBeamMode, StandardGridder, StandardMfsModelPredictor, VisibilityBatch,
         VisibilityMetadataBatch, WProjectSkipReason, WTermMode, WeightDensityMode, WeightingMode,
         add_shifted_kernel, apply_chauvenet_clipping, apply_weighting, build_direct_components,
-        build_direct_pixel_coordinates, compute_cycle_threshold,
+        build_direct_pixel_coordinates, build_multiscale_scale_masks, compute_cycle_threshold,
         compute_dirty_psf_and_residual_standard, compute_psf, compute_psf_direct, compute_residual,
         compute_residual_direct, direct_predict_visibility, dirty_clean_config,
         make_multiscale_kernel, mean_stddev, minor_cycle_stop_reason,
@@ -9095,6 +9152,27 @@ mod tests {
             .filter(|value| value.abs() > 0.0)
             .count();
         assert_eq!(nonzero, 1);
+    }
+
+    #[test]
+    fn multiscale_clean_mask_uses_casa_scale_dependent_edges() {
+        let shape = (32, 32);
+        let mask = Array2::<bool>::from_elem(shape, true);
+        let scales = vec![0.0, 8.0];
+        let scale_images = scales
+            .iter()
+            .copied()
+            .map(|scale| make_multiscale_kernel(shape, scale))
+            .collect::<Vec<_>>();
+
+        let scale_masks = build_multiscale_scale_masks(&mask, &scale_images, &scales);
+
+        assert!(!scale_masks[0][(0, 16)]);
+        assert!(scale_masks[0][(1, 16)]);
+        assert!(!scale_masks[1][(12, 16)]);
+        assert!(scale_masks[1][(13, 16)]);
+        assert!(scale_masks[1][(18, 16)]);
+        assert!(!scale_masks[1][(19, 16)]);
     }
 
     #[test]

--- a/crates/casa-ms/Cargo.toml
+++ b/crates/casa-ms/Cargo.toml
@@ -21,6 +21,7 @@ casa-provider-contracts = { path = "../casa-provider-contracts" }
 casa-tables = { path = "../casa-tables" }
 casa-types = { path = "../casa-types" }
 image = { version = "0.25", default-features = false, features = ["png"] }
+libm = "0.2"
 nalgebra.workspace = true
 ndarray.workspace = true
 num-complex.workspace = true

--- a/crates/casa-ms/src/flagging.rs
+++ b/crates/casa-ms/src/flagging.rs
@@ -36,6 +36,7 @@ const FLAG_COLUMN: &str = "FLAG";
 const FLAG_ROW_COLUMN: &str = "FLAG_ROW";
 const FLAG_VERSION_LIST: &str = "FLAG_VERSION_LIST";
 const CLIP_SCAN_CHUNK_ROWS: usize = 4096;
+const CASA_SIMOBSERVE_SHADOW_FRACTION_LIMIT: f64 = 1.0e-6;
 type FlagSampleKey = (usize, usize, usize);
 type FlagSampleSet = HashSet<FlagSampleKey>;
 
@@ -51,18 +52,58 @@ where
         if antenna1 == antenna2 || antenna1 >= antenna_count || antenna2 >= antenna_count {
             continue;
         }
-        let diameter_sum = diameter1_m + diameter2_m;
-        let threshold_squared = diameter_sum * diameter_sum / 4.0;
-        let projected_distance_squared = uvw_m[0] * uvw_m[0] + uvw_m[1] * uvw_m[1];
-        if projected_distance_squared < threshold_squared {
-            if uvw_m[2] > 0.0 {
-                shadowed[antenna1] = true;
-            } else {
-                shadowed[antenna2] = true;
-            }
+        let (fraction1, fraction2) =
+            casa_projected_blockage_fractions(uvw_m, diameter1_m, diameter2_m);
+        if fraction1 > CASA_SIMOBSERVE_SHADOW_FRACTION_LIMIT {
+            shadowed[antenna1] = true;
+        }
+        if fraction2 > CASA_SIMOBSERVE_SHADOW_FRACTION_LIMIT {
+            shadowed[antenna2] = true;
         }
     }
     shadowed
+}
+
+fn casa_projected_blockage_fractions(
+    uvw_m: [f64; 3],
+    diameter1_m: f64,
+    diameter2_m: f64,
+) -> (f64, f64) {
+    let separation = (uvw_m[0] * uvw_m[0] + uvw_m[1] * uvw_m[1]).sqrt();
+    let diameter1 = diameter1_m.abs();
+    let diameter2 = diameter2_m.abs();
+    let rmin = 0.5 * diameter1.min(diameter2);
+    let rmax = 0.5 * diameter1.max(diameter2);
+    let (mut fraction1, mut fraction2) = if separation >= rmin + rmax {
+        (0.0, 0.0)
+    } else if separation + rmin <= rmax {
+        (
+            1.0_f64.min((diameter2 / diameter1).powi(2)),
+            1.0_f64.min((diameter1 / diameter2).powi(2)),
+        )
+    } else {
+        let c = separation / (0.5 * diameter1);
+        let s = diameter2 / diameter1;
+        let sinb = (2.0 * ((c * s).powi(2) + c.powi(2) + s.powi(2)) - c.powi(4) - s.powi(4) - 1.0)
+            .sqrt()
+            / (2.0 * c);
+        let sinb = sinb.min(1.0);
+        let sina = (sinb / s).min(1.0);
+        let b = sinb.asin();
+        let a = sina.asin();
+        let area = (s.powi(2) * a + b) - (s.powi(2) * sina * a.cos() + sinb * b.cos());
+        let fraction1 = area / std::f64::consts::PI;
+        let fraction2 = fraction1 / s.powi(2);
+        (fraction1, fraction2)
+    };
+
+    if uvw_m[2] > 0.0 {
+        fraction2 = 0.0;
+    }
+    if uvw_m[2] < 0.0 {
+        fraction1 = 0.0;
+    }
+    (fraction1, fraction2)
 }
 
 /// Input visibility column used by automatic flagging modes.
@@ -3057,6 +3098,20 @@ mod tests {
         );
 
         assert_eq!(shadowed, vec![true, false, true]);
+    }
+
+    #[test]
+    fn shadowed_antennas_respect_casa_fractional_blockage_limit() {
+        let (fraction1, fraction2) =
+            casa_projected_blockage_fractions([24.999, 0.0, 1.0], 25.0, 25.0);
+        assert!(fraction1 > 0.0);
+        assert!(fraction1 < CASA_SIMOBSERVE_SHADOW_FRACTION_LIMIT);
+        assert_eq!(fraction2, 0.0);
+
+        let shadowed =
+            shadowed_antennas_from_projected_baselines(2, [(0, 1, [24.999, 0.0, 1.0], 25.0, 25.0)]);
+
+        assert_eq!(shadowed, vec![false, false]);
     }
 
     #[test]

--- a/crates/casa-ms/src/flagging.rs
+++ b/crates/casa-ms/src/flagging.rs
@@ -39,6 +39,32 @@ const CLIP_SCAN_CHUNK_ROWS: usize = 4096;
 type FlagSampleKey = (usize, usize, usize);
 type FlagSampleSet = HashSet<FlagSampleKey>;
 
+pub(crate) fn shadowed_antennas_from_projected_baselines<I>(
+    antenna_count: usize,
+    baselines: I,
+) -> Vec<bool>
+where
+    I: IntoIterator<Item = (usize, usize, [f64; 3], f64, f64)>,
+{
+    let mut shadowed = vec![false; antenna_count];
+    for (antenna1, antenna2, uvw_m, diameter1_m, diameter2_m) in baselines {
+        if antenna1 == antenna2 || antenna1 >= antenna_count || antenna2 >= antenna_count {
+            continue;
+        }
+        let diameter_sum = diameter1_m + diameter2_m;
+        let threshold_squared = diameter_sum * diameter_sum / 4.0;
+        let projected_distance_squared = uvw_m[0] * uvw_m[0] + uvw_m[1] * uvw_m[1];
+        if projected_distance_squared < threshold_squared {
+            if uvw_m[2] > 0.0 {
+                shadowed[antenna1] = true;
+            } else {
+                shadowed[antenna2] = true;
+            }
+        }
+    }
+    shadowed
+}
+
 /// Input visibility column used by automatic flagging modes.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -3017,6 +3043,20 @@ mod tests {
             ant1: 0,
             ant2: 1,
         }
+    }
+
+    #[test]
+    fn shadowed_antennas_follow_casa_projected_baseline_rule() {
+        let shadowed = shadowed_antennas_from_projected_baselines(
+            3,
+            [
+                (0, 1, [10.0, 0.0, 1.0], 25.0, 25.0),
+                (0, 2, [100.0, 0.0, -1.0], 25.0, 25.0),
+                (1, 2, [10.0, 0.0, -1.0], 25.0, 25.0),
+            ],
+        );
+
+        assert_eq!(shadowed, vec![true, false, true]);
     }
 
     #[test]

--- a/crates/casa-ms/src/lib.rs
+++ b/crates/casa-ms/src/lib.rs
@@ -123,7 +123,7 @@ pub use selection_syntax::{
 };
 pub use simulation::{
     SyntheticAntenna, SyntheticBandpassCorruption, SyntheticBandpassMode,
-    SyntheticCorruptionConfig, SyntheticGainCorruption, SyntheticGainMode,
+    SyntheticCorruptionConfig, SyntheticField, SyntheticGainCorruption, SyntheticGainMode,
     SyntheticNoiseCorruption, SyntheticNoiseMode, SyntheticObservationReport,
     SyntheticObservationRequest, SyntheticPointingCorruption,
     SyntheticPolarizationLeakageCorruption, SyntheticPolarizationLeakageMode,

--- a/crates/casa-ms/src/ms.rs
+++ b/crates/casa-ms/src/ms.rs
@@ -174,6 +174,32 @@ impl MeasurementSet {
         Ok(())
     }
 
+    pub(crate) fn save_assuming_valid_with_main_column_overrides(
+        &mut self,
+        column_overrides: &HashMap<String, Vec<Option<Value>>>,
+    ) -> MsResult<()> {
+        let path = self
+            .path
+            .as_ref()
+            .ok_or_else(|| MsError::VersionError("MS has no path; use save_as()".to_string()))?
+            .clone();
+
+        self.refresh_subtable_paths(&path);
+        self.sync_main_metadata(&path);
+        save_main_table_with_policy_and_column_overrides(&self.main, &path, column_overrides)?;
+
+        for (id, table) in &self.subtables {
+            let subtable_path = self
+                .subtable_paths
+                .get(id)
+                .cloned()
+                .unwrap_or_else(|| path.join(id.name()));
+            table.save_assuming_valid(measurement_set_table_options(&subtable_path))?;
+        }
+
+        Ok(())
+    }
+
     /// Save only the MS main table back to disk.
     ///
     /// This is intended for workflows that mutate only MAIN columns/keywords
@@ -843,6 +869,28 @@ fn save_main_table_with_policy(main: &Table, path: &Path, assume_valid: bool) ->
     Ok(())
 }
 
+fn save_main_table_with_policy_and_column_overrides(
+    main: &Table,
+    path: &Path,
+    column_overrides: &HashMap<String, Vec<Option<Value>>>,
+) -> MsResult<()> {
+    let options = measurement_set_table_options(path);
+    match measurement_set_save_policy() {
+        MeasurementSetSavePolicy::Standard => {
+            main.save_assuming_valid(options)?;
+        }
+        MeasurementSetSavePolicy::CasaLikeMixed => {
+            let bindings = measurement_set_main_table_bindings(main);
+            main.save_with_bindings_and_column_overrides_assuming_valid(
+                options,
+                &bindings,
+                column_overrides,
+            )?;
+        }
+    }
+    Ok(())
+}
+
 pub(crate) fn measurement_set_main_table_bindings(main: &Table) -> HashMap<String, ColumnBinding> {
     let column_names: HashSet<_> = main
         .schema()
@@ -855,17 +903,30 @@ pub(crate) fn measurement_set_main_table_bindings(main: &Table) -> HashMap<Strin
         })
         .unwrap_or_default();
     let mut bindings = HashMap::new();
-    let mut bind = |name: &str, data_manager: DataManagerKind| {
+    let mut bind = |name: &str, data_manager: DataManagerKind, tile_shape: Option<Vec<usize>>| {
         if column_names.contains(name) {
             bindings.insert(
                 name.to_string(),
                 ColumnBinding {
                     data_manager,
-                    tile_shape: None,
+                    tile_shape,
                 },
             );
         }
     };
+
+    let (num_corr, num_chan) = main_visibility_cell_shape(main).unwrap_or((4, 128));
+    let visibility_tile = casa_visibility_tile_shape(num_corr, num_chan, "");
+    let visibility_tile_shape = Some(visibility_tile.clone());
+    let flag_tile_shape = Some(visibility_tile.clone());
+    let flag_category_tile_shape = Some(vec![
+        visibility_tile[0],
+        visibility_tile[1],
+        1,
+        visibility_tile[2],
+    ]);
+    let weight_tile_shape = Some(casa_weight_tile_shape(&visibility_tile));
+    let uvw_tile_shape = Some(casa_uvw_tile_shape(&visibility_tile));
 
     for name in [
         "ARRAY_ID",
@@ -873,7 +934,6 @@ pub(crate) fn measurement_set_main_table_bindings(main: &Table) -> HashMap<Strin
         "FEED1",
         "FEED2",
         "FIELD_ID",
-        "FLAG_ROW",
         "INTERVAL",
         "OBSERVATION_ID",
         "PROCESSOR_ID",
@@ -882,25 +942,142 @@ pub(crate) fn measurement_set_main_table_bindings(main: &Table) -> HashMap<Strin
         "TIME",
         "TIME_CENTROID",
     ] {
-        bind(name, DataManagerKind::IncrementalStMan);
+        bind(name, DataManagerKind::IncrementalStMan, None);
     }
-    for name in ["ANTENNA1", "ANTENNA2", "DATA_DESC_ID"] {
-        bind(name, DataManagerKind::StandardStMan);
+    for name in ["ANTENNA1", "ANTENNA2", "DATA_DESC_ID", "FLAG_ROW"] {
+        bind(name, DataManagerKind::StandardStMan, None);
     }
-    for name in [
-        "DATA",
-        "MODEL_DATA",
-        "CORRECTED_DATA",
-        "FLAG",
-        "SIGMA",
-        "WEIGHT",
+    for name in ["DATA", "MODEL_DATA", "CORRECTED_DATA"] {
+        bind(
+            name,
+            DataManagerKind::TiledShapeStMan,
+            visibility_tile_shape.clone(),
+        );
+    }
+    bind("FLAG", DataManagerKind::TiledShapeStMan, flag_tile_shape);
+    bind(
         "FLAG_CATEGORY",
-    ] {
-        bind(name, DataManagerKind::TiledShapeStMan);
+        DataManagerKind::TiledShapeStMan,
+        flag_category_tile_shape,
+    );
+    for name in ["SIGMA", "WEIGHT"] {
+        bind(
+            name,
+            DataManagerKind::TiledShapeStMan,
+            weight_tile_shape.clone(),
+        );
     }
-    bind("UVW", DataManagerKind::TiledColumnStMan);
+    bind("UVW", DataManagerKind::TiledColumnStMan, uvw_tile_shape);
 
     bindings
+}
+
+fn main_visibility_cell_shape(main: &Table) -> Option<(usize, usize)> {
+    let row = main.rows().ok()?.first()?;
+    for column in ["DATA", "MODEL_DATA", "CORRECTED_DATA"] {
+        let Some(Value::Array(array)) = row.get(column) else {
+            continue;
+        };
+        let shape = array.shape();
+        if shape.len() >= 2 && shape[0] > 0 && shape[1] > 0 {
+            return Some((shape[0], shape[1]));
+        }
+    }
+    None
+}
+
+pub(crate) fn casa_visibility_tile_shape(
+    num_corr: usize,
+    num_chan: usize,
+    telescope_name: &str,
+) -> Vec<usize> {
+    let corr_tile = num_corr.max(1);
+    let mut chan_tile = num_chan.max(1);
+    let n_ifr = match telescope_name {
+        "ATCA" => 15usize,
+        "VLA" => 351usize,
+        "WSRT" => 91usize,
+        "BIMA" => 36usize,
+        "DRAO" => 21usize,
+        "SMA" => 28usize,
+        _ => 200usize,
+    };
+    let io_block_size = 131_072usize;
+    let mut element_io_block_size = io_block_size;
+    if chan_tile < 100 {
+        chan_tile = (io_block_size / corr_tile / n_ifr).max(1);
+    } else if chan_tile < 10_000 {
+        chan_tile = ((chan_tile as f32 / 99.9).sqrt().floor() as usize).max(1) * 10;
+    } else {
+        chan_tile = 100;
+    }
+    while (io_block_size / corr_tile / chan_tile) > 10 * n_ifr && chan_tile < num_chan {
+        chan_tile += 2;
+    }
+    if (io_block_size / corr_tile / chan_tile) > 10 * n_ifr {
+        element_io_block_size = 10 * n_ifr * corr_tile * chan_tile;
+    }
+    chan_tile = chan_tile.min(num_chan).max(1);
+    let row_tile = (element_io_block_size / corr_tile / chan_tile).max(1);
+    vec![corr_tile, chan_tile, row_tile]
+}
+
+pub(crate) fn casa_weight_tile_shape(visibility_tile_shape: &[usize]) -> Vec<usize> {
+    vec![
+        visibility_tile_shape[0],
+        visibility_tile_shape[1] * visibility_tile_shape[2],
+    ]
+}
+
+pub(crate) fn casa_uvw_tile_shape(visibility_tile_shape: &[usize]) -> Vec<usize> {
+    vec![
+        3,
+        (visibility_tile_shape[0] * visibility_tile_shape[1] * visibility_tile_shape[2] / 3).max(1),
+    ]
+}
+
+pub(crate) fn measurement_set_main_data_manager_sequence(
+    main: &Table,
+    target_column: &str,
+) -> Option<u32> {
+    let schema = main.schema()?;
+    let bindings = measurement_set_main_table_bindings(main);
+    let mut binding_seq_map: HashMap<String, u32> = HashMap::new();
+    let mut next_seq = 1u32;
+
+    for column in schema.columns() {
+        let column_name = column.name();
+        let Some(binding) = bindings.get(column_name) else {
+            if column_name == target_column {
+                return Some(0);
+            }
+            continue;
+        };
+        let group_key = if matches!(
+            binding.data_manager,
+            DataManagerKind::TiledColumnStMan
+                | DataManagerKind::TiledShapeStMan
+                | DataManagerKind::TiledCellStMan
+                | DataManagerKind::TiledDataStMan
+        ) {
+            format!("{:?}:{column_name}", binding.data_manager)
+        } else {
+            format!("{:?}", binding.data_manager)
+        };
+        let seq = if let Some(seq) = binding_seq_map.get(&group_key) {
+            *seq
+        } else {
+            let seq = next_seq;
+            binding_seq_map.insert(group_key, seq);
+            next_seq += 1;
+            seq
+        };
+        if column_name == target_column {
+            return Some(seq);
+        }
+    }
+
+    None
 }
 
 fn merge_measinfo_keywords(existing: Option<&RecordValue>, defaults: &RecordValue) -> RecordValue {

--- a/crates/casa-ms/src/simulation.rs
+++ b/crates/casa-ms/src/simulation.rs
@@ -7,7 +7,8 @@
 //! spectral window and field, sample the requested observing time range, and
 //! write CASA-compatible MS subtables plus uncorrupted visibility rows.
 
-use casa_coordinates::{Coordinate, DirectionCoordinate, Projection, ProjectionType};
+use casa_coordinates::fits::{FitsHeader, from_fits_header};
+use casa_coordinates::{Coordinate, CoordinateSystem, CoordinateType};
 use casa_imaging::{
     ImageGeometry, PrimaryBeamModel, StandardMfsModelPredictor, primary_beam_voltage_pattern,
 };
@@ -16,6 +17,7 @@ use casa_types::measures::epoch::{EpochRef, MEpoch};
 use casa_types::measures::frame::MeasFrame;
 use casa_types::measures::position::MPosition;
 use casa_types::{ArrayValue, RecordField, RecordValue, ScalarValue, Value};
+use libm::j1;
 use ndarray::{Array2, ArrayD};
 use num_complex::Complex32;
 use schemars::JsonSchema;
@@ -23,9 +25,12 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use crate::column_def::{ColumnDef, ColumnKind};
 use crate::error::{MsError, MsResult};
+use crate::flagging::shadowed_antennas_from_projected_baselines;
 use crate::schema::{self, SubtableId};
 use crate::{MeasurementSet, MeasurementSetBuilder, OptionalMainColumn};
 
@@ -508,17 +513,57 @@ pub struct SyntheticObservationReport {
     pub nonzero_visibility_count: usize,
     /// Names of corruption effects applied to `MAIN.DATA`.
     pub applied_corruptions: Vec<String>,
+    /// Wall-clock timing breakdown for the native generator.
+    pub timing: SyntheticObservationTimingReport,
+}
+
+/// Wall-clock timing breakdown for one synthetic observation generation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct SyntheticObservationTimingReport {
+    /// Request validation time.
+    pub validate_millis: u128,
+    /// Existing-output removal and MeasurementSet creation time.
+    pub setup_millis: u128,
+    /// Static metadata subtable write time before MAIN rows.
+    pub metadata_millis: u128,
+    /// FITS model read and predictor preparation time.
+    pub model_prepare_millis: u128,
+    /// MAIN-row generation and writeback timing.
+    pub main_rows: SyntheticMainRowTimingReport,
+    /// MeasurementSet save time.
+    pub save_millis: u128,
+    /// End-to-end generation time inside the native library call.
+    pub total_millis: u128,
+}
+
+/// MAIN table timing breakdown for one synthetic observation generation.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct SyntheticMainRowTimingReport {
+    /// Number of channel prediction workers selected for each time sample.
+    pub channel_prediction_workers: usize,
+    /// Time spent computing UVW coordinates and row identities.
+    pub uvw_and_row_setup_millis: u128,
+    /// Time spent predicting model visibilities across channels.
+    pub prediction_millis: u128,
+    /// Time spent applying deterministic corruption/noise.
+    pub corruption_millis: u128,
+    /// Time spent constructing MAIN rows and appending them to the table.
+    pub main_write_millis: u128,
 }
 
 /// Generate an uncorrupted CASA-compatible synthetic MeasurementSet.
 ///
 /// The current implementation writes structurally complete MS metadata and can
-/// predict uncorrupted visibility samples from a single-plane FITS model image.
+/// predict uncorrupted visibility samples from a FITS model image.
 pub fn generate_synthetic_observation_ms(
     request: &SyntheticObservationRequest,
 ) -> MsResult<SyntheticObservationReport> {
+    let total_started = Instant::now();
+    let validate_started = Instant::now();
     validate_request(request)?;
+    let validate_millis = elapsed_millis(validate_started.elapsed());
 
+    let setup_started = Instant::now();
     if request.output_ms.exists() {
         if request.overwrite {
             fs::remove_dir_all(&request.output_ms).map_err(|error| {
@@ -539,7 +584,9 @@ pub fn generate_synthetic_observation_ms(
         &request.output_ms,
         MeasurementSetBuilder::new().with_main_column(OptionalMainColumn::Data),
     )?;
+    let setup_millis = elapsed_millis(setup_started.elapsed());
 
+    let metadata_started = Instant::now();
     populate_antennas(&mut ms, &request.antennas)?;
     populate_field(&mut ms, request)?;
     populate_pointing(&mut ms, request)?;
@@ -551,22 +598,27 @@ pub fn generate_synthetic_observation_ms(
     populate_feed(&mut ms, request)?;
     populate_observation(&mut ms, request)?;
     populate_history(&mut ms, request)?;
+    let metadata_millis = elapsed_millis(metadata_started.elapsed());
 
     let time_sample_count =
         time_sample_count(request.duration_seconds, request.integration_seconds);
     let baseline_count = request.antennas.len() * (request.antennas.len() - 1) / 2;
+    let model_started = Instant::now();
     let model = if request.predict_model {
         Some(read_fits_model_image(
             &request.model_image,
             request.model_peak_jy_per_pixel,
+            request.spectral_setup.channel_count,
         )?)
     } else {
         None
     };
-    let nonzero_visibility_count =
-        populate_main_rows(&mut ms, request, time_sample_count, model.as_ref())?;
+    let model_prepare_millis = elapsed_millis(model_started.elapsed());
+    let main_rows = populate_main_rows(&mut ms, request, time_sample_count, model.as_ref())?;
 
-    ms.save()?;
+    let save_started = Instant::now();
+    ms.save_assuming_valid()?;
+    let save_millis = elapsed_millis(save_started.elapsed());
 
     Ok(SyntheticObservationReport {
         output_ms: request.output_ms.clone(),
@@ -576,8 +628,17 @@ pub fn generate_synthetic_observation_ms(
         time_sample_count,
         main_row_count: baseline_count * time_sample_count,
         channel_count: request.spectral_setup.channel_count,
-        nonzero_visibility_count,
+        nonzero_visibility_count: main_rows.nonzero_visibility_count,
         applied_corruptions: applied_corruption_names(request.corruption.as_ref()),
+        timing: SyntheticObservationTimingReport {
+            validate_millis,
+            setup_millis,
+            metadata_millis,
+            model_prepare_millis,
+            main_rows: main_rows.timing,
+            save_millis,
+            total_millis: elapsed_millis(total_started.elapsed()),
+        },
     })
 }
 
@@ -1091,15 +1152,13 @@ fn populate_main_rows(
     request: &SyntheticObservationRequest,
     samples: usize,
     model: Option<&FitsModelImage>,
-) -> MsResult<usize> {
+) -> MsResult<MainRowsReport> {
     let num_corr = 2usize;
     let num_chan = request.spectral_setup.channel_count;
+    let channel_prediction_workers = simobserve_channel_worker_count(num_chan);
     let template = MainRowTemplate {
         flag: bool_array(&vec![false; num_corr * num_chan], vec![num_corr, num_chan]),
-        flag_category: bool_array(
-            &vec![false; num_corr * num_chan],
-            vec![1, num_corr, num_chan],
-        ),
+        flag_category: bool_array(&[], vec![0, num_corr, num_chan]),
         weight: f32_array(&vec![1.0; num_corr], vec![num_corr]),
         sigma: f32_array(&vec![1.0; num_corr], vec![num_corr]),
     };
@@ -1114,14 +1173,20 @@ fn populate_main_rows(
         )
     });
     let mut nonzero_visibility_count = 0usize;
+    let mut timing = MainRowTimingDurations {
+        channel_prediction_workers,
+        ..MainRowTimingDurations::default()
+    };
 
     for sample in 0..samples {
+        let uvw_started = Instant::now();
         let field_id = sample % field_plans.len();
         let field_plan = &field_plans[field_id];
         let time =
             request.start_time_mjd_seconds + (sample as f64 + 0.5) * request.integration_seconds;
         let antenna_uvws =
             antenna_uvw_positions(&request.antennas, field_plan.phase_center_rad, time)?;
+        let mut row_specs = Vec::with_capacity(request.antennas.len() * request.antennas.len());
         for antenna1 in 0..request.antennas.len() {
             for antenna2 in (antenna1 + 1)..request.antennas.len() {
                 let uvw = [
@@ -1129,52 +1194,196 @@ fn populate_main_rows(
                     antenna_uvws[antenna2][1] - antenna_uvws[antenna1][1],
                     antenna_uvws[antenna2][2] - antenna_uvws[antenna1][2],
                 ];
-                let mut data_values = predicted_data_values(
-                    field_plan.predictors.as_ref(),
-                    &request.spectral_setup,
+                row_specs.push(MainRowVisibilitySpec {
+                    antenna1,
+                    antenna2,
+                    field_id,
+                    time,
                     uvw,
-                    num_corr,
-                );
-                if let Some(corruption) = corruption.as_ref() {
-                    corruption.apply(&mut data_values, antenna1, antenna2, num_chan, sample);
-                }
-                nonzero_visibility_count += data_values
-                    .iter()
-                    .filter(|value| value.re != 0.0 || value.im != 0.0)
-                    .count();
-                let data = complex_array(&data_values, vec![num_corr, num_chan]);
-                let row = row_from_defs(
-                    &main_defs,
-                    &[
-                        ("ANTENNA1", i(antenna1 as i32)),
-                        ("ANTENNA2", i(antenna2 as i32)),
-                        ("ARRAY_ID", i(0)),
-                        ("DATA_DESC_ID", i(0)),
-                        ("EXPOSURE", f(request.integration_seconds)),
-                        ("FEED1", i(0)),
-                        ("FEED2", i(0)),
-                        ("FIELD_ID", i(field_id as i32)),
-                        ("FLAG", template.flag.clone()),
-                        ("FLAG_CATEGORY", template.flag_category.clone()),
-                        ("FLAG_ROW", b(false)),
-                        ("INTERVAL", f(request.integration_seconds)),
-                        ("OBSERVATION_ID", i(0)),
-                        ("PROCESSOR_ID", i(0)),
-                        ("SCAN_NUMBER", i(1)),
-                        ("SIGMA", template.sigma.clone()),
-                        ("STATE_ID", i(0)),
-                        ("TIME", f(time)),
-                        ("TIME_CENTROID", f(time)),
-                        ("UVW", f64_array(&uvw, vec![3])),
-                        ("WEIGHT", template.weight.clone()),
-                        ("DATA", data),
-                    ],
-                );
-                ms.main_table_mut().add_row(row)?;
+                });
             }
         }
+        let row_uvws = row_specs.iter().map(|spec| spec.uvw).collect::<Vec<_>>();
+        let shadowed_antennas = shadowed_antennas_for_rows(&row_specs, &request.antennas);
+        timing.uvw_and_row_setup += uvw_started.elapsed();
+
+        let prediction_started = Instant::now();
+        let mut data_rows = predicted_data_values_for_rows_with_workers(
+            field_plan.predictors.as_deref(),
+            &request.spectral_setup,
+            &row_uvws,
+            num_corr,
+            channel_prediction_workers,
+        );
+        timing.prediction += prediction_started.elapsed();
+        let corruption_started = Instant::now();
+        nonzero_visibility_count += apply_corruption_and_count_rows_with_workers(
+            corruption.as_ref(),
+            &row_specs,
+            &mut data_rows,
+            num_chan,
+            sample,
+        );
+        timing.corruption += corruption_started.elapsed();
+        for (spec, data_values) in row_specs.into_iter().zip(data_rows) {
+            let write_started = Instant::now();
+            let data = complex_array(&data_values, vec![num_corr, num_chan]);
+            let shadowed_row = shadowed_antennas[spec.antenna1] || shadowed_antennas[spec.antenna2];
+            let row = row_from_defs(
+                &main_defs,
+                &[
+                    ("ANTENNA1", i(spec.antenna1 as i32)),
+                    ("ANTENNA2", i(spec.antenna2 as i32)),
+                    ("ARRAY_ID", i(0)),
+                    ("DATA_DESC_ID", i(0)),
+                    ("EXPOSURE", f(request.integration_seconds)),
+                    ("FEED1", i(0)),
+                    ("FEED2", i(0)),
+                    ("FIELD_ID", i(spec.field_id as i32)),
+                    ("FLAG", template.flag.clone()),
+                    ("FLAG_CATEGORY", template.flag_category.clone()),
+                    ("FLAG_ROW", b(shadowed_row)),
+                    ("INTERVAL", f(request.integration_seconds)),
+                    ("OBSERVATION_ID", i(0)),
+                    ("PROCESSOR_ID", i(0)),
+                    ("SCAN_NUMBER", i(1)),
+                    ("SIGMA", template.sigma.clone()),
+                    ("STATE_ID", i(0)),
+                    ("TIME", f(spec.time)),
+                    ("TIME_CENTROID", f(spec.time)),
+                    ("UVW", f64_array(&spec.uvw, vec![3])),
+                    ("WEIGHT", template.weight.clone()),
+                    ("DATA", data),
+                ],
+            );
+            ms.main_table_mut().add_row_assuming_valid(row)?;
+            timing.main_write += write_started.elapsed();
+        }
     }
-    Ok(nonzero_visibility_count)
+    Ok(MainRowsReport {
+        nonzero_visibility_count,
+        timing: timing.into_report(),
+    })
+}
+
+fn shadowed_antennas_for_rows(
+    rows: &[MainRowVisibilitySpec],
+    antennas: &[SyntheticAntenna],
+) -> Vec<bool> {
+    shadowed_antennas_from_projected_baselines(
+        antennas.len(),
+        rows.iter().map(|spec| {
+            (
+                spec.antenna1,
+                spec.antenna2,
+                spec.uvw,
+                antennas[spec.antenna1].dish_diameter_m,
+                antennas[spec.antenna2].dish_diameter_m,
+            )
+        }),
+    )
+}
+
+fn apply_corruption_and_count_rows_with_workers(
+    corruption: Option<&SyntheticCorruptionState>,
+    row_specs: &[MainRowVisibilitySpec],
+    data_rows: &mut [Vec<Complex32>],
+    channel_count: usize,
+    sample_index: usize,
+) -> usize {
+    let worker_count = simobserve_row_worker_count(data_rows.len(), channel_count);
+    if worker_count <= 1 {
+        return apply_corruption_and_count_rows(
+            corruption,
+            row_specs,
+            data_rows,
+            channel_count,
+            sample_index,
+        );
+    }
+
+    let chunk_size = data_rows.len().div_ceil(worker_count);
+    thread::scope(|scope| {
+        let mut handles = Vec::new();
+        for (spec_chunk, data_chunk) in row_specs
+            .chunks(chunk_size)
+            .zip(data_rows.chunks_mut(chunk_size))
+        {
+            handles.push(scope.spawn(move || {
+                apply_corruption_and_count_rows(
+                    corruption,
+                    spec_chunk,
+                    data_chunk,
+                    channel_count,
+                    sample_index,
+                )
+            }));
+        }
+        handles
+            .into_iter()
+            .map(|handle| {
+                handle
+                    .join()
+                    .expect("synthetic observation row worker should not panic")
+            })
+            .sum()
+    })
+}
+
+fn apply_corruption_and_count_rows(
+    corruption: Option<&SyntheticCorruptionState>,
+    row_specs: &[MainRowVisibilitySpec],
+    data_rows: &mut [Vec<Complex32>],
+    channel_count: usize,
+    sample_index: usize,
+) -> usize {
+    let mut nonzero_visibility_count = 0usize;
+    for (spec, data_values) in row_specs.iter().zip(data_rows.iter_mut()) {
+        if let Some(corruption) = corruption {
+            corruption.apply(
+                data_values,
+                spec.antenna1,
+                spec.antenna2,
+                channel_count,
+                sample_index,
+            );
+        }
+        nonzero_visibility_count += count_nonzero_complex(data_values);
+    }
+    nonzero_visibility_count
+}
+
+fn count_nonzero_complex(values: &[Complex32]) -> usize {
+    values
+        .iter()
+        .filter(|value| value.re != 0.0 || value.im != 0.0)
+        .count()
+}
+
+struct MainRowsReport {
+    nonzero_visibility_count: usize,
+    timing: SyntheticMainRowTimingReport,
+}
+
+#[derive(Default)]
+struct MainRowTimingDurations {
+    channel_prediction_workers: usize,
+    uvw_and_row_setup: Duration,
+    prediction: Duration,
+    corruption: Duration,
+    main_write: Duration,
+}
+
+impl MainRowTimingDurations {
+    fn into_report(self) -> SyntheticMainRowTimingReport {
+        SyntheticMainRowTimingReport {
+            channel_prediction_workers: self.channel_prediction_workers,
+            uvw_and_row_setup_millis: elapsed_millis(self.uvw_and_row_setup),
+            prediction_millis: elapsed_millis(self.prediction),
+            corruption_millis: elapsed_millis(self.corruption),
+            main_write_millis: elapsed_millis(self.main_write),
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -1185,11 +1394,41 @@ struct MainRowTemplate {
     sigma: Value,
 }
 
+#[derive(Clone, Copy)]
+struct MainRowVisibilitySpec {
+    antenna1: usize,
+    antenna2: usize,
+    field_id: usize,
+    time: f64,
+    uvw: [f64; 3],
+}
+
 #[derive(Debug, Clone)]
 struct FitsModelImage {
     pixels: Array2<f32>,
+    channel_planes: Vec<Array2<f32>>,
     cell_size_rad: [f64; 2],
+    direction_wcs: Option<FitsModelDirectionWcs>,
+    ra_axis_increases_with_x: bool,
     reference_direction_rad: Option<[f64; 2]>,
+}
+
+impl FitsModelImage {
+    fn pixels_for_channel(&self, channel: usize) -> &Array2<f32> {
+        self.channel_planes.get(channel).unwrap_or(&self.pixels)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct FitsModelDirectionWcs {
+    coordinate_system: CoordinateSystem,
+    coordinate_index: usize,
+}
+
+impl FitsModelDirectionWcs {
+    fn coordinate(&self) -> &dyn Coordinate {
+        self.coordinate_system.coordinate(self.coordinate_index)
+    }
 }
 
 struct SyntheticChannelPredictor {
@@ -1209,6 +1448,7 @@ struct SyntheticFieldPlan {
 // offset, the tutorial model needs this residual image-x phase alignment to
 // match CASA's GridFT prediction at numerical-noise scale.
 const CASA_GRIDFT_IMAGE_INVERSION_PHASE_PIXELS: f64 = 0.015_122_8;
+const CASA_GRIDFT_NEGATIVE_RA_PHASE_ALIGNMENT_PIXELS: [f64; 2] = [0.001_757_8, 0.001_115_9];
 
 fn build_field_plans(
     request: &SyntheticObservationRequest,
@@ -1285,19 +1525,30 @@ fn build_channel_predictors(
                 + channel as f64 * spectral_setup.channel_width_hz;
             let beam_corrected_pixels = apply_simulator_primary_beam(
                 model,
+                model.pixels_for_channel(channel),
                 phase_center_rad,
                 frequency_hz,
                 pointing_offset_rad,
                 primary_beam,
             );
-            let mut casa_oriented_pixels = Array2::<f32>::zeros(model.pixels.raw_dim());
-            for x in 0..model.pixels.shape()[0] {
-                for y in 0..model.pixels.shape()[1] {
-                    // CASA's simulator image prediction treats positive RA
-                    // offsets with the opposite image-x handedness from this
-                    // crate's pure imaging gridder.
-                    casa_oriented_pixels[(model.pixels.shape()[0] - 1 - x, y)] =
-                        beam_corrected_pixels[(x, y)];
+            let mut casa_oriented_pixels = Array2::<f32>::zeros(beam_corrected_pixels.raw_dim());
+            if model.ra_axis_increases_with_x {
+                for x in 0..beam_corrected_pixels.shape()[0] {
+                    for y in 0..beam_corrected_pixels.shape()[1] {
+                        // CASA's simulator image prediction treats positive RA
+                        // offsets with the opposite image-x handedness from this
+                        // crate's pure imaging gridder. Conventional FITS images
+                        // already have CDELT1 < 0, so only positive-RA image axes
+                        // need this compatibility flip.
+                        casa_oriented_pixels[(beam_corrected_pixels.shape()[0] - 1 - x, y)] =
+                            beam_corrected_pixels[(x, y)];
+                    }
+                }
+            } else {
+                for x in 0..beam_corrected_pixels.shape()[0] {
+                    for y in 0..beam_corrected_pixels.shape()[1] {
+                        casa_oriented_pixels[(x, y)] = beam_corrected_pixels[(x, y)];
+                    }
                 }
             }
             let predictor = StandardMfsModelPredictor::new(geometry, &casa_oriented_pixels)
@@ -1316,28 +1567,33 @@ fn build_channel_predictors(
 
 fn apply_simulator_primary_beam(
     model: &FitsModelImage,
+    model_pixels: &Array2<f32>,
     phase_center_rad: [f64; 2],
     frequency_hz: f64,
     pointing_offset_rad: [f64; 2],
     primary_beam: SyntheticPrimaryBeam,
 ) -> Array2<f32> {
-    let mut pixels = model.pixels.clone();
-    let Some(reference_direction_rad) = model.reference_direction_rad else {
+    let mut pixels = model_pixels.clone();
+    let Some(wcs) = model.direction_wcs.as_ref() else {
         return pixels;
     };
-    let center_ra_offset =
-        circular_angle_delta_rad(reference_direction_rad[0] - phase_center_rad[0])
-            * phase_center_rad[1].cos()
-            - pointing_offset_rad[0];
-    let center_dec_offset =
-        reference_direction_rad[1] - phase_center_rad[1] - pointing_offset_rad[1];
-    let x_ref = model.pixels.shape()[0] as f64 / 2.0;
-    let y_ref = model.pixels.shape()[1] as f64 / 2.0;
+    let pointing_direction_rad = [
+        phase_center_rad[0] + pointing_offset_rad[0] / phase_center_rad[1].cos(),
+        phase_center_rad[1] + pointing_offset_rad[1],
+    ];
+    let coordinate = wcs.coordinate();
+    let Ok(pointing_pixel) = coordinate.to_pixel(&pointing_direction_rad) else {
+        return pixels;
+    };
+    let increments = coordinate.increment();
+    if pointing_pixel.len() < 2 || increments.len() < 2 {
+        return pixels;
+    }
 
-    for x in 0..model.pixels.shape()[0] {
-        for y in 0..model.pixels.shape()[1] {
-            let l = center_ra_offset + (x as f64 - x_ref) * model.cell_size_rad[0];
-            let m = center_dec_offset + (y as f64 - y_ref) * model.cell_size_rad[1];
+    for x in 0..model_pixels.shape()[0] {
+        for y in 0..model_pixels.shape()[1] {
+            let l = (x as f64 - pointing_pixel[0]) * increments[0];
+            let m = (y as f64 - pointing_pixel[1]) * increments[1];
             let vp = synthetic_primary_beam_voltage_pattern(
                 primary_beam,
                 (l * l + m * m).sqrt(),
@@ -1390,18 +1646,14 @@ fn casa_vla_q_primary_beam_voltage_pattern(radius_rad: f64, frequency_hz: f64) -
         return 1.0;
     }
 
-    let quantized_radius_arcmin_ghz =
-        table_index as f64 * CASA_VLA_Q_MAX_RADIUS_ARCMIN / (CASA_AIRY_SAMPLES - 1) as f64;
-    let quantized_radius_rad =
-        (quantized_radius_arcmin_ghz / (frequency_hz / 1.0e9) / 60.0).to_radians();
-    primary_beam_voltage_pattern(
-        PrimaryBeamModel::Airy {
-            dish_diameter_m: DISH_DIAMETER_M,
-            blockage_diameter_m: BLOCKAGE_DIAMETER_M,
-        },
-        quantized_radius_rad,
-        frequency_hz,
-    )
+    let dimensionless_max_radius =
+        CASA_VLA_Q_MAX_RADIUS_ARCMIN * 7.016 / (1.566 * 60.0) * DISH_DIAMETER_M / 24.5;
+    let x = table_index as f64 * dimensionless_max_radius / (CASA_AIRY_SAMPLES - 1) as f64;
+    let area_ratio = (DISH_DIAMETER_M / BLOCKAGE_DIAMETER_M).powi(2);
+    let area_norm = area_ratio - 1.0;
+    let length_ratio = DISH_DIAMETER_M / BLOCKAGE_DIAMETER_M;
+    ((area_ratio * 2.0 * j1(x) / x - 2.0 * j1(x * length_ratio) / (x * length_ratio)) / area_norm)
+        as f32
 }
 
 fn casa_model_phase_offset(model: &FitsModelImage, phase_center_rad: [f64; 2]) -> [f64; 2] {
@@ -1411,10 +1663,21 @@ fn casa_model_phase_offset(model: &FitsModelImage, phase_center_rad: [f64; 2]) -
     let ra_offset = circular_angle_delta_rad(reference_direction_rad[0] - phase_center_rad[0])
         * phase_center_rad[1].cos();
     let dec_offset = reference_direction_rad[1] - phase_center_rad[1];
-    [
-        ra_offset - (0.5 - CASA_GRIDFT_IMAGE_INVERSION_PHASE_PIXELS) * model.cell_size_rad[0],
-        dec_offset - 0.5 * model.cell_size_rad[1],
-    ]
+    if model.ra_axis_increases_with_x {
+        [
+            ra_offset - (0.5 - CASA_GRIDFT_IMAGE_INVERSION_PHASE_PIXELS) * model.cell_size_rad[0],
+            dec_offset - 0.5 * model.cell_size_rad[1],
+        ]
+    } else {
+        // CASA GridFT uses a signed RA increment plus an internal UV negation
+        // convention for conventional FITS images. A phase-residual fit against
+        // CASA's full simulator path shows this leaves a sub-pixel alignment
+        // offset after the larger half-pixel center alignment is accounted for.
+        [
+            ra_offset + CASA_GRIDFT_NEGATIVE_RA_PHASE_ALIGNMENT_PIXELS[0] * model.cell_size_rad[0],
+            dec_offset + CASA_GRIDFT_NEGATIVE_RA_PHASE_ALIGNMENT_PIXELS[1] * model.cell_size_rad[1],
+        ]
+    }
 }
 
 fn circular_angle_delta_rad(delta: f64) -> f64 {
@@ -1422,7 +1685,7 @@ fn circular_angle_delta_rad(delta: f64) -> f64 {
 }
 
 fn predicted_data_values(
-    predictors: Option<&Vec<SyntheticChannelPredictor>>,
+    predictors: Option<&[SyntheticChannelPredictor]>,
     spectral_setup: &SyntheticSpectralSetup,
     uvw_m: [f64; 3],
     num_corr: usize,
@@ -1458,6 +1721,189 @@ fn predicted_data_values(
         }
     }
     values
+}
+
+struct ChannelPredictionChunk {
+    start_channel: usize,
+    values_by_row: Vec<Vec<Complex32>>,
+}
+
+fn predicted_data_values_for_rows_with_workers(
+    predictors: Option<&[SyntheticChannelPredictor]>,
+    spectral_setup: &SyntheticSpectralSetup,
+    row_uvws: &[[f64; 3]],
+    num_corr: usize,
+    worker_count: usize,
+) -> Vec<Vec<Complex32>> {
+    let Some(predictors) = predictors else {
+        return vec![
+            vec![Complex32::new(0.0, 0.0); num_corr * spectral_setup.channel_count];
+            row_uvws.len()
+        ];
+    };
+    if worker_count <= 1 {
+        return row_uvws
+            .iter()
+            .map(|uvw| predicted_data_values(Some(predictors), spectral_setup, *uvw, num_corr))
+            .collect();
+    }
+
+    let channel_count = spectral_setup.channel_count;
+    let chunk_size = channel_count.div_ceil(worker_count);
+    let chunks = thread::scope(|scope| {
+        let mut handles = Vec::new();
+        for start_channel in (0..channel_count).step_by(chunk_size) {
+            let end_channel = (start_channel + chunk_size).min(channel_count);
+            handles.push(scope.spawn(move || {
+                predict_channel_chunk(
+                    predictors,
+                    spectral_setup,
+                    row_uvws,
+                    num_corr,
+                    start_channel,
+                    end_channel,
+                )
+            }));
+        }
+
+        handles
+            .into_iter()
+            .map(|handle| {
+                handle
+                    .join()
+                    .expect("synthetic observation prediction worker should not panic")
+            })
+            .collect::<Vec<_>>()
+    });
+
+    let mut values_by_row =
+        vec![vec![Complex32::new(0.0, 0.0); num_corr * channel_count]; row_uvws.len()];
+    for chunk in chunks {
+        if chunk.values_by_row.is_empty() {
+            continue;
+        }
+        let chunk_len = chunk.values_by_row[0].len() / num_corr;
+        for (row_index, row_chunk) in chunk.values_by_row.into_iter().enumerate() {
+            for corr in 0..num_corr {
+                let src_start = corr * chunk_len;
+                let dst_start = corr * channel_count + chunk.start_channel;
+                values_by_row[row_index][dst_start..dst_start + chunk_len]
+                    .copy_from_slice(&row_chunk[src_start..src_start + chunk_len]);
+            }
+        }
+    }
+    values_by_row
+}
+
+fn predict_channel_chunk(
+    predictors: &[SyntheticChannelPredictor],
+    spectral_setup: &SyntheticSpectralSetup,
+    row_uvws: &[[f64; 3]],
+    num_corr: usize,
+    start_channel: usize,
+    end_channel: usize,
+) -> ChannelPredictionChunk {
+    let chunk_len = end_channel - start_channel;
+    let mut values_by_row = Vec::with_capacity(row_uvws.len());
+    for uvw_m in row_uvws {
+        let mut row_values = vec![Complex32::new(0.0, 0.0); num_corr * chunk_len];
+        for (offset, channel) in (start_channel..end_channel).enumerate() {
+            let predictor = &predictors[channel];
+            let visibility = predict_channel_visibility(predictor, spectral_setup, *uvw_m, channel);
+            for corr in 0..num_corr {
+                row_values[corr * chunk_len + offset] = visibility;
+            }
+        }
+        values_by_row.push(row_values);
+    }
+    ChannelPredictionChunk {
+        start_channel,
+        values_by_row,
+    }
+}
+
+fn predict_channel_visibility(
+    predictor: &SyntheticChannelPredictor,
+    spectral_setup: &SyntheticSpectralSetup,
+    uvw_m: [f64; 3],
+    channel: usize,
+) -> Complex32 {
+    let frequency_hz =
+        spectral_setup.start_frequency_hz + channel as f64 * spectral_setup.channel_width_hz;
+    let wavelength_m = 299_792_458.0 / frequency_hz;
+    let prediction_uvw_m =
+        if let Some(model_reference_direction_rad) = predictor.model_reference_direction_rad {
+            rotate_uvw_between_directions(
+                uvw_m,
+                predictor.phase_center_rad,
+                model_reference_direction_rad,
+            )
+        } else {
+            uvw_m
+        };
+    let u_lambda = prediction_uvw_m[0] / wavelength_m;
+    let v_lambda = prediction_uvw_m[1] / wavelength_m;
+    let phase = std::f64::consts::TAU
+        * (u_lambda * predictor.phase_offset_rad[0] + v_lambda * predictor.phase_offset_rad[1]);
+    let phase_shift = Complex32::new(phase.cos() as f32, phase.sin() as f32);
+    predictor.predictor.predict(u_lambda, v_lambda) * phase_shift
+}
+
+fn simobserve_channel_worker_count(channel_count: usize) -> usize {
+    let available = thread::available_parallelism()
+        .map(|parallelism| parallelism.get())
+        .unwrap_or(1);
+    let requested = std::env::var("CASA_RS_SIMOBSERVE_CHANNEL_WORKERS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(available);
+    let min_channels = std::env::var("CASA_RS_SIMOBSERVE_CHANNEL_PARALLEL_MIN_CHANNELS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(64);
+    simobserve_channel_worker_count_for(channel_count, requested, available, min_channels)
+}
+
+fn simobserve_channel_worker_count_for(
+    channel_count: usize,
+    requested: usize,
+    available: usize,
+    min_channels: usize,
+) -> usize {
+    if channel_count < min_channels {
+        return 1;
+    }
+    requested
+        .max(1)
+        .min(available.max(1))
+        .min(channel_count)
+        .max(1)
+}
+
+fn simobserve_row_worker_count(row_count: usize, channel_count: usize) -> usize {
+    let available = thread::available_parallelism()
+        .map(|parallelism| parallelism.get())
+        .unwrap_or(1);
+    let requested = std::env::var("CASA_RS_SIMOBSERVE_ROW_WORKERS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(available);
+    simobserve_row_worker_count_for(row_count, channel_count, requested, available, 64 * 1024)
+}
+
+fn simobserve_row_worker_count_for(
+    row_count: usize,
+    channel_count: usize,
+    requested: usize,
+    available: usize,
+    min_values: usize,
+) -> usize {
+    if row_count <= 1 || row_count * channel_count < min_values {
+        return 1;
+    }
+    requested.max(1).min(available.max(1)).min(row_count).max(1)
 }
 
 fn rotate_uvw_between_directions(
@@ -1794,6 +2240,7 @@ impl DeterministicRng {
 fn read_fits_model_image(
     path: &PathBuf,
     model_peak_jy_per_pixel: Option<f32>,
+    spectral_channel_count: usize,
 ) -> MsResult<FitsModelImage> {
     let mut file = fs::File::open(path).map_err(|error| {
         MsError::SyntheticObservation(format!(
@@ -1819,28 +2266,43 @@ fn read_fits_model_image(
     }
     let nx = fits_i64(&cards, "NAXIS1", path)? as usize;
     let ny = fits_i64(&cards, "NAXIS2", path)? as usize;
+    let shape = (1..=naxis)
+        .map(|axis| fits_i64(&cards, &format!("NAXIS{axis}"), path).map(|value| value as usize))
+        .collect::<MsResult<Vec<_>>>()?;
     if nx < 8 || ny < 8 {
         return Err(MsError::SyntheticObservation(format!(
             "model image {} must be at least 8x8 pixels",
             path.display()
         )));
     }
-    let trailing_planes = (3..=naxis)
-        .map(|axis| fits_i64(&cards, &format!("NAXIS{axis}"), path).unwrap_or(1))
-        .product::<i64>();
-    if trailing_planes != 1 {
-        return Err(MsError::SyntheticObservation(format!(
-            "model image {} must have one Stokes/frequency plane for this Wave 5 slice",
-            path.display()
-        )));
-    }
-    let cell_size_rad = [
-        fits_axis_cell_rad(&cards, 1, path)?.abs(),
-        fits_axis_cell_rad(&cards, 2, path)?.abs(),
+    let channel_axis = fits_model_channel_axis(&cards, &shape, spectral_channel_count, path)?;
+    let axis_cell_rad = [
+        fits_axis_cell_rad(&cards, 1, path)?,
+        fits_axis_cell_rad(&cards, 2, path)?,
     ];
-    let reference_direction_rad = fits_center_direction_rad(&cards, nx, ny, path)?;
-    let pixel_count = nx
+    let direction_wcs = fits_model_direction_wcs(&cards, &shape, path)?;
+    let (cell_size_rad, ra_axis_increases_with_x, reference_direction_rad) =
+        if let Some(wcs) = direction_wcs.as_ref() {
+            (
+                fits_direction_cell_size_rad(wcs)?,
+                fits_direction_ra_axis_increases_with_x(wcs, path)?,
+                Some(fits_direction_center_rad(wcs, nx, ny, path)?),
+            )
+        } else {
+            (
+                [axis_cell_rad[0].abs(), axis_cell_rad[1].abs()],
+                axis_cell_rad[0] > 0.0,
+                None,
+            )
+        };
+    let plane_pixel_count = nx
         .checked_mul(ny)
+        .ok_or_else(|| MsError::SyntheticObservation("model image shape overflows".to_string()))?;
+    let total_pixel_count = shape
+        .iter()
+        .try_fold(1usize, |accumulator, axis_len| {
+            accumulator.checked_mul(*axis_len)
+        })
         .ok_or_else(|| MsError::SyntheticObservation("model image shape overflows".to_string()))?;
     let bytes_per_pixel = match bitpix {
         -32 => 4usize,
@@ -1852,7 +2314,7 @@ fn read_fits_model_image(
             )));
         }
     };
-    let data_len = pixel_count * bytes_per_pixel;
+    let data_len = total_pixel_count * bytes_per_pixel;
     if bytes.len() < data_offset + data_len {
         return Err(MsError::SyntheticObservation(format!(
             "model image {} is truncated before primary image data",
@@ -1862,42 +2324,27 @@ fn read_fits_model_image(
 
     let bscale = fits_optional_f64(&cards, "BSCALE").unwrap_or(1.0);
     let bzero = fits_optional_f64(&cards, "BZERO").unwrap_or(0.0);
-    let mut pixels = Array2::<f32>::zeros((nx, ny));
     let data = &bytes[data_offset..data_offset + data_len];
-    for y in 0..ny {
-        for x in 0..nx {
-            let index = y * nx + x;
-            let raw = match bitpix {
-                -32 => {
-                    let start = index * 4;
-                    f32::from_bits(u32::from_be_bytes([
-                        data[start],
-                        data[start + 1],
-                        data[start + 2],
-                        data[start + 3],
-                    ])) as f64
-                }
-                -64 => {
-                    let start = index * 8;
-                    f64::from_bits(u64::from_be_bytes([
-                        data[start],
-                        data[start + 1],
-                        data[start + 2],
-                        data[start + 3],
-                        data[start + 4],
-                        data[start + 5],
-                        data[start + 6],
-                        data[start + 7],
-                    ]))
-                }
-                _ => unreachable!(),
-            };
-            pixels[(x, y)] = (raw * bscale + bzero) as f32;
+    let channel_plane_count = channel_axis
+        .map(|axis| shape[axis])
+        .filter(|count| *count > 1)
+        .unwrap_or(1);
+    let mut channel_planes = Vec::with_capacity(channel_plane_count);
+    for channel in 0..channel_plane_count {
+        let mut plane = Array2::<f32>::zeros((nx, ny));
+        for y in 0..ny {
+            for x in 0..nx {
+                let index = fits_model_flat_index(&shape, x, y, channel_axis, channel);
+                plane[(x, y)] = fits_model_pixel_value(data, bitpix, index, bscale, bzero);
+            }
         }
+        debug_assert_eq!(plane.len(), plane_pixel_count);
+        channel_planes.push(plane);
     }
     if let Some(target_peak) = model_peak_jy_per_pixel {
-        let current_peak = pixels
+        let current_peak = channel_planes
             .iter()
+            .flat_map(|plane| plane.iter())
             .copied()
             .fold(0.0f32, |peak, value| peak.max(value.abs()));
         if current_peak <= 0.0 || !current_peak.is_finite() {
@@ -1907,22 +2354,137 @@ fn read_fits_model_image(
             )));
         }
         let scale = target_peak / current_peak;
-        pixels.mapv_inplace(|value| value * scale);
+        for plane in &mut channel_planes {
+            plane.mapv_inplace(|value| value * scale);
+        }
     }
+    let pixels = channel_planes
+        .first()
+        .cloned()
+        .unwrap_or_else(|| Array2::<f32>::zeros((nx, ny)));
 
     Ok(FitsModelImage {
         pixels,
+        channel_planes,
         cell_size_rad,
+        direction_wcs,
+        ra_axis_increases_with_x,
         reference_direction_rad,
     })
 }
 
-fn fits_center_direction_rad(
+fn fits_model_channel_axis(
     cards: &[String],
-    nx: usize,
-    ny: usize,
+    shape: &[usize],
+    spectral_channel_count: usize,
     path: &Path,
-) -> MsResult<Option<[f64; 2]>> {
+) -> MsResult<Option<usize>> {
+    let mut spectral_axis = None;
+    for axis in 3..=shape.len() {
+        if fits_axis_is_spectral(cards, axis) {
+            spectral_axis = Some(axis - 1);
+            break;
+        }
+    }
+    if spectral_axis.is_none() && spectral_channel_count > 1 {
+        spectral_axis = (2..shape.len()).find(|axis| shape[*axis] == spectral_channel_count);
+    }
+
+    for (axis, axis_len) in shape.iter().copied().enumerate().skip(2) {
+        if Some(axis) == spectral_axis {
+            if axis_len != 1 && axis_len != spectral_channel_count {
+                return Err(MsError::SyntheticObservation(format!(
+                    "model image {} spectral axis length {axis_len} does not match requested channel count {spectral_channel_count}",
+                    path.display()
+                )));
+            }
+        } else if axis_len != 1 && !fits_axis_is_stokes(cards, axis + 1) {
+            return Err(MsError::SyntheticObservation(format!(
+                "model image {} has unsupported non-spectral FITS axis {} with length {}; only singleton or STOKES axes are supported",
+                path.display(),
+                axis + 1,
+                axis_len
+            )));
+        }
+    }
+    Ok(spectral_axis)
+}
+
+fn fits_axis_is_spectral(cards: &[String], axis: usize) -> bool {
+    fits_string(cards, &format!("CTYPE{axis}"))
+        .map(|ctype| {
+            let upper = ctype.to_ascii_uppercase();
+            upper.starts_with("FREQ")
+                || upper.starts_with("VRAD")
+                || upper.starts_with("VOPT")
+                || upper.starts_with("VELO")
+        })
+        .unwrap_or(false)
+}
+
+fn fits_axis_is_stokes(cards: &[String], axis: usize) -> bool {
+    fits_string(cards, &format!("CTYPE{axis}"))
+        .map(|ctype| ctype.to_ascii_uppercase().starts_with("STOKES"))
+        .unwrap_or(false)
+}
+
+fn fits_model_flat_index(
+    shape: &[usize],
+    x: usize,
+    y: usize,
+    channel_axis: Option<usize>,
+    channel: usize,
+) -> usize {
+    let mut index = 0usize;
+    let mut stride = 1usize;
+    for (axis, axis_len) in shape.iter().copied().enumerate() {
+        let axis_index = match axis {
+            0 => x,
+            1 => y,
+            _ if Some(axis) == channel_axis => channel,
+            _ => 0,
+        };
+        debug_assert!(axis_index < axis_len);
+        index += axis_index * stride;
+        stride *= axis_len;
+    }
+    index
+}
+
+fn fits_model_pixel_value(data: &[u8], bitpix: i64, index: usize, bscale: f64, bzero: f64) -> f32 {
+    let raw = match bitpix {
+        -32 => {
+            let start = index * 4;
+            f32::from_bits(u32::from_be_bytes([
+                data[start],
+                data[start + 1],
+                data[start + 2],
+                data[start + 3],
+            ])) as f64
+        }
+        -64 => {
+            let start = index * 8;
+            f64::from_bits(u64::from_be_bytes([
+                data[start],
+                data[start + 1],
+                data[start + 2],
+                data[start + 3],
+                data[start + 4],
+                data[start + 5],
+                data[start + 6],
+                data[start + 7],
+            ]))
+        }
+        _ => unreachable!(),
+    };
+    (raw * bscale + bzero) as f32
+}
+
+fn fits_model_direction_wcs(
+    cards: &[String],
+    shape: &[usize],
+    path: &Path,
+) -> MsResult<Option<FitsModelDirectionWcs>> {
     if !(fits_value(cards, "CRVAL1").is_some()
         && fits_value(cards, "CRVAL2").is_some()
         && fits_value(cards, "CTYPE1").is_some()
@@ -1930,41 +2492,71 @@ fn fits_center_direction_rad(
     {
         return Ok(None);
     }
-    let projection = fits_string(cards, "CTYPE1")
-        .and_then(|ctype| {
-            ctype
-                .rsplit_once('-')
-                .map(|(_, projection)| projection.to_string())
-        })
-        .and_then(|projection| ProjectionType::from_name(&projection))
-        .unwrap_or(ProjectionType::SIN);
-    let crval = [
-        fits_axis_angle_rad(cards, "CRVAL1", path)?,
-        fits_axis_angle_rad(cards, "CRVAL2", path)?,
-    ];
-    let cdelt = [
-        fits_axis_cell_rad(cards, 1, path)?,
-        fits_axis_cell_rad(cards, 2, path)?,
-    ];
-    let crpix = [
-        fits_optional_f64(cards, "CRPIX1").unwrap_or(1.0) - 1.0,
-        fits_optional_f64(cards, "CRPIX2").unwrap_or(1.0) - 1.0,
-    ];
-    let coordinate = DirectionCoordinate::new(
-        DirectionRef::J2000,
-        Projection::new(projection),
-        crval,
-        cdelt,
-        crpix,
-    );
+    let header_cards = cards.iter().map(String::as_str).collect::<Vec<_>>();
+    let header = FitsHeader::from_cards(&header_cards);
+    let coordinate_system = from_fits_header(&header, shape).map_err(|error| {
+        MsError::SyntheticObservation(format!(
+            "failed to parse model-image FITS WCS for {}: {error}",
+            path.display()
+        ))
+    })?;
+    let Some(coordinate_index) = coordinate_system.find_coordinate(CoordinateType::Direction)
+    else {
+        return Ok(None);
+    };
+    Ok(Some(FitsModelDirectionWcs {
+        coordinate_system,
+        coordinate_index,
+    }))
+}
+
+fn fits_direction_cell_size_rad(wcs: &FitsModelDirectionWcs) -> MsResult<[f64; 2]> {
+    let increment = wcs.coordinate().increment();
+    if increment.len() < 2 {
+        return Err(MsError::SyntheticObservation(
+            "model image direction coordinate has fewer than two increments".to_string(),
+        ));
+    }
+    Ok([increment[0].abs(), increment[1].abs()])
+}
+
+fn fits_direction_center_rad(
+    wcs: &FitsModelDirectionWcs,
+    nx: usize,
+    ny: usize,
+    path: &Path,
+) -> MsResult<[f64; 2]> {
     let center_pixel = [0.5 * nx as f64, 0.5 * ny as f64];
-    let world = coordinate.to_world(&center_pixel).map_err(|error| {
+    let world = wcs.coordinate().to_world(&center_pixel).map_err(|error| {
         MsError::SyntheticObservation(format!(
             "failed to resolve model-image center direction for {}: {error}",
             path.display()
         ))
     })?;
-    Ok(Some([world[0], world[1]]))
+    Ok([world[0], world[1]])
+}
+
+fn fits_direction_ra_axis_increases_with_x(
+    wcs: &FitsModelDirectionWcs,
+    path: &Path,
+) -> MsResult<bool> {
+    let coordinate = wcs.coordinate();
+    let reference_pixel = coordinate.reference_pixel();
+    let reference_value = coordinate.reference_value();
+    if reference_pixel.len() < 2 || reference_value.len() < 2 {
+        return Err(MsError::SyntheticObservation(
+            "model image direction coordinate has fewer than two axes".to_string(),
+        ));
+    }
+    let x_step_world = coordinate
+        .to_world(&[reference_pixel[0] + 1.0, reference_pixel[1]])
+        .map_err(|error| {
+            MsError::SyntheticObservation(format!(
+                "failed to resolve model-image RA axis handedness for {}: {error}",
+                path.display()
+            ))
+        })?;
+    Ok(circular_angle_delta_rad(x_step_world[0] - reference_value[0]) > 0.0)
 }
 
 fn parse_fits_header(bytes: &[u8], path: &Path) -> MsResult<(Vec<String>, usize)> {
@@ -2021,26 +2613,6 @@ fn fits_axis_cell_rad(cards: &[String], axis: usize, path: &Path) -> MsResult<f6
     }
 }
 
-fn fits_axis_angle_rad(cards: &[String], key: &str, path: &Path) -> MsResult<f64> {
-    let value = fits_optional_f64(cards, key).ok_or_else(|| {
-        MsError::SyntheticObservation(format!("model image {} missing FITS {key}", path.display()))
-    })?;
-    let axis = key
-        .chars()
-        .last()
-        .and_then(|ch| ch.to_digit(10))
-        .unwrap_or(1) as usize;
-    let unit = fits_string(cards, &format!("CUNIT{axis}")).unwrap_or_else(|| "deg".to_string());
-    match unit.trim().to_ascii_lowercase().as_str() {
-        "deg" | "degree" | "degrees" => Ok(value.to_radians()),
-        "rad" | "radian" | "radians" => Ok(value),
-        other => Err(MsError::SyntheticObservation(format!(
-            "model image {} uses unsupported CUNIT{axis}={other:?}; expected deg or rad",
-            path.display()
-        ))),
-    }
-}
-
 fn fits_optional_f64(cards: &[String], key: &str) -> Option<f64> {
     fits_value(cards, key).and_then(|value| value.parse::<f64>().ok())
 }
@@ -2066,6 +2638,10 @@ fn subtable_mut(ms: &mut MeasurementSet, id: SubtableId) -> MsResult<&mut casa_t
 
 fn time_sample_count(duration_seconds: f64, integration_seconds: f64) -> usize {
     (duration_seconds / integration_seconds).ceil().max(1.0) as usize
+}
+
+fn elapsed_millis(duration: Duration) -> u128 {
+    duration.as_millis()
 }
 
 fn antenna_uvw_positions(
@@ -2615,5 +3191,329 @@ mod tests {
         assert_ne!(base, row_noise_seed(42, 0, 1, 2, 0));
         assert_ne!(base, row_noise_seed(42, 0, 0, 1, 1));
         assert_eq!(base, row_noise_seed(42, 0, 0, 1, 0));
+    }
+
+    #[test]
+    fn fits_model_cube_uses_per_channel_planes() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("cube.fits");
+        write_test_fits_cube(&path, 3);
+
+        let model = read_fits_model_image(&path, None, 3).expect("read model cube");
+
+        assert_eq!(model.channel_planes.len(), 3);
+        assert_eq!(model.pixels_for_channel(0)[(2, 3)], 32.0);
+        assert_eq!(model.pixels_for_channel(1)[(2, 3)], 132.0);
+        assert_eq!(model.pixels_for_channel(2)[(2, 3)], 232.0);
+    }
+
+    #[test]
+    fn fits_model_plane_repeats_for_all_requested_channels() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("plane.fits");
+        write_test_fits_plane(&path);
+
+        let model = read_fits_model_image(&path, None, 4).expect("read model plane");
+
+        assert_eq!(model.channel_planes.len(), 1);
+        assert_eq!(model.pixels_for_channel(0)[(2, 3)], 32.0);
+        assert_eq!(model.pixels_for_channel(3)[(2, 3)], 32.0);
+    }
+
+    #[test]
+    fn simobserve_channel_worker_count_is_bounded_by_frequency_work() {
+        assert_eq!(simobserve_channel_worker_count_for(8, 8, 8, 64), 1);
+        assert_eq!(simobserve_channel_worker_count_for(64, 8, 8, 64), 8);
+        assert_eq!(simobserve_channel_worker_count_for(64, 16, 4, 64), 4);
+        assert_eq!(simobserve_channel_worker_count_for(3, 16, 16, 1), 3);
+        assert_eq!(simobserve_channel_worker_count_for(64, 0, 0, 64), 1);
+    }
+
+    #[test]
+    fn simobserve_row_worker_count_is_bounded_by_row_work() {
+        assert_eq!(simobserve_row_worker_count_for(8, 16, 8, 8, 1024), 1);
+        assert_eq!(simobserve_row_worker_count_for(351, 512, 16, 10, 1024), 10);
+        assert_eq!(simobserve_row_worker_count_for(351, 512, 16, 4, 1024), 4);
+        assert_eq!(simobserve_row_worker_count_for(3, 512, 16, 16, 1024), 3);
+        assert_eq!(simobserve_row_worker_count_for(351, 512, 0, 16, 1024), 1);
+    }
+
+    #[test]
+    fn parallel_row_corruption_matches_serial_corruption() {
+        let config = SyntheticCorruptionConfig {
+            seed: 11,
+            noise: Some(SyntheticNoiseCorruption {
+                mode: SyntheticNoiseMode::SimpleNoise,
+                simplenoise_jy: 0.01,
+            }),
+            gain: Some(SyntheticGainCorruption {
+                mode: SyntheticGainMode::Fbm,
+                interval_seconds: 10.0,
+                amplitude: [0.03, 0.02],
+            }),
+            bandpass: Some(SyntheticBandpassCorruption {
+                mode: SyntheticBandpassMode::Calculate,
+                interval_seconds: 10.0,
+                amplitude: [0.02, 0.01],
+            }),
+            leakage: Some(SyntheticPolarizationLeakageCorruption {
+                mode: SyntheticPolarizationLeakageMode::Constant,
+                amplitude: [0.02, 0.01],
+                offset: [0.0, 0.0],
+            }),
+            pointing: None,
+        };
+        let corruption = SyntheticCorruptionState::new(&config, 8, 16, 5);
+        let row_specs = (0..7)
+            .flat_map(|antenna1| {
+                ((antenna1 + 1)..8).map(move |antenna2| MainRowVisibilitySpec {
+                    antenna1,
+                    antenna2,
+                    field_id: 0,
+                    time: 0.0,
+                    uvw: [antenna1 as f64, antenna2 as f64, 0.0],
+                })
+            })
+            .collect::<Vec<_>>();
+        let base_rows = row_specs
+            .iter()
+            .enumerate()
+            .map(|(row, _)| {
+                (0..32)
+                    .map(|index| Complex32::new(row as f32, index as f32 * 0.25))
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        let mut serial = base_rows.clone();
+        let mut parallel = base_rows;
+
+        let serial_nonzero =
+            apply_corruption_and_count_rows(Some(&corruption), &row_specs, &mut serial, 16, 3);
+        let parallel_nonzero = apply_corruption_and_count_rows_with_workers(
+            Some(&corruption),
+            &row_specs,
+            &mut parallel,
+            16,
+            3,
+        );
+
+        assert_eq!(serial_nonzero, parallel_nonzero);
+        assert_eq!(serial, parallel);
+    }
+
+    #[test]
+    fn parallel_channel_prediction_matches_serial_prediction() {
+        let channel_count = 96;
+        let spectral_setup = SyntheticSpectralSetup {
+            name: "test".to_string(),
+            start_frequency_hz: 1.0e9,
+            channel_width_hz: 1.0e6,
+            channel_count,
+        };
+        let geometry = ImageGeometry {
+            image_shape: [16, 16],
+            cell_size_rad: [1.0e-5, 1.0e-5],
+        };
+        let model = Array2::<f32>::from_shape_fn((16, 16), |(x, y)| {
+            let dx = x as f32 - 7.5;
+            let dy = y as f32 - 7.5;
+            (-0.03 * (dx * dx + dy * dy)).exp()
+        });
+        let predictors = (0..channel_count)
+            .map(|_| SyntheticChannelPredictor {
+                predictor: StandardMfsModelPredictor::new(geometry, &model).unwrap(),
+                phase_offset_rad: [1.0e-6, -2.0e-6],
+                phase_center_rad: [1.0, -0.5],
+                model_reference_direction_rad: None,
+            })
+            .collect::<Vec<_>>();
+        let row_uvws = [[10.0, 20.0, 0.0], [100.0, -30.0, 5.0], [-55.0, 7.0, -3.0]];
+
+        let serial = predicted_data_values_for_rows_with_workers(
+            Some(&predictors),
+            &spectral_setup,
+            &row_uvws,
+            2,
+            1,
+        );
+        let parallel = predicted_data_values_for_rows_with_workers(
+            Some(&predictors),
+            &spectral_setup,
+            &row_uvws,
+            2,
+            4,
+        );
+
+        assert_eq!(serial, parallel);
+    }
+
+    fn write_test_fits_plane(path: &Path) {
+        let mut cards = test_fits_cards(&[
+            ("SIMPLE", "T"),
+            ("BITPIX", "-32"),
+            ("NAXIS", "2"),
+            ("NAXIS1", "8"),
+            ("NAXIS2", "8"),
+            ("CDELT1", "-0.1"),
+            ("CUNIT1", "'deg'"),
+            ("CDELT2", "0.1"),
+            ("CUNIT2", "'deg'"),
+        ]);
+        let mut bytes = Vec::new();
+        bytes.append(&mut cards);
+        for y in 0..8 {
+            for x in 0..8 {
+                bytes.extend_from_slice(&((x + 10 * y) as f32).to_bits().to_be_bytes());
+            }
+        }
+        pad_fits_block(&mut bytes);
+        std::fs::write(path, bytes).expect("write test FITS plane");
+    }
+
+    fn write_test_fits_cube(path: &Path, channels: usize) {
+        let channels_text = channels.to_string();
+        let mut cards = test_fits_cards(&[
+            ("SIMPLE", "T"),
+            ("BITPIX", "-32"),
+            ("NAXIS", "4"),
+            ("NAXIS1", "8"),
+            ("NAXIS2", "8"),
+            ("NAXIS3", "1"),
+            ("NAXIS4", channels_text.as_str()),
+            ("CDELT1", "-0.1"),
+            ("CUNIT1", "'deg'"),
+            ("CDELT2", "0.1"),
+            ("CUNIT2", "'deg'"),
+            ("CTYPE3", "'STOKES'"),
+            ("CTYPE4", "'FREQ'"),
+        ]);
+        let mut bytes = Vec::new();
+        bytes.append(&mut cards);
+        for channel in 0..channels {
+            for y in 0..8 {
+                for x in 0..8 {
+                    let value = (100 * channel + x + 10 * y) as f32;
+                    bytes.extend_from_slice(&value.to_bits().to_be_bytes());
+                }
+            }
+        }
+        pad_fits_block(&mut bytes);
+        std::fs::write(path, bytes).expect("write test FITS cube");
+    }
+
+    fn test_fits_cards(entries: &[(&str, &str)]) -> Vec<u8> {
+        let mut text = String::new();
+        for (key, value) in entries {
+            text.push_str(
+                &format!("{key:<8}= {value:>20}")
+                    .chars()
+                    .take(80)
+                    .collect::<String>(),
+            );
+            let last_card_len = text.len() % 80;
+            if last_card_len != 0 {
+                text.push_str(&" ".repeat(80 - last_card_len));
+            }
+        }
+        text.push_str(&format!("{:<80}", "END"));
+        let mut bytes = text.into_bytes();
+        pad_fits_block(&mut bytes);
+        bytes
+    }
+
+    fn pad_fits_block(bytes: &mut Vec<u8>) {
+        let pad = (2880 - bytes.len() % 2880) % 2880;
+        bytes.extend(std::iter::repeat_n(b' ', pad));
+    }
+
+    #[test]
+    fn simulator_primary_beam_is_centered_on_fits_reference_pixel() {
+        let mut pixels = Array2::<f32>::zeros((5, 5));
+        pixels[(1, 1)] = 1.0;
+        pixels[(2, 1)] = 1.0;
+        let mut coordinate_system = CoordinateSystem::new();
+        coordinate_system.add_coordinate(Box::new(casa_coordinates::DirectionCoordinate::new(
+            DirectionRef::J2000,
+            casa_coordinates::Projection::new(casa_coordinates::ProjectionType::SIN),
+            [1.25, -0.3],
+            [-1.0e-3, 1.0e-3],
+            [1.0, 1.0],
+        )));
+        let model = FitsModelImage {
+            pixels,
+            channel_planes: Vec::new(),
+            cell_size_rad: [1.0e-3, 1.0e-3],
+            direction_wcs: Some(FitsModelDirectionWcs {
+                coordinate_system,
+                coordinate_index: 0,
+            }),
+            ra_axis_increases_with_x: false,
+            reference_direction_rad: Some([1.25, -0.3]),
+        };
+        let corrected = apply_simulator_primary_beam(
+            &model,
+            &model.pixels,
+            [1.25, -0.3],
+            43.0e9,
+            [0.0, 0.0],
+            SyntheticPrimaryBeam {
+                use_casa_vla_q_table: true,
+                dish_diameter_m: 25.0,
+                blockage_diameter_m: 2.36,
+            },
+        );
+
+        assert_eq!(corrected[(1, 1)], 1.0);
+        assert!(
+            corrected[(2, 1)] < 1.0,
+            "adjacent pixels should be attenuated away from the FITS reference pixel"
+        );
+    }
+
+    #[test]
+    fn casa_vla_q_primary_beam_uses_common_pb_table_support() {
+        let at_half_max_radius =
+            casa_vla_q_primary_beam_voltage_pattern((0.5 * 0.8564_f64).to_radians(), 1.0e9);
+        let at_support = casa_vla_q_primary_beam_voltage_pattern(0.8564_f64.to_radians(), 1.0e9);
+
+        assert!((at_half_max_radius - 0.596_901_4).abs() < 1.0e-7);
+        assert!((at_support - -0.017_125_657).abs() < 1.0e-8);
+    }
+
+    #[test]
+    fn shadowing_marks_nearer_antenna_and_flags_rows_involving_it() {
+        let antennas = vec![
+            SyntheticAntenna::vla("A0", "A0", [0.0, 0.0, 0.0]),
+            SyntheticAntenna::vla("A1", "A1", [0.0, 0.0, 0.0]),
+            SyntheticAntenna::vla("A2", "A2", [0.0, 0.0, 0.0]),
+        ];
+        let rows = vec![
+            MainRowVisibilitySpec {
+                antenna1: 0,
+                antenna2: 1,
+                field_id: 0,
+                time: 0.0,
+                uvw: [10.0, 0.0, 1.0],
+            },
+            MainRowVisibilitySpec {
+                antenna1: 0,
+                antenna2: 2,
+                field_id: 0,
+                time: 0.0,
+                uvw: [100.0, 0.0, -1.0],
+            },
+            MainRowVisibilitySpec {
+                antenna1: 1,
+                antenna2: 2,
+                field_id: 0,
+                time: 0.0,
+                uvw: [10.0, 0.0, -1.0],
+            },
+        ];
+
+        assert_eq!(
+            shadowed_antennas_for_rows(&rows, &antennas),
+            vec![true, false, true]
+        );
     }
 }

--- a/crates/casa-ms/src/simulation.rs
+++ b/crates/casa-ms/src/simulation.rs
@@ -12,6 +12,12 @@ use casa_coordinates::{Coordinate, CoordinateSystem, CoordinateType};
 use casa_imaging::{
     ImageGeometry, PrimaryBeamModel, StandardMfsModelPredictor, primary_beam_voltage_pattern,
 };
+use casa_tables::{
+    StreamedTiledPrimitiveColumn, StreamedTiledPrimitiveType, StreamedTiledShapeComplex32Column,
+    StreamingTiledPrimitiveWriter, StreamingTiledShapeComplex32Writer,
+    install_streamed_tiled_column_primitive_column, install_streamed_tiled_shape_complex32_column,
+    install_streamed_tiled_shape_primitive_column,
+};
 use casa_types::measures::direction::{DirectionRef, MDirection};
 use casa_types::measures::epoch::{EpochRef, MEpoch};
 use casa_types::measures::frame::MeasFrame;
@@ -22,9 +28,11 @@ use ndarray::{Array2, ArrayD};
 use num_complex::Complex32;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -547,6 +555,21 @@ pub struct SyntheticMainRowTimingReport {
     pub prediction_millis: u128,
     /// Time spent applying deterministic corruption/noise.
     pub corruption_millis: u128,
+    /// Time spent waiting to enqueue DATA row batches to the background writer.
+    #[serde(default)]
+    pub data_io_enqueue_millis: u128,
+    /// Time spent joining and finalizing the background DATA writer.
+    #[serde(default)]
+    pub data_io_finalize_millis: u128,
+    /// Time spent packing DATA rows into tiled storage buffers.
+    #[serde(default)]
+    pub data_io_assemble_millis: u128,
+    /// Time spent writing DATA tile buffers to disk.
+    #[serde(default)]
+    pub data_io_write_millis: u128,
+    /// Bytes written through the streamed tiled MAIN column writers.
+    #[serde(default)]
+    pub data_io_bytes: u64,
     /// Time spent constructing MAIN rows and appending them to the table.
     pub main_write_millis: u128,
 }
@@ -584,6 +607,12 @@ pub fn generate_synthetic_observation_ms(
         &request.output_ms,
         MeasurementSetBuilder::new().with_main_column(OptionalMainColumn::Data),
     )?;
+    fs::create_dir_all(&request.output_ms).map_err(|error| {
+        MsError::SyntheticObservation(format!(
+            "failed to create output MeasurementSet directory {}: {error}",
+            request.output_ms.display()
+        ))
+    })?;
     let setup_millis = elapsed_millis(setup_started.elapsed());
 
     let metadata_started = Instant::now();
@@ -614,10 +643,32 @@ pub fn generate_synthetic_observation_ms(
         None
     };
     let model_prepare_millis = elapsed_millis(model_started.elapsed());
-    let main_rows = populate_main_rows(&mut ms, request, time_sample_count, model.as_ref())?;
+    let mut main_column_writer = SimobserveMainColumnWriter::start(
+        &request.output_ms,
+        baseline_count * time_sample_count,
+        2,
+        request.spectral_setup.channel_count,
+        &request.telescope_name,
+    )?;
+    let mut main_rows = populate_main_rows(
+        &mut ms,
+        request,
+        time_sample_count,
+        model.as_ref(),
+        &mut main_column_writer,
+    )?;
+    let data_io_finalize_started = Instant::now();
+    let streamed_main_columns = main_column_writer.finish()?;
+    main_rows.timing.data_io_finalize_millis = elapsed_millis(data_io_finalize_started.elapsed());
+    main_rows.timing.data_io_assemble_millis =
+        elapsed_seconds_to_millis(streamed_main_columns.assemble_seconds());
+    main_rows.timing.data_io_write_millis =
+        elapsed_seconds_to_millis(streamed_main_columns.write_seconds());
+    main_rows.timing.data_io_bytes = streamed_main_columns.bytes_written() as u64;
 
     let save_started = Instant::now();
-    ms.save_assuming_valid()?;
+    ms.save_assuming_valid_with_main_column_overrides(&main_rows.scalar_column_overrides)?;
+    install_streamed_main_columns(ms.main_table(), &request.output_ms, streamed_main_columns)?;
     let save_millis = elapsed_millis(save_started.elapsed());
 
     Ok(SyntheticObservationReport {
@@ -1152,18 +1203,23 @@ fn populate_main_rows(
     request: &SyntheticObservationRequest,
     samples: usize,
     model: Option<&FitsModelImage>,
+    main_column_writer: &mut SimobserveMainColumnWriter,
 ) -> MsResult<MainRowsReport> {
     let num_corr = 2usize;
     let num_chan = request.spectral_setup.channel_count;
     let channel_prediction_workers = simobserve_channel_worker_count(num_chan);
     let template = MainRowTemplate {
-        flag: bool_array(&vec![false; num_corr * num_chan], vec![num_corr, num_chan]),
         flag_category: bool_array(&[], vec![0, num_corr, num_chan]),
-        weight: f32_array(&vec![1.0; num_corr], vec![num_corr]),
-        sigma: f32_array(&vec![1.0; num_corr], vec![num_corr]),
     };
-    let main_defs = ms_main_defs(ms);
+    let field_plan_started = Instant::now();
     let field_plans = build_field_plans(request, model)?;
+    if trace_simobserve_setup() {
+        eprintln!(
+            "simobserve_setup_trace stage=field_plans fields={} total_millis={}",
+            field_plans.len(),
+            elapsed_millis(field_plan_started.elapsed())
+        );
+    }
     let corruption = request.corruption.as_ref().map(|config| {
         SyntheticCorruptionState::new(
             config,
@@ -1177,6 +1233,9 @@ fn populate_main_rows(
         channel_prediction_workers,
         ..MainRowTimingDurations::default()
     };
+    let baseline_count = request.antennas.len() * (request.antennas.len() - 1) / 2;
+    let mut scalar_column_overrides =
+        MainScalarColumnOverrides::with_capacity(samples * baseline_count);
 
     for sample in 0..samples {
         let uvw_started = Instant::now();
@@ -1225,37 +1284,25 @@ fn populate_main_rows(
             sample,
         );
         timing.corruption += corruption_started.elapsed();
-        for (spec, data_values) in row_specs.into_iter().zip(data_rows) {
+        let flag_rows = row_specs
+            .iter()
+            .map(|spec| shadowed_antennas[spec.antenna1] || shadowed_antennas[spec.antenna2])
+            .collect::<Vec<_>>();
+        let uvw_rows = row_specs.iter().map(|spec| spec.uvw).collect::<Vec<_>>();
+        let data_io_started = Instant::now();
+        main_column_writer.send_batch(SimobserveMainColumnBatch {
+            data_rows,
+            flag_rows: flag_rows.clone(),
+            uvw_rows,
+        })?;
+        timing.data_io_enqueue += data_io_started.elapsed();
+        for (spec, shadowed_row) in row_specs.into_iter().zip(flag_rows.into_iter()) {
             let write_started = Instant::now();
-            let data = complex_array(&data_values, vec![num_corr, num_chan]);
-            let shadowed_row = shadowed_antennas[spec.antenna1] || shadowed_antennas[spec.antenna2];
-            let row = row_from_defs(
-                &main_defs,
-                &[
-                    ("ANTENNA1", i(spec.antenna1 as i32)),
-                    ("ANTENNA2", i(spec.antenna2 as i32)),
-                    ("ARRAY_ID", i(0)),
-                    ("DATA_DESC_ID", i(0)),
-                    ("EXPOSURE", f(request.integration_seconds)),
-                    ("FEED1", i(0)),
-                    ("FEED2", i(0)),
-                    ("FIELD_ID", i(spec.field_id as i32)),
-                    ("FLAG", template.flag.clone()),
-                    ("FLAG_CATEGORY", template.flag_category.clone()),
-                    ("FLAG_ROW", b(shadowed_row)),
-                    ("INTERVAL", f(request.integration_seconds)),
-                    ("OBSERVATION_ID", i(0)),
-                    ("PROCESSOR_ID", i(0)),
-                    ("SCAN_NUMBER", i(1)),
-                    ("SIGMA", template.sigma.clone()),
-                    ("STATE_ID", i(0)),
-                    ("TIME", f(spec.time)),
-                    ("TIME_CENTROID", f(spec.time)),
-                    ("UVW", f64_array(&spec.uvw, vec![3])),
-                    ("WEIGHT", template.weight.clone()),
-                    ("DATA", data),
-                ],
-            );
+            scalar_column_overrides.push(&spec, request.integration_seconds, shadowed_row);
+            let row = RecordValue::new(vec![RecordField::new(
+                "FLAG_CATEGORY",
+                template.flag_category.clone(),
+            )]);
             ms.main_table_mut().add_row_assuming_valid(row)?;
             timing.main_write += write_started.elapsed();
         }
@@ -1263,6 +1310,7 @@ fn populate_main_rows(
     Ok(MainRowsReport {
         nonzero_visibility_count,
         timing: timing.into_report(),
+        scalar_column_overrides: scalar_column_overrides.into_column_overrides(),
     })
 }
 
@@ -1363,6 +1411,379 @@ fn count_nonzero_complex(values: &[Complex32]) -> usize {
 struct MainRowsReport {
     nonzero_visibility_count: usize,
     timing: SyntheticMainRowTimingReport,
+    scalar_column_overrides: HashMap<String, Vec<Option<Value>>>,
+}
+
+struct SimobserveMainColumnBatch {
+    data_rows: Vec<Vec<Complex32>>,
+    flag_rows: Vec<bool>,
+    uvw_rows: Vec<[f64; 3]>,
+}
+
+struct StreamedSimobserveMainColumns {
+    data: StreamedTiledShapeComplex32Column,
+    flag: StreamedTiledPrimitiveColumn,
+    uvw: StreamedTiledPrimitiveColumn,
+    weight: StreamedTiledPrimitiveColumn,
+    sigma: StreamedTiledPrimitiveColumn,
+}
+
+impl StreamedSimobserveMainColumns {
+    fn assemble_seconds(&self) -> f64 {
+        self.data.assemble_seconds()
+            + self.flag.assemble_seconds()
+            + self.uvw.assemble_seconds()
+            + self.weight.assemble_seconds()
+            + self.sigma.assemble_seconds()
+    }
+
+    fn write_seconds(&self) -> f64 {
+        self.data.write_seconds()
+            + self.flag.write_seconds()
+            + self.uvw.write_seconds()
+            + self.weight.write_seconds()
+            + self.sigma.write_seconds()
+    }
+
+    fn bytes_written(&self) -> usize {
+        self.data.bytes_written()
+            + self.flag.bytes_written()
+            + self.uvw.bytes_written()
+            + self.weight.bytes_written()
+            + self.sigma.bytes_written()
+    }
+}
+
+struct SimobserveMainColumnWriter {
+    sender: mpsc::SyncSender<SimobserveMainColumnBatch>,
+    handle: thread::JoinHandle<MsResult<StreamedSimobserveMainColumns>>,
+}
+
+impl SimobserveMainColumnWriter {
+    fn start(
+        output_ms: &Path,
+        row_count: usize,
+        num_corr: usize,
+        num_chan: usize,
+        telescope_name: &str,
+    ) -> MsResult<Self> {
+        let visibility_tile_shape =
+            crate::ms::casa_visibility_tile_shape(num_corr, num_chan, telescope_name);
+        let weight_tile_shape = crate::ms::casa_weight_tile_shape(&visibility_tile_shape);
+        let uvw_tile_shape = crate::ms::casa_uvw_tile_shape(&visibility_tile_shape);
+
+        let data_writer = StreamingTiledShapeComplex32Writer::create(
+            output_ms.join(".casa-rs.DATA.table.f.tmp"),
+            row_count,
+            vec![num_corr, num_chan],
+            visibility_tile_shape.clone(),
+            false,
+        )
+        .map_err(|error| {
+            MsError::SyntheticObservation(format!("failed to create streamed DATA writer: {error}"))
+        })?;
+        let flag_writer = StreamingTiledPrimitiveWriter::create_shape(
+            output_ms.join(".casa-rs.FLAG.table.f.tmp"),
+            row_count,
+            vec![num_corr, num_chan],
+            visibility_tile_shape,
+            StreamedTiledPrimitiveType::Bool,
+            false,
+        )
+        .map_err(|error| {
+            MsError::SyntheticObservation(format!("failed to create streamed FLAG writer: {error}"))
+        })?;
+        let uvw_writer = StreamingTiledPrimitiveWriter::create_column(
+            output_ms.join(".casa-rs.UVW.table.f.tmp"),
+            row_count,
+            vec![3],
+            uvw_tile_shape,
+            StreamedTiledPrimitiveType::Float64,
+            false,
+        )
+        .map_err(|error| {
+            MsError::SyntheticObservation(format!("failed to create streamed UVW writer: {error}"))
+        })?;
+        let weight_writer = StreamingTiledPrimitiveWriter::create_shape(
+            output_ms.join(".casa-rs.WEIGHT.table.f.tmp"),
+            row_count,
+            vec![num_corr],
+            weight_tile_shape.clone(),
+            StreamedTiledPrimitiveType::Float32,
+            false,
+        )
+        .map_err(|error| {
+            MsError::SyntheticObservation(format!(
+                "failed to create streamed WEIGHT writer: {error}"
+            ))
+        })?;
+        let sigma_writer = StreamingTiledPrimitiveWriter::create_shape(
+            output_ms.join(".casa-rs.SIGMA.table.f.tmp"),
+            row_count,
+            vec![num_corr],
+            weight_tile_shape,
+            StreamedTiledPrimitiveType::Float32,
+            false,
+        )
+        .map_err(|error| {
+            MsError::SyntheticObservation(format!(
+                "failed to create streamed SIGMA writer: {error}"
+            ))
+        })?;
+
+        let (sender, receiver) =
+            mpsc::sync_channel::<SimobserveMainColumnBatch>(simobserve_io_queue_depth());
+        let handle = thread::spawn(move || {
+            let mut data_writer = data_writer;
+            let mut flag_writer = flag_writer;
+            let mut uvw_writer = uvw_writer;
+            let mut weight_writer = weight_writer;
+            let mut sigma_writer = sigma_writer;
+            let weight_row = vec![1.0f32; num_corr];
+            let sigma_row = vec![1.0f32; num_corr];
+            let flag_true_row = vec![true; num_corr * num_chan];
+
+            for batch in receiver {
+                if batch.data_rows.len() != batch.flag_rows.len()
+                    || batch.data_rows.len() != batch.uvw_rows.len()
+                {
+                    return Err(MsError::SyntheticObservation(format!(
+                        "background MAIN column writer received inconsistent batch sizes: DATA={} FLAG={} UVW={}",
+                        batch.data_rows.len(),
+                        batch.flag_rows.len(),
+                        batch.uvw_rows.len()
+                    )));
+                }
+                for ((data_row, flag_row), uvw_row) in batch
+                    .data_rows
+                    .into_iter()
+                    .zip(batch.flag_rows.into_iter())
+                    .zip(batch.uvw_rows.into_iter())
+                {
+                    data_writer.push_row(&data_row).map_err(|error| {
+                        MsError::SyntheticObservation(format!(
+                            "failed to stream DATA row into tiled storage: {error}"
+                        ))
+                    })?;
+                    if flag_row {
+                        flag_writer.push_bool_row(&flag_true_row).map_err(|error| {
+                            MsError::SyntheticObservation(format!(
+                                "failed to stream FLAG row into tiled storage: {error}"
+                            ))
+                        })?;
+                    } else {
+                        flag_writer.push_zero_row().map_err(|error| {
+                            MsError::SyntheticObservation(format!(
+                                "failed to stream empty FLAG row into tiled storage: {error}"
+                            ))
+                        })?;
+                    }
+                    uvw_writer.push_f64_row(&uvw_row).map_err(|error| {
+                        MsError::SyntheticObservation(format!(
+                            "failed to stream UVW row into tiled storage: {error}"
+                        ))
+                    })?;
+                    weight_writer.push_f32_row(&weight_row).map_err(|error| {
+                        MsError::SyntheticObservation(format!(
+                            "failed to stream WEIGHT row into tiled storage: {error}"
+                        ))
+                    })?;
+                    sigma_writer.push_f32_row(&sigma_row).map_err(|error| {
+                        MsError::SyntheticObservation(format!(
+                            "failed to stream SIGMA row into tiled storage: {error}"
+                        ))
+                    })?;
+                }
+            }
+            Ok(StreamedSimobserveMainColumns {
+                data: data_writer.finish().map_err(|error| {
+                    MsError::SyntheticObservation(format!(
+                        "failed to finalize streamed DATA writer: {error}"
+                    ))
+                })?,
+                flag: flag_writer.finish().map_err(|error| {
+                    MsError::SyntheticObservation(format!(
+                        "failed to finalize streamed FLAG writer: {error}"
+                    ))
+                })?,
+                uvw: uvw_writer.finish().map_err(|error| {
+                    MsError::SyntheticObservation(format!(
+                        "failed to finalize streamed UVW writer: {error}"
+                    ))
+                })?,
+                weight: weight_writer.finish().map_err(|error| {
+                    MsError::SyntheticObservation(format!(
+                        "failed to finalize streamed WEIGHT writer: {error}"
+                    ))
+                })?,
+                sigma: sigma_writer.finish().map_err(|error| {
+                    MsError::SyntheticObservation(format!(
+                        "failed to finalize streamed SIGMA writer: {error}"
+                    ))
+                })?,
+            })
+        });
+        Ok(Self { sender, handle })
+    }
+
+    fn send_batch(&self, batch: SimobserveMainColumnBatch) -> MsResult<()> {
+        self.sender.send(batch).map_err(|error| {
+            MsError::SyntheticObservation(format!(
+                "background MAIN column writer stopped before accepting rows: {error}"
+            ))
+        })
+    }
+
+    fn finish(self) -> MsResult<StreamedSimobserveMainColumns> {
+        drop(self.sender);
+        self.handle.join().map_err(|_| {
+            MsError::SyntheticObservation("background MAIN column writer panicked".to_string())
+        })?
+    }
+}
+
+fn install_streamed_main_columns(
+    main: &casa_tables::Table,
+    output_ms: &Path,
+    streamed: StreamedSimobserveMainColumns,
+) -> MsResult<()> {
+    let data_seq = data_manager_sequence(main, "DATA")?;
+    install_streamed_tiled_shape_complex32_column(output_ms, data_seq, "DATA", streamed.data)
+        .map_err(|error| {
+            MsError::SyntheticObservation(format!(
+                "failed to install streamed DATA column: {error}"
+            ))
+        })?;
+
+    let flag_seq = data_manager_sequence(main, "FLAG")?;
+    install_streamed_tiled_shape_primitive_column(output_ms, flag_seq, "FLAG", streamed.flag)
+        .map_err(|error| {
+            MsError::SyntheticObservation(format!(
+                "failed to install streamed FLAG column: {error}"
+            ))
+        })?;
+
+    let uvw_seq = data_manager_sequence(main, "UVW")?;
+    install_streamed_tiled_column_primitive_column(output_ms, uvw_seq, "UVW", streamed.uvw)
+        .map_err(|error| {
+            MsError::SyntheticObservation(format!("failed to install streamed UVW column: {error}"))
+        })?;
+
+    let weight_seq = data_manager_sequence(main, "WEIGHT")?;
+    install_streamed_tiled_shape_primitive_column(output_ms, weight_seq, "WEIGHT", streamed.weight)
+        .map_err(|error| {
+            MsError::SyntheticObservation(format!(
+                "failed to install streamed WEIGHT column: {error}"
+            ))
+        })?;
+
+    let sigma_seq = data_manager_sequence(main, "SIGMA")?;
+    install_streamed_tiled_shape_primitive_column(output_ms, sigma_seq, "SIGMA", streamed.sigma)
+        .map_err(|error| {
+            MsError::SyntheticObservation(format!(
+                "failed to install streamed SIGMA column: {error}"
+            ))
+        })?;
+
+    Ok(())
+}
+
+fn data_manager_sequence(main: &casa_tables::Table, column: &str) -> MsResult<u32> {
+    crate::ms::measurement_set_main_data_manager_sequence(main, column).ok_or_else(|| {
+        MsError::SyntheticObservation(format!(
+            "could not resolve {column} data-manager sequence for streamed install"
+        ))
+    })
+}
+
+fn simobserve_io_queue_depth() -> usize {
+    std::env::var("CASA_RS_SIMOBSERVE_IO_QUEUE_DEPTH")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(2)
+}
+
+struct MainScalarColumnOverrides {
+    antenna1: Vec<Option<Value>>,
+    antenna2: Vec<Option<Value>>,
+    array_id: Vec<Option<Value>>,
+    data_desc_id: Vec<Option<Value>>,
+    exposure: Vec<Option<Value>>,
+    feed1: Vec<Option<Value>>,
+    feed2: Vec<Option<Value>>,
+    field_id: Vec<Option<Value>>,
+    flag_row: Vec<Option<Value>>,
+    interval: Vec<Option<Value>>,
+    observation_id: Vec<Option<Value>>,
+    processor_id: Vec<Option<Value>>,
+    scan_number: Vec<Option<Value>>,
+    state_id: Vec<Option<Value>>,
+    time: Vec<Option<Value>>,
+    time_centroid: Vec<Option<Value>>,
+}
+
+impl MainScalarColumnOverrides {
+    fn with_capacity(row_count: usize) -> Self {
+        Self {
+            antenna1: Vec::with_capacity(row_count),
+            antenna2: Vec::with_capacity(row_count),
+            array_id: Vec::with_capacity(row_count),
+            data_desc_id: Vec::with_capacity(row_count),
+            exposure: Vec::with_capacity(row_count),
+            feed1: Vec::with_capacity(row_count),
+            feed2: Vec::with_capacity(row_count),
+            field_id: Vec::with_capacity(row_count),
+            flag_row: Vec::with_capacity(row_count),
+            interval: Vec::with_capacity(row_count),
+            observation_id: Vec::with_capacity(row_count),
+            processor_id: Vec::with_capacity(row_count),
+            scan_number: Vec::with_capacity(row_count),
+            state_id: Vec::with_capacity(row_count),
+            time: Vec::with_capacity(row_count),
+            time_centroid: Vec::with_capacity(row_count),
+        }
+    }
+
+    fn push(&mut self, spec: &MainRowVisibilitySpec, integration_seconds: f64, flag_row: bool) {
+        self.antenna1.push(Some(i(spec.antenna1 as i32)));
+        self.antenna2.push(Some(i(spec.antenna2 as i32)));
+        self.array_id.push(Some(i(0)));
+        self.data_desc_id.push(Some(i(0)));
+        self.exposure.push(Some(f(integration_seconds)));
+        self.feed1.push(Some(i(0)));
+        self.feed2.push(Some(i(0)));
+        self.field_id.push(Some(i(spec.field_id as i32)));
+        self.flag_row.push(Some(b(flag_row)));
+        self.interval.push(Some(f(integration_seconds)));
+        self.observation_id.push(Some(i(0)));
+        self.processor_id.push(Some(i(0)));
+        self.scan_number.push(Some(i(1)));
+        self.state_id.push(Some(i(0)));
+        self.time.push(Some(f(spec.time)));
+        self.time_centroid.push(Some(f(spec.time)));
+    }
+
+    fn into_column_overrides(self) -> HashMap<String, Vec<Option<Value>>> {
+        HashMap::from([
+            ("ANTENNA1".to_string(), self.antenna1),
+            ("ANTENNA2".to_string(), self.antenna2),
+            ("ARRAY_ID".to_string(), self.array_id),
+            ("DATA_DESC_ID".to_string(), self.data_desc_id),
+            ("EXPOSURE".to_string(), self.exposure),
+            ("FEED1".to_string(), self.feed1),
+            ("FEED2".to_string(), self.feed2),
+            ("FIELD_ID".to_string(), self.field_id),
+            ("FLAG_ROW".to_string(), self.flag_row),
+            ("INTERVAL".to_string(), self.interval),
+            ("OBSERVATION_ID".to_string(), self.observation_id),
+            ("PROCESSOR_ID".to_string(), self.processor_id),
+            ("SCAN_NUMBER".to_string(), self.scan_number),
+            ("STATE_ID".to_string(), self.state_id),
+            ("TIME".to_string(), self.time),
+            ("TIME_CENTROID".to_string(), self.time_centroid),
+        ])
+    }
 }
 
 #[derive(Default)]
@@ -1371,6 +1792,7 @@ struct MainRowTimingDurations {
     uvw_and_row_setup: Duration,
     prediction: Duration,
     corruption: Duration,
+    data_io_enqueue: Duration,
     main_write: Duration,
 }
 
@@ -1381,17 +1803,23 @@ impl MainRowTimingDurations {
             uvw_and_row_setup_millis: elapsed_millis(self.uvw_and_row_setup),
             prediction_millis: elapsed_millis(self.prediction),
             corruption_millis: elapsed_millis(self.corruption),
+            data_io_enqueue_millis: elapsed_millis(self.data_io_enqueue),
+            data_io_finalize_millis: 0,
+            data_io_assemble_millis: 0,
+            data_io_write_millis: 0,
+            data_io_bytes: 0,
             main_write_millis: elapsed_millis(self.main_write),
         }
     }
 }
 
+fn elapsed_seconds_to_millis(seconds: f64) -> u128 {
+    (seconds * 1000.0).round() as u128
+}
+
 #[derive(Clone)]
 struct MainRowTemplate {
-    flag: Value,
     flag_category: Value,
-    weight: Value,
-    sigma: Value,
 }
 
 #[derive(Clone, Copy)]
@@ -1500,10 +1928,20 @@ fn synthetic_primary_beam(request: &SyntheticObservationRequest) -> SyntheticPri
         .sum::<f64>()
         / request.antennas.len().max(1) as f64;
     let telescope_is_vla = request.telescope_name.eq_ignore_ascii_case("VLA");
+    let telescope_is_alma_family = request.telescope_name.eq_ignore_ascii_case("ALMA")
+        || request.telescope_name.eq_ignore_ascii_case("ACA");
+    let (beam_dish_diameter_m, blockage_diameter_m) =
+        if telescope_is_alma_family && (dish_diameter_m - 12.0).abs() < 0.5 {
+            (10.7, 0.75)
+        } else if telescope_is_alma_family && (dish_diameter_m - 7.0).abs() < 0.5 {
+            (6.25, 0.75)
+        } else {
+            (dish_diameter_m, if telescope_is_vla { 2.36 } else { 0.0 })
+        };
     SyntheticPrimaryBeam {
         use_casa_vla_q_table: telescope_is_vla && (dish_diameter_m - 25.0).abs() < 1.0e-6,
-        dish_diameter_m,
-        blockage_diameter_m: if telescope_is_vla { 2.36 } else { 0.0 },
+        dish_diameter_m: beam_dish_diameter_m,
+        blockage_diameter_m,
     }
 }
 
@@ -1519,50 +1957,151 @@ fn build_channel_predictors(
         cell_size_rad: model.cell_size_rad,
     };
     let phase_offset_rad = casa_model_phase_offset(model, phase_center_rad);
-    (0..spectral_setup.channel_count)
-        .map(|channel| {
-            let frequency_hz = spectral_setup.start_frequency_hz
-                + channel as f64 * spectral_setup.channel_width_hz;
-            let beam_corrected_pixels = apply_simulator_primary_beam(
-                model,
-                model.pixels_for_channel(channel),
-                phase_center_rad,
-                frequency_hz,
-                pointing_offset_rad,
-                primary_beam,
+    let context = ChannelPredictorContext {
+        model,
+        spectral_setup,
+        geometry,
+        phase_center_rad,
+        phase_offset_rad,
+        pointing_offset_rad,
+        primary_beam,
+    };
+    let worker_count = simobserve_channel_worker_count(spectral_setup.channel_count);
+    if worker_count <= 1 || spectral_setup.channel_count <= 1 {
+        return build_channel_predictor_range(&context, 0, spectral_setup.channel_count);
+    }
+
+    let chunk_size = spectral_setup.channel_count.div_ceil(worker_count);
+    thread::scope(|scope| {
+        let mut handles = Vec::new();
+        for start_channel in (0..spectral_setup.channel_count).step_by(chunk_size) {
+            let end_channel = (start_channel + chunk_size).min(spectral_setup.channel_count);
+            let worker_context = context;
+            handles.push(scope.spawn(move || {
+                build_channel_predictor_range(&worker_context, start_channel, end_channel)
+            }));
+        }
+
+        let mut predictors = Vec::with_capacity(spectral_setup.channel_count);
+        for handle in handles {
+            predictors.extend(
+                handle
+                    .join()
+                    .expect("synthetic observation predictor setup worker should not panic")?,
             );
-            let mut casa_oriented_pixels = Array2::<f32>::zeros(beam_corrected_pixels.raw_dim());
-            if model.ra_axis_increases_with_x {
-                for x in 0..beam_corrected_pixels.shape()[0] {
-                    for y in 0..beam_corrected_pixels.shape()[1] {
-                        // CASA's simulator image prediction treats positive RA
-                        // offsets with the opposite image-x handedness from this
-                        // crate's pure imaging gridder. Conventional FITS images
-                        // already have CDELT1 < 0, so only positive-RA image axes
-                        // need this compatibility flip.
-                        casa_oriented_pixels[(beam_corrected_pixels.shape()[0] - 1 - x, y)] =
-                            beam_corrected_pixels[(x, y)];
-                    }
-                }
-            } else {
-                for x in 0..beam_corrected_pixels.shape()[0] {
-                    for y in 0..beam_corrected_pixels.shape()[1] {
-                        casa_oriented_pixels[(x, y)] = beam_corrected_pixels[(x, y)];
-                    }
-                }
+        }
+        Ok(predictors)
+    })
+}
+
+#[derive(Clone, Copy)]
+struct ChannelPredictorContext<'a> {
+    model: &'a FitsModelImage,
+    spectral_setup: &'a SyntheticSpectralSetup,
+    geometry: ImageGeometry,
+    phase_center_rad: [f64; 2],
+    phase_offset_rad: [f64; 2],
+    pointing_offset_rad: [f64; 2],
+    primary_beam: SyntheticPrimaryBeam,
+}
+
+fn build_channel_predictor_range(
+    context: &ChannelPredictorContext<'_>,
+    start_channel: usize,
+    end_channel: usize,
+) -> MsResult<Vec<SyntheticChannelPredictor>> {
+    let range_started = Instant::now();
+    let mut timing = ChannelPredictorBuildTiming::default();
+    let mut predictors = Vec::with_capacity(end_channel - start_channel);
+    for channel in start_channel..end_channel {
+        let (predictor, channel_timing) = build_one_channel_predictor(context, channel)?;
+        timing += channel_timing;
+        predictors.push(predictor);
+    }
+    if trace_simobserve_setup() {
+        eprintln!(
+            "simobserve_setup_trace stage=channel_predictor_range start_channel={} end_channel={} channels={} total_millis={} primary_beam_millis={} orientation_millis={} fft_predictor_millis={}",
+            start_channel,
+            end_channel,
+            end_channel - start_channel,
+            elapsed_millis(range_started.elapsed()),
+            elapsed_millis(timing.primary_beam),
+            elapsed_millis(timing.orientation),
+            elapsed_millis(timing.fft_predictor),
+        );
+    }
+    Ok(predictors)
+}
+
+#[derive(Default, Clone, Copy)]
+struct ChannelPredictorBuildTiming {
+    primary_beam: Duration,
+    orientation: Duration,
+    fft_predictor: Duration,
+}
+
+impl std::ops::AddAssign for ChannelPredictorBuildTiming {
+    fn add_assign(&mut self, rhs: Self) {
+        self.primary_beam += rhs.primary_beam;
+        self.orientation += rhs.orientation;
+        self.fft_predictor += rhs.fft_predictor;
+    }
+}
+
+fn build_one_channel_predictor(
+    context: &ChannelPredictorContext<'_>,
+    channel: usize,
+) -> MsResult<(SyntheticChannelPredictor, ChannelPredictorBuildTiming)> {
+    let mut timing = ChannelPredictorBuildTiming::default();
+    let frequency_hz = context.spectral_setup.start_frequency_hz
+        + channel as f64 * context.spectral_setup.channel_width_hz;
+    let primary_beam_started = Instant::now();
+    let beam_corrected_pixels = apply_simulator_primary_beam(
+        context.model,
+        context.model.pixels_for_channel(channel),
+        context.phase_center_rad,
+        frequency_hz,
+        context.pointing_offset_rad,
+        context.primary_beam,
+    );
+    timing.primary_beam = primary_beam_started.elapsed();
+    let orientation_started = Instant::now();
+    let mut casa_oriented_pixels = Array2::<f32>::zeros(beam_corrected_pixels.raw_dim());
+    if context.model.ra_axis_increases_with_x {
+        for x in 0..beam_corrected_pixels.shape()[0] {
+            for y in 0..beam_corrected_pixels.shape()[1] {
+                // CASA's simulator image prediction treats positive RA offsets
+                // with the opposite image-x handedness from this crate's pure
+                // imaging gridder. Conventional FITS images already have
+                // CDELT1 < 0, so only positive-RA image axes need this
+                // compatibility flip.
+                casa_oriented_pixels[(beam_corrected_pixels.shape()[0] - 1 - x, y)] =
+                    beam_corrected_pixels[(x, y)];
             }
-            let predictor = StandardMfsModelPredictor::new(geometry, &casa_oriented_pixels)
-                .map_err(|error| {
-                    MsError::SyntheticObservation(format!("model prediction setup failed: {error}"))
-                })?;
-            Ok(SyntheticChannelPredictor {
-                predictor,
-                phase_offset_rad,
-                phase_center_rad,
-                model_reference_direction_rad: model.reference_direction_rad,
-            })
-        })
-        .collect()
+        }
+    } else {
+        for x in 0..beam_corrected_pixels.shape()[0] {
+            for y in 0..beam_corrected_pixels.shape()[1] {
+                casa_oriented_pixels[(x, y)] = beam_corrected_pixels[(x, y)];
+            }
+        }
+    }
+    timing.orientation = orientation_started.elapsed();
+    let fft_started = Instant::now();
+    let predictor = StandardMfsModelPredictor::new(context.geometry, &casa_oriented_pixels)
+        .map_err(|error| {
+            MsError::SyntheticObservation(format!("model prediction setup failed: {error}"))
+        })?;
+    timing.fft_predictor = fft_started.elapsed();
+    Ok((
+        SyntheticChannelPredictor {
+            predictor,
+            phase_offset_rad: context.phase_offset_rad,
+            phase_center_rad: context.phase_center_rad,
+            model_reference_direction_rad: context.model.reference_direction_rad,
+        },
+        timing,
+    ))
 }
 
 fn apply_simulator_primary_beam(
@@ -1715,7 +2254,7 @@ fn predicted_data_values(
             let phase_shift = Complex32::new(phase.cos() as f32, phase.sin() as f32);
             let visibility = predictor.predictor.predict(u_lambda, v_lambda) * phase_shift;
             for corr in 0..num_corr {
-                let index = corr * spectral_setup.channel_count + channel;
+                let index = ms_data_index(corr, channel, num_corr);
                 values[index] = visibility;
             }
         }
@@ -1782,14 +2321,10 @@ fn predicted_data_values_for_rows_with_workers(
         if chunk.values_by_row.is_empty() {
             continue;
         }
-        let chunk_len = chunk.values_by_row[0].len() / num_corr;
         for (row_index, row_chunk) in chunk.values_by_row.into_iter().enumerate() {
-            for corr in 0..num_corr {
-                let src_start = corr * chunk_len;
-                let dst_start = corr * channel_count + chunk.start_channel;
-                values_by_row[row_index][dst_start..dst_start + chunk_len]
-                    .copy_from_slice(&row_chunk[src_start..src_start + chunk_len]);
-            }
+            let dst_start = chunk.start_channel * num_corr;
+            let dst_end = dst_start + row_chunk.len();
+            values_by_row[row_index][dst_start..dst_end].copy_from_slice(&row_chunk);
         }
     }
     values_by_row
@@ -1811,7 +2346,7 @@ fn predict_channel_chunk(
             let predictor = &predictors[channel];
             let visibility = predict_channel_visibility(predictor, spectral_setup, *uvw_m, channel);
             for corr in 0..num_corr {
-                row_values[corr * chunk_len + offset] = visibility;
+                row_values[ms_data_index(corr, offset, num_corr)] = visibility;
             }
         }
         values_by_row.push(row_values);
@@ -1880,6 +2415,10 @@ fn simobserve_channel_worker_count_for(
         .min(available.max(1))
         .min(channel_count)
         .max(1)
+}
+
+fn trace_simobserve_setup() -> bool {
+    std::env::var("CASA_RS_SIMOBSERVE_TRACE_SETUP").is_ok_and(|value| value != "0")
 }
 
 fn simobserve_row_worker_count(row_count: usize, channel_count: usize) -> usize {
@@ -2002,9 +2541,15 @@ impl SyntheticCorruptionState {
         sample_index: usize,
     ) {
         let gains = &self.gains_by_sample[sample_index % self.gains_by_sample.len()];
+        let correlation_count = if channel_count == 0 {
+            0
+        } else {
+            values.len() / channel_count
+        };
         for (index, value) in values.iter_mut().enumerate() {
-            let channel = index % channel_count;
-            let correlation = index / channel_count;
+            let channel = index / correlation_count;
+            let correlation = index % correlation_count;
+            let logical_index = correlation * channel_count + channel;
             let baseline_gain = gains[antenna1][correlation]
                 * gains[antenna2][correlation].conj()
                 * self.bandpass_gains[antenna1][channel]
@@ -2016,7 +2561,7 @@ impl SyntheticCorruptionState {
                     sample_index,
                     antenna1,
                     antenna2,
-                    index,
+                    logical_index,
                 ));
                 value.re += rng.gaussian_f32() * self.simplenoise_jy;
                 value.im += rng.gaussian_f32() * self.simplenoise_jy;
@@ -2029,8 +2574,8 @@ impl SyntheticCorruptionState {
                 self.leakage_terms[antenna1][1] * self.leakage_terms[antenna2][1].conj();
             if rr_leakage != Complex32::new(0.0, 0.0) || ll_leakage != Complex32::new(0.0, 0.0) {
                 for channel in 0..channel_count {
-                    let rr_index = channel;
-                    let ll_index = channel_count + channel;
+                    let rr_index = ms_data_index(0, channel, 2);
+                    let ll_index = ms_data_index(1, channel, 2);
                     let rr = values[rr_index];
                     let ll = values[ll_index];
                     values[rr_index] = rr + rr_leakage * ll;
@@ -3049,26 +3594,6 @@ fn scale_vector(vector: [f64; 3], scale: f64) -> [f64; 3] {
     [vector[0] * scale, vector[1] * scale, vector[2] * scale]
 }
 
-fn ms_main_defs(ms: &MeasurementSet) -> Vec<ColumnDef> {
-    let all_defs = schema::main_table::REQUIRED_COLUMNS
-        .iter()
-        .chain(schema::main_table::OPTIONAL_COLUMNS.iter())
-        .copied()
-        .collect::<Vec<_>>();
-    ms.main_table()
-        .schema()
-        .expect("main table schema")
-        .columns()
-        .iter()
-        .map(|column| {
-            *all_defs
-                .iter()
-                .find(|definition| definition.name == column.name())
-                .expect("known MS main column")
-        })
-        .collect()
-}
-
 fn row_from_defs(defs: &[ColumnDef], overrides: &[(&str, Value)]) -> RecordValue {
     let fields = defs
         .iter()
@@ -3167,6 +3692,24 @@ fn complex_array(values: &[Complex32], shape: Vec<usize>) -> Value {
     Value::Array(ArrayValue::Complex32(
         ArrayD::from_shape_vec(shape, values.to_vec()).unwrap(),
     ))
+}
+
+#[cfg(test)]
+fn complex_array_from_ms_data_storage(
+    values: &[Complex32],
+    num_corr: usize,
+    num_chan: usize,
+) -> Value {
+    use ndarray::{IxDyn, ShapeBuilder};
+
+    let shape = IxDyn(&[num_corr, num_chan]).strides(IxDyn(&[1, num_corr]));
+    Value::Array(ArrayValue::Complex32(
+        ArrayD::from_shape_vec(shape, values.to_vec()).unwrap(),
+    ))
+}
+
+fn ms_data_index(correlation: usize, channel: usize, num_corr: usize) -> usize {
+    channel * num_corr + correlation
 }
 
 fn string_array(values: &[&str], shape: Vec<usize>) -> Value {
@@ -3347,6 +3890,31 @@ mod tests {
         assert_eq!(serial, parallel);
     }
 
+    #[test]
+    fn ms_data_array_uses_casacore_storage_order() {
+        let values = vec![
+            Complex32::new(10.0, 0.0),
+            Complex32::new(20.0, 0.0),
+            Complex32::new(11.0, 0.0),
+            Complex32::new(21.0, 0.0),
+            Complex32::new(12.0, 0.0),
+            Complex32::new(22.0, 0.0),
+        ];
+        let Value::Array(ArrayValue::Complex32(array)) =
+            complex_array_from_ms_data_storage(&values, 2, 3)
+        else {
+            panic!("expected complex DATA array");
+        };
+
+        assert_eq!(array.shape(), &[2, 3]);
+        assert_eq!(array.strides(), &[1, 2]);
+        assert_eq!(array[[0, 0]], Complex32::new(10.0, 0.0));
+        assert_eq!(array[[1, 0]], Complex32::new(20.0, 0.0));
+        assert_eq!(array[[0, 2]], Complex32::new(12.0, 0.0));
+        assert_eq!(array[[1, 2]], Complex32::new(22.0, 0.0));
+        assert_eq!(array.as_slice_memory_order().unwrap(), values.as_slice());
+    }
+
     fn write_test_fits_plane(path: &Path) {
         let mut cards = test_fits_cards(&[
             ("SIMPLE", "T"),
@@ -3478,6 +4046,27 @@ mod tests {
 
         assert!((at_half_max_radius - 0.596_901_4).abs() < 1.0e-7);
         assert!((at_support - -0.017_125_657).abs() < 1.0e-8);
+    }
+
+    #[test]
+    fn alma_primary_beam_uses_casa_effective_diameter_for_model_prediction() {
+        let mut request = SyntheticObservationRequest::vla_ppdisk(
+            PathBuf::from("model.fits"),
+            PathBuf::from("out.ms"),
+            vec![SyntheticAntenna {
+                name: "A000".to_string(),
+                station: "A000".to_string(),
+                position_m: [0.0, 0.0, 0.0],
+                dish_diameter_m: 12.0,
+            }],
+        );
+        request.telescope_name = "ALMA".to_string();
+
+        let primary_beam = synthetic_primary_beam(&request);
+
+        assert_eq!(primary_beam.dish_diameter_m, 10.7);
+        assert_eq!(primary_beam.blockage_diameter_m, 0.75);
+        assert!(!primary_beam.use_casa_vla_q_table);
     }
 
     #[test]

--- a/crates/casa-ms/src/simulation.rs
+++ b/crates/casa-ms/src/simulation.rs
@@ -8,7 +8,9 @@
 //! write CASA-compatible MS subtables plus uncorrupted visibility rows.
 
 use casa_coordinates::fits::{FitsHeader, from_fits_header};
-use casa_coordinates::{Coordinate, CoordinateSystem, CoordinateType};
+use casa_coordinates::{
+    Coordinate, CoordinateSystem, CoordinateType, DirectionCoordinate, Projection, ProjectionType,
+};
 use casa_imaging::{
     ImageGeometry, PrimaryBeamModel, StandardMfsModelPredictor, primary_beam_voltage_pattern,
 };
@@ -41,6 +43,8 @@ use crate::error::{MsError, MsResult};
 use crate::flagging::shadowed_antennas_from_projected_baselines;
 use crate::schema::{self, SubtableId};
 use crate::{MeasurementSet, MeasurementSetBuilder, OptionalMainColumn};
+
+const CASA_SIMOBSERVE_ELEVATION_LIMIT_RAD: f64 = 8.0_f64.to_radians();
 
 /// Antenna configuration row for a synthetic observation.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -290,6 +294,10 @@ impl SyntheticSpectralSetup {
 
     fn total_bandwidth_hz(&self) -> f64 {
         self.channel_width_hz.abs() * self.channel_count as f64
+    }
+
+    fn reference_frequency_hz(&self) -> f64 {
+        self.start_frequency_hz + (self.channel_count / 2) as f64 * self.channel_width_hz
     }
 }
 
@@ -1021,7 +1029,7 @@ fn populate_spectral_window(
         &[
             ("NUM_CHAN", i(spectral_setup.channel_count as i32)),
             ("NAME", s(&spectral_setup.name)),
-            ("REF_FREQUENCY", f(spectral_setup.start_frequency_hz)),
+            ("REF_FREQUENCY", f(spectral_setup.reference_frequency_hz())),
             ("TOTAL_BANDWIDTH", f(spectral_setup.total_bandwidth_hz())),
             (
                 "CHAN_FREQ",
@@ -1236,6 +1244,9 @@ fn populate_main_rows(
     let baseline_count = request.antennas.len() * (request.antennas.len() - 1) / 2;
     let mut scalar_column_overrides =
         MainScalarColumnOverrides::with_capacity(samples * baseline_count);
+    let observatory = simulation_observatory_position(&request.telescope_name, &request.antennas);
+    let elevation_margin_rad = antenna_elevation_margin_rad(&request.antennas, &observatory);
+    let uvw_production_trace = SimobserveUvwProductionTrace::from_env();
 
     for sample in 0..samples {
         let uvw_started = Instant::now();
@@ -1243,8 +1254,12 @@ fn populate_main_rows(
         let field_plan = &field_plans[field_id];
         let time =
             request.start_time_mjd_seconds + (sample as f64 + 0.5) * request.integration_seconds;
-        let antenna_uvws =
-            antenna_uvw_positions(&request.antennas, field_plan.phase_center_rad, time)?;
+        let antenna_uvws = antenna_uvw_positions(
+            &request.antennas,
+            field_plan.phase_center_rad,
+            time,
+            &observatory,
+        )?;
         let mut row_specs = Vec::with_capacity(request.antennas.len() * request.antennas.len());
         for antenna1 in 0..request.antennas.len() {
             for antenna2 in (antenna1 + 1)..request.antennas.len() {
@@ -1253,6 +1268,24 @@ fn populate_main_rows(
                     antenna_uvws[antenna2][1] - antenna_uvws[antenna1][1],
                     antenna_uvws[antenna2][2] - antenna_uvws[antenna1][2],
                 ];
+                let row_number = sample * baseline_count + row_specs.len();
+                if uvw_production_trace
+                    .as_ref()
+                    .is_some_and(|trace| trace.matches(antenna1, antenna2, time))
+                {
+                    trace_simobserve_production_uvw(
+                        row_number,
+                        sample,
+                        antenna1,
+                        antenna2,
+                        time,
+                        field_plan.phase_center_rad,
+                        &observatory,
+                        &request.antennas,
+                        &antenna_uvws,
+                        uvw,
+                    );
+                }
                 row_specs.push(MainRowVisibilitySpec {
                     antenna1,
                     antenna2,
@@ -1264,6 +1297,13 @@ fn populate_main_rows(
         }
         let row_uvws = row_specs.iter().map(|spec| spec.uvw).collect::<Vec<_>>();
         let shadowed_antennas = shadowed_antennas_for_rows(&row_specs, &request.antennas);
+        let low_elevation_antennas = antennas_below_elevation_limit(
+            field_plan.phase_center_rad,
+            time,
+            &request.antennas,
+            &observatory,
+            elevation_margin_rad,
+        )?;
         timing.uvw_and_row_setup += uvw_started.elapsed();
 
         let prediction_started = Instant::now();
@@ -1286,7 +1326,12 @@ fn populate_main_rows(
         timing.corruption += corruption_started.elapsed();
         let flag_rows = row_specs
             .iter()
-            .map(|spec| shadowed_antennas[spec.antenna1] || shadowed_antennas[spec.antenna2])
+            .map(|spec| {
+                low_elevation_antennas[spec.antenna1]
+                    || low_elevation_antennas[spec.antenna2]
+                    || shadowed_antennas[spec.antenna1]
+                    || shadowed_antennas[spec.antenna2]
+            })
             .collect::<Vec<_>>();
         let uvw_rows = row_specs.iter().map(|spec| spec.uvw).collect::<Vec<_>>();
         let data_io_started = Instant::now();
@@ -1330,6 +1375,84 @@ fn shadowed_antennas_for_rows(
             )
         }),
     )
+}
+
+fn antennas_below_elevation_limit(
+    phase_center_rad: [f64; 2],
+    time_mjd_seconds: f64,
+    antennas: &[SyntheticAntenna],
+    observatory: &MPosition,
+    elevation_margin_rad: f64,
+) -> MsResult<Vec<bool>> {
+    let observatory_elevation_rad =
+        field_elevation_rad(phase_center_rad, time_mjd_seconds, observatory)?;
+    if observatory_elevation_rad + elevation_margin_rad < CASA_SIMOBSERVE_ELEVATION_LIMIT_RAD {
+        return Ok(vec![true; antennas.len()]);
+    }
+    if observatory_elevation_rad - elevation_margin_rad > CASA_SIMOBSERVE_ELEVATION_LIMIT_RAD {
+        return Ok(vec![false; antennas.len()]);
+    }
+
+    antennas
+        .iter()
+        .map(|antenna| {
+            let position = MPosition::new_itrf(
+                antenna.position_m[0],
+                antenna.position_m[1],
+                antenna.position_m[2],
+            );
+            Ok(
+                field_elevation_rad(phase_center_rad, time_mjd_seconds, &position)?
+                    < CASA_SIMOBSERVE_ELEVATION_LIMIT_RAD,
+            )
+        })
+        .collect()
+}
+
+fn antenna_elevation_margin_rad(antennas: &[SyntheticAntenna], observatory: &MPosition) -> f64 {
+    let observatory_itrf = observatory.as_itrf();
+    let observatory_radius_m = vector_norm(observatory_itrf);
+    if observatory_radius_m == 0.0 {
+        return 0.0;
+    }
+
+    antennas
+        .iter()
+        .map(|antenna| {
+            let offset = [
+                antenna.position_m[0] - observatory_itrf[0],
+                antenna.position_m[1] - observatory_itrf[1],
+                antenna.position_m[2] - observatory_itrf[2],
+            ];
+            vector_norm(offset) / observatory_radius_m
+        })
+        .fold(0.0_f64, f64::max)
+        + 1.0e-9
+}
+
+fn field_elevation_rad(
+    phase_center_rad: [f64; 2],
+    time_mjd_seconds: f64,
+    observatory: &MPosition,
+) -> MsResult<f64> {
+    let phase_center = MDirection::from_angles(
+        phase_center_rad[0],
+        phase_center_rad[1],
+        DirectionRef::J2000,
+    );
+    let frame = MeasFrame::new()
+        .with_epoch(MEpoch::from_mjd(time_mjd_seconds / 86_400.0, EpochRef::UT1))
+        .with_position(observatory.clone())
+        .with_direction(phase_center.clone())
+        .with_bundled_eop();
+    let azel = phase_center
+        .convert_to(DirectionRef::AZEL, &frame)
+        .map_err(|error| {
+            MsError::SyntheticObservation(format!(
+                "simobserve elevation-limit direction conversion failed: {error}"
+            ))
+        })?;
+    Ok(azel.latitude_rad())
 }
 
 fn apply_corruption_and_count_rows_with_workers(
@@ -1861,22 +1984,22 @@ impl FitsModelDirectionWcs {
 
 struct SyntheticChannelPredictor {
     predictor: StandardMfsModelPredictor,
-    phase_offset_rad: [f64; 2],
+    phase_offset: ModelPhaseOffset,
     phase_center_rad: [f64; 2],
     model_reference_direction_rad: Option<[f64; 2]>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ModelPhaseOffset {
+    l_rad: f64,
+    m_rad: f64,
+    n_minus_one: f64,
 }
 
 struct SyntheticFieldPlan {
     phase_center_rad: [f64; 2],
     predictors: Option<Vec<SyntheticChannelPredictor>>,
 }
-
-// CASA GridFT negates u/v to compensate for an image-inversion convention in
-// the degridding path. After matching that handedness and the FITS center-pixel
-// offset, the tutorial model needs this residual image-x phase alignment to
-// match CASA's GridFT prediction at numerical-noise scale.
-const CASA_GRIDFT_IMAGE_INVERSION_PHASE_PIXELS: f64 = 0.015_122_8;
-const CASA_GRIDFT_NEGATIVE_RA_PHASE_ALIGNMENT_PIXELS: [f64; 2] = [0.001_757_8, 0.001_115_9];
 
 fn build_field_plans(
     request: &SyntheticObservationRequest,
@@ -1956,13 +2079,13 @@ fn build_channel_predictors(
         image_shape: [model.pixels.shape()[0], model.pixels.shape()[1]],
         cell_size_rad: model.cell_size_rad,
     };
-    let phase_offset_rad = casa_model_phase_offset(model, phase_center_rad);
+    let phase_offset = casa_model_phase_offset(model, phase_center_rad);
     let context = ChannelPredictorContext {
         model,
         spectral_setup,
         geometry,
         phase_center_rad,
-        phase_offset_rad,
+        phase_offset,
         pointing_offset_rad,
         primary_beam,
     };
@@ -2000,7 +2123,7 @@ struct ChannelPredictorContext<'a> {
     spectral_setup: &'a SyntheticSpectralSetup,
     geometry: ImageGeometry,
     phase_center_rad: [f64; 2],
-    phase_offset_rad: [f64; 2],
+    phase_offset: ModelPhaseOffset,
     pointing_offset_rad: [f64; 2],
     primary_beam: SyntheticPrimaryBeam,
 }
@@ -2096,7 +2219,7 @@ fn build_one_channel_predictor(
     Ok((
         SyntheticChannelPredictor {
             predictor,
-            phase_offset_rad: context.phase_offset_rad,
+            phase_offset: context.phase_offset,
             phase_center_rad: context.phase_center_rad,
             model_reference_direction_rad: context.model.reference_direction_rad,
         },
@@ -2112,7 +2235,30 @@ fn apply_simulator_primary_beam(
     pointing_offset_rad: [f64; 2],
     primary_beam: SyntheticPrimaryBeam,
 ) -> Array2<f32> {
+    apply_simulator_primary_beam_power(
+        model,
+        model_pixels,
+        phase_center_rad,
+        frequency_hz,
+        pointing_offset_rad,
+        primary_beam,
+        2,
+    )
+}
+
+fn apply_simulator_primary_beam_power(
+    model: &FitsModelImage,
+    model_pixels: &Array2<f32>,
+    phase_center_rad: [f64; 2],
+    frequency_hz: f64,
+    pointing_offset_rad: [f64; 2],
+    primary_beam: SyntheticPrimaryBeam,
+    beam_power: u32,
+) -> Array2<f32> {
     let mut pixels = model_pixels.clone();
+    if beam_power == 0 {
+        return pixels;
+    }
     let Some(wcs) = model.direction_wcs.as_ref() else {
         return pixels;
     };
@@ -2121,10 +2267,36 @@ fn apply_simulator_primary_beam(
         phase_center_rad[1] + pointing_offset_rad[1],
     ];
     let coordinate = wcs.coordinate();
-    let Ok(pointing_pixel) = coordinate.to_pixel(&pointing_direction_rad) else {
+    let raw_increments = coordinate.increment();
+    if raw_increments.len() < 2 {
+        return pixels;
+    }
+    let imported_coordinate;
+    let pb_coordinate: &dyn Coordinate =
+        if let Some(reference_direction_rad) = model.reference_direction_rad {
+            // CASA simobserve imports the FITS model into a casacore image and
+            // recenters the direction coordinate on the image center before
+            // PBMath applies the primary beam.
+            imported_coordinate = DirectionCoordinate::new(
+                DirectionRef::J2000,
+                Projection::new(ProjectionType::SIN),
+                reference_direction_rad,
+                [raw_increments[0], raw_increments[1]],
+                [
+                    model_pixels.shape()[0] as f64 / 2.0,
+                    model_pixels.shape()[1] as f64 / 2.0,
+                ],
+            )
+            .with_longpole(std::f64::consts::PI)
+            .with_latpole(reference_direction_rad[1]);
+            &imported_coordinate
+        } else {
+            coordinate
+        };
+    let Ok(pointing_pixel) = pb_coordinate.to_pixel(&pointing_direction_rad) else {
         return pixels;
     };
-    let increments = coordinate.increment();
+    let increments = pb_coordinate.increment();
     if pointing_pixel.len() < 2 || increments.len() < 2 {
         return pixels;
     }
@@ -2138,7 +2310,12 @@ fn apply_simulator_primary_beam(
                 (l * l + m * m).sqrt(),
                 frequency_hz,
             );
-            pixels[(x, y)] *= vp * vp;
+            let taper = match beam_power {
+                1 => vp,
+                2 => vp * vp,
+                _ => vp.powi(beam_power as i32),
+            };
+            pixels[(x, y)] *= taper;
         }
     }
     pixels
@@ -2195,27 +2372,25 @@ fn casa_vla_q_primary_beam_voltage_pattern(radius_rad: f64, frequency_hz: f64) -
         as f32
 }
 
-fn casa_model_phase_offset(model: &FitsModelImage, phase_center_rad: [f64; 2]) -> [f64; 2] {
+fn casa_model_phase_offset(model: &FitsModelImage, phase_center_rad: [f64; 2]) -> ModelPhaseOffset {
     let Some(reference_direction_rad) = model.reference_direction_rad else {
-        return [0.0, 0.0];
+        return ModelPhaseOffset {
+            l_rad: 0.0,
+            m_rad: 0.0,
+            n_minus_one: 0.0,
+        };
     };
-    let ra_offset = circular_angle_delta_rad(reference_direction_rad[0] - phase_center_rad[0])
-        * phase_center_rad[1].cos();
-    let dec_offset = reference_direction_rad[1] - phase_center_rad[1];
-    if model.ra_axis_increases_with_x {
-        [
-            ra_offset - (0.5 - CASA_GRIDFT_IMAGE_INVERSION_PHASE_PIXELS) * model.cell_size_rad[0],
-            dec_offset - 0.5 * model.cell_size_rad[1],
-        ]
-    } else {
-        // CASA GridFT uses a signed RA increment plus an internal UV negation
-        // convention for conventional FITS images. A phase-residual fit against
-        // CASA's full simulator path shows this leaves a sub-pixel alignment
-        // offset after the larger half-pixel center alignment is accounted for.
-        [
-            ra_offset + CASA_GRIDFT_NEGATIVE_RA_PHASE_ALIGNMENT_PIXELS[0] * model.cell_size_rad[0],
-            dec_offset + CASA_GRIDFT_NEGATIVE_RA_PHASE_ALIGNMENT_PIXELS[1] * model.cell_size_rad[1],
-        ]
+    let delta_ra = circular_angle_delta_rad(reference_direction_rad[0] - phase_center_rad[0]);
+    let cos_delta_ra = delta_ra.cos();
+    let (sin_ref_dec, cos_ref_dec) = reference_direction_rad[1].sin_cos();
+    let (sin_phase_dec, cos_phase_dec) = phase_center_rad[1].sin_cos();
+    let direction_l = delta_ra * phase_center_rad[1].cos();
+    let direction_m = reference_direction_rad[1] - phase_center_rad[1];
+    let direction_n = sin_ref_dec * sin_phase_dec + cos_ref_dec * cos_phase_dec * cos_delta_ra;
+    ModelPhaseOffset {
+        l_rad: direction_l,
+        m_rad: direction_m,
+        n_minus_one: direction_n - 1.0,
     }
 }
 
@@ -2248,9 +2423,11 @@ fn predicted_data_values(
             };
             let u_lambda = prediction_uvw_m[0] / wavelength_m;
             let v_lambda = prediction_uvw_m[1] / wavelength_m;
+            let w_lambda = prediction_uvw_m[2] / wavelength_m;
             let phase = std::f64::consts::TAU
-                * (u_lambda * predictor.phase_offset_rad[0]
-                    + v_lambda * predictor.phase_offset_rad[1]);
+                * (u_lambda * predictor.phase_offset.l_rad
+                    + v_lambda * predictor.phase_offset.m_rad
+                    - w_lambda * predictor.phase_offset.n_minus_one);
             let phase_shift = Complex32::new(phase.cos() as f32, phase.sin() as f32);
             let visibility = predictor.predictor.predict(u_lambda, v_lambda) * phase_shift;
             for corr in 0..num_corr {
@@ -2378,8 +2555,10 @@ fn predict_channel_visibility(
         };
     let u_lambda = prediction_uvw_m[0] / wavelength_m;
     let v_lambda = prediction_uvw_m[1] / wavelength_m;
+    let w_lambda = prediction_uvw_m[2] / wavelength_m;
     let phase = std::f64::consts::TAU
-        * (u_lambda * predictor.phase_offset_rad[0] + v_lambda * predictor.phase_offset_rad[1]);
+        * (u_lambda * predictor.phase_offset.l_rad + v_lambda * predictor.phase_offset.m_rad
+            - w_lambda * predictor.phase_offset.n_minus_one);
     let phase_shift = Complex32::new(phase.cos() as f32, phase.sin() as f32);
     predictor.predictor.predict(u_lambda, v_lambda) * phase_shift
 }
@@ -3193,14 +3372,13 @@ fn antenna_uvw_positions(
     antennas: &[SyntheticAntenna],
     phase_center_rad: [f64; 2],
     time_mjd_seconds: f64,
+    observatory: &MPosition,
 ) -> MsResult<Vec<[f64; 3]>> {
     let phase_center = MDirection::from_angles(
         phase_center_rad[0],
         phase_center_rad[1],
         DirectionRef::J2000,
     );
-    let observatory = MPosition::from_observatory_name("VLA")
-        .unwrap_or_else(|| MPosition::new_itrf(-1_601_192.0, -5_041_984.0, 3_554_876.0));
     let frame = MeasFrame::new()
         .with_epoch(MEpoch::from_mjd(time_mjd_seconds / 86_400.0, EpochRef::UT1))
         .with_position(observatory.clone())
@@ -3221,6 +3399,88 @@ fn antenna_uvw_positions(
             Ok(project_j2000_baseline_to_uvw(baseline_j2000, &phase_center))
         })
         .collect()
+}
+
+fn simulation_observatory_position(
+    telescope_name: &str,
+    antennas: &[SyntheticAntenna],
+) -> MPosition {
+    MPosition::from_observatory_name(telescope_name)
+        .unwrap_or_else(|| antenna_centroid_position(antennas))
+}
+
+fn antenna_centroid_position(antennas: &[SyntheticAntenna]) -> MPosition {
+    let count = antennas.len().max(1) as f64;
+    let [x, y, z] = antennas.iter().fold([0.0_f64; 3], |mut sum, antenna| {
+        sum[0] += antenna.position_m[0];
+        sum[1] += antenna.position_m[1];
+        sum[2] += antenna.position_m[2];
+        sum
+    });
+    MPosition::new_itrf(x / count, y / count, z / count)
+}
+
+struct SimobserveUvwProductionTrace {
+    antenna1: usize,
+    antenna2: usize,
+    time_mjd_seconds: f64,
+    time_tolerance_seconds: f64,
+}
+
+impl SimobserveUvwProductionTrace {
+    fn from_env() -> Option<Self> {
+        let antenna_text = std::env::var("CASA_RS_SIMOBSERVE_TRACE_UVW_ANTENNAS").ok()?;
+        let (antenna1_text, antenna2_text) = antenna_text.split_once(',')?;
+        let time_text = std::env::var("CASA_RS_SIMOBSERVE_TRACE_UVW_TIME_S").ok()?;
+        let time_tolerance_seconds = std::env::var("CASA_RS_SIMOBSERVE_TRACE_UVW_TIME_TOL_S")
+            .ok()
+            .and_then(|value| value.parse::<f64>().ok())
+            .unwrap_or(1.0e-6);
+        Some(Self {
+            antenna1: antenna1_text.trim().parse().ok()?,
+            antenna2: antenna2_text.trim().parse().ok()?,
+            time_mjd_seconds: time_text.trim().parse().ok()?,
+            time_tolerance_seconds,
+        })
+    }
+
+    fn matches(&self, antenna1: usize, antenna2: usize, time_mjd_seconds: f64) -> bool {
+        self.antenna1 == antenna1
+            && self.antenna2 == antenna2
+            && (self.time_mjd_seconds - time_mjd_seconds).abs() <= self.time_tolerance_seconds
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn trace_simobserve_production_uvw(
+    row_number: usize,
+    sample: usize,
+    antenna1: usize,
+    antenna2: usize,
+    time_mjd_seconds: f64,
+    phase_center_rad: [f64; 2],
+    observatory: &MPosition,
+    antennas: &[SyntheticAntenna],
+    antenna_uvws: &[[f64; 3]],
+    row_uvw: [f64; 3],
+) {
+    let obs_itrf = observatory.as_itrf();
+    let ant1_itrf = antennas[antenna1].position_m;
+    let ant2_itrf = antennas[antenna2].position_m;
+    let ant1_baseline_itrf = [
+        obs_itrf[0] - ant1_itrf[0],
+        obs_itrf[1] - ant1_itrf[1],
+        obs_itrf[2] - ant1_itrf[2],
+    ];
+    let ant2_baseline_itrf = [
+        obs_itrf[0] - ant2_itrf[0],
+        obs_itrf[1] - ant2_itrf[1],
+        obs_itrf[2] - ant2_itrf[2],
+    ];
+    eprintln!(
+        "simobserve_uvw_production_trace row={row_number} sample={sample} ant1={antenna1} ant2={antenna2} time_s={time_mjd_seconds:.15} phase_center_rad={phase_center_rad:?} obs_itrf={obs_itrf:?} ant1_itrf={ant1_itrf:?} ant2_itrf={ant2_itrf:?} ant1_obs_minus_ant_itrf={ant1_baseline_itrf:?} ant2_obs_minus_ant_itrf={ant2_baseline_itrf:?} ant1_uvw={:?} ant2_uvw={:?} row_uvw={row_uvw:?}",
+        antenna_uvws[antenna1], antenna_uvws[antenna2],
+    );
 }
 
 fn project_j2000_baseline_to_uvw(
@@ -3727,6 +3987,20 @@ mod tests {
     use super::*;
 
     #[test]
+    fn spectral_setup_reference_frequency_matches_casa_center_channel_convention() {
+        let setup = SyntheticSpectralSetup {
+            name: "spw".to_string(),
+            start_frequency_hz: 8.0e9,
+            channel_width_hz: 2.0e6,
+            channel_count: 512,
+        };
+
+        assert_eq!(setup.channel_frequencies_hz()[0], 8.0e9);
+        assert_eq!(setup.channel_frequencies_hz()[511], 9.022e9);
+        assert_eq!(setup.reference_frequency_hz(), 8.512e9);
+    }
+
+    #[test]
     fn row_noise_seed_varies_by_row_coordinates() {
         let base = row_noise_seed(42, 0, 0, 1, 0);
         assert_ne!(base, row_noise_seed(43, 0, 0, 1, 0));
@@ -3865,7 +4139,11 @@ mod tests {
         let predictors = (0..channel_count)
             .map(|_| SyntheticChannelPredictor {
                 predictor: StandardMfsModelPredictor::new(geometry, &model).unwrap(),
-                phase_offset_rad: [1.0e-6, -2.0e-6],
+                phase_offset: ModelPhaseOffset {
+                    l_rad: 1.0e-6,
+                    m_rad: -2.0e-6,
+                    n_minus_one: 3.0e-12,
+                },
                 phase_center_rad: [1.0, -0.5],
                 model_reference_direction_rad: None,
             })
@@ -3996,9 +4274,9 @@ mod tests {
 
     #[test]
     fn simulator_primary_beam_is_centered_on_fits_reference_pixel() {
-        let mut pixels = Array2::<f32>::zeros((5, 5));
-        pixels[(1, 1)] = 1.0;
-        pixels[(2, 1)] = 1.0;
+        let mut pixels = Array2::<f32>::zeros((6, 6));
+        pixels[(3, 3)] = 1.0;
+        pixels[(4, 3)] = 1.0;
         let mut coordinate_system = CoordinateSystem::new();
         coordinate_system.add_coordinate(Box::new(casa_coordinates::DirectionCoordinate::new(
             DirectionRef::J2000,
@@ -4031,9 +4309,9 @@ mod tests {
             },
         );
 
-        assert_eq!(corrected[(1, 1)], 1.0);
+        assert_eq!(corrected[(3, 3)], 1.0);
         assert!(
-            corrected[(2, 1)] < 1.0,
+            corrected[(4, 3)] < 1.0,
             "adjacent pixels should be attenuated away from the FITS reference pixel"
         );
     }
@@ -4070,6 +4348,378 @@ mod tests {
     }
 
     #[test]
+    fn simobserve_uvw_trace_when_requested() {
+        let Ok(a1_text) = std::env::var("CASA_RS_SIMOBSERVE_UVW_TRACE_A1_ITRF") else {
+            return;
+        };
+        let Ok(a2_text) = std::env::var("CASA_RS_SIMOBSERVE_UVW_TRACE_A2_ITRF") else {
+            return;
+        };
+        let Ok(time_text) = std::env::var("CASA_RS_SIMOBSERVE_UVW_TRACE_TIME_S") else {
+            return;
+        };
+        let a1 = parse_trace_triplet(&a1_text);
+        let a2 = parse_trace_triplet(&a2_text);
+        let time_s = time_text.parse::<f64>().expect("trace time seconds");
+        let phase_center = MDirection::from_angles(
+            -1.570_794_075_320_161_2,
+            -0.401_423_790_643_226_1,
+            DirectionRef::J2000,
+        );
+        let observatory = std::env::var("CASA_RS_SIMOBSERVE_UVW_TRACE_OBSERVATORY")
+            .ok()
+            .and_then(|name| MPosition::from_observatory_name(&name))
+            .unwrap_or_else(|| {
+                MPosition::new_itrf(
+                    2_225_052.376_592_874_5,
+                    -5_440_045.715_534_717,
+                    -2_481_673.806_727_262_7,
+                )
+            });
+        let frame = MeasFrame::new()
+            .with_epoch(MEpoch::from_mjd(time_s / 86_400.0, EpochRef::UT1))
+            .with_position(observatory)
+            .with_direction(phase_center.clone())
+            .with_bundled_eop();
+        let a1_j2000 = baseline_itrf_to_j2000(a1, &phase_center, &frame).unwrap();
+        let a2_j2000 = baseline_itrf_to_j2000(a2, &phase_center, &frame).unwrap();
+        let a1_uvw = project_j2000_baseline_to_uvw(a1_j2000, &phase_center);
+        let a2_uvw = project_j2000_baseline_to_uvw(a2_j2000, &phase_center);
+        eprintln!("TRACE_A1_J2000={a1_j2000:?}");
+        eprintln!("TRACE_A2_J2000={a2_j2000:?}");
+        eprintln!("TRACE_A1_UVW={a1_uvw:?}");
+        eprintln!("TRACE_A2_UVW={a2_uvw:?}");
+        eprintln!(
+            "TRACE_A2_MINUS_A1_UVW={:?}",
+            [
+                a2_uvw[0] - a1_uvw[0],
+                a2_uvw[1] - a1_uvw[1],
+                a2_uvw[2] - a1_uvw[2],
+            ]
+        );
+    }
+
+    #[test]
+    fn simobserve_model_predictor_trace_matches_casacore_gridder_when_requested() {
+        let Ok(model_path) = std::env::var("CASA_RS_SIMOBSERVE_MODEL_TRACE_FITS") else {
+            return;
+        };
+        let Ok(uvw_text) = std::env::var("CASA_RS_SIMOBSERVE_MODEL_TRACE_UVW_M") else {
+            return;
+        };
+        let uvw_m = parse_trace_triplet(&uvw_text);
+        let channel = std::env::var("CASA_RS_SIMOBSERVE_MODEL_TRACE_CHANNEL")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(0);
+        let channel_count = std::env::var("CASA_RS_SIMOBSERVE_MODEL_TRACE_CHANNEL_COUNT")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(channel + 1);
+        let start_frequency_hz = std::env::var("CASA_RS_SIMOBSERVE_MODEL_TRACE_START_HZ")
+            .ok()
+            .and_then(|value| value.parse::<f64>().ok())
+            .unwrap_or(230.0e9);
+        let channel_width_hz = std::env::var("CASA_RS_SIMOBSERVE_MODEL_TRACE_WIDTH_HZ")
+            .ok()
+            .and_then(|value| value.parse::<f64>().ok())
+            .unwrap_or(2.0e6);
+        let frequency_hz = start_frequency_hz + channel as f64 * channel_width_hz;
+        let model_path = PathBuf::from(model_path);
+        let model =
+            read_fits_model_image(&model_path, None, channel_count).expect("read trace FITS model");
+        let phase_center_rad = std::env::var("CASA_RS_SIMOBSERVE_MODEL_TRACE_PHASE_CENTER_RAD")
+            .ok()
+            .map(|value| parse_trace_triplet(&value)[0..2].try_into().unwrap())
+            .unwrap_or([4.712_391_234_768_306, -0.401_423_788_703_971_4]);
+        if let Some(wcs) = model.direction_wcs.as_ref() {
+            let coordinate = wcs.coordinate();
+            let pointing_pixel = coordinate
+                .to_pixel(&phase_center_rad)
+                .expect("trace phase center pixel");
+            eprintln!(
+                "simobserve_model_predictor_trace_wcs reference_pixel={:?} reference_value={:?} increment={:?} phase_center_rad={phase_center_rad:?} pointing_pixel={pointing_pixel:?} reference_direction_rad={:?} ra_axis_increases_with_x={}",
+                coordinate.reference_pixel(),
+                coordinate.reference_value(),
+                coordinate.increment(),
+                model.reference_direction_rad,
+                model.ra_axis_increases_with_x,
+            );
+        }
+        let primary_beam = SyntheticPrimaryBeam {
+            use_casa_vla_q_table: false,
+            dish_diameter_m: std::env::var("CASA_RS_SIMOBSERVE_MODEL_TRACE_DISH_M")
+                .ok()
+                .and_then(|value| value.parse::<f64>().ok())
+                .unwrap_or(10.7),
+            blockage_diameter_m: std::env::var("CASA_RS_SIMOBSERVE_MODEL_TRACE_BLOCKAGE_M")
+                .ok()
+                .and_then(|value| value.parse::<f64>().ok())
+                .unwrap_or(0.75),
+        };
+        let source_pixels = model.pixels_for_channel(channel);
+        let casa_oriented_pixels = trace_oriented_pixels_for_beam_power(
+            &model,
+            source_pixels,
+            phase_center_rad,
+            frequency_hz,
+            primary_beam,
+            2,
+        );
+        let casa_oriented_moments = trace_pixels_moments(&casa_oriented_pixels);
+        eprintln!(
+            "simobserve_model_predictor_trace_pixels sum={:.9e} peak={:.9e} x_mean={:.9e} y_mean={:.9e} x_rms={:.9e} y_rms={:.9e}",
+            casa_oriented_moments.sum,
+            casa_oriented_moments.peak,
+            casa_oriented_moments.x_mean(),
+            casa_oriented_moments.y_mean(),
+            casa_oriented_moments.x_rms(),
+            casa_oriented_moments.y_rms(),
+        );
+        if let Ok(path) = std::env::var("CASA_RS_SIMOBSERVE_MODEL_TRACE_DUMP_PIXELS") {
+            trace_dump_pixels(&casa_oriented_pixels, &path);
+        }
+        let geometry = ImageGeometry {
+            image_shape: [
+                casa_oriented_pixels.shape()[0],
+                casa_oriented_pixels.shape()[1],
+            ],
+            cell_size_rad: model.cell_size_rad,
+        };
+        let predictor = StandardMfsModelPredictor::new(geometry, &casa_oriented_pixels)
+            .expect("build native predictor");
+        let phase_offset = casa_model_phase_offset(&model, phase_center_rad);
+        let casa_small_shift_disabled = model
+            .reference_direction_rad
+            .map(|reference_direction_rad| {
+                let delta_ra =
+                    circular_angle_delta_rad(reference_direction_rad[0] - phase_center_rad[0]);
+                delta_ra.abs() < model.cell_size_rad[0].abs()
+                    && (reference_direction_rad[1] - phase_center_rad[1]).abs()
+                        < model.cell_size_rad[1].abs()
+            })
+            .unwrap_or(false);
+        let prediction_uvw_m = if let Some(model_reference_direction_rad) =
+            model.reference_direction_rad
+        {
+            rotate_uvw_between_directions(uvw_m, phase_center_rad, model_reference_direction_rad)
+        } else {
+            uvw_m
+        };
+        let wavelength_m = 299_792_458.0 / frequency_hz;
+        let u_lambda = prediction_uvw_m[0] / wavelength_m;
+        let v_lambda = prediction_uvw_m[1] / wavelength_m;
+        let w_lambda = prediction_uvw_m[2] / wavelength_m;
+        let phase = std::f64::consts::TAU
+            * (u_lambda * phase_offset.l_rad + v_lambda * phase_offset.m_rad
+                - w_lambda * phase_offset.n_minus_one);
+        let phase_shift = Complex32::new(phase.cos() as f32, phase.sin() as f32);
+        let native_gridder = predictor.predict(u_lambda, v_lambda);
+        let native = native_gridder * phase_shift;
+        let grid_shape = [
+            trace_casa_composite_padded_len(geometry.image_shape[0], 1.3),
+            trace_casa_composite_padded_len(geometry.image_shape[1], 1.3),
+        ];
+        let cpp = casa_test_support::gridder_interop::cpp_convolve_gridder_predict_visibility_2d(
+            grid_shape,
+            geometry.image_shape,
+            [
+                grid_shape[0] as f64 * geometry.cell_size_rad[0],
+                grid_shape[1] as f64 * geometry.cell_size_rad[1],
+            ],
+            [grid_shape[0] as f64 / 2.0, grid_shape[1] as f64 / 2.0],
+            [u_lambda, -v_lambda],
+            casa_oriented_pixels
+                .as_slice()
+                .expect("contiguous oriented model"),
+        )
+        .expect("casacore gridder predictor");
+        let cpp_gridder = Complex32::new(cpp.re, cpp.im);
+        let cpp_value = cpp_gridder * phase_shift;
+        let casa_data = std::env::var("CASA_RS_SIMOBSERVE_MODEL_TRACE_CASA_DATA")
+            .ok()
+            .map(|value| parse_trace_complex(&value));
+        for beam_power in [0, 1, 2] {
+            let pixels = trace_oriented_pixels_for_beam_power(
+                &model,
+                source_pixels,
+                phase_center_rad,
+                frequency_hz,
+                primary_beam,
+                beam_power,
+            );
+            if let Ok(prefix) = std::env::var("CASA_RS_SIMOBSERVE_MODEL_TRACE_DUMP_VARIANT_PREFIX")
+            {
+                trace_dump_pixels(&pixels, &format!("{prefix}-beam{beam_power}.bin"));
+            }
+            let trace_predictor =
+                StandardMfsModelPredictor::new(geometry, &pixels).expect("build trace predictor");
+            let trace_gridder = trace_predictor.predict(u_lambda, v_lambda);
+            let trace_native = trace_gridder * phase_shift;
+            let casa_delta = casa_data
+                .map(|casa_data| (trace_native - casa_data).norm())
+                .unwrap_or(f32::NAN);
+            let moments = trace_pixels_moments(&pixels);
+            eprintln!(
+                "simobserve_model_predictor_trace_variant beam_power={beam_power} model_sum={:.9e} model_peak={:.9e} x_mean={:.9e} y_mean={:.9e} x_rms={:.9e} y_rms={:.9e} native={trace_native:?} casa_delta_abs={casa_delta:.9e}",
+                moments.sum,
+                moments.peak,
+                moments.x_mean(),
+                moments.y_mean(),
+                moments.x_rms(),
+                moments.y_rms(),
+            );
+        }
+        if casa_small_shift_disabled {
+            let no_shift_gridder =
+                predictor.predict(uvw_m[0] / wavelength_m, uvw_m[1] / wavelength_m);
+            let casa_delta = casa_data
+                .map(|casa_data| (no_shift_gridder - casa_data).norm())
+                .unwrap_or(f32::NAN);
+            eprintln!(
+                "simobserve_model_predictor_trace_casa_small_shift_disabled native_no_rotation_no_phase={no_shift_gridder:?} casa_delta_abs={casa_delta:.9e}"
+            );
+        }
+        eprintln!(
+            "simobserve_model_predictor_trace channel={channel} frequency_hz={frequency_hz:.9e} uvw_m={uvw_m:?} prediction_uvw_m={prediction_uvw_m:?} u_lambda={u_lambda:.9e} v_lambda={v_lambda:.9e} w_lambda={w_lambda:.9e} native_gridder={native_gridder:?} cpp_gridder={cpp_gridder:?} gridder_delta_abs={:.9e} phase_offset=({:.9e},{:.9e},{:.9e}) phase_rad={phase:.9e} native={native:?} cpp={cpp_value:?} final_delta_abs={:.9e}",
+            (native_gridder - cpp_gridder).norm(),
+            phase_offset.l_rad,
+            phase_offset.m_rad,
+            phase_offset.n_minus_one,
+            (native - cpp_value).norm(),
+        );
+        assert!((native_gridder - cpp_gridder).norm() < 1.0e-3);
+    }
+
+    fn trace_oriented_pixels_for_beam_power(
+        model: &FitsModelImage,
+        source_pixels: &Array2<f32>,
+        phase_center_rad: [f64; 2],
+        frequency_hz: f64,
+        primary_beam: SyntheticPrimaryBeam,
+        beam_power: u32,
+    ) -> Array2<f32> {
+        let beam_corrected_pixels = apply_simulator_primary_beam_power(
+            model,
+            source_pixels,
+            phase_center_rad,
+            frequency_hz,
+            [0.0, 0.0],
+            primary_beam,
+            beam_power,
+        );
+        let mut casa_oriented_pixels = Array2::<f32>::zeros(beam_corrected_pixels.raw_dim());
+        if model.ra_axis_increases_with_x {
+            for x in 0..beam_corrected_pixels.shape()[0] {
+                for y in 0..beam_corrected_pixels.shape()[1] {
+                    casa_oriented_pixels[(beam_corrected_pixels.shape()[0] - 1 - x, y)] =
+                        beam_corrected_pixels[(x, y)];
+                }
+            }
+        } else {
+            casa_oriented_pixels.assign(&beam_corrected_pixels);
+        }
+        casa_oriented_pixels
+    }
+
+    struct TracePixelMoments {
+        sum: f64,
+        peak: f64,
+        x_sum: f64,
+        y_sum: f64,
+        xx_sum: f64,
+        yy_sum: f64,
+    }
+
+    impl TracePixelMoments {
+        fn x_mean(&self) -> f64 {
+            self.x_sum / self.sum
+        }
+
+        fn y_mean(&self) -> f64 {
+            self.y_sum / self.sum
+        }
+
+        fn x_rms(&self) -> f64 {
+            (self.xx_sum / self.sum).sqrt()
+        }
+
+        fn y_rms(&self) -> f64 {
+            (self.yy_sum / self.sum).sqrt()
+        }
+    }
+
+    fn trace_pixels_moments(pixels: &Array2<f32>) -> TracePixelMoments {
+        let mut moments = TracePixelMoments {
+            sum: 0.0,
+            peak: 0.0,
+            x_sum: 0.0,
+            y_sum: 0.0,
+            xx_sum: 0.0,
+            yy_sum: 0.0,
+        };
+        for ((x, y), value) in pixels.indexed_iter() {
+            let value = f64::from(*value);
+            let x = x as f64;
+            let y = y as f64;
+            moments.sum += value;
+            moments.peak = moments.peak.max(value.abs());
+            moments.x_sum += value * x;
+            moments.y_sum += value * y;
+            moments.xx_sum += value * x * x;
+            moments.yy_sum += value * y * y;
+        }
+        moments
+    }
+
+    fn trace_dump_pixels(pixels: &Array2<f32>, path: &str) {
+        let mut bytes = Vec::with_capacity(pixels.len() * std::mem::size_of::<f32>());
+        for value in pixels.iter() {
+            bytes.extend_from_slice(&value.to_le_bytes());
+        }
+        std::fs::write(path, bytes).expect("write trace pixel dump");
+    }
+
+    fn parse_trace_triplet(text: &str) -> [f64; 3] {
+        let values = text
+            .split(',')
+            .map(|part| part.trim().parse::<f64>().expect("trace triplet value"))
+            .collect::<Vec<_>>();
+        assert_eq!(values.len(), 3);
+        [values[0], values[1], values[2]]
+    }
+
+    fn parse_trace_complex(text: &str) -> Complex32 {
+        let values = text
+            .split(',')
+            .map(|part| part.trim().parse::<f32>().expect("trace complex value"))
+            .collect::<Vec<_>>();
+        assert_eq!(values.len(), 2);
+        Complex32::new(values[0], values[1])
+    }
+
+    fn trace_casa_composite_padded_len(image_len: usize, padding_factor: f64) -> usize {
+        let padded = (padding_factor * image_len as f64 - 0.5).floor() as usize;
+        let mut padded = padded.max(image_len);
+        if padded % 2 != 0 {
+            padded += 1;
+        }
+        while !trace_is_casa_composite_len(padded) {
+            padded += 2;
+        }
+        padded
+    }
+
+    fn trace_is_casa_composite_len(mut value: usize) -> bool {
+        for factor in [2, 3, 5] {
+            while value > 1 && value % factor == 0 {
+                value /= factor;
+            }
+        }
+        value == 1
+    }
+
+    #[test]
     fn shadowing_marks_nearer_antenna_and_flags_rows_involving_it() {
         let antennas = vec![
             SyntheticAntenna::vla("A0", "A0", [0.0, 0.0, 0.0]),
@@ -4103,6 +4753,24 @@ mod tests {
         assert_eq!(
             shadowed_antennas_for_rows(&rows, &antennas),
             vec![true, false, true]
+        );
+    }
+
+    #[test]
+    fn elevation_limit_identifies_below_limit_full_track_samples() {
+        let observatory = MPosition::from_observatory_name("ALMA").expect("ALMA position");
+        let phase_center = [-1.570_794_075_320_161, -0.401_423_790_643_226_1];
+        let start_time_mjd_seconds = 4_895_178_609.486_364;
+        let first_sample = start_time_mjd_seconds + 5.0;
+        let transit_sample = start_time_mjd_seconds + 43_200.0;
+
+        assert!(
+            field_elevation_rad(phase_center, first_sample, &observatory).unwrap()
+                < CASA_SIMOBSERVE_ELEVATION_LIMIT_RAD
+        );
+        assert!(
+            field_elevation_rad(phase_center, transit_sample, &observatory).unwrap()
+                > CASA_SIMOBSERVE_ELEVATION_LIMIT_RAD
         );
     }
 }

--- a/crates/casa-ms/src/simulation.rs
+++ b/crates/casa-ms/src/simulation.rs
@@ -10,6 +10,7 @@
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::thread;
 
 use casa_coordinates::{Coordinate, DirectionCoordinate, Projection, ProjectionType};
 use casa_imaging::{
@@ -53,6 +54,15 @@ impl SyntheticAntenna {
             dish_diameter_m: 25.0,
         }
     }
+}
+
+/// One synthetic target field or mosaic pointing.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct SyntheticField {
+    /// Field/source name.
+    pub name: String,
+    /// J2000 phase center `[right_ascension, declination]` in radians.
+    pub phase_center_rad: [f64; 2],
 }
 
 /// Return the CASA Guide VLA A-configuration antenna list used by the
@@ -295,6 +305,10 @@ pub struct SyntheticObservationRequest {
     pub field_name: String,
     /// J2000 phase center `[right_ascension, declination]` in radians.
     pub phase_center_rad: [f64; 2],
+    /// Optional multi-field target list. When empty, `field_name` and
+    /// `phase_center_rad` define a single-field observation.
+    #[serde(default)]
+    pub fields: Vec<SyntheticField>,
     /// Observation start time in MJD seconds UTC.
     pub start_time_mjd_seconds: f64,
     /// Requested on-source duration in seconds.
@@ -329,6 +343,7 @@ impl SyntheticObservationRequest {
             observer: "casa-rs".to_string(),
             field_name: "ppdisk".to_string(),
             phase_center_rad: [4.712_391_234_768_306, -0.401_423_788_703_971_4],
+            fields: Vec::new(),
             start_time_mjd_seconds: 4_895_229_577.784_943,
             duration_seconds: 3_600.0,
             integration_seconds: 2.0,
@@ -529,6 +544,7 @@ pub fn generate_synthetic_observation_ms(
 
     populate_antennas(&mut ms, &request.antennas)?;
     populate_field(&mut ms, request)?;
+    populate_pointing(&mut ms, request)?;
     populate_spectral_window(&mut ms, &request.spectral_setup)?;
     populate_polarization(&mut ms)?;
     populate_data_description(&mut ms)?;
@@ -641,6 +657,28 @@ fn validate_request(request: &SyntheticObservationRequest) -> MsResult<()> {
         return Err(MsError::SyntheticObservation(
             "phase center coordinates must be finite".to_string(),
         ));
+    }
+    if request.field_name.trim().is_empty() && request.fields.is_empty() {
+        return Err(MsError::SyntheticObservation(
+            "field name must not be empty".to_string(),
+        ));
+    }
+    for field in &request.fields {
+        if field.name.trim().is_empty() {
+            return Err(MsError::SyntheticObservation(
+                "field names must not be empty".to_string(),
+            ));
+        }
+        if field
+            .phase_center_rad
+            .iter()
+            .any(|value| !value.is_finite())
+        {
+            return Err(MsError::SyntheticObservation(format!(
+                "field {} phase center coordinates must be finite",
+                field.name
+            )));
+        }
     }
     if let Some(corruption) = &request.corruption {
         validate_corruption(corruption)?;
@@ -797,25 +835,69 @@ fn populate_antennas(ms: &mut MeasurementSet, antennas: &[SyntheticAntenna]) -> 
 }
 
 fn populate_field(ms: &mut MeasurementSet, request: &SyntheticObservationRequest) -> MsResult<()> {
-    let direction = Value::Array(ArrayValue::Float64(
-        ArrayD::from_shape_vec(vec![2, 1], request.phase_center_rad.to_vec()).unwrap(),
-    ));
-    let row = row_from_defs(
-        schema::field::REQUIRED_COLUMNS,
-        &[
-            ("NAME", s(&request.field_name)),
-            ("CODE", s("")),
-            ("NUM_POLY", i(0)),
-            ("DELAY_DIR", direction.clone()),
-            ("PHASE_DIR", direction.clone()),
-            ("REFERENCE_DIR", direction),
-            ("SOURCE_ID", i(-1)),
-            ("TIME", f(request.start_time_mjd_seconds)),
-            ("FLAG_ROW", b(false)),
-        ],
-    );
-    subtable_mut(ms, SubtableId::Field)?.add_row(row)?;
+    for field in effective_fields(request) {
+        let direction = direction_poly_array(field.phase_center_rad);
+        let row = row_from_defs(
+            schema::field::REQUIRED_COLUMNS,
+            &[
+                ("NAME", s(&field.name)),
+                ("CODE", s("")),
+                ("NUM_POLY", i(0)),
+                ("DELAY_DIR", direction.clone()),
+                ("PHASE_DIR", direction.clone()),
+                ("REFERENCE_DIR", direction),
+                ("SOURCE_ID", i(-1)),
+                ("TIME", f(request.start_time_mjd_seconds)),
+                ("FLAG_ROW", b(false)),
+            ],
+        );
+        subtable_mut(ms, SubtableId::Field)?.add_row(row)?;
+    }
     Ok(())
+}
+
+fn populate_pointing(
+    ms: &mut MeasurementSet,
+    request: &SyntheticObservationRequest,
+) -> MsResult<()> {
+    let time = request.start_time_mjd_seconds + 0.5 * request.duration_seconds;
+    for field in effective_fields(request) {
+        let direction = direction_poly_array(field.phase_center_rad);
+        for antenna_id in 0..request.antennas.len() {
+            let row = row_from_defs(
+                schema::pointing::REQUIRED_COLUMNS,
+                &[
+                    ("ANTENNA_ID", i(antenna_id as i32)),
+                    ("DIRECTION", direction.clone()),
+                    ("INTERVAL", f(request.duration_seconds)),
+                    ("NAME", s(&field.name)),
+                    ("NUM_POLY", i(0)),
+                    ("TARGET", direction.clone()),
+                    ("TIME", f(time)),
+                    ("TIME_ORIGIN", f(request.start_time_mjd_seconds)),
+                    ("TRACKING", b(true)),
+                ],
+            );
+            subtable_mut(ms, SubtableId::Pointing)?.add_row(row)?;
+        }
+    }
+    Ok(())
+}
+
+fn effective_fields(request: &SyntheticObservationRequest) -> Vec<SyntheticField> {
+    if request.fields.is_empty() {
+        return vec![SyntheticField {
+            name: request.field_name.clone(),
+            phase_center_rad: request.phase_center_rad,
+        }];
+    }
+    request.fields.clone()
+}
+
+fn direction_poly_array(direction_rad: [f64; 2]) -> Value {
+    Value::Array(ArrayValue::Float64(
+        ArrayD::from_shape_vec(vec![2, 1], direction_rad.to_vec()).unwrap(),
+    ))
 }
 
 fn populate_spectral_window(
@@ -1014,31 +1096,18 @@ fn populate_main_rows(
 ) -> MsResult<usize> {
     let num_corr = 2usize;
     let num_chan = request.spectral_setup.channel_count;
-    let flag = bool_array(&vec![false; num_corr * num_chan], vec![num_corr, num_chan]);
-    let flag_category = bool_array(
-        &vec![false; num_corr * num_chan],
-        vec![1, num_corr, num_chan],
-    );
-    let weight = f32_array(&vec![1.0; num_corr], vec![num_corr]);
-    let sigma = f32_array(&vec![1.0; num_corr], vec![num_corr]);
+    let template = MainRowTemplate {
+        flag: bool_array(&vec![false; num_corr * num_chan], vec![num_corr, num_chan]),
+        flag_category: bool_array(
+            &vec![false; num_corr * num_chan],
+            vec![1, num_corr, num_chan],
+        ),
+        weight: f32_array(&vec![1.0; num_corr], vec![num_corr]),
+        sigma: f32_array(&vec![1.0; num_corr], vec![num_corr]),
+    };
     let main_defs = ms_main_defs(ms);
-    let predictors = model
-        .map(|model| {
-            build_channel_predictors(
-                model,
-                &request.spectral_setup,
-                request.phase_center_rad,
-                request
-                    .corruption
-                    .as_ref()
-                    .and_then(|corruption| corruption.pointing.as_ref())
-                    .filter(|pointing| pointing.apply_pointing_offsets)
-                    .map(|pointing| pointing.offset_rad)
-                    .unwrap_or([0.0, 0.0]),
-            )
-        })
-        .transpose()?;
-    let mut corruption = request.corruption.as_ref().map(|config| {
+    let field_plans = build_field_plans(request, model)?;
+    let corruption = request.corruption.as_ref().map(|config| {
         SyntheticCorruptionState::new(
             config,
             request.antennas.len(),
@@ -1046,13 +1115,125 @@ fn populate_main_rows(
             samples,
         )
     });
+    let context = MainRowBuildContext {
+        request,
+        num_corr,
+        num_chan,
+        main_defs: &main_defs,
+        template: &template,
+        field_plans: &field_plans,
+        corruption: corruption.as_ref(),
+    };
+    let row_batches = build_main_row_batches(&context, samples)?;
     let mut nonzero_visibility_count = 0usize;
 
-    for sample in 0..samples {
+    for batch in row_batches {
+        nonzero_visibility_count += batch.nonzero_visibility_count;
+        for row in batch.rows {
+            ms.main_table_mut().add_row(row)?;
+        }
+    }
+    Ok(nonzero_visibility_count)
+}
+
+#[derive(Clone)]
+struct MainRowTemplate {
+    flag: Value,
+    flag_category: Value,
+    weight: Value,
+    sigma: Value,
+}
+
+struct MainRowBatch {
+    rows: Vec<RecordValue>,
+    nonzero_visibility_count: usize,
+}
+
+#[derive(Clone, Copy)]
+struct MainRowBuildContext<'a> {
+    request: &'a SyntheticObservationRequest,
+    num_corr: usize,
+    num_chan: usize,
+    main_defs: &'a [ColumnDef],
+    template: &'a MainRowTemplate,
+    field_plans: &'a [SyntheticFieldPlan],
+    corruption: Option<&'a SyntheticCorruptionState>,
+}
+
+fn build_main_row_batches(
+    context: &MainRowBuildContext<'_>,
+    samples: usize,
+) -> MsResult<Vec<MainRowBatch>> {
+    let baseline_count = context.request.antennas.len() * (context.request.antennas.len() - 1) / 2;
+    let worker_count = synthetic_observation_worker_count(samples, baseline_count);
+    if worker_count <= 1 {
+        return Ok(vec![build_main_row_batch(*context, 0, samples)?]);
+    }
+
+    let chunk_size = samples.div_ceil(worker_count);
+    thread::scope(|scope| {
+        let mut handles = Vec::new();
+        for start_sample in (0..samples).step_by(chunk_size) {
+            let end_sample = (start_sample + chunk_size).min(samples);
+            let context = *context;
+            handles
+                .push(scope.spawn(move || build_main_row_batch(context, start_sample, end_sample)));
+        }
+
+        let mut batches = Vec::with_capacity(handles.len());
+        for handle in handles {
+            let batch = handle.join().map_err(|_| {
+                MsError::SyntheticObservation(
+                    "synthetic-observation row worker panicked".to_string(),
+                )
+            })??;
+            batches.push(batch);
+        }
+        Ok(batches)
+    })
+}
+
+fn synthetic_observation_worker_count(samples: usize, baseline_count: usize) -> usize {
+    let available = thread::available_parallelism()
+        .map(|parallelism| parallelism.get())
+        .unwrap_or(1);
+    let requested = std::env::var("CASA_RS_SIMOBSERVE_WORKERS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(available);
+    synthetic_observation_worker_count_for(samples, baseline_count, requested, available)
+}
+
+fn synthetic_observation_worker_count_for(
+    samples: usize,
+    baseline_count: usize,
+    requested: usize,
+    available: usize,
+) -> usize {
+    if samples <= 1 || baseline_count == 0 {
+        return 1;
+    }
+    requested.max(1).min(available.max(1)).min(samples).max(1)
+}
+
+fn build_main_row_batch(
+    context: MainRowBuildContext<'_>,
+    start_sample: usize,
+    end_sample: usize,
+) -> MsResult<MainRowBatch> {
+    let request = context.request;
+    let baseline_count = request.antennas.len() * (request.antennas.len() - 1) / 2;
+    let mut rows = Vec::with_capacity((end_sample - start_sample) * baseline_count);
+    let mut nonzero_visibility_count = 0usize;
+
+    for sample in start_sample..end_sample {
+        let field_id = sample % context.field_plans.len();
+        let field_plan = &context.field_plans[field_id];
         let time =
             request.start_time_mjd_seconds + (sample as f64 + 0.5) * request.integration_seconds;
         let antenna_uvws =
-            antenna_uvw_positions(&request.antennas, request.phase_center_rad, time)?;
+            antenna_uvw_positions(&request.antennas, field_plan.phase_center_rad, time)?;
         for antenna1 in 0..request.antennas.len() {
             for antenna2 in (antenna1 + 1)..request.antennas.len() {
                 let uvw = [
@@ -1061,21 +1242,27 @@ fn populate_main_rows(
                     antenna_uvws[antenna2][2] - antenna_uvws[antenna1][2],
                 ];
                 let mut data_values = predicted_data_values(
-                    predictors.as_ref(),
+                    field_plan.predictors.as_ref(),
                     &request.spectral_setup,
                     uvw,
-                    num_corr,
+                    context.num_corr,
                 );
-                if let Some(corruption) = corruption.as_mut() {
-                    corruption.apply(&mut data_values, antenna1, antenna2, num_chan, sample);
+                if let Some(corruption) = context.corruption {
+                    corruption.apply(
+                        &mut data_values,
+                        antenna1,
+                        antenna2,
+                        context.num_chan,
+                        sample,
+                    );
                 }
                 nonzero_visibility_count += data_values
                     .iter()
                     .filter(|value| value.re != 0.0 || value.im != 0.0)
                     .count();
-                let data = complex_array(&data_values, vec![num_corr, num_chan]);
+                let data = complex_array(&data_values, vec![context.num_corr, context.num_chan]);
                 let row = row_from_defs(
-                    &main_defs,
+                    context.main_defs,
                     &[
                         ("ANTENNA1", i(antenna1 as i32)),
                         ("ANTENNA2", i(antenna2 as i32)),
@@ -1084,28 +1271,31 @@ fn populate_main_rows(
                         ("EXPOSURE", f(request.integration_seconds)),
                         ("FEED1", i(0)),
                         ("FEED2", i(0)),
-                        ("FIELD_ID", i(0)),
-                        ("FLAG", flag.clone()),
-                        ("FLAG_CATEGORY", flag_category.clone()),
+                        ("FIELD_ID", i(field_id as i32)),
+                        ("FLAG", context.template.flag.clone()),
+                        ("FLAG_CATEGORY", context.template.flag_category.clone()),
                         ("FLAG_ROW", b(false)),
                         ("INTERVAL", f(request.integration_seconds)),
                         ("OBSERVATION_ID", i(0)),
                         ("PROCESSOR_ID", i(0)),
                         ("SCAN_NUMBER", i(1)),
-                        ("SIGMA", sigma.clone()),
+                        ("SIGMA", context.template.sigma.clone()),
                         ("STATE_ID", i(0)),
                         ("TIME", f(time)),
                         ("TIME_CENTROID", f(time)),
                         ("UVW", f64_array(&uvw, vec![3])),
-                        ("WEIGHT", weight.clone()),
-                        ("DATA", data.clone()),
+                        ("WEIGHT", context.template.weight.clone()),
+                        ("DATA", data),
                     ],
                 );
-                ms.main_table_mut().add_row(row)?;
+                rows.push(row);
             }
         }
     }
-    Ok(nonzero_visibility_count)
+    Ok(MainRowBatch {
+        rows,
+        nonzero_visibility_count,
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -1122,17 +1312,80 @@ struct SyntheticChannelPredictor {
     model_reference_direction_rad: Option<[f64; 2]>,
 }
 
+struct SyntheticFieldPlan {
+    phase_center_rad: [f64; 2],
+    predictors: Option<Vec<SyntheticChannelPredictor>>,
+}
+
 // CASA GridFT negates u/v to compensate for an image-inversion convention in
 // the degridding path. After matching that handedness and the FITS center-pixel
 // offset, the tutorial model needs this residual image-x phase alignment to
 // match CASA's GridFT prediction at numerical-noise scale.
 const CASA_GRIDFT_IMAGE_INVERSION_PHASE_PIXELS: f64 = 0.015_122_8;
 
+fn build_field_plans(
+    request: &SyntheticObservationRequest,
+    model: Option<&FitsModelImage>,
+) -> MsResult<Vec<SyntheticFieldPlan>> {
+    let primary_beam = synthetic_primary_beam(request);
+    let pointing_offset_rad = request
+        .corruption
+        .as_ref()
+        .and_then(|corruption| corruption.pointing.as_ref())
+        .filter(|pointing| pointing.apply_pointing_offsets)
+        .map(|pointing| pointing.offset_rad)
+        .unwrap_or([0.0, 0.0]);
+
+    effective_fields(request)
+        .into_iter()
+        .map(|field| {
+            let predictors = model
+                .map(|model| {
+                    build_channel_predictors(
+                        model,
+                        &request.spectral_setup,
+                        field.phase_center_rad,
+                        pointing_offset_rad,
+                        primary_beam,
+                    )
+                })
+                .transpose()?;
+            Ok(SyntheticFieldPlan {
+                phase_center_rad: field.phase_center_rad,
+                predictors,
+            })
+        })
+        .collect()
+}
+
+#[derive(Clone, Copy)]
+struct SyntheticPrimaryBeam {
+    use_casa_vla_q_table: bool,
+    dish_diameter_m: f64,
+    blockage_diameter_m: f64,
+}
+
+fn synthetic_primary_beam(request: &SyntheticObservationRequest) -> SyntheticPrimaryBeam {
+    let dish_diameter_m = request
+        .antennas
+        .iter()
+        .map(|antenna| antenna.dish_diameter_m)
+        .sum::<f64>()
+        / request.antennas.len().max(1) as f64;
+    let telescope_is_vla = request.telescope_name.eq_ignore_ascii_case("VLA");
+    SyntheticPrimaryBeam {
+        use_casa_vla_q_table: telescope_is_vla && (dish_diameter_m - 25.0).abs() < 1.0e-6,
+        dish_diameter_m,
+        blockage_diameter_m: if telescope_is_vla { 2.36 } else { 0.0 },
+    }
+}
+
 fn build_channel_predictors(
     model: &FitsModelImage,
     spectral_setup: &SyntheticSpectralSetup,
     phase_center_rad: [f64; 2],
     pointing_offset_rad: [f64; 2],
+    primary_beam: SyntheticPrimaryBeam,
 ) -> MsResult<Vec<SyntheticChannelPredictor>> {
     let geometry = ImageGeometry {
         image_shape: [model.pixels.shape()[0], model.pixels.shape()[1]],
@@ -1148,6 +1401,7 @@ fn build_channel_predictors(
                 phase_center_rad,
                 frequency_hz,
                 pointing_offset_rad,
+                primary_beam,
             );
             let mut casa_oriented_pixels = Array2::<f32>::zeros(model.pixels.raw_dim());
             for x in 0..model.pixels.shape()[0] {
@@ -1178,6 +1432,7 @@ fn apply_simulator_primary_beam(
     phase_center_rad: [f64; 2],
     frequency_hz: f64,
     pointing_offset_rad: [f64; 2],
+    primary_beam: SyntheticPrimaryBeam,
 ) -> Array2<f32> {
     let mut pixels = model.pixels.clone();
     let Some(reference_direction_rad) = model.reference_direction_rad else {
@@ -1196,11 +1451,33 @@ fn apply_simulator_primary_beam(
         for y in 0..model.pixels.shape()[1] {
             let l = center_ra_offset + (x as f64 - x_ref) * model.cell_size_rad[0];
             let m = center_dec_offset + (y as f64 - y_ref) * model.cell_size_rad[1];
-            let vp = casa_vla_q_primary_beam_voltage_pattern((l * l + m * m).sqrt(), frequency_hz);
+            let vp = synthetic_primary_beam_voltage_pattern(
+                primary_beam,
+                (l * l + m * m).sqrt(),
+                frequency_hz,
+            );
             pixels[(x, y)] *= vp * vp;
         }
     }
     pixels
+}
+
+fn synthetic_primary_beam_voltage_pattern(
+    primary_beam: SyntheticPrimaryBeam,
+    radius_rad: f64,
+    frequency_hz: f64,
+) -> f32 {
+    if primary_beam.use_casa_vla_q_table {
+        return casa_vla_q_primary_beam_voltage_pattern(radius_rad, frequency_hz);
+    }
+    primary_beam_voltage_pattern(
+        PrimaryBeamModel::Airy {
+            dish_diameter_m: primary_beam.dish_diameter_m,
+            blockage_diameter_m: primary_beam.blockage_diameter_m,
+        },
+        radius_rad,
+        frequency_hz,
+    )
 }
 
 fn casa_vla_q_primary_beam_voltage_pattern(radius_rad: f64, frequency_hz: f64) -> f32 {
@@ -1325,11 +1602,11 @@ fn baseline_from_uvw(uvw_m: [f64; 3], direction_rad: [f64; 2]) -> [f64; 3] {
 }
 
 struct SyntheticCorruptionState {
+    seed: u64,
     simplenoise_jy: f32,
     gains_by_sample: Vec<Vec<[Complex32; 2]>>,
     bandpass_gains: Vec<Vec<Complex32>>,
     leakage_terms: Vec<[Complex32; 2]>,
-    rng: DeterministicRng,
 }
 
 impl SyntheticCorruptionState {
@@ -1371,6 +1648,7 @@ impl SyntheticCorruptionState {
             })
             .collect();
         Self {
+            seed: config.seed,
             simplenoise_jy: config
                 .noise
                 .as_ref()
@@ -1379,12 +1657,11 @@ impl SyntheticCorruptionState {
             gains_by_sample,
             bandpass_gains,
             leakage_terms,
-            rng,
         }
     }
 
     fn apply(
-        &mut self,
+        &self,
         values: &mut [Complex32],
         antenna1: usize,
         antenna2: usize,
@@ -1401,8 +1678,15 @@ impl SyntheticCorruptionState {
                 * self.bandpass_gains[antenna2][channel].conj();
             *value *= baseline_gain;
             if self.simplenoise_jy > 0.0 {
-                value.re += self.rng.gaussian_f32() * self.simplenoise_jy;
-                value.im += self.rng.gaussian_f32() * self.simplenoise_jy;
+                let mut rng = DeterministicRng::new(row_noise_seed(
+                    self.seed,
+                    sample_index,
+                    antenna1,
+                    antenna2,
+                    index,
+                ));
+                value.re += rng.gaussian_f32() * self.simplenoise_jy;
+                value.im += rng.gaussian_f32() * self.simplenoise_jy;
             }
         }
         if channel_count > 0 && values.len() == 2 * channel_count {
@@ -1422,6 +1706,27 @@ impl SyntheticCorruptionState {
             }
         }
     }
+}
+
+fn row_noise_seed(
+    seed: u64,
+    sample_index: usize,
+    antenna1: usize,
+    antenna2: usize,
+    value_index: usize,
+) -> u64 {
+    let mut mixed = seed ^ 0x9E37_79B9_7F4A_7C15;
+    mixed = mix_u64(mixed ^ sample_index as u64);
+    mixed = mix_u64(mixed ^ ((antenna1 as u64) << 32) ^ antenna2 as u64);
+    mix_u64(mixed ^ value_index as u64)
+}
+
+fn mix_u64(mut value: u64) -> u64 {
+    value ^= value >> 30;
+    value = value.wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    value ^= value >> 27;
+    value = value.wrapping_mul(0x94D0_49BB_1331_11EB);
+    value ^ (value >> 31)
 }
 
 fn build_gain_terms(
@@ -2409,4 +2714,29 @@ fn string_array(values: &[&str], shape: Vec<usize>) -> Value {
         )
         .unwrap(),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn synthetic_observation_worker_count_is_bounded_by_work_and_capacity() {
+        assert_eq!(synthetic_observation_worker_count_for(0, 10, 8, 8), 1);
+        assert_eq!(synthetic_observation_worker_count_for(10, 0, 8, 8), 1);
+        assert_eq!(synthetic_observation_worker_count_for(3, 10, 8, 8), 3);
+        assert_eq!(synthetic_observation_worker_count_for(10, 10, 2, 8), 2);
+        assert_eq!(synthetic_observation_worker_count_for(10, 10, 8, 2), 2);
+        assert_eq!(synthetic_observation_worker_count_for(10, 10, 0, 0), 1);
+    }
+
+    #[test]
+    fn row_noise_seed_varies_by_row_coordinates() {
+        let base = row_noise_seed(42, 0, 0, 1, 0);
+        assert_ne!(base, row_noise_seed(43, 0, 0, 1, 0));
+        assert_ne!(base, row_noise_seed(42, 1, 0, 1, 0));
+        assert_ne!(base, row_noise_seed(42, 0, 1, 2, 0));
+        assert_ne!(base, row_noise_seed(42, 0, 0, 1, 1));
+        assert_eq!(base, row_noise_seed(42, 0, 0, 1, 0));
+    }
 }

--- a/crates/casa-ms/src/simulation.rs
+++ b/crates/casa-ms/src/simulation.rs
@@ -1341,7 +1341,7 @@ fn populate_main_rows(
             uvw_rows,
         })?;
         timing.data_io_enqueue += data_io_started.elapsed();
-        for (spec, shadowed_row) in row_specs.into_iter().zip(flag_rows.into_iter()) {
+        for (spec, shadowed_row) in row_specs.into_iter().zip(flag_rows) {
             let write_started = Instant::now();
             scalar_column_overrides.push(&spec, request.integration_seconds, shadowed_row);
             let row = RecordValue::new(vec![RecordField::new(
@@ -1680,8 +1680,8 @@ impl SimobserveMainColumnWriter {
                 for ((data_row, flag_row), uvw_row) in batch
                     .data_rows
                     .into_iter()
-                    .zip(batch.flag_rows.into_iter())
-                    .zip(batch.uvw_rows.into_iter())
+                    .zip(batch.flag_rows)
+                    .zip(batch.uvw_rows)
                 {
                     data_writer.push_row(&data_row).map_err(|error| {
                         MsError::SyntheticObservation(format!(
@@ -2720,11 +2720,12 @@ impl SyntheticCorruptionState {
         sample_index: usize,
     ) {
         let gains = &self.gains_by_sample[sample_index % self.gains_by_sample.len()];
-        let correlation_count = if channel_count == 0 {
-            0
-        } else {
-            values.len() / channel_count
+        let Some(correlation_count) = values.len().checked_div(channel_count) else {
+            return;
         };
+        if correlation_count == 0 {
+            return;
+        }
         for (index, value) in values.iter_mut().enumerate() {
             let channel = index / correlation_count;
             let correlation = index % correlation_count;

--- a/crates/casa-ms/src/simulation.rs
+++ b/crates/casa-ms/src/simulation.rs
@@ -44,7 +44,13 @@ use crate::flagging::shadowed_antennas_from_projected_baselines;
 use crate::schema::{self, SubtableId};
 use crate::{MeasurementSet, MeasurementSetBuilder, OptionalMainColumn};
 
-const CASA_SIMOBSERVE_ELEVATION_LIMIT_RAD: f64 = 8.0_f64.to_radians();
+const DEFAULT_SIMOBSERVE_ELEVATION_LIMIT_RAD: f64 = 20.0_f64.to_radians();
+const DEFAULT_SIMOBSERVE_IO_QUEUE_DEPTH: usize = 16;
+const SIDEREAL_DAY_SECONDS: f64 = 86_164.090_5;
+
+fn default_simobserve_elevation_limit_rad() -> f64 {
+    DEFAULT_SIMOBSERVE_ELEVATION_LIMIT_RAD
+}
 
 /// Antenna configuration row for a synthetic observation.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -334,6 +340,15 @@ pub struct SyntheticObservationRequest {
     pub duration_seconds: f64,
     /// Integration time in seconds.
     pub integration_seconds: f64,
+    /// Minimum antenna elevation in radians for scheduled samples and flags.
+    #[serde(default = "default_simobserve_elevation_limit_rad")]
+    pub elevation_limit_rad: f64,
+    /// Permit continuous tracks that include samples below the elevation limit.
+    ///
+    /// When false, the simulator schedules as many above-elevation transit
+    /// sessions as needed to accumulate the requested on-source duration.
+    #[serde(default)]
+    pub allow_below_elevation_limit: bool,
     /// Antenna configuration.
     pub antennas: Vec<SyntheticAntenna>,
     /// Spectral-window setup.
@@ -366,6 +381,8 @@ impl SyntheticObservationRequest {
             start_time_mjd_seconds: 4_895_229_577.784_943,
             duration_seconds: 3_600.0,
             integration_seconds: 2.0,
+            elevation_limit_rad: default_simobserve_elevation_limit_rad(),
+            allow_below_elevation_limit: false,
             antennas,
             spectral_setup: SyntheticSpectralSetup {
                 name: "Qband".to_string(),
@@ -527,6 +544,16 @@ pub struct SyntheticObservationReport {
     pub channel_count: usize,
     /// Number of complex visibility cells with non-zero predicted model values.
     pub nonzero_visibility_count: usize,
+    /// Number of MAIN rows whose `FLAG_ROW` is true.
+    #[serde(default)]
+    pub flagged_row_count: usize,
+    /// Number of MAIN rows flagged because one or both antennas were below the
+    /// elevation limit.
+    #[serde(default)]
+    pub elevation_flagged_row_count: usize,
+    /// Number of MAIN rows flagged because one or both antennas were shadowed.
+    #[serde(default)]
+    pub shadow_flagged_row_count: usize,
     /// Names of corruption effects applied to `MAIN.DATA`.
     pub applied_corruptions: Vec<String>,
     /// Wall-clock timing breakdown for the native generator.
@@ -561,6 +588,12 @@ pub struct SyntheticMainRowTimingReport {
     pub uvw_and_row_setup_millis: u128,
     /// Time spent predicting model visibilities across channels.
     pub prediction_millis: u128,
+    /// Wall-clock time spent inside prediction worker scopes.
+    #[serde(default)]
+    pub prediction_worker_wall_millis: u128,
+    /// Time spent gathering channel-worker chunks into full row arrays.
+    #[serde(default)]
+    pub prediction_gather_millis: u128,
     /// Time spent applying deterministic corruption/noise.
     pub corruption_millis: u128,
     /// Time spent waiting to enqueue DATA row batches to the background writer.
@@ -578,8 +611,30 @@ pub struct SyntheticMainRowTimingReport {
     /// Bytes written through the streamed tiled MAIN column writers.
     #[serde(default)]
     pub data_io_bytes: u64,
+    /// Per-column timing for the streamed tiled MAIN column writers.
+    #[serde(default)]
+    pub data_io_columns: Vec<SyntheticMainColumnIoTimingReport>,
     /// Time spent constructing MAIN rows and appending them to the table.
     pub main_write_millis: u128,
+    /// Time spent building scalar-column override vectors.
+    #[serde(default)]
+    pub scalar_column_millis: u128,
+    /// Time spent appending placeholder MAIN rows.
+    #[serde(default)]
+    pub main_row_add_millis: u128,
+}
+
+/// Per-column streamed MAIN table I/O timing.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct SyntheticMainColumnIoTimingReport {
+    /// MAIN table column name.
+    pub column: String,
+    /// Time spent packing rows into tiled storage buffers.
+    pub assemble_millis: u128,
+    /// Time spent writing tile buffers to disk.
+    pub write_millis: u128,
+    /// Bytes written for this streamed column.
+    pub bytes_written: u64,
 }
 
 /// Generate an uncorrupted CASA-compatible synthetic MeasurementSet.
@@ -623,6 +678,10 @@ pub fn generate_synthetic_observation_ms(
     })?;
     let setup_millis = elapsed_millis(setup_started.elapsed());
 
+    let time_sample_count =
+        time_sample_count(request.duration_seconds, request.integration_seconds);
+    let sample_times = observation_sample_times(request, time_sample_count)?;
+
     let metadata_started = Instant::now();
     populate_antennas(&mut ms, &request.antennas)?;
     populate_field(&mut ms, request)?;
@@ -633,12 +692,10 @@ pub fn generate_synthetic_observation_ms(
     populate_state(&mut ms)?;
     populate_processor(&mut ms)?;
     populate_feed(&mut ms, request)?;
-    populate_observation(&mut ms, request)?;
+    populate_observation(&mut ms, request, &sample_times)?;
     populate_history(&mut ms, request)?;
     let metadata_millis = elapsed_millis(metadata_started.elapsed());
 
-    let time_sample_count =
-        time_sample_count(request.duration_seconds, request.integration_seconds);
     let baseline_count = request.antennas.len() * (request.antennas.len() - 1) / 2;
     let model_started = Instant::now();
     let model = if request.predict_model {
@@ -661,7 +718,7 @@ pub fn generate_synthetic_observation_ms(
     let mut main_rows = populate_main_rows(
         &mut ms,
         request,
-        time_sample_count,
+        &sample_times,
         model.as_ref(),
         &mut main_column_writer,
     )?;
@@ -673,6 +730,7 @@ pub fn generate_synthetic_observation_ms(
     main_rows.timing.data_io_write_millis =
         elapsed_seconds_to_millis(streamed_main_columns.write_seconds());
     main_rows.timing.data_io_bytes = streamed_main_columns.bytes_written() as u64;
+    main_rows.timing.data_io_columns = streamed_main_columns.column_timing_reports();
 
     let save_started = Instant::now();
     ms.save_assuming_valid_with_main_column_overrides(&main_rows.scalar_column_overrides)?;
@@ -688,6 +746,9 @@ pub fn generate_synthetic_observation_ms(
         main_row_count: baseline_count * time_sample_count,
         channel_count: request.spectral_setup.channel_count,
         nonzero_visibility_count: main_rows.nonzero_visibility_count,
+        flagged_row_count: main_rows.flagged_row_count,
+        elevation_flagged_row_count: main_rows.elevation_flagged_row_count,
+        shadow_flagged_row_count: main_rows.shadow_flagged_row_count,
         applied_corruptions: applied_corruption_names(request.corruption.as_ref()),
         timing: SyntheticObservationTimingReport {
             validate_millis,
@@ -765,6 +826,14 @@ fn validate_request(request: &SyntheticObservationRequest) -> MsResult<()> {
     if request.integration_seconds <= 0.0 || !request.integration_seconds.is_finite() {
         return Err(MsError::SyntheticObservation(
             "integration time must be positive".to_string(),
+        ));
+    }
+    if !request.elevation_limit_rad.is_finite()
+        || request.elevation_limit_rad <= -std::f64::consts::FRAC_PI_2
+        || request.elevation_limit_rad >= std::f64::consts::FRAC_PI_2
+    {
+        return Err(MsError::SyntheticObservation(
+            "elevation limit must be finite and between -90 and +90 degrees".to_string(),
         ));
     }
     if request
@@ -1154,8 +1223,18 @@ fn populate_feed(ms: &mut MeasurementSet, request: &SyntheticObservationRequest)
 fn populate_observation(
     ms: &mut MeasurementSet,
     request: &SyntheticObservationRequest,
+    sample_times: &[f64],
 ) -> MsResult<()> {
-    let end_time = request.start_time_mjd_seconds + request.duration_seconds;
+    let first_time = sample_times
+        .first()
+        .copied()
+        .unwrap_or(request.start_time_mjd_seconds);
+    let last_time = sample_times
+        .last()
+        .copied()
+        .unwrap_or(request.start_time_mjd_seconds);
+    let start_time = first_time - 0.5 * request.integration_seconds;
+    let end_time = last_time + 0.5 * request.integration_seconds;
     let row = row_from_defs(
         schema::observation::REQUIRED_COLUMNS,
         &[
@@ -1170,10 +1249,7 @@ fn populate_observation(
             ("SCHEDULE", string_array(&["synthetic"], vec![1])),
             ("SCHEDULE_TYPE", s("synthetic")),
             ("TELESCOPE_NAME", s(&request.telescope_name)),
-            (
-                "TIME_RANGE",
-                f64_array(&[request.start_time_mjd_seconds, end_time], vec![2]),
-            ),
+            ("TIME_RANGE", f64_array(&[start_time, end_time], vec![2])),
         ],
     );
     subtable_mut(ms, SubtableId::Observation)?.add_row(row)?;
@@ -1209,10 +1285,11 @@ fn populate_history(
 fn populate_main_rows(
     ms: &mut MeasurementSet,
     request: &SyntheticObservationRequest,
-    samples: usize,
+    sample_times: &[f64],
     model: Option<&FitsModelImage>,
     main_column_writer: &mut SimobserveMainColumnWriter,
 ) -> MsResult<MainRowsReport> {
+    let samples = sample_times.len();
     let num_corr = 2usize;
     let num_chan = request.spectral_setup.channel_count;
     let channel_prediction_workers = simobserve_channel_worker_count(num_chan);
@@ -1247,13 +1324,14 @@ fn populate_main_rows(
     let observatory = simulation_observatory_position(&request.telescope_name, &request.antennas);
     let elevation_margin_rad = antenna_elevation_margin_rad(&request.antennas, &observatory);
     let uvw_production_trace = SimobserveUvwProductionTrace::from_env();
+    let mut flagged_row_count = 0usize;
+    let mut elevation_flagged_row_count = 0usize;
+    let mut shadow_flagged_row_count = 0usize;
 
-    for sample in 0..samples {
+    for (sample, time) in sample_times.iter().copied().enumerate() {
         let uvw_started = Instant::now();
         let field_id = sample % field_plans.len();
         let field_plan = &field_plans[field_id];
-        let time =
-            request.start_time_mjd_seconds + (sample as f64 + 0.5) * request.integration_seconds;
         let antenna_uvws = antenna_uvw_positions(
             &request.antennas,
             field_plan.phase_center_rad,
@@ -1303,17 +1381,21 @@ fn populate_main_rows(
             &request.antennas,
             &observatory,
             elevation_margin_rad,
+            request.elevation_limit_rad,
         )?;
         timing.uvw_and_row_setup += uvw_started.elapsed();
 
         let prediction_started = Instant::now();
-        let mut data_rows = predicted_data_values_for_rows_with_workers(
+        let prediction = predicted_data_values_for_rows_with_workers_timed(
             field_plan.predictors.as_deref(),
             &request.spectral_setup,
             &row_uvws,
             num_corr,
             channel_prediction_workers,
         );
+        let mut data_rows = prediction.rows;
+        timing.prediction_worker_wall += prediction.worker_wall;
+        timing.prediction_gather += prediction.gather;
         timing.prediction += prediction_started.elapsed();
         let corruption_started = Instant::now();
         nonzero_visibility_count += apply_corruption_and_count_rows_with_workers(
@@ -1324,15 +1406,17 @@ fn populate_main_rows(
             sample,
         );
         timing.corruption += corruption_started.elapsed();
-        let flag_rows = row_specs
-            .iter()
-            .map(|spec| {
-                low_elevation_antennas[spec.antenna1]
-                    || low_elevation_antennas[spec.antenna2]
-                    || shadowed_antennas[spec.antenna1]
-                    || shadowed_antennas[spec.antenna2]
-            })
-            .collect::<Vec<_>>();
+        let mut flag_rows = Vec::with_capacity(row_specs.len());
+        for spec in &row_specs {
+            let elevation_flagged =
+                low_elevation_antennas[spec.antenna1] || low_elevation_antennas[spec.antenna2];
+            let shadow_flagged =
+                shadowed_antennas[spec.antenna1] || shadowed_antennas[spec.antenna2];
+            elevation_flagged_row_count += usize::from(elevation_flagged);
+            shadow_flagged_row_count += usize::from(shadow_flagged);
+            flagged_row_count += usize::from(elevation_flagged || shadow_flagged);
+            flag_rows.push(elevation_flagged || shadow_flagged);
+        }
         let uvw_rows = row_specs.iter().map(|spec| spec.uvw).collect::<Vec<_>>();
         let data_io_started = Instant::now();
         main_column_writer.send_batch(SimobserveMainColumnBatch {
@@ -1343,17 +1427,24 @@ fn populate_main_rows(
         timing.data_io_enqueue += data_io_started.elapsed();
         for (spec, shadowed_row) in row_specs.into_iter().zip(flag_rows) {
             let write_started = Instant::now();
+            let scalar_started = Instant::now();
             scalar_column_overrides.push(&spec, request.integration_seconds, shadowed_row);
+            timing.scalar_column += scalar_started.elapsed();
             let row = RecordValue::new(vec![RecordField::new(
                 "FLAG_CATEGORY",
                 template.flag_category.clone(),
             )]);
+            let row_add_started = Instant::now();
             ms.main_table_mut().add_row_assuming_valid(row)?;
+            timing.main_row_add += row_add_started.elapsed();
             timing.main_write += write_started.elapsed();
         }
     }
     Ok(MainRowsReport {
         nonzero_visibility_count,
+        flagged_row_count,
+        elevation_flagged_row_count,
+        shadow_flagged_row_count,
         timing: timing.into_report(),
         scalar_column_overrides: scalar_column_overrides.into_column_overrides(),
     })
@@ -1383,13 +1474,14 @@ fn antennas_below_elevation_limit(
     antennas: &[SyntheticAntenna],
     observatory: &MPosition,
     elevation_margin_rad: f64,
+    elevation_limit_rad: f64,
 ) -> MsResult<Vec<bool>> {
     let observatory_elevation_rad =
         field_elevation_rad(phase_center_rad, time_mjd_seconds, observatory)?;
-    if observatory_elevation_rad + elevation_margin_rad < CASA_SIMOBSERVE_ELEVATION_LIMIT_RAD {
+    if observatory_elevation_rad + elevation_margin_rad < elevation_limit_rad {
         return Ok(vec![true; antennas.len()]);
     }
-    if observatory_elevation_rad - elevation_margin_rad > CASA_SIMOBSERVE_ELEVATION_LIMIT_RAD {
+    if observatory_elevation_rad - elevation_margin_rad > elevation_limit_rad {
         return Ok(vec![false; antennas.len()]);
     }
 
@@ -1403,7 +1495,7 @@ fn antennas_below_elevation_limit(
             );
             Ok(
                 field_elevation_rad(phase_center_rad, time_mjd_seconds, &position)?
-                    < CASA_SIMOBSERVE_ELEVATION_LIMIT_RAD,
+                    < elevation_limit_rad,
             )
         })
         .collect()
@@ -1533,6 +1625,9 @@ fn count_nonzero_complex(values: &[Complex32]) -> usize {
 
 struct MainRowsReport {
     nonzero_visibility_count: usize,
+    flagged_row_count: usize,
+    elevation_flagged_row_count: usize,
+    shadow_flagged_row_count: usize,
     timing: SyntheticMainRowTimingReport,
     scalar_column_overrides: HashMap<String, Vec<Option<Value>>>,
 }
@@ -1552,6 +1647,56 @@ struct StreamedSimobserveMainColumns {
 }
 
 impl StreamedSimobserveMainColumns {
+    fn column_timing_reports(&self) -> Vec<SyntheticMainColumnIoTimingReport> {
+        vec![
+            self.column_timing_report(
+                "DATA",
+                self.data.assemble_seconds(),
+                self.data.write_seconds(),
+                self.data.bytes_written(),
+            ),
+            self.column_timing_report(
+                "FLAG",
+                self.flag.assemble_seconds(),
+                self.flag.write_seconds(),
+                self.flag.bytes_written(),
+            ),
+            self.column_timing_report(
+                "UVW",
+                self.uvw.assemble_seconds(),
+                self.uvw.write_seconds(),
+                self.uvw.bytes_written(),
+            ),
+            self.column_timing_report(
+                "WEIGHT",
+                self.weight.assemble_seconds(),
+                self.weight.write_seconds(),
+                self.weight.bytes_written(),
+            ),
+            self.column_timing_report(
+                "SIGMA",
+                self.sigma.assemble_seconds(),
+                self.sigma.write_seconds(),
+                self.sigma.bytes_written(),
+            ),
+        ]
+    }
+
+    fn column_timing_report(
+        &self,
+        column: &str,
+        assemble_seconds: f64,
+        write_seconds: f64,
+        bytes_written: usize,
+    ) -> SyntheticMainColumnIoTimingReport {
+        SyntheticMainColumnIoTimingReport {
+            column: column.to_string(),
+            assemble_millis: elapsed_seconds_to_millis(assemble_seconds),
+            write_millis: elapsed_seconds_to_millis(write_seconds),
+            bytes_written: bytes_written as u64,
+        }
+    }
+
     fn assemble_seconds(&self) -> f64 {
         self.data.assemble_seconds()
             + self.flag.assemble_seconds()
@@ -1664,7 +1809,6 @@ impl SimobserveMainColumnWriter {
             let mut sigma_writer = sigma_writer;
             let weight_row = vec![1.0f32; num_corr];
             let sigma_row = vec![1.0f32; num_corr];
-            let flag_true_row = vec![true; num_corr * num_chan];
 
             for batch in receiver {
                 if batch.data_rows.len() != batch.flag_rows.len()
@@ -1689,7 +1833,7 @@ impl SimobserveMainColumnWriter {
                         ))
                     })?;
                     if flag_row {
-                        flag_writer.push_bool_row(&flag_true_row).map_err(|error| {
+                        flag_writer.push_bool_fill_row(true).map_err(|error| {
                             MsError::SyntheticObservation(format!(
                                 "failed to stream FLAG row into tiled storage: {error}"
                             ))
@@ -1824,7 +1968,7 @@ fn simobserve_io_queue_depth() -> usize {
         .ok()
         .and_then(|value| value.parse::<usize>().ok())
         .filter(|value| *value > 0)
-        .unwrap_or(2)
+        .unwrap_or(DEFAULT_SIMOBSERVE_IO_QUEUE_DEPTH)
 }
 
 struct MainScalarColumnOverrides {
@@ -1914,9 +2058,13 @@ struct MainRowTimingDurations {
     channel_prediction_workers: usize,
     uvw_and_row_setup: Duration,
     prediction: Duration,
+    prediction_worker_wall: Duration,
+    prediction_gather: Duration,
     corruption: Duration,
     data_io_enqueue: Duration,
     main_write: Duration,
+    scalar_column: Duration,
+    main_row_add: Duration,
 }
 
 impl MainRowTimingDurations {
@@ -1925,13 +2073,18 @@ impl MainRowTimingDurations {
             channel_prediction_workers: self.channel_prediction_workers,
             uvw_and_row_setup_millis: elapsed_millis(self.uvw_and_row_setup),
             prediction_millis: elapsed_millis(self.prediction),
+            prediction_worker_wall_millis: elapsed_millis(self.prediction_worker_wall),
+            prediction_gather_millis: elapsed_millis(self.prediction_gather),
             corruption_millis: elapsed_millis(self.corruption),
             data_io_enqueue_millis: elapsed_millis(self.data_io_enqueue),
             data_io_finalize_millis: 0,
             data_io_assemble_millis: 0,
             data_io_write_millis: 0,
             data_io_bytes: 0,
+            data_io_columns: Vec::new(),
             main_write_millis: elapsed_millis(self.main_write),
+            scalar_column_millis: elapsed_millis(self.scalar_column),
+            main_row_add_millis: elapsed_millis(self.main_row_add),
         }
     }
 }
@@ -1994,6 +2147,12 @@ struct ModelPhaseOffset {
     l_rad: f64,
     m_rad: f64,
     n_minus_one: f64,
+}
+
+impl ModelPhaseOffset {
+    fn is_negligible(self) -> bool {
+        self.l_rad.abs() < 1.0e-15 && self.m_rad.abs() < 1.0e-15 && self.n_minus_one.abs() < 1.0e-15
+    }
 }
 
 struct SyntheticFieldPlan {
@@ -2406,30 +2565,14 @@ fn predicted_data_values(
 ) -> Vec<Complex32> {
     let mut values = vec![Complex32::new(0.0, 0.0); num_corr * spectral_setup.channel_count];
     if let Some(predictors) = predictors {
+        let prediction_uvw_m = prediction_uvw_for_row(predictors, uvw_m);
         for (channel, predictor) in predictors.iter().enumerate() {
-            let frequency_hz = spectral_setup.start_frequency_hz
-                + channel as f64 * spectral_setup.channel_width_hz;
-            let wavelength_m = 299_792_458.0 / frequency_hz;
-            let prediction_uvw_m = if let Some(model_reference_direction_rad) =
-                predictor.model_reference_direction_rad
-            {
-                rotate_uvw_between_directions(
-                    uvw_m,
-                    predictor.phase_center_rad,
-                    model_reference_direction_rad,
-                )
-            } else {
-                uvw_m
-            };
-            let u_lambda = prediction_uvw_m[0] / wavelength_m;
-            let v_lambda = prediction_uvw_m[1] / wavelength_m;
-            let w_lambda = prediction_uvw_m[2] / wavelength_m;
-            let phase = std::f64::consts::TAU
-                * (u_lambda * predictor.phase_offset.l_rad
-                    + v_lambda * predictor.phase_offset.m_rad
-                    - w_lambda * predictor.phase_offset.n_minus_one);
-            let phase_shift = Complex32::new(phase.cos() as f32, phase.sin() as f32);
-            let visibility = predictor.predictor.predict(u_lambda, v_lambda) * phase_shift;
+            let visibility = predict_channel_visibility_preprojected(
+                predictor,
+                spectral_setup,
+                prediction_uvw_m,
+                channel,
+            );
             for corr in 0..num_corr {
                 let index = ms_data_index(corr, channel, num_corr);
                 values[index] = visibility;
@@ -2439,11 +2582,18 @@ fn predicted_data_values(
     values
 }
 
+struct TimedPredictionRows {
+    rows: Vec<Vec<Complex32>>,
+    worker_wall: Duration,
+    gather: Duration,
+}
+
 struct ChannelPredictionChunk {
     start_channel: usize,
     values_by_row: Vec<Vec<Complex32>>,
 }
 
+#[cfg(test)]
 fn predicted_data_values_for_rows_with_workers(
     predictors: Option<&[SyntheticChannelPredictor]>,
     spectral_setup: &SyntheticSpectralSetup,
@@ -2451,21 +2601,49 @@ fn predicted_data_values_for_rows_with_workers(
     num_corr: usize,
     worker_count: usize,
 ) -> Vec<Vec<Complex32>> {
+    predicted_data_values_for_rows_with_workers_timed(
+        predictors,
+        spectral_setup,
+        row_uvws,
+        num_corr,
+        worker_count,
+    )
+    .rows
+}
+
+fn predicted_data_values_for_rows_with_workers_timed(
+    predictors: Option<&[SyntheticChannelPredictor]>,
+    spectral_setup: &SyntheticSpectralSetup,
+    row_uvws: &[[f64; 3]],
+    num_corr: usize,
+    worker_count: usize,
+) -> TimedPredictionRows {
     let Some(predictors) = predictors else {
-        return vec![
-            vec![Complex32::new(0.0, 0.0); num_corr * spectral_setup.channel_count];
-            row_uvws.len()
-        ];
+        return TimedPredictionRows {
+            rows: vec![
+                vec![Complex32::new(0.0, 0.0); num_corr * spectral_setup.channel_count];
+                row_uvws.len()
+            ],
+            worker_wall: Duration::ZERO,
+            gather: Duration::ZERO,
+        };
     };
     if worker_count <= 1 {
-        return row_uvws
+        let worker_started = Instant::now();
+        let rows = row_uvws
             .iter()
             .map(|uvw| predicted_data_values(Some(predictors), spectral_setup, *uvw, num_corr))
             .collect();
+        return TimedPredictionRows {
+            rows,
+            worker_wall: worker_started.elapsed(),
+            gather: Duration::ZERO,
+        };
     }
 
     let channel_count = spectral_setup.channel_count;
     let chunk_size = channel_count.div_ceil(worker_count);
+    let worker_started = Instant::now();
     let chunks = thread::scope(|scope| {
         let mut handles = Vec::new();
         for start_channel in (0..channel_count).step_by(chunk_size) {
@@ -2491,7 +2669,9 @@ fn predicted_data_values_for_rows_with_workers(
             })
             .collect::<Vec<_>>()
     });
+    let worker_wall = worker_started.elapsed();
 
+    let gather_started = Instant::now();
     let mut values_by_row =
         vec![vec![Complex32::new(0.0, 0.0); num_corr * channel_count]; row_uvws.len()];
     for chunk in chunks {
@@ -2504,7 +2684,13 @@ fn predicted_data_values_for_rows_with_workers(
             values_by_row[row_index][dst_start..dst_end].copy_from_slice(&row_chunk);
         }
     }
-    values_by_row
+    let gather = gather_started.elapsed();
+
+    TimedPredictionRows {
+        rows: values_by_row,
+        worker_wall,
+        gather,
+    }
 }
 
 fn predict_channel_chunk(
@@ -2518,10 +2704,16 @@ fn predict_channel_chunk(
     let chunk_len = end_channel - start_channel;
     let mut values_by_row = Vec::with_capacity(row_uvws.len());
     for uvw_m in row_uvws {
+        let prediction_uvw_m = prediction_uvw_for_row(predictors, *uvw_m);
         let mut row_values = vec![Complex32::new(0.0, 0.0); num_corr * chunk_len];
         for (offset, channel) in (start_channel..end_channel).enumerate() {
             let predictor = &predictors[channel];
-            let visibility = predict_channel_visibility(predictor, spectral_setup, *uvw_m, channel);
+            let visibility = predict_channel_visibility_preprojected(
+                predictor,
+                spectral_setup,
+                prediction_uvw_m,
+                channel,
+            );
             for corr in 0..num_corr {
                 row_values[ms_data_index(corr, offset, num_corr)] = visibility;
             }
@@ -2534,27 +2726,34 @@ fn predict_channel_chunk(
     }
 }
 
-fn predict_channel_visibility(
+fn prediction_uvw_for_row(predictors: &[SyntheticChannelPredictor], uvw_m: [f64; 3]) -> [f64; 3] {
+    let Some(first) = predictors.first() else {
+        return uvw_m;
+    };
+    let Some(model_reference_direction_rad) = first.model_reference_direction_rad else {
+        return uvw_m;
+    };
+    debug_assert!(predictors.iter().all(|predictor| {
+        predictor.model_reference_direction_rad == first.model_reference_direction_rad
+            && predictor.phase_center_rad == first.phase_center_rad
+    }));
+    rotate_uvw_between_directions(uvw_m, first.phase_center_rad, model_reference_direction_rad)
+}
+
+fn predict_channel_visibility_preprojected(
     predictor: &SyntheticChannelPredictor,
     spectral_setup: &SyntheticSpectralSetup,
-    uvw_m: [f64; 3],
+    prediction_uvw_m: [f64; 3],
     channel: usize,
 ) -> Complex32 {
     let frequency_hz =
         spectral_setup.start_frequency_hz + channel as f64 * spectral_setup.channel_width_hz;
     let wavelength_m = 299_792_458.0 / frequency_hz;
-    let prediction_uvw_m =
-        if let Some(model_reference_direction_rad) = predictor.model_reference_direction_rad {
-            rotate_uvw_between_directions(
-                uvw_m,
-                predictor.phase_center_rad,
-                model_reference_direction_rad,
-            )
-        } else {
-            uvw_m
-        };
     let u_lambda = prediction_uvw_m[0] / wavelength_m;
     let v_lambda = prediction_uvw_m[1] / wavelength_m;
+    if predictor.phase_offset.is_negligible() {
+        return predictor.predictor.predict(u_lambda, v_lambda);
+    }
     let w_lambda = prediction_uvw_m[2] / wavelength_m;
     let phase = std::f64::consts::TAU
         * (u_lambda * predictor.phase_offset.l_rad + v_lambda * predictor.phase_offset.m_rad
@@ -3363,6 +3562,133 @@ fn subtable_mut(ms: &mut MeasurementSet, id: SubtableId) -> MsResult<&mut casa_t
 
 fn time_sample_count(duration_seconds: f64, integration_seconds: f64) -> usize {
     (duration_seconds / integration_seconds).ceil().max(1.0) as usize
+}
+
+fn observation_sample_times(
+    request: &SyntheticObservationRequest,
+    sample_count: usize,
+) -> MsResult<Vec<f64>> {
+    if request.allow_below_elevation_limit {
+        return Ok((0..sample_count)
+            .map(|sample| {
+                request.start_time_mjd_seconds + (sample as f64 + 0.5) * request.integration_seconds
+            })
+            .collect());
+    }
+
+    let observatory = simulation_observatory_position(&request.telescope_name, &request.antennas);
+    let elevation_margin_rad = antenna_elevation_margin_rad(&request.antennas, &observatory);
+    let phase_center_rad = effective_fields(request)
+        .first()
+        .map(|field| field.phase_center_rad)
+        .unwrap_or(request.phase_center_rad);
+    let first_transit = next_transit_time_mjd_seconds(
+        phase_center_rad,
+        request.start_time_mjd_seconds,
+        &observatory,
+    )?;
+    let mut sample_times = Vec::with_capacity(sample_count);
+    let mut transit = first_transit;
+
+    while sample_times.len() < sample_count {
+        let remaining = sample_count - sample_times.len();
+        let mut offsets = above_elevation_offsets_for_transit(
+            request,
+            phase_center_rad,
+            transit,
+            &observatory,
+            elevation_margin_rad,
+        )?;
+        if offsets.is_empty() {
+            return Err(MsError::SyntheticObservation(format!(
+                "target never reaches the {:.1} deg elevation limit for telescope {}; set allow_below_elevation_limit=true to generate a below-limit track",
+                request.elevation_limit_rad.to_degrees(),
+                request.telescope_name
+            )));
+        }
+        if remaining < offsets.len() {
+            offsets.sort_by(|left, right| {
+                left.abs()
+                    .partial_cmp(&right.abs())
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal))
+            });
+            offsets.truncate(remaining);
+        }
+        offsets.sort_by(|left, right| left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal));
+        sample_times.extend(offsets.into_iter().map(|offset| transit + offset));
+        transit += SIDEREAL_DAY_SECONDS;
+    }
+
+    Ok(sample_times)
+}
+
+fn next_transit_time_mjd_seconds(
+    phase_center_rad: [f64; 2],
+    reference_time_mjd_seconds: f64,
+    observatory: &MPosition,
+) -> MsResult<f64> {
+    let frame = MeasFrame::new()
+        .with_epoch(MEpoch::from_mjd(
+            reference_time_mjd_seconds / 86_400.0,
+            EpochRef::UT1,
+        ))
+        .with_position(observatory.clone())
+        .with_direction(MDirection::from_angles(
+            phase_center_rad[0],
+            phase_center_rad[1],
+            DirectionRef::J2000,
+        ))
+        .with_bundled_eop();
+    let last = local_apparent_sidereal_time(&frame)?;
+    let mut delta = circular_angle_delta_rad(phase_center_rad[0] - last);
+    if delta < -1.0e-12 {
+        delta += std::f64::consts::TAU;
+    }
+    Ok(reference_time_mjd_seconds + delta / std::f64::consts::TAU * SIDEREAL_DAY_SECONDS)
+}
+
+fn above_elevation_offsets_for_transit(
+    request: &SyntheticObservationRequest,
+    phase_center_rad: [f64; 2],
+    transit_time_mjd_seconds: f64,
+    observatory: &MPosition,
+    elevation_margin_rad: f64,
+) -> MsResult<Vec<f64>> {
+    let slots_per_sidereal_day = (SIDEREAL_DAY_SECONDS / request.integration_seconds)
+        .floor()
+        .max(1.0) as usize;
+    let day_duration = slots_per_sidereal_day as f64 * request.integration_seconds;
+    let first_offset = -0.5 * day_duration + 0.5 * request.integration_seconds;
+    let mut offsets = Vec::new();
+    for slot in 0..slots_per_sidereal_day {
+        let offset = first_offset + slot as f64 * request.integration_seconds;
+        let time = transit_time_mjd_seconds + offset;
+        let elevation = field_elevation_rad(phase_center_rad, time, observatory)?;
+        if elevation - elevation_margin_rad >= request.elevation_limit_rad {
+            offsets.push(offset);
+        }
+    }
+    Ok(offsets)
+}
+
+pub(crate) fn zenith_transit_phase_center_rad(
+    telescope_name: &str,
+    antennas: &[SyntheticAntenna],
+    transit_time_mjd_seconds: f64,
+) -> MsResult<[f64; 2]> {
+    let observatory = simulation_observatory_position(telescope_name, antennas);
+    let frame = MeasFrame::new()
+        .with_epoch(MEpoch::from_mjd(
+            transit_time_mjd_seconds / 86_400.0,
+            EpochRef::UT1,
+        ))
+        .with_position(observatory.clone())
+        .with_bundled_eop();
+    Ok([
+        local_apparent_sidereal_time(&frame)?.rem_euclid(std::f64::consts::TAU),
+        observatory.latitude_rad(),
+    ])
 }
 
 fn elapsed_millis(duration: Duration) -> u128 {
@@ -4767,11 +5093,85 @@ mod tests {
 
         assert!(
             field_elevation_rad(phase_center, first_sample, &observatory).unwrap()
-                < CASA_SIMOBSERVE_ELEVATION_LIMIT_RAD
+                < DEFAULT_SIMOBSERVE_ELEVATION_LIMIT_RAD
         );
         assert!(
             field_elevation_rad(phase_center, transit_sample, &observatory).unwrap()
-                > CASA_SIMOBSERVE_ELEVATION_LIMIT_RAD
+                > DEFAULT_SIMOBSERVE_ELEVATION_LIMIT_RAD
+        );
+    }
+
+    #[test]
+    fn default_sample_scheduler_splits_long_tracks_into_above_limit_sessions() {
+        let antennas = tutorial_vla_a_antennas();
+        let start_time_mjd_seconds = 59_000.25 * 86_400.0;
+        let phase_center =
+            zenith_transit_phase_center_rad("VLA", &antennas, start_time_mjd_seconds).unwrap();
+        let mut request = SyntheticObservationRequest::vla_ppdisk("model.fits", "out.ms", antennas);
+        request.telescope_name = "VLA".to_string();
+        request.phase_center_rad = phase_center;
+        request.start_time_mjd_seconds = start_time_mjd_seconds;
+        request.duration_seconds = 20.0 * 3_600.0;
+        request.integration_seconds = 600.0;
+
+        let samples = time_sample_count(request.duration_seconds, request.integration_seconds);
+        let times = observation_sample_times(&request, samples).unwrap();
+        let observatory =
+            simulation_observatory_position(&request.telescope_name, &request.antennas);
+        let elevation_margin_rad = antenna_elevation_margin_rad(&request.antennas, &observatory);
+
+        assert_eq!(times.len(), samples);
+        assert!(times.windows(2).any(|pair| pair[1] - pair[0] > 3_600.0));
+        for time in &times {
+            let elevation = field_elevation_rad(phase_center, *time, &observatory).unwrap();
+            assert!(
+                elevation - elevation_margin_rad >= request.elevation_limit_rad,
+                "scheduled sample below elevation limit: {} deg",
+                elevation.to_degrees()
+            );
+        }
+
+        let mut sessions = Vec::new();
+        let mut start = 0usize;
+        for index in 1..times.len() {
+            if times[index] - times[index - 1] > 3_600.0 {
+                sessions.push(&times[start..index]);
+                start = index;
+            }
+        }
+        sessions.push(&times[start..]);
+        let final_session = sessions.last().expect("final session");
+        let final_center = 0.5 * (final_session[0] + final_session[final_session.len() - 1]);
+        let final_transit = next_transit_time_mjd_seconds(
+            phase_center,
+            request.start_time_mjd_seconds,
+            &observatory,
+        )
+        .unwrap()
+            + (sessions.len() - 1) as f64 * SIDEREAL_DAY_SECONDS;
+        assert!(
+            (final_center - final_transit).abs() <= request.integration_seconds,
+            "final short session is not centered on transit"
+        );
+    }
+
+    #[test]
+    fn below_elevation_override_preserves_continuous_sample_times() {
+        let antennas = tutorial_vla_a_antennas();
+        let mut request = SyntheticObservationRequest::vla_ppdisk("model.fits", "out.ms", antennas);
+        request.start_time_mjd_seconds = 59_000.25 * 86_400.0;
+        request.duration_seconds = 1_200.0;
+        request.integration_seconds = 300.0;
+        request.allow_below_elevation_limit = true;
+
+        assert_eq!(
+            observation_sample_times(&request, 4).unwrap(),
+            vec![
+                request.start_time_mjd_seconds + 150.0,
+                request.start_time_mjd_seconds + 450.0,
+                request.start_time_mjd_seconds + 750.0,
+                request.start_time_mjd_seconds + 1_050.0,
+            ]
         );
     }
 }

--- a/crates/casa-ms/src/simulation.rs
+++ b/crates/casa-ms/src/simulation.rs
@@ -7,11 +7,6 @@
 //! spectral window and field, sample the requested observing time range, and
 //! write CASA-compatible MS subtables plus uncorrupted visibility rows.
 
-use std::fs;
-use std::io::Read;
-use std::path::{Path, PathBuf};
-use std::thread;
-
 use casa_coordinates::{Coordinate, DirectionCoordinate, Projection, ProjectionType};
 use casa_imaging::{
     ImageGeometry, PrimaryBeamModel, StandardMfsModelPredictor, primary_beam_voltage_pattern,
@@ -25,6 +20,9 @@ use ndarray::{Array2, ArrayD};
 use num_complex::Complex32;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
 
 use crate::column_def::{ColumnDef, ColumnKind};
 use crate::error::{MsError, MsResult};
@@ -1115,121 +1113,11 @@ fn populate_main_rows(
             samples,
         )
     });
-    let context = MainRowBuildContext {
-        request,
-        num_corr,
-        num_chan,
-        main_defs: &main_defs,
-        template: &template,
-        field_plans: &field_plans,
-        corruption: corruption.as_ref(),
-    };
-    let row_batches = build_main_row_batches(&context, samples)?;
     let mut nonzero_visibility_count = 0usize;
 
-    for batch in row_batches {
-        nonzero_visibility_count += batch.nonzero_visibility_count;
-        for row in batch.rows {
-            ms.main_table_mut().add_row(row)?;
-        }
-    }
-    Ok(nonzero_visibility_count)
-}
-
-#[derive(Clone)]
-struct MainRowTemplate {
-    flag: Value,
-    flag_category: Value,
-    weight: Value,
-    sigma: Value,
-}
-
-struct MainRowBatch {
-    rows: Vec<RecordValue>,
-    nonzero_visibility_count: usize,
-}
-
-#[derive(Clone, Copy)]
-struct MainRowBuildContext<'a> {
-    request: &'a SyntheticObservationRequest,
-    num_corr: usize,
-    num_chan: usize,
-    main_defs: &'a [ColumnDef],
-    template: &'a MainRowTemplate,
-    field_plans: &'a [SyntheticFieldPlan],
-    corruption: Option<&'a SyntheticCorruptionState>,
-}
-
-fn build_main_row_batches(
-    context: &MainRowBuildContext<'_>,
-    samples: usize,
-) -> MsResult<Vec<MainRowBatch>> {
-    let baseline_count = context.request.antennas.len() * (context.request.antennas.len() - 1) / 2;
-    let worker_count = synthetic_observation_worker_count(samples, baseline_count);
-    if worker_count <= 1 {
-        return Ok(vec![build_main_row_batch(*context, 0, samples)?]);
-    }
-
-    let chunk_size = samples.div_ceil(worker_count);
-    thread::scope(|scope| {
-        let mut handles = Vec::new();
-        for start_sample in (0..samples).step_by(chunk_size) {
-            let end_sample = (start_sample + chunk_size).min(samples);
-            let context = *context;
-            handles
-                .push(scope.spawn(move || build_main_row_batch(context, start_sample, end_sample)));
-        }
-
-        let mut batches = Vec::with_capacity(handles.len());
-        for handle in handles {
-            let batch = handle.join().map_err(|_| {
-                MsError::SyntheticObservation(
-                    "synthetic-observation row worker panicked".to_string(),
-                )
-            })??;
-            batches.push(batch);
-        }
-        Ok(batches)
-    })
-}
-
-fn synthetic_observation_worker_count(samples: usize, baseline_count: usize) -> usize {
-    let available = thread::available_parallelism()
-        .map(|parallelism| parallelism.get())
-        .unwrap_or(1);
-    let requested = std::env::var("CASA_RS_SIMOBSERVE_WORKERS")
-        .ok()
-        .and_then(|value| value.parse::<usize>().ok())
-        .filter(|value| *value > 0)
-        .unwrap_or(available);
-    synthetic_observation_worker_count_for(samples, baseline_count, requested, available)
-}
-
-fn synthetic_observation_worker_count_for(
-    samples: usize,
-    baseline_count: usize,
-    requested: usize,
-    available: usize,
-) -> usize {
-    if samples <= 1 || baseline_count == 0 {
-        return 1;
-    }
-    requested.max(1).min(available.max(1)).min(samples).max(1)
-}
-
-fn build_main_row_batch(
-    context: MainRowBuildContext<'_>,
-    start_sample: usize,
-    end_sample: usize,
-) -> MsResult<MainRowBatch> {
-    let request = context.request;
-    let baseline_count = request.antennas.len() * (request.antennas.len() - 1) / 2;
-    let mut rows = Vec::with_capacity((end_sample - start_sample) * baseline_count);
-    let mut nonzero_visibility_count = 0usize;
-
-    for sample in start_sample..end_sample {
-        let field_id = sample % context.field_plans.len();
-        let field_plan = &context.field_plans[field_id];
+    for sample in 0..samples {
+        let field_id = sample % field_plans.len();
+        let field_plan = &field_plans[field_id];
         let time =
             request.start_time_mjd_seconds + (sample as f64 + 0.5) * request.integration_seconds;
         let antenna_uvws =
@@ -1245,24 +1133,18 @@ fn build_main_row_batch(
                     field_plan.predictors.as_ref(),
                     &request.spectral_setup,
                     uvw,
-                    context.num_corr,
+                    num_corr,
                 );
-                if let Some(corruption) = context.corruption {
-                    corruption.apply(
-                        &mut data_values,
-                        antenna1,
-                        antenna2,
-                        context.num_chan,
-                        sample,
-                    );
+                if let Some(corruption) = corruption.as_ref() {
+                    corruption.apply(&mut data_values, antenna1, antenna2, num_chan, sample);
                 }
                 nonzero_visibility_count += data_values
                     .iter()
                     .filter(|value| value.re != 0.0 || value.im != 0.0)
                     .count();
-                let data = complex_array(&data_values, vec![context.num_corr, context.num_chan]);
+                let data = complex_array(&data_values, vec![num_corr, num_chan]);
                 let row = row_from_defs(
-                    context.main_defs,
+                    &main_defs,
                     &[
                         ("ANTENNA1", i(antenna1 as i32)),
                         ("ANTENNA2", i(antenna2 as i32)),
@@ -1272,30 +1154,35 @@ fn build_main_row_batch(
                         ("FEED1", i(0)),
                         ("FEED2", i(0)),
                         ("FIELD_ID", i(field_id as i32)),
-                        ("FLAG", context.template.flag.clone()),
-                        ("FLAG_CATEGORY", context.template.flag_category.clone()),
+                        ("FLAG", template.flag.clone()),
+                        ("FLAG_CATEGORY", template.flag_category.clone()),
                         ("FLAG_ROW", b(false)),
                         ("INTERVAL", f(request.integration_seconds)),
                         ("OBSERVATION_ID", i(0)),
                         ("PROCESSOR_ID", i(0)),
                         ("SCAN_NUMBER", i(1)),
-                        ("SIGMA", context.template.sigma.clone()),
+                        ("SIGMA", template.sigma.clone()),
                         ("STATE_ID", i(0)),
                         ("TIME", f(time)),
                         ("TIME_CENTROID", f(time)),
                         ("UVW", f64_array(&uvw, vec![3])),
-                        ("WEIGHT", context.template.weight.clone()),
+                        ("WEIGHT", template.weight.clone()),
                         ("DATA", data),
                     ],
                 );
-                rows.push(row);
+                ms.main_table_mut().add_row(row)?;
             }
         }
     }
-    Ok(MainRowBatch {
-        rows,
-        nonzero_visibility_count,
-    })
+    Ok(nonzero_visibility_count)
+}
+
+#[derive(Clone)]
+struct MainRowTemplate {
+    flag: Value,
+    flag_category: Value,
+    weight: Value,
+    sigma: Value,
 }
 
 #[derive(Debug, Clone)]
@@ -2719,16 +2606,6 @@ fn string_array(values: &[&str], shape: Vec<usize>) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn synthetic_observation_worker_count_is_bounded_by_work_and_capacity() {
-        assert_eq!(synthetic_observation_worker_count_for(0, 10, 8, 8), 1);
-        assert_eq!(synthetic_observation_worker_count_for(10, 0, 8, 8), 1);
-        assert_eq!(synthetic_observation_worker_count_for(3, 10, 8, 8), 3);
-        assert_eq!(synthetic_observation_worker_count_for(10, 10, 2, 8), 2);
-        assert_eq!(synthetic_observation_worker_count_for(10, 10, 8, 2), 2);
-        assert_eq!(synthetic_observation_worker_count_for(10, 10, 0, 0), 1);
-    }
 
     #[test]
     fn row_noise_seed_varies_by_row_coordinates() {

--- a/crates/casa-ms/src/simulation_task.rs
+++ b/crates/casa-ms/src/simulation_task.rs
@@ -17,7 +17,7 @@ use serde_json::Value as JsonValue;
 
 use crate::simulation::{
     SyntheticAntenna, SyntheticBandpassCorruption, SyntheticBandpassMode,
-    SyntheticCorruptionConfig, SyntheticGainCorruption, SyntheticGainMode,
+    SyntheticCorruptionConfig, SyntheticField, SyntheticGainCorruption, SyntheticGainMode,
     SyntheticNoiseCorruption, SyntheticNoiseMode, SyntheticObservationReport,
     SyntheticObservationRequest, SyntheticPointingCorruption,
     SyntheticPolarizationLeakageCorruption, SyntheticPolarizationLeakageMode,
@@ -70,12 +70,21 @@ pub struct SimobserveRunTaskRequest {
     /// Replace an existing output MeasurementSet directory.
     #[serde(default)]
     pub overwrite: bool,
+    /// Telescope name written to `OBSERVATION`.
+    #[serde(default)]
+    pub telescope_name: Option<String>,
+    /// Single-field name used when `fields` is empty.
+    #[serde(default)]
+    pub field_name: Option<String>,
     /// Antenna configuration. Defaults to the CASA Guide VLA A configuration.
     #[serde(default)]
     pub antennas: Vec<SyntheticAntenna>,
     /// J2000 phase center `[right_ascension, declination]` in radians.
     #[serde(default)]
     pub phase_center_rad: Option<[f64; 2]>,
+    /// Optional multi-field target list. When empty, use the single phase center.
+    #[serde(default)]
+    pub fields: Vec<SyntheticField>,
     /// Observation start time in MJD seconds UTC.
     #[serde(default)]
     pub start_time_mjd_seconds: Option<f64>,
@@ -108,9 +117,16 @@ impl SimobserveRunTaskRequest {
             SyntheticObservationRequest::vla_ppdisk(&self.model_image, &self.output_ms, antennas);
         request.model_peak_jy_per_pixel = self.model_peak_jy_per_pixel;
         request.overwrite = self.overwrite;
+        if let Some(telescope_name) = &self.telescope_name {
+            request.telescope_name = telescope_name.clone();
+        }
+        if let Some(field_name) = &self.field_name {
+            request.field_name = field_name.clone();
+        }
         if let Some(phase_center_rad) = self.phase_center_rad {
             request.phase_center_rad = phase_center_rad;
         }
+        request.fields = self.fields.clone();
         if let Some(start_time_mjd_seconds) = self.start_time_mjd_seconds {
             request.start_time_mjd_seconds = start_time_mjd_seconds;
         }
@@ -601,8 +617,11 @@ fn request_from_cli_args(args: &[std::ffi::OsString]) -> Result<SimobserveRunTas
         model_peak_jy_per_pixel,
         output_ms,
         overwrite: has_flag(args, "--overwrite"),
+        telescope_name: optional_string(args, "--telescope"),
+        field_name: optional_string(args, "--field-name"),
         antennas: Vec::new(),
         phase_center_rad: None,
+        fields: Vec::new(),
         start_time_mjd_seconds: None,
         duration_seconds,
         integration_seconds,

--- a/crates/casa-ms/src/simulation_task.rs
+++ b/crates/casa-ms/src/simulation_task.rs
@@ -22,6 +22,7 @@ use crate::simulation::{
     SyntheticObservationRequest, SyntheticPointingCorruption,
     SyntheticPolarizationLeakageCorruption, SyntheticPolarizationLeakageMode,
     SyntheticSpectralSetup, generate_synthetic_observation_ms, tutorial_vla_a_antennas,
+    zenith_transit_phase_center_rad,
 };
 use crate::ui_schema::{
     UiActionKind, UiArgumentParser, UiArgumentSchema, UiCommandSchema, UiValueKind,
@@ -94,6 +95,12 @@ pub struct SimobserveRunTaskRequest {
     /// Integration time in seconds.
     #[serde(default)]
     pub integration_seconds: Option<f64>,
+    /// Minimum antenna elevation in radians for scheduled samples and flags.
+    #[serde(default)]
+    pub elevation_limit_rad: Option<f64>,
+    /// Permit continuous tracks that include samples below the elevation limit.
+    #[serde(default)]
+    pub allow_below_elevation_limit: bool,
     /// Spectral-window setup. Defaults to the VLA ppdisk tutorial frequency.
     #[serde(default)]
     pub spectral_setup: Option<SyntheticSpectralSetup>,
@@ -123,9 +130,6 @@ impl SimobserveRunTaskRequest {
         if let Some(field_name) = &self.field_name {
             request.field_name = field_name.clone();
         }
-        if let Some(phase_center_rad) = self.phase_center_rad {
-            request.phase_center_rad = phase_center_rad;
-        }
         request.fields = self.fields.clone();
         if let Some(start_time_mjd_seconds) = self.start_time_mjd_seconds {
             request.start_time_mjd_seconds = start_time_mjd_seconds;
@@ -135,6 +139,20 @@ impl SimobserveRunTaskRequest {
         }
         if let Some(integration_seconds) = self.integration_seconds {
             request.integration_seconds = integration_seconds;
+        }
+        if let Some(elevation_limit_rad) = self.elevation_limit_rad {
+            request.elevation_limit_rad = elevation_limit_rad;
+        }
+        request.allow_below_elevation_limit = self.allow_below_elevation_limit;
+        if let Some(phase_center_rad) = self.phase_center_rad {
+            request.phase_center_rad = phase_center_rad;
+        } else if request.fields.is_empty() {
+            request.phase_center_rad = zenith_transit_phase_center_rad(
+                &request.telescope_name,
+                &request.antennas,
+                request.start_time_mjd_seconds,
+            )
+            .unwrap_or(request.phase_center_rad);
         }
         if let Some(spectral_setup) = &self.spectral_setup {
             request.spectral_setup = spectral_setup.clone();
@@ -608,6 +626,7 @@ fn request_from_cli_args(args: &[std::ffi::OsString]) -> Result<SimobserveRunTas
     let model_peak_jy_per_pixel = optional_f32(args, "--inbright-jy-per-pixel")?.or(Some(3.0e-5));
     let duration_seconds = optional_f64(args, "--duration")?;
     let integration_seconds = optional_f64(args, "--integration")?;
+    let elevation_limit_rad = optional_f64(args, "--elevation-limit-deg")?.map(f64::to_radians);
     let start_frequency_hz = optional_f64(args, "--start-frequency-hz")?.unwrap_or(44.0e9);
     let channel_width_hz = optional_f64(args, "--channel-width-hz")?.unwrap_or(128.0e6);
     let channel_count = optional_usize(args, "--channels")?.unwrap_or(1);
@@ -625,6 +644,8 @@ fn request_from_cli_args(args: &[std::ffi::OsString]) -> Result<SimobserveRunTas
         start_time_mjd_seconds: None,
         duration_seconds,
         integration_seconds,
+        elevation_limit_rad,
+        allow_below_elevation_limit: has_flag(args, "--allow-below-elevation-limit"),
         spectral_setup: Some(SyntheticSpectralSetup {
             name: "band1".to_string(),
             start_frequency_hz,
@@ -1011,6 +1032,8 @@ mod tests {
                 "2.5",
                 "--pointing-offset-dec-arcsec",
                 "-1.5",
+                "--elevation-limit-deg",
+                "25",
             ]
             .iter()
             .map(std::ffi::OsString::from)
@@ -1039,5 +1062,25 @@ mod tests {
         assert!(pointing.apply_pointing_offsets);
         assert!(pointing.offset_rad[0] > 0.0);
         assert!(pointing.offset_rad[1] < 0.0);
+        assert!((request.elevation_limit_rad.unwrap().to_degrees() - 25.0).abs() < 1.0e-12);
+    }
+
+    #[test]
+    fn cli_parses_below_elevation_override() {
+        let request = request_from_cli_args(
+            &[
+                "--model",
+                "model.fits",
+                "--out",
+                "out.ms",
+                "--allow-below-elevation-limit",
+            ]
+            .iter()
+            .map(std::ffi::OsString::from)
+            .collect::<Vec<_>>(),
+        )
+        .expect("parse simobserve cli request");
+
+        assert!(request.allow_below_elevation_limit);
     }
 }

--- a/crates/casa-ms/tests/simulation_ms.rs
+++ b/crates/casa-ms/tests/simulation_ms.rs
@@ -3,7 +3,7 @@
 
 use casa_ms::{
     MeasurementSet, SyntheticAntenna, SyntheticBandpassCorruption, SyntheticBandpassMode,
-    SyntheticCorruptionConfig, SyntheticGainCorruption, SyntheticGainMode,
+    SyntheticCorruptionConfig, SyntheticField, SyntheticGainCorruption, SyntheticGainMode,
     SyntheticNoiseCorruption, SyntheticNoiseMode, SyntheticObservationRequest,
     SyntheticPointingCorruption, SyntheticPolarizationLeakageCorruption,
     SyntheticPolarizationLeakageMode, SyntheticSpectralSetup, generate_synthetic_observation_ms,
@@ -107,6 +107,42 @@ fn generates_vla_ppdisk_synthetic_ms_skeleton() {
         }
         other => panic!("expected Float64 UVW array, got {other:?}"),
     }
+}
+
+#[test]
+fn multi_field_synthetic_ms_cycles_field_ids_and_writes_pointings() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut request = request(temp.path());
+    request.duration_seconds = 40.0;
+    request.integration_seconds = 10.0;
+    request.fields = vec![
+        SyntheticField {
+            name: "mosaic_0".to_string(),
+            phase_center_rad: request.phase_center_rad,
+        },
+        SyntheticField {
+            name: "mosaic_1".to_string(),
+            phase_center_rad: [
+                request.phase_center_rad[0] + 10.0_f64.to_radians() / 3600.0,
+                request.phase_center_rad[1],
+            ],
+        },
+    ];
+
+    let report = generate_synthetic_observation_ms(&request).unwrap();
+    assert_eq!(report.main_row_count, 12);
+
+    let ms = MeasurementSet::open(&request.output_ms).unwrap();
+    assert!(ms.validate().unwrap().is_empty());
+    assert_eq!(ms.field().unwrap().row_count(), 2);
+    assert_eq!(ms.field().unwrap().name(0).unwrap(), "mosaic_0");
+    assert_eq!(ms.field().unwrap().name(1).unwrap(), "mosaic_1");
+    assert_eq!(ms.pointing().unwrap().row_count(), 6);
+
+    assert_eq!(main_i32_cell(&ms, 0, "FIELD_ID"), 0);
+    assert_eq!(main_i32_cell(&ms, 3, "FIELD_ID"), 1);
+    assert_eq!(main_i32_cell(&ms, 6, "FIELD_ID"), 0);
+    assert_eq!(main_i32_cell(&ms, 9, "FIELD_ID"), 1);
 }
 
 #[test]
@@ -524,6 +560,19 @@ fn row_data(path: &std::path::Path, row: usize) -> Vec<(f32, f32)> {
             .map(|value| (value.re, value.im))
             .collect::<Vec<_>>(),
         other => panic!("expected Complex32 DATA array, got {other:?}"),
+    }
+}
+
+fn main_i32_cell(ms: &MeasurementSet, row: usize, column: &str) -> i32 {
+    let value = ms
+        .main_table()
+        .cell_accessor(row, column)
+        .unwrap()
+        .value()
+        .unwrap();
+    match value {
+        Some(Value::Scalar(ScalarValue::Int32(value))) => *value,
+        other => panic!("expected Int32 {column} cell, got {other:?}"),
     }
 }
 

--- a/crates/casa-ms/tests/simulation_ms.rs
+++ b/crates/casa-ms/tests/simulation_ms.rs
@@ -10,6 +10,7 @@ use casa_ms::{
     tutorial_vla_a_antennas,
 };
 use casa_test_support::{discover_casa_python, tutorial_dataset_path};
+use casa_types::measures::position::MPosition;
 use casa_types::{ArrayValue, ScalarValue, Value};
 use std::process::Command;
 
@@ -107,6 +108,43 @@ fn generates_vla_ppdisk_synthetic_ms_skeleton() {
         }
         other => panic!("expected Float64 UVW array, got {other:?}"),
     }
+}
+
+#[test]
+fn zenith_transit_schedule_writes_unflagged_vla_track() {
+    let temp = tempfile::tempdir().unwrap();
+    let model = temp.path().join("ppdisk672_GHz_50pc.fits");
+    write_test_fits_model(&model, 16, 16);
+    let vla = MPosition::from_observatory_name("VLA").expect("VLA position");
+    let mut request = SyntheticObservationRequest::vla_ppdisk(
+        &model,
+        temp.path().join("zenith.synthetic.ms"),
+        tutorial_vla_a_antennas(),
+    );
+    request.phase_center_rad = [0.0, vla.latitude_rad()];
+    request.start_time_mjd_seconds = 59_000.25 * 86_400.0;
+    request.duration_seconds = 2.0 * 3_600.0;
+    request.integration_seconds = 600.0;
+    request.predict_model = false;
+    request.corruption = None;
+
+    let report = generate_synthetic_observation_ms(&request).unwrap();
+    let ms = MeasurementSet::open(&request.output_ms).unwrap();
+    let flag_rows = ms.flag_row_column();
+    let flags = ms.flag_column();
+    let mut true_flag_rows = 0usize;
+    let mut true_flags = 0usize;
+    for row in 0..ms.row_count() {
+        true_flag_rows += usize::from(flag_rows.get(row).unwrap());
+        let ArrayValue::Bool(row_flags) = flags.get(row).unwrap() else {
+            panic!("expected Bool FLAG row");
+        };
+        true_flags += row_flags.iter().filter(|flag| **flag).count();
+    }
+
+    assert_eq!(report.main_row_count, ms.row_count());
+    assert_eq!(true_flag_rows, 0);
+    assert_eq!(true_flags, 0);
 }
 
 #[test]

--- a/crates/casa-tables/src/lib.rs
+++ b/crates/casa-tables/src/lib.rs
@@ -264,7 +264,11 @@ pub use schema::{
 };
 pub use sorting::{TableGroup, TableIterator};
 pub use storage::{
-    DataManagerInfo, StorageError, TableInfo, TilePixel, TiledFileIO, set_table_cache_budget_bytes,
+    DataManagerInfo, StorageError, StreamedTiledPrimitiveColumn, StreamedTiledPrimitiveType,
+    StreamedTiledShapeComplex32Column, StreamingTiledPrimitiveWriter,
+    StreamingTiledShapeComplex32Writer, TableInfo, TilePixel, TiledFileIO,
+    install_streamed_tiled_column_primitive_column, install_streamed_tiled_shape_complex32_column,
+    install_streamed_tiled_shape_primitive_column, set_table_cache_budget_bytes,
     table_cache_budget_bytes,
 };
 pub use table::{

--- a/crates/casa-tables/src/storage/mod.rs
+++ b/crates/casa-tables/src/storage/mod.rs
@@ -10,7 +10,11 @@ pub(crate) mod stman_array_file;
 pub(crate) mod table_control;
 pub(crate) mod tiled_stman;
 pub use tiled_stman::{
-    TilePixel, TiledFileIO, set_table_cache_budget_bytes, table_cache_budget_bytes,
+    StreamedTiledPrimitiveColumn, StreamedTiledPrimitiveType, StreamedTiledShapeComplex32Column,
+    StreamingTiledPrimitiveWriter, StreamingTiledShapeComplex32Writer, TilePixel, TiledFileIO,
+    install_streamed_tiled_column_primitive_column, install_streamed_tiled_shape_complex32_column,
+    install_streamed_tiled_shape_primitive_column, set_table_cache_budget_bytes,
+    table_cache_budget_bytes,
 };
 pub(crate) mod virtual_bitflags;
 pub(crate) mod virtual_compress;

--- a/crates/casa-tables/src/storage/tiled_stman.rs
+++ b/crates/casa-tables/src/storage/tiled_stman.rs
@@ -438,6 +438,15 @@ fn write_tile_storage(dst: &mut [u8], dt: CasacoreDataType, unpacked: &[u8], nrp
     }
 }
 
+fn write_bool_bits_fill(dst: &mut [u8], nrpixels: usize) {
+    let full_bytes = nrpixels / 8;
+    let remaining_bits = nrpixels % 8;
+    dst[..full_bytes].fill(0xff);
+    if remaining_bits > 0 {
+        dst[full_bytes] = (1u8 << remaining_bits) - 1;
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Header read
 // ---------------------------------------------------------------------------
@@ -3477,6 +3486,29 @@ impl StreamingTiledPrimitiveWriter {
         self.push_encoded_row(&encoded)
     }
 
+    /// Append one bool row with every logical value set to `value`.
+    pub fn push_bool_fill_row(&mut self, value: bool) -> Result<(), StorageError> {
+        if self.primitive_type != StreamedTiledPrimitiveType::Bool {
+            return Err(StorageError::FormatMismatch(
+                "streamed primitive writer was not configured for bool rows".to_string(),
+            ));
+        }
+        if !value {
+            return self.push_zero_row();
+        }
+        if self.rows_written >= self.row_count {
+            return Err(StorageError::FormatMismatch(format!(
+                "streamed primitive writer received too many rows: expected {}",
+                self.row_count
+            )));
+        }
+        let assemble_started = Instant::now();
+        let row_in_tile = self.rows_written % self.rows_per_tile;
+        self.fill_row_into_tile_buffers(row_in_tile, 1);
+        self.assemble_seconds += assemble_started.elapsed().as_secs_f64();
+        self.advance_row_after_copy()
+    }
+
     /// Append one float row.
     pub fn push_f32_row(&mut self, values: &[f32]) -> Result<(), StorageError> {
         if self.primitive_type != StreamedTiledPrimitiveType::Float32 {
@@ -3574,6 +3606,27 @@ impl StreamingTiledPrimitiveWriter {
         }
     }
 
+    fn fill_row_into_tile_buffers(&mut self, row_in_tile: usize, value: u8) {
+        let cell_rank = self.cell_shape.len();
+        let tile_cell_shape = &self.tile_shape[..cell_rank];
+        let tile_cell_nelem: usize = tile_cell_shape.iter().product();
+        let elem_size = self.primitive_type.elem_size();
+        let row_block_bytes = tile_cell_nelem * elem_size;
+
+        for (tile_index, plan) in self.tile_plans.iter().enumerate() {
+            let row_slice_start = row_in_tile * row_block_bytes;
+            let row_slice_end = row_slice_start + row_block_bytes;
+            let row_tile = &mut self.tile_buffers[tile_index][row_slice_start..row_slice_end];
+            fill_cube_tile_region(
+                row_tile,
+                tile_cell_shape,
+                &plan.actual_extent,
+                elem_size,
+                value,
+            );
+        }
+    }
+
     /// Finish writing and return an installable streamed-column payload.
     pub fn finish(mut self) -> Result<StreamedTiledPrimitiveColumn, StorageError> {
         if self.rows_written != self.row_count {
@@ -3613,12 +3666,18 @@ impl StreamingTiledPrimitiveWriter {
             let mut bucket = vec![0u8; self.bucket_size];
             for tile in &self.tile_buffers {
                 bucket.fill(0);
-                write_tile_storage(
-                    &mut bucket,
-                    self.primitive_type.casacore_type(),
-                    tile,
-                    self.tile_nelem,
-                );
+                if tile.iter().all(|&value| value == 0) {
+                    // Already zero-filled.
+                } else if tile.iter().all(|&value| value != 0) {
+                    write_bool_bits_fill(&mut bucket, self.tile_nelem);
+                } else {
+                    write_tile_storage(
+                        &mut bucket,
+                        self.primitive_type.casacore_type(),
+                        tile,
+                        self.tile_nelem,
+                    );
+                }
                 self.writer.write_all(&bucket)?;
                 self.logical_write_calls += 1;
                 self.max_logical_write_bytes = self.max_logical_write_bytes.max(bucket.len());
@@ -5684,6 +5743,44 @@ fn copy_cube_to_tile(
         let dst_start = tile_off * elem_size;
         tile_data[dst_start..dst_start + inner_bytes]
             .copy_from_slice(&cube_data[src_start..src_start + inner_bytes]);
+
+        increment_position(&mut outer_pos, outer_dims);
+    }
+}
+
+fn fill_cube_tile_region(
+    tile_data: &mut [u8],
+    tile_shape: &[usize],
+    actual_extent: &[usize],
+    elem_size: usize,
+    value: u8,
+) {
+    let ndim = tile_shape.len();
+    if ndim == 0 {
+        return;
+    }
+
+    let inner_bytes = actual_extent[0] * elem_size;
+
+    if ndim == 1 {
+        tile_data[..inner_bytes].fill(value);
+        return;
+    }
+
+    let outer_dims = &actual_extent[1..];
+    let outer_total: usize = outer_dims.iter().product();
+    let mut outer_pos = vec![0usize; outer_dims.len()];
+
+    for _ in 0..outer_total {
+        let mut tile_off = 0;
+        let mut stride = tile_shape[0];
+        for (d, &p) in outer_pos.iter().enumerate() {
+            tile_off += p * stride;
+            stride *= tile_shape[d + 1];
+        }
+
+        let dst_start = tile_off * elem_size;
+        tile_data[dst_start..dst_start + inner_bytes].fill(value);
 
         increment_position(&mut outer_pos, outer_dims);
     }

--- a/crates/casa-tables/src/storage/tiled_stman.rs
+++ b/crates/casa-tables/src/storage/tiled_stman.rs
@@ -17,8 +17,8 @@
 
 use std::borrow::Cow;
 use std::collections::HashSet;
-use std::fs::OpenOptions;
-use std::io::{Read as IoRead, Seek, SeekFrom, Write as IoWrite};
+use std::fs::{File, OpenOptions};
+use std::io::{BufWriter, Read as IoRead, Seek, SeekFrom, Write as IoWrite};
 #[cfg(unix)]
 use std::os::unix::fs::FileExt;
 use std::path::{Path, PathBuf};
@@ -36,6 +36,68 @@ use ndarray::{ArrayD, IxDyn, ShapeBuilder};
 const MAX_NDIM: usize = 8;
 const DEFAULT_TABLE_CACHE_BYTES: usize = 64 * 1024 * 1024;
 const TABLE_CACHE_BUDGET_ENV: &str = "CASA_RS_TABLE_CACHE_BYTES";
+const DEFAULT_STREAMED_TILED_WRITER_BUFFER_BYTES: usize = 8 * 1024 * 1024;
+const STREAMED_TILED_WRITER_BUFFER_BYTES_ENV: &str = "CASA_RS_STREAMED_TILED_WRITER_BUFFER_BYTES";
+const STREAMED_TILED_TRACE_ENV: &str = "CASA_RS_STREAMED_TILED_TRACE";
+
+#[derive(Clone, Debug, Default)]
+struct CountingWriteStats {
+    write_calls: usize,
+    bytes_written: usize,
+    max_write_bytes: usize,
+    flush_calls: usize,
+}
+
+struct CountingFile {
+    file: File,
+    stats: CountingWriteStats,
+}
+
+impl CountingFile {
+    fn create(path: &Path) -> std::io::Result<Self> {
+        Ok(Self {
+            file: File::create(path)?,
+            stats: CountingWriteStats::default(),
+        })
+    }
+
+    fn stats(&self) -> CountingWriteStats {
+        self.stats.clone()
+    }
+}
+
+impl IoWrite for CountingFile {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let written = self.file.write(buf)?;
+        self.stats.write_calls += 1;
+        self.stats.bytes_written += written;
+        self.stats.max_write_bytes = self.stats.max_write_bytes.max(written);
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.stats.flush_calls += 1;
+        self.file.flush()
+    }
+}
+
+fn streamed_tiled_writer_buffer_bytes() -> usize {
+    std::env::var(STREAMED_TILED_WRITER_BUFFER_BYTES_ENV)
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_STREAMED_TILED_WRITER_BUFFER_BYTES)
+}
+
+fn trace_streamed_tiled_writes() -> bool {
+    matches!(
+        std::env::var(STREAMED_TILED_TRACE_ENV)
+            .ok()
+            .as_deref()
+            .map(str::trim),
+        Some("1" | "true" | "TRUE" | "yes" | "YES")
+    )
+}
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct SharedTileKey {
@@ -830,12 +892,11 @@ fn copy_tile_to_cube(
     }
 
     // Iterate over all outer-dimension positions.
-    let outer_dims: Vec<usize> = actual_extent[1..].to_vec();
+    let outer_dims = &actual_extent[1..];
     let outer_total: usize = outer_dims.iter().product();
+    let mut outer_pos = vec![0usize; outer_dims.len()];
 
-    for outer_linear in 0..outer_total {
-        let outer_pos = linear_to_nd(outer_linear, &outer_dims);
-
+    for _ in 0..outer_total {
         // Compute tile linear offset for this outer position.
         let mut tile_off = 0;
         let mut stride = tile_shape[0];
@@ -856,6 +917,8 @@ fn copy_tile_to_cube(
         let dst_start = cube_off * elem_size;
         cube_data[dst_start..dst_start + inner_bytes]
             .copy_from_slice(&tile_data[src_start..src_start + inner_bytes]);
+
+        increment_position(&mut outer_pos, outer_dims);
     }
 }
 
@@ -3158,6 +3221,1030 @@ struct StreamedShapeCubeWrite {
     write_seconds: f64,
 }
 
+/// Primitive element type for the streaming tiled-column writer.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum StreamedTiledPrimitiveType {
+    /// `TpBool`, stored bit-packed in tiled storage.
+    Bool,
+    /// `TpFloat`.
+    Float32,
+    /// `TpDouble`.
+    Float64,
+}
+
+impl StreamedTiledPrimitiveType {
+    fn casacore_type(self) -> CasacoreDataType {
+        match self {
+            Self::Bool => CasacoreDataType::TpBool,
+            Self::Float32 => CasacoreDataType::TpFloat,
+            Self::Float64 => CasacoreDataType::TpDouble,
+        }
+    }
+
+    fn elem_size(self) -> usize {
+        tile_element_size(self.casacore_type())
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum StreamedTiledPrimitiveVariant {
+    Column,
+    Shape,
+}
+
+#[derive(Debug, Clone)]
+struct StreamedPrimitiveTilePlan {
+    cell_start: Vec<usize>,
+    actual_extent: Vec<usize>,
+}
+
+/// Completed payload for one streamed primitive tiled column.
+#[derive(Debug, Clone)]
+pub struct StreamedTiledPrimitiveColumn {
+    temp_data_path: PathBuf,
+    row_count: usize,
+    cell_shape: Vec<usize>,
+    tile_shape: Vec<usize>,
+    primitive_type: StreamedTiledPrimitiveType,
+    variant: StreamedTiledPrimitiveVariant,
+    bytes_written: usize,
+    big_endian: bool,
+    assemble_seconds: f64,
+    write_seconds: f64,
+}
+
+impl StreamedTiledPrimitiveColumn {
+    /// Number of completed table rows in the streamed column.
+    pub fn row_count(&self) -> usize {
+        self.row_count
+    }
+
+    /// Number of bytes written to the TSM data file.
+    pub fn bytes_written(&self) -> usize {
+        self.bytes_written
+    }
+
+    /// Time spent packing row cells into tile buffers.
+    pub fn assemble_seconds(&self) -> f64 {
+        self.assemble_seconds
+    }
+
+    /// Time spent writing tile buffers to the temporary TSM file.
+    pub fn write_seconds(&self) -> f64 {
+        self.write_seconds
+    }
+}
+
+/// Streaming writer for one sequential primitive tiled column.
+///
+/// Rows must be pushed in table-row order. Row byte payloads are the unpacked
+/// casacore array memory order for `cell_shape`; bool rows use one byte per
+/// logical flag and are bit-packed when tile buffers are flushed.
+pub struct StreamingTiledPrimitiveWriter {
+    temp_data_path: PathBuf,
+    writer: BufWriter<CountingFile>,
+    row_count: usize,
+    rows_written: usize,
+    cell_shape: Vec<usize>,
+    tile_shape: Vec<usize>,
+    tile_plans: Vec<StreamedPrimitiveTilePlan>,
+    rows_per_tile: usize,
+    bucket_size: usize,
+    tile_nelem: usize,
+    tile_buffers: Vec<Vec<u8>>,
+    primitive_type: StreamedTiledPrimitiveType,
+    variant: StreamedTiledPrimitiveVariant,
+    big_endian: bool,
+    assemble_seconds: f64,
+    write_seconds: f64,
+    bytes_written: usize,
+    logical_write_calls: usize,
+    max_logical_write_bytes: usize,
+    tile_row_blocks_flushed: usize,
+    writer_buffer_bytes: usize,
+}
+
+impl StreamingTiledPrimitiveWriter {
+    /// Create a sequential `TiledShapeStMan` primitive writer.
+    pub fn create_shape(
+        temp_data_path: impl Into<PathBuf>,
+        row_count: usize,
+        cell_shape: Vec<usize>,
+        tile_shape: Vec<usize>,
+        primitive_type: StreamedTiledPrimitiveType,
+        big_endian: bool,
+    ) -> Result<Self, StorageError> {
+        Self::create(
+            temp_data_path,
+            row_count,
+            cell_shape,
+            tile_shape,
+            primitive_type,
+            StreamedTiledPrimitiveVariant::Shape,
+            big_endian,
+        )
+    }
+
+    /// Create a sequential `TiledColumnStMan` primitive writer.
+    pub fn create_column(
+        temp_data_path: impl Into<PathBuf>,
+        row_count: usize,
+        cell_shape: Vec<usize>,
+        tile_shape: Vec<usize>,
+        primitive_type: StreamedTiledPrimitiveType,
+        big_endian: bool,
+    ) -> Result<Self, StorageError> {
+        Self::create(
+            temp_data_path,
+            row_count,
+            cell_shape,
+            tile_shape,
+            primitive_type,
+            StreamedTiledPrimitiveVariant::Column,
+            big_endian,
+        )
+    }
+
+    fn create(
+        temp_data_path: impl Into<PathBuf>,
+        row_count: usize,
+        cell_shape: Vec<usize>,
+        tile_shape: Vec<usize>,
+        primitive_type: StreamedTiledPrimitiveType,
+        variant: StreamedTiledPrimitiveVariant,
+        big_endian: bool,
+    ) -> Result<Self, StorageError> {
+        if tile_shape.len() != cell_shape.len() + 1 {
+            return Err(StorageError::FormatMismatch(format!(
+                "streamed primitive tile rank must be cell rank + row axis; cell={cell_shape:?} tile={tile_shape:?}"
+            )));
+        }
+        if cell_shape.contains(&0) || tile_shape.contains(&0) {
+            return Err(StorageError::FormatMismatch(
+                "streamed primitive tiled dimensions must be positive".to_string(),
+            ));
+        }
+
+        let mut cube_shape = cell_shape.clone();
+        cube_shape.push(row_count);
+        let tiles_per_dim: Vec<usize> = cube_shape
+            .iter()
+            .zip(tile_shape.iter())
+            .map(|(&cube, &tile)| cube.div_ceil(tile))
+            .collect();
+        let cell_rank = cell_shape.len();
+        let cell_tiles_per_dim = &tiles_per_dim[..cell_rank];
+        let non_row_tile_count: usize = cell_tiles_per_dim.iter().product();
+        let elem_size = primitive_type.elem_size();
+        let rows_per_tile = *tile_shape.last().expect("validated non-empty tile shape");
+        let tile_plans = (0..non_row_tile_count)
+            .map(|tile_index| {
+                let tile_pos = linear_to_nd(tile_index, cell_tiles_per_dim);
+                let cell_start: Vec<usize> = tile_pos
+                    .iter()
+                    .enumerate()
+                    .map(|(axis, &pos)| pos * tile_shape[axis])
+                    .collect();
+                let actual_extent: Vec<usize> = cell_start
+                    .iter()
+                    .enumerate()
+                    .map(|(axis, &start)| std::cmp::min(tile_shape[axis], cell_shape[axis] - start))
+                    .collect();
+                StreamedPrimitiveTilePlan {
+                    cell_start,
+                    actual_extent,
+                }
+            })
+            .collect();
+
+        let (bucket_size, _offsets) =
+            compute_tile_layout(&[primitive_type.casacore_type()], &tile_shape);
+        let tile_nelem: usize = tile_shape.iter().product();
+        let tile_buffers = (0..non_row_tile_count)
+            .map(|_| vec![0u8; tile_nelem * elem_size])
+            .collect();
+
+        let temp_data_path = temp_data_path.into();
+        if let Some(parent) = temp_data_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let writer_buffer_bytes = streamed_tiled_writer_buffer_bytes();
+        let writer =
+            BufWriter::with_capacity(writer_buffer_bytes, CountingFile::create(&temp_data_path)?);
+
+        Ok(Self {
+            temp_data_path,
+            writer,
+            row_count,
+            rows_written: 0,
+            cell_shape,
+            tile_shape,
+            tile_plans,
+            rows_per_tile,
+            bucket_size,
+            tile_nelem,
+            tile_buffers,
+            primitive_type,
+            variant,
+            big_endian,
+            assemble_seconds: 0.0,
+            write_seconds: 0.0,
+            bytes_written: 0,
+            logical_write_calls: 0,
+            max_logical_write_bytes: 0,
+            tile_row_blocks_flushed: 0,
+            writer_buffer_bytes,
+        })
+    }
+
+    /// Append one zero-valued row. This avoids touching tile buffers that are
+    /// already zero-filled.
+    pub fn push_zero_row(&mut self) -> Result<(), StorageError> {
+        self.advance_row_after_copy()
+    }
+
+    /// Append one bool row.
+    pub fn push_bool_row(&mut self, values: &[bool]) -> Result<(), StorageError> {
+        if self.primitive_type != StreamedTiledPrimitiveType::Bool {
+            return Err(StorageError::FormatMismatch(
+                "streamed primitive writer was not configured for bool rows".to_string(),
+            ));
+        }
+        let mut encoded = vec![0u8; values.len()];
+        for (dst, value) in encoded.iter_mut().zip(values.iter()) {
+            *dst = u8::from(*value);
+        }
+        self.push_encoded_row(&encoded)
+    }
+
+    /// Append one float row.
+    pub fn push_f32_row(&mut self, values: &[f32]) -> Result<(), StorageError> {
+        if self.primitive_type != StreamedTiledPrimitiveType::Float32 {
+            return Err(StorageError::FormatMismatch(
+                "streamed primitive writer was not configured for f32 rows".to_string(),
+            ));
+        }
+        let mut encoded = vec![0u8; values.len() * 4];
+        for (idx, &value) in values.iter().enumerate() {
+            if self.big_endian {
+                write_f32_be(&mut encoded[idx * 4..], value);
+            } else {
+                write_f32_le(&mut encoded[idx * 4..], value);
+            }
+        }
+        self.push_encoded_row(&encoded)
+    }
+
+    /// Append one double row.
+    pub fn push_f64_row(&mut self, values: &[f64]) -> Result<(), StorageError> {
+        if self.primitive_type != StreamedTiledPrimitiveType::Float64 {
+            return Err(StorageError::FormatMismatch(
+                "streamed primitive writer was not configured for f64 rows".to_string(),
+            ));
+        }
+        let mut encoded = vec![0u8; values.len() * 8];
+        for (idx, &value) in values.iter().enumerate() {
+            if self.big_endian {
+                write_f64_be(&mut encoded[idx * 8..], value);
+            } else {
+                write_f64_le(&mut encoded[idx * 8..], value);
+            }
+        }
+        self.push_encoded_row(&encoded)
+    }
+
+    fn push_encoded_row(&mut self, row_bytes: &[u8]) -> Result<(), StorageError> {
+        if self.rows_written >= self.row_count {
+            return Err(StorageError::FormatMismatch(format!(
+                "streamed primitive writer received too many rows: expected {}",
+                self.row_count
+            )));
+        }
+        let expected_len =
+            self.cell_shape.iter().product::<usize>() * self.primitive_type.elem_size();
+        if row_bytes.len() != expected_len {
+            return Err(StorageError::FormatMismatch(format!(
+                "streamed primitive row has {} bytes, expected {expected_len}",
+                row_bytes.len()
+            )));
+        }
+
+        let assemble_started = Instant::now();
+        let row_in_tile = self.rows_written % self.rows_per_tile;
+        self.copy_row_into_tile_buffers(row_in_tile, row_bytes);
+        self.assemble_seconds += assemble_started.elapsed().as_secs_f64();
+        self.advance_row_after_copy()
+    }
+
+    fn advance_row_after_copy(&mut self) -> Result<(), StorageError> {
+        if self.rows_written >= self.row_count {
+            return Err(StorageError::FormatMismatch(format!(
+                "streamed primitive writer received too many rows: expected {}",
+                self.row_count
+            )));
+        }
+        let row_in_tile = self.rows_written % self.rows_per_tile;
+        self.rows_written += 1;
+        if row_in_tile + 1 == self.rows_per_tile {
+            self.flush_tile_row_block()?;
+        }
+        Ok(())
+    }
+
+    fn copy_row_into_tile_buffers(&mut self, row_in_tile: usize, row_bytes: &[u8]) {
+        let cell_rank = self.cell_shape.len();
+        let tile_cell_shape = &self.tile_shape[..cell_rank];
+        let tile_cell_nelem: usize = tile_cell_shape.iter().product();
+        let elem_size = self.primitive_type.elem_size();
+        let row_block_bytes = tile_cell_nelem * elem_size;
+
+        for (tile_index, plan) in self.tile_plans.iter().enumerate() {
+            let row_slice_start = row_in_tile * row_block_bytes;
+            let row_slice_end = row_slice_start + row_block_bytes;
+            let row_tile = &mut self.tile_buffers[tile_index][row_slice_start..row_slice_end];
+            copy_cube_to_tile(
+                row_bytes,
+                &self.cell_shape,
+                row_tile,
+                tile_cell_shape,
+                &plan.cell_start,
+                &plan.actual_extent,
+                elem_size,
+            );
+        }
+    }
+
+    /// Finish writing and return an installable streamed-column payload.
+    pub fn finish(mut self) -> Result<StreamedTiledPrimitiveColumn, StorageError> {
+        if self.rows_written != self.row_count {
+            return Err(StorageError::FormatMismatch(format!(
+                "streamed primitive writer finished with {} rows, expected {}",
+                self.rows_written, self.row_count
+            )));
+        }
+        if self.rows_written > 0 && self.rows_written % self.rows_per_tile != 0 {
+            self.flush_tile_row_block()?;
+        }
+        let write_started = Instant::now();
+        self.writer.flush()?;
+        self.write_seconds += write_started.elapsed().as_secs_f64();
+        if trace_streamed_tiled_writes() {
+            self.trace_write_stats();
+        }
+
+        Ok(StreamedTiledPrimitiveColumn {
+            temp_data_path: self.temp_data_path,
+            row_count: self.row_count,
+            cell_shape: self.cell_shape,
+            tile_shape: self.tile_shape,
+            primitive_type: self.primitive_type,
+            variant: self.variant,
+            bytes_written: self.bytes_written,
+            big_endian: self.big_endian,
+            assemble_seconds: self.assemble_seconds,
+            write_seconds: self.write_seconds,
+        })
+    }
+
+    fn flush_tile_row_block(&mut self) -> Result<(), StorageError> {
+        let write_started = Instant::now();
+        self.tile_row_blocks_flushed += 1;
+        if self.primitive_type == StreamedTiledPrimitiveType::Bool {
+            let mut bucket = vec![0u8; self.bucket_size];
+            for tile in &self.tile_buffers {
+                bucket.fill(0);
+                write_tile_storage(
+                    &mut bucket,
+                    self.primitive_type.casacore_type(),
+                    tile,
+                    self.tile_nelem,
+                );
+                self.writer.write_all(&bucket)?;
+                self.logical_write_calls += 1;
+                self.max_logical_write_bytes = self.max_logical_write_bytes.max(bucket.len());
+                self.bytes_written += bucket.len();
+            }
+        } else {
+            for tile in &self.tile_buffers {
+                debug_assert_eq!(tile.len(), self.bucket_size);
+                self.writer.write_all(tile)?;
+                self.logical_write_calls += 1;
+                self.max_logical_write_bytes = self.max_logical_write_bytes.max(tile.len());
+                self.bytes_written += tile.len();
+            }
+        }
+        self.write_seconds += write_started.elapsed().as_secs_f64();
+
+        for tile in &mut self.tile_buffers {
+            tile.fill(0);
+        }
+        Ok(())
+    }
+
+    fn trace_write_stats(&self) {
+        let stats = self.writer.get_ref().stats();
+        eprintln!(
+            "casa-rs streamed tiled write column={} variant={:?} type={:?} rows={} cell_shape={:?} tile_shape={:?} row_tile={} tile_buffers={} tile_row_blocks={} logical_write_calls={} logical_max_write_bytes={} buffered_write_calls={} buffered_max_write_bytes={} buffered_flush_calls={} writer_buffer_bytes={} bytes_written={} assemble_seconds={:.6} write_seconds={:.6}",
+            self.temp_data_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("<unknown>"),
+            self.variant,
+            self.primitive_type,
+            self.rows_written,
+            self.cell_shape,
+            self.tile_shape,
+            self.rows_per_tile,
+            self.tile_buffers.len(),
+            self.tile_row_blocks_flushed,
+            self.logical_write_calls,
+            self.max_logical_write_bytes,
+            stats.write_calls,
+            stats.max_write_bytes,
+            stats.flush_calls,
+            self.writer_buffer_bytes,
+            self.bytes_written,
+            self.assemble_seconds,
+            self.write_seconds,
+        );
+    }
+}
+
+/// Install a completed streamed primitive column as a `TiledShapeStMan` data manager.
+pub fn install_streamed_tiled_shape_primitive_column(
+    table_path: &Path,
+    dm_seq_nr: u32,
+    dm_name: &str,
+    streamed: StreamedTiledPrimitiveColumn,
+) -> Result<(), StorageError> {
+    if streamed.variant != StreamedTiledPrimitiveVariant::Shape {
+        return Err(StorageError::FormatMismatch(
+            "streamed primitive payload is not a TiledShapeStMan column".to_string(),
+        ));
+    }
+    install_streamed_tiled_primitive_column(table_path, dm_seq_nr, dm_name, streamed)
+}
+
+/// Install a completed streamed primitive column as a `TiledColumnStMan` data manager.
+pub fn install_streamed_tiled_column_primitive_column(
+    table_path: &Path,
+    dm_seq_nr: u32,
+    dm_name: &str,
+    streamed: StreamedTiledPrimitiveColumn,
+) -> Result<(), StorageError> {
+    if streamed.variant != StreamedTiledPrimitiveVariant::Column {
+        return Err(StorageError::FormatMismatch(
+            "streamed primitive payload is not a TiledColumnStMan column".to_string(),
+        ));
+    }
+    install_streamed_tiled_primitive_column(table_path, dm_seq_nr, dm_name, streamed)
+}
+
+fn install_streamed_tiled_primitive_column(
+    table_path: &Path,
+    dm_seq_nr: u32,
+    dm_name: &str,
+    streamed: StreamedTiledPrimitiveColumn,
+) -> Result<(), StorageError> {
+    std::fs::create_dir_all(table_path)?;
+    let tsm_path = tsm_data_path(table_path, dm_seq_nr, 0);
+    match std::fs::rename(&streamed.temp_data_path, &tsm_path) {
+        Ok(()) => {}
+        Err(_) => {
+            std::fs::copy(&streamed.temp_data_path, &tsm_path)?;
+            std::fs::remove_file(&streamed.temp_data_path)?;
+        }
+    }
+
+    let mut cube_shape = streamed.cell_shape.clone();
+    cube_shape.push(streamed.row_count);
+    let data_type = streamed.primitive_type.casacore_type();
+    let files = if streamed.row_count == 0 {
+        vec![]
+    } else {
+        vec![Some(TsmFileInfo {
+            seq_nr: 0,
+            length: streamed.bytes_written as i64,
+        })]
+    };
+    let real_cube = TsmCubeInfo {
+        values: RecordValue::default(),
+        extensible: true,
+        cube_shape: cube_shape.clone(),
+        tile_shape: streamed.tile_shape.clone(),
+        file_seq_nr: if streamed.row_count == 0 { -1 } else { 0 },
+        file_offset: 0,
+    };
+    let header_path = table_path.join(format!("table.f{dm_seq_nr}"));
+
+    match streamed.variant {
+        StreamedTiledPrimitiveVariant::Column => {
+            let header = TiledStManHeader {
+                big_endian: streamed.big_endian,
+                seq_nr: dm_seq_nr,
+                nrrow: streamed.row_count as u64,
+                col_data_types: vec![data_type],
+                hypercolumn_name: dm_name.to_string(),
+                max_cache_size: 0,
+                nrdim: (streamed.cell_shape.len() + 1) as u32,
+                files,
+                cubes: if streamed.row_count == 0 {
+                    vec![]
+                } else {
+                    vec![real_cube]
+                },
+            };
+            let variant = TiledVariant::Column {
+                default_tile_shape: streamed
+                    .tile_shape
+                    .iter()
+                    .map(|&value| value as i32)
+                    .collect(),
+            };
+            write_tiled_header(&header_path, &variant, &header)?;
+        }
+        StreamedTiledPrimitiveVariant::Shape => {
+            let header = TiledStManHeader {
+                big_endian: streamed.big_endian,
+                seq_nr: dm_seq_nr,
+                nrrow: streamed.row_count as u64,
+                col_data_types: vec![data_type],
+                hypercolumn_name: dm_name.to_string(),
+                max_cache_size: 0,
+                nrdim: (streamed.cell_shape.len() + 1) as u32,
+                files,
+                cubes: if streamed.row_count == 0 {
+                    vec![TsmCubeInfo {
+                        values: RecordValue::default(),
+                        extensible: false,
+                        cube_shape: vec![],
+                        tile_shape: vec![],
+                        file_seq_nr: -1,
+                        file_offset: 0,
+                    }]
+                } else {
+                    vec![
+                        TsmCubeInfo {
+                            values: RecordValue::default(),
+                            extensible: false,
+                            cube_shape: vec![],
+                            tile_shape: vec![],
+                            file_seq_nr: -1,
+                            file_offset: 0,
+                        },
+                        real_cube,
+                    ]
+                },
+            };
+            let variant = TiledVariant::Shape {
+                default_tile_shape: streamed
+                    .tile_shape
+                    .iter()
+                    .map(|&value| value as i32)
+                    .collect(),
+                nr_used_row_map: if streamed.row_count == 0 { 0 } else { 1 },
+                row_map: if streamed.row_count == 0 {
+                    vec![]
+                } else {
+                    vec![(streamed.row_count - 1) as u32]
+                },
+                cube_map: if streamed.row_count == 0 {
+                    vec![]
+                } else {
+                    vec![1]
+                },
+                pos_map: if streamed.row_count == 0 {
+                    vec![]
+                } else {
+                    vec![(streamed.row_count - 1) as u32]
+                },
+            };
+            write_tiled_header(&header_path, &variant, &header)?;
+        }
+    }
+
+    invalidate_shared_tile_cache_for_table(table_path);
+    Ok(())
+}
+
+/// Completed payload for one streamed `TiledShapeStMan` Complex32 column.
+///
+/// This is a narrow high-throughput write primitive for MeasurementSet-like
+/// writers that produce rows in table order and want to overlap simulation or
+/// transformation work with tiled-column I/O.  The caller streams row cells into
+/// a temporary TSM data file, saves the rest of the table normally, then
+/// installs this payload over the placeholder tiled manager written by the
+/// table save path.
+#[derive(Debug, Clone)]
+pub struct StreamedTiledShapeComplex32Column {
+    temp_data_path: PathBuf,
+    row_count: usize,
+    cell_shape: Vec<usize>,
+    tile_shape: Vec<usize>,
+    bytes_written: usize,
+    big_endian: bool,
+    assemble_seconds: f64,
+    write_seconds: f64,
+}
+
+impl StreamedTiledShapeComplex32Column {
+    /// Number of completed table rows in the streamed column.
+    pub fn row_count(&self) -> usize {
+        self.row_count
+    }
+
+    /// Number of bytes written to the TSM data file.
+    pub fn bytes_written(&self) -> usize {
+        self.bytes_written
+    }
+
+    /// Time spent packing row cells into tile buffers.
+    pub fn assemble_seconds(&self) -> f64 {
+        self.assemble_seconds
+    }
+
+    /// Time spent writing tile buffers to the temporary TSM file.
+    pub fn write_seconds(&self) -> f64 {
+        self.write_seconds
+    }
+}
+
+/// Streaming writer for one sequential `TiledShapeStMan` Complex32 column.
+///
+/// Rows must be pushed in table-row order, with each row stored in casacore
+/// array memory order for the supplied `cell_shape`.  For MS visibility cells
+/// that means correlation is the fastest-varying axis: `[corr, chan]`.
+pub struct StreamingTiledShapeComplex32Writer {
+    temp_data_path: PathBuf,
+    writer: BufWriter<CountingFile>,
+    row_count: usize,
+    rows_written: usize,
+    cell_shape: Vec<usize>,
+    tile_shape: Vec<usize>,
+    tile_plans: Vec<StreamedPrimitiveTilePlan>,
+    rows_per_tile: usize,
+    bucket_size: usize,
+    tile_buffers: Vec<Vec<u8>>,
+    big_endian: bool,
+    assemble_seconds: f64,
+    write_seconds: f64,
+    bytes_written: usize,
+    logical_write_calls: usize,
+    max_logical_write_bytes: usize,
+    tile_row_blocks_flushed: usize,
+    writer_buffer_bytes: usize,
+}
+
+impl StreamingTiledShapeComplex32Writer {
+    /// Create a sequential Complex32 tiled-shape writer.
+    ///
+    /// The first two axes of `cell_shape` are currently required to be
+    /// `[corr, chan]`, matching MeasurementSet DATA-like columns.  `tile_shape`
+    /// must include the row axis as its final dimension, for example CASA's
+    /// common visibility tile shape `[4, 128, 256]`.
+    pub fn create(
+        temp_data_path: impl Into<PathBuf>,
+        row_count: usize,
+        cell_shape: Vec<usize>,
+        tile_shape: Vec<usize>,
+        big_endian: bool,
+    ) -> Result<Self, StorageError> {
+        if cell_shape.len() != 2 {
+            return Err(StorageError::FormatMismatch(format!(
+                "streamed Complex32 TiledShape writer currently supports rank-2 cells, got rank {}",
+                cell_shape.len()
+            )));
+        }
+        if tile_shape.len() != cell_shape.len() + 1 {
+            return Err(StorageError::FormatMismatch(format!(
+                "streamed TiledShape tile rank must be cell rank + row axis; cell={cell_shape:?} tile={tile_shape:?}"
+            )));
+        }
+        if cell_shape.contains(&0) || tile_shape.contains(&0) {
+            return Err(StorageError::FormatMismatch(
+                "streamed TiledShape dimensions must be positive".to_string(),
+            ));
+        }
+
+        let mut cube_shape = cell_shape.clone();
+        cube_shape.push(row_count);
+        let tiles_per_dim: Vec<usize> = cube_shape
+            .iter()
+            .zip(tile_shape.iter())
+            .map(|(&cube, &tile)| cube.div_ceil(tile))
+            .collect();
+        let rows_per_tile = *tile_shape.last().expect("validated non-empty tile shape");
+        let cell_rank = cell_shape.len();
+        let cell_tiles_per_dim = &tiles_per_dim[..cell_rank];
+        let non_row_tile_count: usize = cell_tiles_per_dim.iter().product();
+        let tile_plans = (0..non_row_tile_count)
+            .map(|tile_index| {
+                let tile_pos = linear_to_nd(tile_index, cell_tiles_per_dim);
+                let cell_start: Vec<usize> = tile_pos
+                    .iter()
+                    .enumerate()
+                    .map(|(axis, &pos)| pos * tile_shape[axis])
+                    .collect();
+                let actual_extent: Vec<usize> = cell_start
+                    .iter()
+                    .enumerate()
+                    .map(|(axis, &start)| std::cmp::min(tile_shape[axis], cell_shape[axis] - start))
+                    .collect();
+                StreamedPrimitiveTilePlan {
+                    cell_start,
+                    actual_extent,
+                }
+            })
+            .collect();
+        let (bucket_size, _offsets) =
+            compute_tile_layout(&[CasacoreDataType::TpComplex], &tile_shape);
+        let tile_buffers = (0..non_row_tile_count)
+            .map(|_| vec![0u8; bucket_size])
+            .collect();
+
+        let temp_data_path = temp_data_path.into();
+        if let Some(parent) = temp_data_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let writer_buffer_bytes = streamed_tiled_writer_buffer_bytes();
+        let writer =
+            BufWriter::with_capacity(writer_buffer_bytes, CountingFile::create(&temp_data_path)?);
+
+        Ok(Self {
+            temp_data_path,
+            writer,
+            row_count,
+            rows_written: 0,
+            cell_shape,
+            tile_shape,
+            tile_plans,
+            rows_per_tile,
+            bucket_size,
+            tile_buffers,
+            big_endian,
+            assemble_seconds: 0.0,
+            write_seconds: 0.0,
+            bytes_written: 0,
+            logical_write_calls: 0,
+            max_logical_write_bytes: 0,
+            tile_row_blocks_flushed: 0,
+            writer_buffer_bytes,
+        })
+    }
+
+    /// Append one row cell in table-row order.
+    pub fn push_row(&mut self, values: &[Complex32]) -> Result<(), StorageError> {
+        if self.rows_written >= self.row_count {
+            return Err(StorageError::FormatMismatch(format!(
+                "streamed TiledShape writer received too many rows: expected {}",
+                self.row_count
+            )));
+        }
+        let expected_values: usize = self.cell_shape.iter().product();
+        if values.len() != expected_values {
+            return Err(StorageError::FormatMismatch(format!(
+                "streamed TiledShape row has {} values, expected {} for shape {:?}",
+                values.len(),
+                expected_values,
+                self.cell_shape
+            )));
+        }
+
+        let assemble_started = Instant::now();
+        let row_in_tile = self.rows_written % self.rows_per_tile;
+        self.copy_complex32_row_into_tile_buffers(row_in_tile, values)?;
+        self.assemble_seconds += assemble_started.elapsed().as_secs_f64();
+        self.rows_written += 1;
+
+        if row_in_tile + 1 == self.rows_per_tile {
+            self.flush_tile_row_block()?;
+        }
+        Ok(())
+    }
+
+    /// Finish writing and return an installable streamed-column payload.
+    pub fn finish(mut self) -> Result<StreamedTiledShapeComplex32Column, StorageError> {
+        if self.rows_written != self.row_count {
+            return Err(StorageError::FormatMismatch(format!(
+                "streamed TiledShape writer finished with {} rows, expected {}",
+                self.rows_written, self.row_count
+            )));
+        }
+        if self.rows_written > 0 && self.rows_written % self.rows_per_tile != 0 {
+            self.flush_tile_row_block()?;
+        }
+        let write_started = Instant::now();
+        self.writer.flush()?;
+        self.write_seconds += write_started.elapsed().as_secs_f64();
+        if trace_streamed_tiled_writes() {
+            self.trace_write_stats();
+        }
+
+        Ok(StreamedTiledShapeComplex32Column {
+            temp_data_path: self.temp_data_path,
+            row_count: self.row_count,
+            cell_shape: self.cell_shape,
+            tile_shape: self.tile_shape,
+            bytes_written: self.bytes_written,
+            big_endian: self.big_endian,
+            assemble_seconds: self.assemble_seconds,
+            write_seconds: self.write_seconds,
+        })
+    }
+
+    fn copy_complex32_row_into_tile_buffers(
+        &mut self,
+        row_in_tile: usize,
+        values: &[Complex32],
+    ) -> Result<(), StorageError> {
+        let corr_count = self.cell_shape[0];
+        let chan_count = self.cell_shape[1];
+        let tile_corr = self.tile_shape[0];
+        let tile_chan = self.tile_shape[1];
+        let tile_row_stride = tile_corr * tile_chan;
+
+        for (tile_index, plan) in self.tile_plans.iter().enumerate() {
+            let corr_start = plan.cell_start[0];
+            let chan_start = plan.cell_start[1];
+            if corr_start >= corr_count || chan_start >= chan_count {
+                continue;
+            }
+            let corr_extent = plan.actual_extent[0];
+            let chan_extent = plan.actual_extent[1];
+            let tile = &mut self.tile_buffers[tile_index];
+
+            if !self.big_endian && tile_corr == corr_count && corr_start == 0 {
+                let src_start = chan_start * corr_count;
+                let src_end = (chan_start + chan_extent) * corr_count;
+                let dst_start = row_in_tile * tile_row_stride * std::mem::size_of::<Complex32>();
+                let dst_end = dst_start + std::mem::size_of_val(&values[src_start..src_end]);
+                copy_complex32_native_bytes(
+                    &mut tile[dst_start..dst_end],
+                    &values[src_start..src_end],
+                );
+                continue;
+            }
+
+            for chan_offset in 0..chan_extent {
+                let channel = chan_start + chan_offset;
+                for corr_offset in 0..corr_extent {
+                    let corr = corr_start + corr_offset;
+                    let src_idx = channel * corr_count + corr;
+                    let tile_idx =
+                        row_in_tile * tile_row_stride + chan_offset * tile_corr + corr_offset;
+                    let dst_start = tile_idx * 8;
+                    write_complex32_component_bytes(
+                        &mut tile[dst_start..dst_start + 8],
+                        values[src_idx],
+                        self.big_endian,
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn flush_tile_row_block(&mut self) -> Result<(), StorageError> {
+        let write_started = Instant::now();
+        self.tile_row_blocks_flushed += 1;
+        for tile in &self.tile_buffers {
+            debug_assert_eq!(tile.len(), self.bucket_size);
+            self.writer.write_all(tile)?;
+            self.logical_write_calls += 1;
+            self.max_logical_write_bytes = self.max_logical_write_bytes.max(tile.len());
+            self.bytes_written += tile.len();
+        }
+        self.write_seconds += write_started.elapsed().as_secs_f64();
+
+        for tile in &mut self.tile_buffers {
+            tile.fill(0);
+        }
+        Ok(())
+    }
+
+    fn trace_write_stats(&self) {
+        let stats = self.writer.get_ref().stats();
+        eprintln!(
+            "casa-rs streamed tiled write column={} variant=Shape type=Complex32 rows={} cell_shape={:?} tile_shape={:?} row_tile={} tile_buffers={} tile_row_blocks={} logical_write_calls={} logical_max_write_bytes={} buffered_write_calls={} buffered_max_write_bytes={} buffered_flush_calls={} writer_buffer_bytes={} bytes_written={} assemble_seconds={:.6} write_seconds={:.6}",
+            self.temp_data_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("<unknown>"),
+            self.rows_written,
+            self.cell_shape,
+            self.tile_shape,
+            self.rows_per_tile,
+            self.tile_buffers.len(),
+            self.tile_row_blocks_flushed,
+            self.logical_write_calls,
+            self.max_logical_write_bytes,
+            stats.write_calls,
+            stats.max_write_bytes,
+            stats.flush_calls,
+            self.writer_buffer_bytes,
+            self.bytes_written,
+            self.assemble_seconds,
+            self.write_seconds,
+        );
+    }
+}
+
+/// Install a completed streamed Complex32 column as a one-shape
+/// `TiledShapeStMan` data manager.
+pub fn install_streamed_tiled_shape_complex32_column(
+    table_path: &Path,
+    dm_seq_nr: u32,
+    dm_name: &str,
+    streamed: StreamedTiledShapeComplex32Column,
+) -> Result<(), StorageError> {
+    std::fs::create_dir_all(table_path)?;
+    let tsm_path = tsm_data_path(table_path, dm_seq_nr, 0);
+    match std::fs::rename(&streamed.temp_data_path, &tsm_path) {
+        Ok(()) => {}
+        Err(_) => {
+            std::fs::copy(&streamed.temp_data_path, &tsm_path)?;
+            std::fs::remove_file(&streamed.temp_data_path)?;
+        }
+    }
+
+    let mut cube_shape = streamed.cell_shape.clone();
+    cube_shape.push(streamed.row_count);
+    let header = TiledStManHeader {
+        big_endian: streamed.big_endian,
+        seq_nr: dm_seq_nr,
+        nrrow: streamed.row_count as u64,
+        col_data_types: vec![CasacoreDataType::TpComplex],
+        hypercolumn_name: dm_name.to_string(),
+        max_cache_size: 0,
+        nrdim: (streamed.cell_shape.len() + 1) as u32,
+        files: if streamed.row_count == 0 {
+            vec![]
+        } else {
+            vec![Some(TsmFileInfo {
+                seq_nr: 0,
+                length: streamed.bytes_written as i64,
+            })]
+        },
+        cubes: if streamed.row_count == 0 {
+            vec![TsmCubeInfo {
+                values: RecordValue::default(),
+                extensible: false,
+                cube_shape: vec![],
+                tile_shape: vec![],
+                file_seq_nr: -1,
+                file_offset: 0,
+            }]
+        } else {
+            vec![
+                TsmCubeInfo {
+                    values: RecordValue::default(),
+                    extensible: false,
+                    cube_shape: vec![],
+                    tile_shape: vec![],
+                    file_seq_nr: -1,
+                    file_offset: 0,
+                },
+                TsmCubeInfo {
+                    values: RecordValue::default(),
+                    extensible: true,
+                    cube_shape,
+                    tile_shape: streamed.tile_shape.clone(),
+                    file_seq_nr: 0,
+                    file_offset: 0,
+                },
+            ]
+        },
+    };
+    let variant = TiledVariant::Shape {
+        default_tile_shape: streamed
+            .tile_shape
+            .iter()
+            .map(|&value| value as i32)
+            .collect(),
+        nr_used_row_map: if streamed.row_count == 0 { 0 } else { 1 },
+        row_map: if streamed.row_count == 0 {
+            vec![]
+        } else {
+            vec![(streamed.row_count - 1) as u32]
+        },
+        cube_map: if streamed.row_count == 0 {
+            vec![]
+        } else {
+            vec![1]
+        },
+        pos_map: if streamed.row_count == 0 {
+            vec![]
+        } else {
+            vec![(streamed.row_count - 1) as u32]
+        },
+    };
+    let header_path = table_path.join(format!("table.f{dm_seq_nr}"));
+    write_tiled_header(&header_path, &variant, &header)?;
+    invalidate_shared_tile_cache_for_table(table_path);
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 fn write_single_column_shape_cube_direct_to_file(
     tsm_path: &Path,
@@ -3277,6 +4364,14 @@ fn encode_complex32_array_into_tile_row(
         ));
     }
 
+    if !big_endian
+        && is_fortran_contiguous(array.shape(), array.strides())
+        && let Some(slice) = array.as_slice_memory_order()
+    {
+        copy_complex32_native_bytes(dst, slice);
+        return Ok(());
+    }
+
     if let Some(slice) = array.as_slice_memory_order()
         && cell_shape.len() == 2
         && array.strides() == [cell_shape[1] as isize, 1]
@@ -3303,6 +4398,18 @@ fn encode_complex32_array_into_tile_row(
         write_complex32_component_bytes(&mut dst[dst_offset..dst_offset + 8], value, big_endian);
     }
     Ok(())
+}
+
+fn copy_complex32_native_bytes(dst: &mut [u8], values: &[Complex32]) {
+    debug_assert_eq!(dst.len(), std::mem::size_of_val(values));
+    // `num_complex::Complex32` is the same in-memory pair of f32 values that
+    // casacore writes for little-endian complex cells. This fast path is only
+    // used after the caller has already established the array's MS storage
+    // order, so no logical transposition happens here.
+    let src = unsafe {
+        std::slice::from_raw_parts(values.as_ptr().cast::<u8>(), std::mem::size_of_val(values))
+    };
+    dst.copy_from_slice(src);
 }
 
 fn write_complex32_component_bytes(dst: &mut [u8], value: Complex32, big_endian: bool) {
@@ -3523,25 +4630,28 @@ fn save_single_column_tiled_shape_stman(
         return write_tiled_header(&header_path, &variant, &header);
     }
 
-    let mut shape_groups: Vec<(Vec<usize>, Vec<usize>)> = Vec::new();
-    for (row_idx, value) in values.iter().enumerate() {
-        let Some(value) = *value else {
-            continue;
-        };
-        let shape = if let Value::Array(av) = value {
-            array_shape(av)
-        } else {
-            vec![]
-        };
-        if let Some(group) = shape_groups
-            .iter_mut()
-            .find(|(candidate, _)| *candidate == shape)
-        {
-            group.1.push(row_idx);
-        } else {
-            shape_groups.push((shape, vec![row_idx]));
+    let shape_groups = same_shape_group(values).unwrap_or_else(|| {
+        let mut shape_groups: Vec<(Vec<usize>, Vec<usize>)> = Vec::new();
+        for (row_idx, value) in values.iter().enumerate() {
+            let Some(value) = *value else {
+                continue;
+            };
+            let shape = if let Value::Array(av) = value {
+                array_shape(av)
+            } else {
+                vec![]
+            };
+            if let Some(group) = shape_groups
+                .iter_mut()
+                .find(|(candidate, _)| *candidate == shape)
+            {
+                group.1.push(row_idx);
+            } else {
+                shape_groups.push((shape, vec![row_idx]));
+            }
         }
-    }
+        shape_groups
+    });
     if let Some(profiler) = profiler.as_mut() {
         profiler.mark_with_detail(
             "group_shapes",
@@ -4551,12 +5661,11 @@ fn copy_cube_to_tile(
         return;
     }
 
-    let outer_dims: Vec<usize> = actual_extent[1..].to_vec();
+    let outer_dims = &actual_extent[1..];
     let outer_total: usize = outer_dims.iter().product();
+    let mut outer_pos = vec![0usize; outer_dims.len()];
 
-    for outer_linear in 0..outer_total {
-        let outer_pos = linear_to_nd(outer_linear, &outer_dims);
-
+    for _ in 0..outer_total {
         let mut tile_off = 0;
         let mut stride = tile_shape[0];
         for (d, &p) in outer_pos.iter().enumerate() {
@@ -4575,6 +5684,18 @@ fn copy_cube_to_tile(
         let dst_start = tile_off * elem_size;
         tile_data[dst_start..dst_start + inner_bytes]
             .copy_from_slice(&cube_data[src_start..src_start + inner_bytes]);
+
+        increment_position(&mut outer_pos, outer_dims);
+    }
+}
+
+fn increment_position(pos: &mut [usize], dims: &[usize]) {
+    for (axis, dim) in pos.iter_mut().zip(dims.iter()) {
+        *axis += 1;
+        if *axis < *dim {
+            break;
+        }
+        *axis = 0;
     }
 }
 
@@ -4594,6 +5715,52 @@ fn array_shape(av: &ArrayValue) -> Vec<usize> {
         ArrayValue::Complex64(a) => a.shape().to_vec(),
         ArrayValue::String(a) => a.shape().to_vec(),
     }
+}
+
+fn array_shape_equals(av: &ArrayValue, shape: &[usize]) -> bool {
+    match av {
+        ArrayValue::Bool(a) => a.shape() == shape,
+        ArrayValue::UInt8(a) => a.shape() == shape,
+        ArrayValue::Int16(a) => a.shape() == shape,
+        ArrayValue::UInt16(a) => a.shape() == shape,
+        ArrayValue::Int32(a) => a.shape() == shape,
+        ArrayValue::UInt32(a) => a.shape() == shape,
+        ArrayValue::Float32(a) => a.shape() == shape,
+        ArrayValue::Float64(a) => a.shape() == shape,
+        ArrayValue::Int64(a) => a.shape() == shape,
+        ArrayValue::Complex32(a) => a.shape() == shape,
+        ArrayValue::Complex64(a) => a.shape() == shape,
+        ArrayValue::String(a) => a.shape() == shape,
+    }
+}
+
+fn same_shape_group(values: &[Option<&Value>]) -> Option<Vec<(Vec<usize>, Vec<usize>)>> {
+    let (first_row, first_value) = values
+        .iter()
+        .enumerate()
+        .find_map(|(row, value)| value.map(|value| (row, value)))?;
+    let first_shape = if let Value::Array(av) = first_value {
+        array_shape(av)
+    } else {
+        Vec::new()
+    };
+    let mut group_rows = Vec::with_capacity(values.len());
+    group_rows.push(first_row);
+    for (row, value) in values.iter().enumerate().skip(first_row + 1) {
+        let Some(value) = *value else {
+            continue;
+        };
+        let matches = if let Value::Array(av) = value {
+            array_shape_equals(av, &first_shape)
+        } else {
+            first_shape.is_empty()
+        };
+        if !matches {
+            return None;
+        }
+        group_rows.push(row);
+    }
+    Some(vec![(first_shape, group_rows)])
 }
 
 // ---------------------------------------------------------------------------
@@ -6622,6 +7789,198 @@ mod tests {
                 Complex32::new(12.0, -12.0),
             ]
         );
+    }
+
+    #[test]
+    fn streamed_complex32_tiled_shape_writer_installs_readable_column() {
+        let dir = tempdir().expect("tempdir");
+        let table_path = dir.path().join("streamed.table");
+        let temp_data_path = dir.path().join("DATA.tmp");
+        let row_count = 5usize;
+        let cell_shape = vec![2, 3];
+        let tile_shape = vec![2, 2, 2];
+        let mut writer = StreamingTiledShapeComplex32Writer::create(
+            &temp_data_path,
+            row_count,
+            cell_shape.clone(),
+            tile_shape.clone(),
+            false,
+        )
+        .expect("create streaming writer");
+
+        for row in 0..row_count {
+            let mut values = Vec::with_capacity(cell_shape.iter().product());
+            for channel in 0..cell_shape[1] {
+                for corr in 0..cell_shape[0] {
+                    let value = row as f32 * 100.0 + channel as f32 * 10.0 + corr as f32;
+                    values.push(Complex32::new(value, -value));
+                }
+            }
+            writer.push_row(&values).expect("push streamed row");
+        }
+
+        let streamed = writer.finish().expect("finish writer");
+        let expected_bytes = 6 * 2 * 2 * 2 * std::mem::size_of::<Complex32>();
+        assert_eq!(streamed.row_count(), row_count);
+        assert_eq!(streamed.bytes_written(), expected_bytes);
+        install_streamed_tiled_shape_complex32_column(&table_path, 0, "DATA", streamed)
+            .expect("install streamed column");
+
+        let (variant, header) =
+            read_tiled_header(&table_path.join("table.f0")).expect("read streamed header");
+        let TiledVariant::Shape {
+            default_tile_shape,
+            nr_used_row_map,
+            row_map,
+            cube_map,
+            pos_map,
+        } = variant
+        else {
+            panic!("expected TiledShapeStMan header");
+        };
+        assert_eq!(default_tile_shape, vec![2, 2, 2]);
+        assert_eq!(nr_used_row_map, 1);
+        assert_eq!(row_map, vec![(row_count - 1) as u32]);
+        assert_eq!(cube_map, vec![1]);
+        assert_eq!(pos_map, vec![(row_count - 1) as u32]);
+        assert_eq!(header.nrrow, row_count as u64);
+        assert_eq!(
+            header.files[0].as_ref().expect("file").length,
+            expected_bytes as i64
+        );
+        assert_eq!(header.cubes[1].cube_shape, vec![2, 3, row_count]);
+        assert_eq!(header.cubes[1].tile_shape, tile_shape);
+
+        let file_data = std::fs::read(tsm_data_path(&table_path, 0, 0)).expect("read TSM file");
+        let (bucket_size, offsets) =
+            compute_tile_layout(&header.col_data_types, &header.cubes[1].tile_shape);
+        let raw = reconstruct_cube_column(
+            &file_data,
+            header.cubes[1].file_offset as usize,
+            &header.cubes[1].cube_shape,
+            &header.cubes[1].tile_shape,
+            offsets[0],
+            bucket_size,
+            CasacoreDataType::TpComplex,
+            std::mem::size_of::<Complex32>(),
+        )
+        .expect("reconstruct streamed cube");
+
+        for row in 0..row_count {
+            for channel in 0..cell_shape[1] {
+                for corr in 0..cell_shape[0] {
+                    let idx = corr + channel * cell_shape[0] + row * cell_shape[0] * cell_shape[1];
+                    let bytes = &raw[idx * 8..idx * 8 + 8];
+                    let re = f32::from_le_bytes(bytes[0..4].try_into().unwrap());
+                    let im = f32::from_le_bytes(bytes[4..8].try_into().unwrap());
+                    let expected = row as f32 * 100.0 + channel as f32 * 10.0 + corr as f32;
+                    assert_eq!(Complex32::new(re, im), Complex32::new(expected, -expected));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn streamed_primitive_writers_install_readable_columns() {
+        let dir = tempdir().expect("tempdir");
+        let table_path = dir.path().join("primitive.table");
+
+        let row_count = 5usize;
+        let mut flag_writer = StreamingTiledPrimitiveWriter::create_shape(
+            dir.path().join("FLAG.tmp"),
+            row_count,
+            vec![2, 3],
+            vec![2, 2, 2],
+            StreamedTiledPrimitiveType::Bool,
+            false,
+        )
+        .expect("create FLAG writer");
+        for row in 0..row_count {
+            if row % 2 == 0 {
+                flag_writer.push_zero_row().expect("zero FLAG row");
+            } else {
+                flag_writer
+                    .push_bool_row(&[true; 6])
+                    .expect("true FLAG row");
+            }
+        }
+        let streamed_flag = flag_writer.finish().expect("finish FLAG");
+        assert_eq!(streamed_flag.bytes_written(), 6);
+        install_streamed_tiled_shape_primitive_column(&table_path, 0, "FLAG", streamed_flag)
+            .expect("install FLAG");
+
+        let (flag_variant, flag_header) =
+            read_tiled_header(&table_path.join("table.f0")).expect("read FLAG header");
+        assert!(matches!(flag_variant, TiledVariant::Shape { .. }));
+        assert_eq!(flag_header.cubes[1].cube_shape, vec![2, 3, row_count]);
+        let flag_file = std::fs::read(tsm_data_path(&table_path, 0, 0)).expect("read FLAG TSM");
+        let (flag_bucket_size, flag_offsets) = compute_tile_layout(
+            &flag_header.col_data_types,
+            &flag_header.cubes[1].tile_shape,
+        );
+        let flag_raw = reconstruct_cube_column(
+            &flag_file,
+            flag_header.cubes[1].file_offset as usize,
+            &flag_header.cubes[1].cube_shape,
+            &flag_header.cubes[1].tile_shape,
+            flag_offsets[0],
+            flag_bucket_size,
+            CasacoreDataType::TpBool,
+            1,
+        )
+        .expect("reconstruct FLAG");
+        for row in 0..row_count {
+            for idx_in_cell in 0..6 {
+                let idx = idx_in_cell + row * 6;
+                assert_eq!(flag_raw[idx] != 0, row % 2 == 1);
+            }
+        }
+
+        let mut uvw_writer = StreamingTiledPrimitiveWriter::create_column(
+            dir.path().join("UVW.tmp"),
+            row_count,
+            vec![3],
+            vec![3, 2],
+            StreamedTiledPrimitiveType::Float64,
+            false,
+        )
+        .expect("create UVW writer");
+        for row in 0..row_count {
+            uvw_writer
+                .push_f64_row(&[row as f64, row as f64 + 10.0, row as f64 + 20.0])
+                .expect("UVW row");
+        }
+        let streamed_uvw = uvw_writer.finish().expect("finish UVW");
+        assert_eq!(streamed_uvw.bytes_written(), 144);
+        install_streamed_tiled_column_primitive_column(&table_path, 1, "UVW", streamed_uvw)
+            .expect("install UVW");
+
+        let (uvw_variant, uvw_header) =
+            read_tiled_header(&table_path.join("table.f1")).expect("read UVW header");
+        assert!(matches!(uvw_variant, TiledVariant::Column { .. }));
+        assert_eq!(uvw_header.cubes[0].cube_shape, vec![3, row_count]);
+        let uvw_file = std::fs::read(tsm_data_path(&table_path, 1, 0)).expect("read UVW TSM");
+        let (uvw_bucket_size, uvw_offsets) =
+            compute_tile_layout(&uvw_header.col_data_types, &uvw_header.cubes[0].tile_shape);
+        let uvw_raw = reconstruct_cube_column(
+            &uvw_file,
+            uvw_header.cubes[0].file_offset as usize,
+            &uvw_header.cubes[0].cube_shape,
+            &uvw_header.cubes[0].tile_shape,
+            uvw_offsets[0],
+            uvw_bucket_size,
+            CasacoreDataType::TpDouble,
+            8,
+        )
+        .expect("reconstruct UVW");
+        for row in 0..row_count {
+            for axis in 0..3 {
+                let idx = axis + row * 3;
+                let bytes = &uvw_raw[idx * 8..idx * 8 + 8];
+                let value = f64::from_le_bytes(bytes.try_into().unwrap());
+                assert_eq!(value, row as f64 + axis as f64 * 10.0);
+            }
+        }
     }
 
     #[test]

--- a/crates/casa-tables/src/storage/tiled_stman.rs
+++ b/crates/casa-tables/src/storage/tiled_stman.rs
@@ -23,6 +23,7 @@ use std::io::{Read as IoRead, Seek, SeekFrom, Write as IoWrite};
 use std::os::unix::fs::FileExt;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock, Mutex};
+use std::time::Instant;
 
 use casa_aipsio::{AipsIo, AipsOpenOption};
 use casa_types::{
@@ -3150,8 +3151,16 @@ fn encode_column_cube_values(
     Ok(cube_bytes)
 }
 
+#[derive(Debug, Clone, Copy)]
+struct StreamedShapeCubeWrite {
+    bytes: usize,
+    assemble_seconds: f64,
+    write_seconds: f64,
+}
+
 #[allow(clippy::too_many_arguments)]
-fn encode_single_column_shape_cube_direct(
+fn write_single_column_shape_cube_direct_to_file(
+    tsm_path: &Path,
     values: &[Option<&Value>],
     cell_shape: &[usize],
     tile_shape: &[usize],
@@ -3162,7 +3171,7 @@ fn encode_single_column_shape_cube_direct(
     col_offset: usize,
     col_data_type: CasacoreDataType,
     big_endian: bool,
-) -> Result<Option<Vec<u8>>, StorageError> {
+) -> Result<Option<StreamedShapeCubeWrite>, StorageError> {
     if tile_shape.len() != cell_shape.len() + 1 {
         return Ok(None);
     }
@@ -3173,48 +3182,137 @@ fn encode_single_column_shape_cube_direct(
     if rows_per_tile == 0 {
         return Ok(None);
     }
+    if col_data_type != CasacoreDataType::TpBool && col_data_type != CasacoreDataType::TpComplex {
+        return Ok(None);
+    }
+
+    for value in values.iter().flatten() {
+        match (col_data_type, *value) {
+            (CasacoreDataType::TpBool, Value::Array(ArrayValue::Bool(array))) => {
+                if array.len() != cell_nelem {
+                    return Ok(None);
+                }
+            }
+            (CasacoreDataType::TpComplex, Value::Array(ArrayValue::Complex32(array))) => {
+                if array.len() != cell_nelem || array.shape() != cell_shape {
+                    return Ok(None);
+                }
+            }
+            _ => return Ok(None),
+        }
+    }
 
     let row_bytes = cell_nelem * elem_size;
     let tile_nelem: usize = tile_shape.iter().product();
     let tile_storage_len = tile_storage_bytes(col_data_type, tile_nelem);
-    let mut tsm_data = vec![0u8; nr_tiles * bucket_size];
-    for (pos_in_cube, value) in values.iter().enumerate() {
-        let Some(value) = value else {
-            continue;
-        };
-        let (encoded, encoded_type) = encode_array_value(value, big_endian)?;
-        if encoded_type != col_data_type {
-            return Ok(None);
-        }
-        let tile_idx = pos_in_cube / rows_per_tile;
-        let row_in_tile = pos_in_cube % rows_per_tile;
-        let tile_start = tile_idx * bucket_size + col_offset;
-        if col_data_type == CasacoreDataType::TpBool {
-            if encoded.len() != cell_nelem {
-                return Ok(None);
-            }
-            let tile_end = tile_start + tile_storage_len;
-            if tile_end > tsm_data.len() {
-                return Ok(None);
-            }
-            write_bool_bits_from_bytes(
-                &mut tsm_data[tile_start..tile_end],
-                row_in_tile * cell_nelem,
-                &encoded,
-            );
-        } else {
-            if encoded.len() != row_bytes {
-                return Ok(None);
-            }
-            let dst_start = tile_start + row_in_tile * row_bytes;
-            let dst_end = dst_start + row_bytes;
-            if dst_end > tsm_data.len() {
-                return Ok(None);
-            }
-            tsm_data[dst_start..dst_end].copy_from_slice(&encoded);
-        }
+    let tile_end = col_offset + tile_storage_len;
+    if tile_end > bucket_size {
+        return Ok(None);
     }
-    Ok(Some(tsm_data))
+
+    let mut file = std::fs::File::create(tsm_path)?;
+    let mut tile_data = vec![0u8; bucket_size];
+    let mut assemble_seconds = 0.0;
+    let mut write_seconds = 0.0;
+    for tile_idx in 0..nr_tiles {
+        tile_data.fill(0);
+        let assemble_started = Instant::now();
+        for row_in_tile in 0..rows_per_tile {
+            let pos_in_cube = tile_idx * rows_per_tile + row_in_tile;
+            let Some(value) = values.get(pos_in_cube).and_then(|value| *value) else {
+                continue;
+            };
+            if col_data_type == CasacoreDataType::TpBool {
+                let Value::Array(ArrayValue::Bool(array)) = value else {
+                    unreachable!("preflight checked bool tiled shape values");
+                };
+                if array.iter().all(|value| !*value) {
+                    continue;
+                }
+                let bools = array_memory_order_values(array);
+                write_bool_bits(
+                    &mut tile_data[col_offset..tile_end],
+                    row_in_tile * cell_nelem,
+                    &bools,
+                );
+            } else {
+                let Value::Array(ArrayValue::Complex32(array)) = value else {
+                    unreachable!("preflight checked complex tiled shape values");
+                };
+                let dst_start = col_offset + row_in_tile * row_bytes;
+                let dst_end = dst_start + row_bytes;
+                if dst_end > tile_data.len() {
+                    return Ok(None);
+                }
+                encode_complex32_array_into_tile_row(
+                    &mut tile_data[dst_start..dst_end],
+                    array,
+                    cell_shape,
+                    big_endian,
+                )?;
+            }
+        }
+        assemble_seconds += assemble_started.elapsed().as_secs_f64();
+        let write_started = Instant::now();
+        file.write_all(&tile_data)?;
+        write_seconds += write_started.elapsed().as_secs_f64();
+    }
+
+    Ok(Some(StreamedShapeCubeWrite {
+        bytes: nr_tiles * bucket_size,
+        assemble_seconds,
+        write_seconds,
+    }))
+}
+
+fn encode_complex32_array_into_tile_row(
+    dst: &mut [u8],
+    array: &ArrayD<Complex32>,
+    cell_shape: &[usize],
+    big_endian: bool,
+) -> Result<(), StorageError> {
+    if dst.len() != array.len() * 8 {
+        return Err(StorageError::FormatMismatch(
+            "complex tile row has unexpected byte length".to_string(),
+        ));
+    }
+
+    if let Some(slice) = array.as_slice_memory_order()
+        && cell_shape.len() == 2
+        && array.strides() == [cell_shape[1] as isize, 1]
+    {
+        let n0 = cell_shape[0];
+        let n1 = cell_shape[1];
+        for axis1 in 0..n1 {
+            for axis0 in 0..n0 {
+                let value = slice[axis0 * n1 + axis1];
+                let dst_offset = (axis1 * n0 + axis0) * 8;
+                write_complex32_component_bytes(
+                    &mut dst[dst_offset..dst_offset + 8],
+                    value,
+                    big_endian,
+                );
+            }
+        }
+        return Ok(());
+    }
+
+    let slice = array_memory_order_values(array);
+    for (idx, &value) in slice.iter().enumerate() {
+        let dst_offset = idx * 8;
+        write_complex32_component_bytes(&mut dst[dst_offset..dst_offset + 8], value, big_endian);
+    }
+    Ok(())
+}
+
+fn write_complex32_component_bytes(dst: &mut [u8], value: Complex32, big_endian: bool) {
+    if big_endian {
+        write_f32_be(dst, value.re);
+        write_f32_be(&mut dst[4..], value.im);
+    } else {
+        write_f32_le(dst, value.re);
+        write_f32_le(&mut dst[4..], value.im);
+    }
 }
 
 fn save_single_column_tiled_column_stman(
@@ -3503,7 +3601,9 @@ fn save_single_column_tiled_shape_stman(
 
         let group_values: Vec<Option<&Value>> =
             group_rows.iter().map(|&row_idx| values[row_idx]).collect();
-        let tsm_data = if let Some(tsm_data) = encode_single_column_shape_cube_direct(
+        let tsm_path = tsm_data_path(table_path, dm_seq_nr, file_seq_nr);
+        let file_len = if let Some(streamed) = write_single_column_shape_cube_direct_to_file(
+            &tsm_path,
             &group_values,
             cell_shape,
             &tile_shape,
@@ -3515,7 +3615,22 @@ fn save_single_column_tiled_shape_stman(
             col_data_type,
             big_endian,
         )? {
-            tsm_data
+            if let Some(profiler) = profiler.as_mut() {
+                profiler.mark_with_detail(
+                    "stream_cube_file",
+                    Some(format!(
+                        "cube={} shape={} rows={} tile_shape={} bytes={} assemble={:.3}s write={:.3}s",
+                        cube_idx,
+                        format_shape(&cube_shape),
+                        n_in_cube,
+                        format_shape(&tile_shape),
+                        streamed.bytes,
+                        streamed.assemble_seconds,
+                        streamed.write_seconds
+                    )),
+                );
+            }
+            streamed.bytes
         } else {
             let cube_bytes = encode_column_cube_values(
                 &group_values,
@@ -3560,28 +3675,40 @@ fn save_single_column_tiled_shape_stman(
                     nrpixels,
                 );
             }
-            tsm_data
-        };
+            if let Some(profiler) = profiler.as_mut() {
+                profiler.mark_with_detail(
+                    "assemble_cube",
+                    Some(format!(
+                        "cube={} shape={} rows={} tile_shape={} bytes={}",
+                        cube_idx,
+                        format_shape(&cube_shape),
+                        n_in_cube,
+                        format_shape(&tile_shape),
+                        tsm_data.len()
+                    )),
+                );
+            }
 
-        let tsm_path = tsm_data_path(table_path, dm_seq_nr, file_seq_nr);
-        std::fs::write(&tsm_path, &tsm_data)?;
-        if let Some(profiler) = profiler.as_mut() {
-            profiler.mark_with_detail(
-                "write_cube",
-                Some(format!(
-                    "cube={} shape={} rows={} tile_shape={} bytes={}",
-                    cube_idx,
-                    format_shape(&cube_shape),
-                    n_in_cube,
-                    format_shape(&tile_shape),
-                    tsm_data.len()
-                )),
-            );
-        }
+            std::fs::write(&tsm_path, &tsm_data)?;
+            if let Some(profiler) = profiler.as_mut() {
+                profiler.mark_with_detail(
+                    "write_cube_file",
+                    Some(format!(
+                        "cube={} shape={} rows={} tile_shape={} bytes={}",
+                        cube_idx,
+                        format_shape(&cube_shape),
+                        n_in_cube,
+                        format_shape(&tile_shape),
+                        tsm_data.len()
+                    )),
+                );
+            }
+            tsm_data.len()
+        };
 
         all_files.push(Some(TsmFileInfo {
             seq_nr: file_seq_nr,
-            length: tsm_data.len() as i64,
+            length: file_len as i64,
         }));
 
         cubes.push(TsmCubeInfo {
@@ -6458,6 +6585,43 @@ mod tests {
     fn bool_tile_storage_is_bit_packed() {
         assert_eq!(tile_storage_bytes(CasacoreDataType::TpBool, 4), 1);
         assert_eq!(tile_storage_bytes(CasacoreDataType::TpBool, 9), 2);
+    }
+
+    #[test]
+    fn complex32_tile_row_encoder_uses_fortran_cell_order() {
+        let values = vec![
+            Complex32::new(0.0, -0.0),
+            Complex32::new(1.0, -1.0),
+            Complex32::new(2.0, -2.0),
+            Complex32::new(10.0, -10.0),
+            Complex32::new(11.0, -11.0),
+            Complex32::new(12.0, -12.0),
+        ];
+        let array = ArrayD::from_shape_vec(vec![2, 3], values).expect("array");
+        let mut encoded = vec![0u8; 2 * 3 * 8];
+
+        encode_complex32_array_into_tile_row(&mut encoded, &array, &[2, 3], false)
+            .expect("encode row");
+
+        let decoded = encoded
+            .chunks_exact(8)
+            .map(|chunk| {
+                let re = f32::from_le_bytes(chunk[0..4].try_into().unwrap());
+                let im = f32::from_le_bytes(chunk[4..8].try_into().unwrap());
+                Complex32::new(re, im)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            decoded,
+            vec![
+                Complex32::new(0.0, -0.0),
+                Complex32::new(10.0, -10.0),
+                Complex32::new(1.0, -1.0),
+                Complex32::new(11.0, -11.0),
+                Complex32::new(2.0, -2.0),
+                Complex32::new(12.0, -12.0),
+            ]
+        );
     }
 
     #[test]

--- a/crates/casa-types/src/measures/position.rs
+++ b/crates/casa-types/src/measures/position.rs
@@ -8,7 +8,8 @@
 //!   to C++ `MPosition`.
 //!
 //! Conversions between ITRF (geocentric Cartesian) and WGS84 (geodetic) use
-//! the [`sofars`] crate's `gd2gc`/`gc2gd` functions with the WGS84 ellipsoid.
+//! casacore-compatible WGS84 ellipsoid constants for WGS84-to-ITRF and the
+//! [`sofars`] crate's `gc2gd` inverse for ITRF-to-WGS84.
 
 use std::fmt;
 use std::str::FromStr;
@@ -19,6 +20,8 @@ use super::error::MeasureError;
 
 /// WGS84 ellipsoid identifier for sofars (n=1).
 const WGS84_ELLIPSOID: i32 = 1;
+const CASACORE_WGS84_A_M: f64 = 6_378_137.0;
+const CASACORE_WGS84_B_M: f64 = 6_356_752.314_2;
 
 /// Position reference frame types.
 ///
@@ -213,13 +216,9 @@ impl MPosition {
     pub fn as_itrf(&self) -> [f64; 3] {
         match self.refer {
             PositionRef::ITRF => self.values,
-            PositionRef::WGS84 => sofars::coords::gd2gc(
-                WGS84_ELLIPSOID,
-                self.values[0],
-                self.values[1],
-                self.values[2],
-            )
-            .unwrap_or(self.values),
+            PositionRef::WGS84 => {
+                casacore_wgs84_to_itrf(self.values[0], self.values[1], self.values[2])
+            }
         }
     }
 
@@ -252,22 +251,26 @@ impl MPosition {
                     refer: PositionRef::WGS84,
                 })
             }
-            (PositionRef::WGS84, PositionRef::ITRF) => {
-                let xyz = sofars::coords::gd2gc(
-                    WGS84_ELLIPSOID,
-                    self.values[0],
-                    self.values[1],
-                    self.values[2],
-                )
-                .map_err(|code| MeasureError::SofarsError { code })?;
-                Ok(MPosition {
-                    values: xyz,
-                    refer: PositionRef::ITRF,
-                })
-            }
+            (PositionRef::WGS84, PositionRef::ITRF) => Ok(MPosition {
+                values: casacore_wgs84_to_itrf(self.values[0], self.values[1], self.values[2]),
+                refer: PositionRef::ITRF,
+            }),
             _ => unreachable!("only two position reference types exist"),
         }
     }
+}
+
+fn casacore_wgs84_to_itrf(longitude_rad: f64, latitude_rad: f64, height_m: f64) -> [f64; 3] {
+    let e2 = (CASACORE_WGS84_A_M * CASACORE_WGS84_A_M - CASACORE_WGS84_B_M * CASACORE_WGS84_B_M)
+        / (CASACORE_WGS84_A_M * CASACORE_WGS84_A_M);
+    let (sin_lat, cos_lat) = latitude_rad.sin_cos();
+    let (sin_lon, cos_lon) = longitude_rad.sin_cos();
+    let n = CASACORE_WGS84_A_M / (1.0 - e2 * sin_lat * sin_lat).sqrt();
+    [
+        (n + height_m) * cos_lat * cos_lon,
+        (n + height_m) * cos_lat * sin_lon,
+        (n * (1.0 - e2) + height_m) * sin_lat,
+    ]
 }
 
 impl fmt::Display for MPosition {
@@ -330,6 +333,20 @@ mod tests {
         // Latitude should match
         let lat_diff = (itrf.latitude_rad() - wgs.latitude_rad()).abs();
         assert!(lat_diff < 1e-10, "latitude mismatch: {lat_diff}");
+    }
+
+    #[test]
+    fn alma_wgs84_matches_casacore_itrf() {
+        let alma = MPosition::new_wgs84(
+            -67.754_929_f64.to_radians(),
+            -23.022_886_f64.to_radians(),
+            5056.8,
+        );
+        let [x, y, z] = alma.as_itrf();
+
+        assert!((x - 2_225_142.180_271_370_3).abs() < 1.0e-7, "x={x}");
+        assert!((y - -5_440_307.370_354_437).abs() < 1.0e-7, "y={y}");
+        assert!((z - -2_481_029.851_840_987_3).abs() < 1.0e-7, "z={z}");
     }
 
     #[test]

--- a/crates/casa-types/tests/measures.rs
+++ b/crates/casa-types/tests/measures.rs
@@ -347,9 +347,10 @@ fn wgs84_to_itrf_roundtrip() {
     let itrf = wgs.convert_to(PositionRef::ITRF).unwrap();
     let wgs2 = itrf.convert_to(PositionRef::WGS84).unwrap();
 
-    for i in 0..3 {
+    let tolerances = [1e-10, 1e-10, 1e-4];
+    for (i, tolerance) in tolerances.iter().enumerate() {
         assert!(
-            (wgs2.values()[i] - wgs.values()[i]).abs() < 1e-6,
+            (wgs2.values()[i] - wgs.values()[i]).abs() < *tolerance,
             "coord {i}: {} vs {}",
             wgs2.values()[i],
             wgs.values()[i]

--- a/crates/casars-imager/examples/profile_imager.rs
+++ b/crates/casars-imager/examples/profile_imager.rs
@@ -457,6 +457,9 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Result<Options, String>
                 mask_image = Some(PathBuf::from(next_value(&mut args, "--mask-image")?))
             }
             "--wterm" => w_term_mode = parse_w_term_mode(&next_value(&mut args, "--wterm")?)?,
+            "--gridder" => {
+                w_term_mode = parse_gridder_w_term_mode(&next_value(&mut args, "--gridder")?)?
+            }
             "--wprojplanes" => w_project_planes = Some(parse_next(&mut args, "--wprojplanes")?),
             "--dirty-only" => dirty_only = true,
             "--repeats" => repeats = parse_next(&mut args, "--repeats")?,
@@ -560,6 +563,20 @@ fn parse_w_term_mode(text: &str) -> Result<WTermMode, String> {
         "wproject" => Ok(WTermMode::WProject),
         _ => Err(format!(
             "unsupported --wterm value {text:?}; expected none, direct, or wproject"
+        )),
+    }
+}
+
+fn parse_gridder_w_term_mode(text: &str) -> Result<WTermMode, String> {
+    match text.to_ascii_lowercase().as_str() {
+        "standard" | "gridft" | "ft" | "mosaic" => Ok(WTermMode::None),
+        "wproject" => Ok(WTermMode::WProject),
+        "widefield" | "awproject" | "awp2" | "awphpg" => Err(format!(
+            "gridder={text:?} is not implemented by casa-rs imager yet; \
+             supported gridder values are standard, wproject, and mosaic"
+        )),
+        _ => Err(format!(
+            "unsupported --gridder value {text:?}; expected standard, wproject, widefield, mosaic, awproject, awp2, or awphpg"
         )),
     }
 }
@@ -670,6 +687,7 @@ Options:
   --mask-box X0,Y0,X1,Y1
   --mask-image PATH
   --wterm none|direct|wproject
+  --gridder standard|mosaic|wproject
   --wprojplanes N
   --dirty-only
   --repeats N

--- a/crates/casars-imager/src/lib.rs
+++ b/crates/casars-imager/src/lib.rs
@@ -1050,6 +1050,7 @@ pub fn build_w_project_trace_from_config(
             config.imsize,
             &config.mask_boxes,
             config.mask_image.as_deref(),
+            config.use_mask == CleanMaskMode::User,
         )?,
         initial_model: None,
         w_term_mode: config.w_term_mode,
@@ -1115,6 +1116,7 @@ pub fn build_cube_channel_w_project_trace_from_config(
             config.imsize,
             &config.mask_boxes,
             config.mask_image.as_deref(),
+            config.use_mask == CleanMaskMode::User,
         )?,
         channel_clean_mask: None,
         auto_mask: None,
@@ -1434,6 +1436,7 @@ fn run_single_image_from_config_with_gridder_override(
                 config.imsize,
                 &config.mask_boxes,
                 config.mask_image.as_deref(),
+                config.use_mask == CleanMaskMode::User,
             )?;
             if config.deconvolver == Deconvolver::Mtmfs {
                 if config.use_mask == CleanMaskMode::AutoMultiThreshold {
@@ -1549,6 +1552,7 @@ fn run_single_image_from_config_with_gridder_override(
                 config.imsize,
                 &config.mask_boxes,
                 config.mask_image.as_deref(),
+                config.use_mask == CleanMaskMode::User,
             )?;
             let mut channel_clean_mask = None::<Array4<bool>>;
             let mut dirty_seed = None;
@@ -2782,6 +2786,7 @@ fn build_joint_outlier_clean_mask(
         config.imsize,
         &config.mask_boxes,
         config.mask_image.as_deref(),
+        config.use_mask == CleanMaskMode::User,
     )?;
     let Some(mask_text) = definition
         .and_then(|definition| definition.mask.as_deref())
@@ -3286,6 +3291,7 @@ pub fn trace_cube_channel_residual_refresh_from_config(
             config.imsize,
             &config.mask_boxes,
             config.mask_image.as_deref(),
+            config.use_mask == CleanMaskMode::User,
         )?,
         channel_clean_mask: None,
         auto_mask: None,
@@ -3350,6 +3356,7 @@ pub fn trace_cube_channel_residual_refresh_from_config_with_model_cube(
             config.imsize,
             &config.mask_boxes,
             config.mask_image.as_deref(),
+            config.use_mask == CleanMaskMode::User,
         )?,
         channel_clean_mask: None,
         auto_mask: None,
@@ -3417,6 +3424,7 @@ pub fn trace_cube_channel_residual_refresh_from_config_with_model_cube_model_cha
             config.imsize,
             &config.mask_boxes,
             config.mask_image.as_deref(),
+            config.use_mask == CleanMaskMode::User,
         )?,
         channel_clean_mask: None,
         auto_mask: None,
@@ -11800,9 +11808,10 @@ fn build_clean_mask(
     imsize: usize,
     mask_boxes: &[[usize; 4]],
     mask_image: Option<&Path>,
+    full_image_if_empty: bool,
 ) -> Result<Option<Array2<bool>>, String> {
     if mask_boxes.is_empty() && mask_image.is_none() {
-        return Ok(None);
+        return Ok(full_image_if_empty.then(|| Array2::<bool>::from_elem((imsize, imsize), true)));
     }
     let mut mask = Array2::<bool>::from_elem((imsize, imsize), false);
     for [x0, y0, x1, y1] in mask_boxes {
@@ -16164,23 +16173,25 @@ mod tests {
         assert_eq!(parse_mask_box("1, 2, 3, 4").unwrap(), [1, 2, 3, 4]);
         assert!(parse_mask_box("1,2,3").unwrap_err().contains("expects"));
 
-        let mask = build_clean_mask(6, &[[1, 2, 3, 4]], None)
+        let mask = build_clean_mask(6, &[[1, 2, 3, 4]], None, false)
             .unwrap()
             .expect("mask");
         assert!(mask[(1, 2)]);
         assert!(mask[(3, 4)]);
         assert!(!mask[(0, 0)]);
         assert!(
-            build_clean_mask(6, &[[4, 1, 3, 2]], None)
+            build_clean_mask(6, &[[4, 1, 3, 2]], None, false)
                 .unwrap_err()
                 .contains("x0 <= x1")
         );
         assert!(
-            build_clean_mask(6, &[[0, 0, 6, 1]], None)
+            build_clean_mask(6, &[[0, 0, 6, 1]], None, false)
                 .unwrap_err()
                 .contains("exceeds image bounds")
         );
-        assert!(build_clean_mask(6, &[], None).unwrap().is_none());
+        assert!(build_clean_mask(6, &[], None, false).unwrap().is_none());
+        let full_mask = build_clean_mask(6, &[], None, true).unwrap().expect("mask");
+        assert!(full_mask.iter().all(|cleanable| *cleanable));
     }
 
     #[test]
@@ -17577,8 +17588,8 @@ mod tests {
 
     #[test]
     fn clean_mask_rejects_invalid_boxes_and_mask_images() {
-        assert!(build_clean_mask(4, &[[2, 1, 1, 0]], None).is_err());
-        assert!(build_clean_mask(4, &[[0, 0, 4, 0]], None).is_err());
+        assert!(build_clean_mask(4, &[[2, 1, 1, 0]], None, false).is_err());
+        assert!(build_clean_mask(4, &[[0, 0, 4, 0]], None, false).is_err());
 
         let tmp = tempdir().unwrap();
         let path = tmp.path().join("mask.im");
@@ -17586,7 +17597,7 @@ mod tests {
         let mut image = PagedImage::<f32>::create(vec![2, 3, 1, 1], coords, &path).unwrap();
         image.save().unwrap();
 
-        let error = build_clean_mask(4, &[], Some(&path)).unwrap_err();
+        let error = build_clean_mask(4, &[], Some(&path), false).unwrap_err();
         assert!(error.contains("expected [4, 4]") || error.contains("expected [4, 4, 1, 1]"));
     }
 
@@ -17601,7 +17612,7 @@ mod tests {
         image.put_slice(&data.into_dyn(), &[0, 0, 0, 0]).unwrap();
         image.save().unwrap();
 
-        let mask = build_clean_mask(8, &[[1, 2, 2, 3], [4, 4, 4, 4]], Some(&path))
+        let mask = build_clean_mask(8, &[[1, 2, 2, 3], [4, 4, 4, 4]], Some(&path), false)
             .unwrap()
             .unwrap();
         assert!(mask[(1, 2)]);

--- a/crates/casars-python/python/casars/tasks/simobserve.py
+++ b/crates/casars-python/python/casars/tasks/simobserve.py
@@ -47,7 +47,10 @@ def vla_ppdisk(
     output_ms: StrPath,
     *,
     overwrite: bool = False,
+    telescope_name: str | None = None,
+    field_name: str | None = None,
     antennas: list[dict[str, Any]] | None = None,
+    fields: list[dict[str, Any]] | None = None,
     model_peak_jy_per_pixel: float | None = 3.0e-5,
     phase_center_rad: tuple[float, float] | None = None,
     start_time_mjd_seconds: float | None = None,
@@ -67,7 +70,10 @@ def vla_ppdisk(
         "model_peak_jy_per_pixel": model_peak_jy_per_pixel,
         "output_ms": os.fspath(output_ms),
         "overwrite": overwrite,
+        "telescope_name": telescope_name,
+        "field_name": field_name,
         "antennas": antennas or [],
+        "fields": fields or [],
         "phase_center_rad": None
         if phase_center_rad is None
         else [phase_center_rad[0], phase_center_rad[1]],

--- a/crates/casars-python/python/tests/test_simobserve.py
+++ b/crates/casars-python/python/tests/test_simobserve.py
@@ -63,6 +63,12 @@ def test_wrapper_encodes_pythonic_arguments(tmp_path: Path) -> None:
         "ppdisk.fits",
         "ppdisk.ms",
         overwrite=True,
+        telescope_name="ALMA",
+        field_name="science",
+        fields=[
+            {"name": "mosaic_0", "phase_center_rad": [1.0, -0.5]},
+            {"name": "mosaic_1", "phase_center_rad": [1.0001, -0.5]},
+        ],
         model_peak_jy_per_pixel=3.0e-5,
         phase_center_rad=(1.0, -0.5),
         duration_seconds=30.0,
@@ -94,6 +100,10 @@ def test_wrapper_encodes_pythonic_arguments(tmp_path: Path) -> None:
     assert request["model_peak_jy_per_pixel"] == 3.0e-5
     assert request["output_ms"] == "ppdisk.ms"
     assert request["overwrite"] is True
+    assert request["telescope_name"] == "ALMA"
+    assert request["field_name"] == "science"
+    assert request["fields"][1]["name"] == "mosaic_1"
+    assert request["fields"][1]["phase_center_rad"] == [1.0001, -0.5]
     assert request["phase_center_rad"] == [1.0, -0.5]
     assert request["duration_seconds"] == 30.0
     assert request["integration_seconds"] == 10.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,8 @@ This directory holds stable project documentation.
   [`tutorial-parity/imperformance-wave-1-mode-selection.md`](tutorial-parity/imperformance-wave-1-mode-selection.md)
 - ImPerformance Wave 1 simulated dataset plan:
   [`tutorial-parity/imperformance-wave-1-datasets.md`](tutorial-parity/imperformance-wave-1-datasets.md)
+- ImPerformance Wave 1 benchmark harness:
+  [`tutorial-parity/imperformance-wave-1-benchmark-harness.md`](tutorial-parity/imperformance-wave-1-benchmark-harness.md)
 
 ## Planning And Program Reference
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,8 @@ This directory holds stable project documentation.
   [`tutorial-parity/imperformance-wave-1-datasets.md`](tutorial-parity/imperformance-wave-1-datasets.md)
 - ImPerformance Wave 1 benchmark harness:
   [`tutorial-parity/imperformance-wave-1-benchmark-harness.md`](tutorial-parity/imperformance-wave-1-benchmark-harness.md)
+- ImPerformance Wave 1 stage instrumentation:
+  [`tutorial-parity/imperformance-wave-1-stage-instrumentation.md`](tutorial-parity/imperformance-wave-1-stage-instrumentation.md)
 
 ## Planning And Program Reference
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,8 @@ This directory holds stable project documentation.
   [`tutorial-parity/tutorial-learning-packs.md`](tutorial-parity/tutorial-learning-packs.md)
 - ImPerformance Wave 1 mode selection:
   [`tutorial-parity/imperformance-wave-1-mode-selection.md`](tutorial-parity/imperformance-wave-1-mode-selection.md)
+- ImPerformance Wave 1 simulated dataset plan:
+  [`tutorial-parity/imperformance-wave-1-datasets.md`](tutorial-parity/imperformance-wave-1-datasets.md)
 
 ## Planning And Program Reference
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,8 @@ This directory holds stable project documentation.
   [`casa-vla-importvla-parity.md`](casa-vla-importvla-parity.md)
 - tutorial learning packs:
   [`tutorial-parity/tutorial-learning-packs.md`](tutorial-parity/tutorial-learning-packs.md)
+- ImPerformance Wave 1 mode selection:
+  [`tutorial-parity/imperformance-wave-1-mode-selection.md`](tutorial-parity/imperformance-wave-1-mode-selection.md)
 
 ## Planning And Program Reference
 

--- a/docs/tutorial-parity/README.md
+++ b/docs/tutorial-parity/README.md
@@ -44,6 +44,7 @@ functionality.
 ## ImPerformance Artifacts
 
 - [Wave 1 mode selection and target styles](imperformance-wave-1-mode-selection.md)
+- [Wave 1 simulated dataset plan](imperformance-wave-1-datasets.md)
 
 ## Source Pages
 

--- a/docs/tutorial-parity/README.md
+++ b/docs/tutorial-parity/README.md
@@ -41,6 +41,10 @@ functionality.
 - [Performance closeout](wave-7-performance-closeout.md)
 - [Ticket-level performance closeout](wave-7-ticket-closeout.md)
 
+## ImPerformance Artifacts
+
+- [Wave 1 mode selection and target styles](imperformance-wave-1-mode-selection.md)
+
 ## Source Pages
 
 - CASA Guides main page:

--- a/docs/tutorial-parity/imperformance-wave-1-benchmark-harness.md
+++ b/docs/tutorial-parity/imperformance-wave-1-benchmark-harness.md
@@ -1,0 +1,156 @@
+# ImPerformance Wave 1 Benchmark Harness
+
+Truth class: current descriptive
+Last reality check: 2026-05-15
+Verification: `python3 -m py_compile tools/perf/imager/run_workload.py tools/perf/imager/stage_wave1_datasets.py`; `bash -n scripts/bench-imager-vs-casa.sh`; `tools/perf/imager/run_workload.py --dry-run --output-dir target/imperformance-wave1/harness-dry-run wave1-standard-mfs-dirty-smoke`; `CASA_RS_TESTDATA_ROOT=/Users/brianglendenning/SoftwareProjects/casatestdata CASA_RS_CASA_PYTHON=/Users/brianglendenning/SoftwareProjects/casa-build/venv/bin/python tools/perf/imager/run_workload.py --repeats 1 --output-dir target/imperformance-wave1/harness-smoke wave1-standard-mfs-dirty-smoke`
+
+Wave issue: #246
+Child issue: #252
+
+This note records the reusable CASA C++ versus `casa-rs` imaging benchmark
+harness for ImPerformance Wave 1. The harness is intentionally manifest driven:
+the same workload JSON chooses the MeasurementSet, imaging mode, gridding mode,
+weighting, deconvolver, image geometry, channel selection, repeat count, and
+product comparison settings for both implementations.
+
+## Entry Point
+
+Run one workload manifest with:
+
+```sh
+tools/perf/imager/run_workload.py wave1-standard-mfs-dirty-smoke
+```
+
+The manifest can be a stable workload id under
+`tools/perf/imager/workloads/` or a generated JSON path from
+`tools/perf/imager/stage_wave1_datasets.py --materialize-workloads`.
+
+For real CASA C++ comparisons, set:
+
+```sh
+CASA_RS_TESTDATA_ROOT=/path/to/casatestdata
+CASA_RS_CASA_PYTHON=/path/to/casa-python
+```
+
+Wave 1 generated datasets should instead use `CASA_RS_IMPERF_DATA_ROOT` in the
+generated manifest.
+
+## Harness Contract
+
+`run_workload.py` performs the reusable outer harness work:
+
+- validates that the requested workload is inside the supported Wave 1 slice;
+- resolves datasets only through an explicit manifest path or root environment
+  variable plus relative path;
+- records git branch/commit, CASA Python path, benchmark script hash, command
+  argv, and delegated environment;
+- delegates to `scripts/bench-imager-vs-casa.sh` for the Rust CLI, Rust core
+  stage profiler, CASA `tclean`, and CASA `PySynthesisImager` stage probe;
+- preserves the final Rust and CASA product prefixes under the run output
+  directory;
+- compares configured image products with CASA `casatools.image`;
+- writes one machine-readable JSON result per run.
+
+The delegated shell script remains the only place that knows how to invoke the
+current `casars-imager` CLI and CASA `tclean` parameter sets. That keeps the
+manifest runner stable while the lower-level commands evolve.
+
+## Supported Slice
+
+The #252 harness slice supports:
+
+| Field | Supported values |
+|---|---|
+| `imaging.mode` | `dirty`, `clean` |
+| `imaging.specmode` | `mfs`, `cube` |
+| `imaging.gridder` | `standard`, `mosaic` |
+| `imaging.interpolation` | `nearest`, `linear` |
+| `imaging.wterm` | `none` |
+
+Unsupported W-projection and AW/widefield workloads fail before timing claims
+are written. Those modes remain deferred to their owning tickets.
+
+## Result JSON
+
+Each completed run records:
+
+- run identity, manifest path, selected workload, dataset path, storage label,
+  repeat count, and mode parameters;
+- exact delegated command and environment variables;
+- Rust CLI per-run wallclock and median;
+- CASA `tclean` per-run wallclock and median;
+- Rust and CASA stage medians when available;
+- preserved product root, Rust prefix, and CASA prefix;
+- product comparison metrics for configured suffixes.
+
+The default product comparison suffixes are:
+
+- `.image`
+- `.residual`
+- `.psf`
+
+Manifest authors can override them with:
+
+```json
+{
+  "comparison": {
+    "products": [".image", ".residual", ".psf"],
+    "max_elements_per_product": 1000000
+  }
+}
+```
+
+The product comparison reports shape, sampling stride, finite overlap count,
+Rust/CASA min/max/RMS, absolute-difference maximum, RMS difference,
+`diff_rms_over_casa_rms`, and `diff_abs_max_over_casa_peak`.
+
+For large products, `max_elements_per_product` bounds comparison cost by using
+CASA image chunk strides rather than forcing a full product read.
+
+## Smoke Evidence
+
+The local #252 smoke run used:
+
+```sh
+CASA_RS_TESTDATA_ROOT=/Users/brianglendenning/SoftwareProjects/casatestdata \
+CASA_RS_CASA_PYTHON=/Users/brianglendenning/SoftwareProjects/casa-build/venv/bin/python \
+tools/perf/imager/run_workload.py \
+  --repeats 1 \
+  --output-dir target/imperformance-wave1/harness-smoke \
+  wave1-standard-mfs-dirty-smoke
+```
+
+Result:
+
+- status: completed
+- Rust CLI median: `0.882409 s`
+- CASA `tclean` median: `0.137461 s`
+- `.image` comparison: `diff_rms_over_casa_rms = 0.0412297`,
+  `diff_abs_max_over_casa_peak = 0.00942697`
+- `.residual` comparison: same as `.image` for dirty imaging
+- `.psf` comparison: `diff_rms_over_casa_rms = 0.0258262`,
+  `diff_abs_max_over_casa_peak = 0.00257105`
+
+This is harness evidence, not a Wave 1 performance conclusion. The smoke
+dataset is a small existing testdata MeasurementSet, not one of the staged
+1 GiB / 32 GiB / 100 GiB simulated benchmark datasets.
+
+## Issue #252 Acceptance Mapping
+
+- Reusable manifest-driven runner: `tools/perf/imager/run_workload.py`.
+- Same manifest drives CASA C++ and `casa-rs`: `run_workload.py` translates
+  manifest fields into the delegated command environment used for both sides.
+- Command, inputs, products, wallclock, exit status, and stage timings:
+  recorded in each result JSON.
+- Product deltas: CASA-backed comparison of preserved `.image`, `.residual`,
+  and `.psf` products, with manifest-configurable product suffixes.
+- Dry-run support: `--dry-run` validates support and writes the planned command
+  without requiring CASA Python or a local MeasurementSet.
+- Unsupported modes: fail before timing claims are written.
+
+## Next Tickets
+
+#249 should move stage timing from the current script-parsed probe into a more
+complete structured stage/resource report. #251 should consume these result
+JSON files to build the baseline matrix and bottleneck ledger for the selected
+Wave 1 workloads.

--- a/docs/tutorial-parity/imperformance-wave-1-benchmark-harness.md
+++ b/docs/tutorial-parity/imperformance-wave-1-benchmark-harness.md
@@ -80,6 +80,7 @@ Each completed run records:
 - Rust CLI per-run wallclock and median;
 - CASA `tclean` per-run wallclock and median;
 - Rust and CASA stage medians when available;
+- normalized `stage_breakdown` categories for the Wave 1 bottleneck ledger;
 - preserved product root, Rust prefix, and CASA prefix;
 - product comparison metrics for configured suffixes.
 

--- a/docs/tutorial-parity/imperformance-wave-1-datasets.md
+++ b/docs/tutorial-parity/imperformance-wave-1-datasets.md
@@ -1,8 +1,8 @@
 # ImPerformance Wave 1 Simulated Dataset Plan
 
 Truth class: current descriptive
-Last reality check: 2026-05-16
-Verification: `python3 -m py_compile tools/perf/imager/stage_wave1_datasets.py tools/perf/imager/test_stage_wave1_datasets.py`; `python3 -m unittest tools/perf/imager/test_stage_wave1_datasets.py`; `tools/perf/imager/stage_wave1_datasets.py --dry-run --data-root /Volumes/GLENDENNING/casa-rs-imperformance --output-dir target/imperformance-wave1/dataset-dry-run`; `tools/perf/imager/stage_wave1_datasets.py --dry-run --data-root /tmp/casa-rs-imperformance --dataset wave1-vla-single-small --output-dir target/imperformance-wave1/dataset-small-dry-run`; `tools/perf/imager/stage_wave1_datasets.py --data-root /tmp/casa-rs-imperformance --dataset wave1-vla-single-small --materialize-models --materialize-workloads --output-dir target/imperformance-wave1/dataset-small-materialized`; `tools/perf/imager/stage_wave1_datasets.py --data-root /tmp/casa-rs-imperformance --dataset wave1-alma-shared-large --allow-non-external-large-root --materialize-workloads --output-dir target/imperformance-wave1/dataset-large-workloads`; `tools/perf/imager/run_workload.py --dry-run --output-dir target/imperformance-wave1/generated-workload-dry-run target/imperformance-wave1/dataset-small-materialized/workloads/wave1-vla-single-small-standard-mfs-dirty-control.json`; `just docs-check`; `just quick`
+Last reality check: 2026-05-17
+Verification: `python3 -m py_compile tools/perf/imager/stage_wave1_datasets.py tools/perf/imager/test_stage_wave1_datasets.py tools/perf/imager/bench_simobserve.py`; `python3 -m unittest tools/perf/imager/test_stage_wave1_datasets.py tools/perf/imager/test_bench_simobserve.py`; `tools/perf/imager/stage_wave1_datasets.py --dry-run --data-root /Volumes/GLENDENNING/casa-rs-imperformance --output-dir target/imperformance-wave1/dataset-dry-run`; `tools/perf/imager/stage_wave1_datasets.py --dry-run --data-root /tmp/casa-rs-imperformance --dataset wave1-vla-single-small --output-dir target/imperformance-wave1/dataset-small-dry-run`; `tools/perf/imager/stage_wave1_datasets.py --data-root /tmp/casa-rs-imperformance --dataset wave1-vla-single-small --materialize-models --materialize-workloads --output-dir target/imperformance-wave1/dataset-small-materialized`; `tools/perf/imager/stage_wave1_datasets.py --data-root /tmp/casa-rs-imperformance --dataset wave1-alma-mosaic-large --allow-non-external-large-root --materialize-workloads --output-dir target/imperformance-wave1/dataset-large-workloads`; `tools/perf/imager/run_workload.py --dry-run --output-dir target/imperformance-wave1/generated-workload-dry-run target/imperformance-wave1/dataset-small-materialized/workloads/wave1-vla-single-small-standard-mfs-dirty-control.json`; `python3 tools/perf/imager/bench_simobserve.py target/imperformance-wave1/current-plan/wave1-dataset-plan.json --dataset wave1-vla-single-small --output-dir target/imperformance-wave1/fixed-axis-vla-small-bench-v2 --disable-noise --strict-values`; `python3 tools/perf/imager/bench_simobserve.py target/imperformance-wave1/current-plan/wave1-dataset-plan.json --dataset wave1-alma-single-small --output-dir target/imperformance-wave1/fixed-axis-alma-small-bench-v2 --disable-noise --strict-values`; `cargo test -p casa-ms`; `just docs-check`; `just quick`
 
 Wave issue: #246
 Child issue: #248
@@ -10,11 +10,13 @@ Child issue: #248
 This note defines the deterministic simulated data inputs for ImPerformance
 Wave 1. The goal is to benchmark imaging behavior, not calibration behavior.
 The datasets therefore use visually interesting deterministic sky models, a
-realistic but simple noise term, and explicit CASA C++ generation plans.
+realistic but simple noise term, and explicit CASA/native generation plans.
 
-For Wave 1, CASA C++ is allowed to be the dataset generator of record. Native
-`casa-rs` simulation gaps discovered by this plan are tracked as backlog issues
-instead of blocking benchmark dataset staging.
+For Wave 1, native `casa-rs` simulation is the primary benchmark dataset
+generator where the capability is supported. CASA C++ generation remains the
+small-case oracle for parity and performance checks. Native gaps discovered by
+this plan are tracked as backlog issues instead of blocking supported dataset
+staging.
 
 ## Size Tiers
 
@@ -28,11 +30,11 @@ The first performance wave uses three memory-pressure tiers:
 
 The large tier is intentionally **not** one 100 GiB dataset per mode. The
 external drive budget allows one large dataset, so the registry contains a
-single shared ALMA mosaic/cube superset:
+single ALMA mosaic/cube superset:
 
-- dataset id: `wave1-alma-shared-large`;
-- instrument/family: ALMA shared-large mosaic/cube superset;
-- observing shape: 7 pointings, 256 channels, 24 h, 2 s integrations;
+- dataset id: `wave1-alma-mosaic-large`;
+- instrument/family: ALMA mosaic-large mosaic/cube superset;
+- observing shape: 7 pointings, 1024 channels, 74300 s, 10 s integrations;
 - logical workloads select from this one MS:
   - standard modes use field `0` with `gridder='standard'`;
   - mosaic modes use all fields with `gridder='mosaic'`;
@@ -50,25 +52,27 @@ The staging root is always explicit. Set `CASA_RS_IMPERF_DATA_ROOT` or pass
 
 ## Instruments And Families
 
-The registry includes both VLA and ALMA simulated datasets. CASA C++ generation
-is the current path for all Wave 1 benchmark datasets.
+The registry includes both VLA and ALMA simulated datasets. Native generation
+is the current path for supported Wave 1 benchmark datasets, with CASA C++
+retained as the parity oracle.
 
 | Instrument | Single-field datasets | Mosaic datasets | Native `casa-rs` simulation status |
 |---|---:|---:|---|
-| VLA | small, medium | small, medium | VLA single-field single-plane is supported by the existing native `simobserve` path; native cube spectral structure and true mosaic generation are backlog |
-| ALMA | small, medium | small, medium, plus one shared large superset | request-plan-only until ALMA simulation parity is checked |
+| VLA | small, medium | small | VLA single-field generation is supported by the existing native `simobserve` path; true mosaic generation is backlog |
+| ALMA | small, medium | small, plus one large mosaic/cube superset | ALMA single-field generation has strict small-tier parity evidence; true mosaic generation is backlog |
 
 The registry also includes both single-field and mosaic families:
 
 | Family | Wave 1 modes | Status |
 |---|---|---|
-| single | standard MFS dirty, standard MFS clean, standard cube, MT-MFS sentinel | CASA C++ generated datasets are usable now; native spectral cube model prediction is backlog #255 |
+| single | standard MFS dirty, standard MFS clean, standard cube, MT-MFS sentinel | Native and CASA C++ small single-field ALMA parity is checked; cube spectral structure remains backlog #255 |
 | mosaic | mosaic MFS clean, mosaic cube bounded | CASA C++ generated datasets are usable now; native multi-field mosaic generation is backlog #254 |
-| shared-large | all selected Wave 1 modes | one ALMA large-tier superset backs all logical large workloads |
+| mosaic-large | all selected Wave 1 modes | one ALMA large-tier superset backs all logical large workloads |
 
-The native blocked/request-plan statuses are intentional. They prevent the
-benchmark program from claiming native simulation capability while allowing the
-performance wave to proceed from CASA C++ generated datasets.
+The native blocked/request-plan statuses are intentional for unsupported
+families. They prevent the benchmark program from claiming native simulation
+capability while allowing the performance wave to proceed from supported native
+datasets and CASA C++ parity oracles.
 
 ## Source Model
 
@@ -116,10 +120,30 @@ This is not a calibration benchmark. The noise term is simple deterministic
 complex visibility noise, tuned to make images realistic enough for repeated
 inspection without adding calibration-solver scope.
 
+Current small-tier strict evidence:
+
+| Dataset | Rows | CASA C++ simobserve | Native simobserve | Speedup | Strict result |
+|---|---:|---:|---:|---:|---|
+| `wave1-vla-single-small` | `3,032,640` | `56.514 s` | `16.051 s` | `3.52x` | rows, UVW, flags, and sampled DATA pass; zero same-cell DATA tolerance violations |
+| `wave1-alma-single-small` | `7,801,920` | `109.738 s` | `24.399 s` | `4.50x` | rows, UVW, flags, and sampled DATA pass; zero same-cell DATA tolerance violations |
+
+The corresponding simulation-isolated image panels run CASA `tclean(niter=0)`
+on both the CASA-generated and native-generated MeasurementSets:
+
+- `target/imperformance-wave1/image-inspection/vla-small/vla-small-simulation-parity-panel.png`
+- `target/imperformance-wave1/image-inspection/alma-small/alma-small-simulation-parity-panel.png`
+
+The current panel statistics are:
+
+| Dataset | Dirty-image difference RMS | Relative RMS |
+|---|---:|---:|
+| `wave1-vla-single-small` | `0.0550370814 Jy/beam` | `1.485678975e-4` |
+| `wave1-alma-single-small` | `0.00293265438 Jy/beam` | `5.168102794e-4` |
+
 ## Native Simulation Follow-Ups
 
-Native simulation is not on the critical path for Wave 1 dataset generation.
-The missing capabilities are tracked separately:
+Native simulation is on the critical path for supported Wave 1 dataset
+generation. Missing families remain tracked separately:
 
 - #254: native multi-field mosaic simulation generation.
 - #255: native spectral cube model simulation.

--- a/docs/tutorial-parity/imperformance-wave-1-datasets.md
+++ b/docs/tutorial-parity/imperformance-wave-1-datasets.md
@@ -1,8 +1,8 @@
 # ImPerformance Wave 1 Simulated Dataset Plan
 
 Truth class: current descriptive
-Last reality check: 2026-05-14
-Verification: `tools/perf/imager/stage_wave1_datasets.py --dry-run --data-root /Volumes/GLENDENNING/casa-rs-imperformance --output-dir target/imperformance-wave1/dataset-dry-run`; `tools/perf/imager/stage_wave1_datasets.py --dry-run --data-root /tmp/casa-rs-imperformance --dataset wave1-vla-single-small --output-dir target/imperformance-wave1/dataset-small-dry-run`; `tools/perf/imager/stage_wave1_datasets.py --data-root /tmp/casa-rs-imperformance --dataset wave1-vla-single-small --materialize-models --materialize-workloads --output-dir target/imperformance-wave1/dataset-small-materialized`; `tools/perf/imager/run_workload.py --dry-run --output-dir target/imperformance-wave1/generated-workload-dry-run target/imperformance-wave1/dataset-small-materialized/workloads/wave1-vla-single-small-standard-mfs-dirty-control.json`; `just docs-check`; `just quick`
+Last reality check: 2026-05-16
+Verification: `python3 -m py_compile tools/perf/imager/stage_wave1_datasets.py tools/perf/imager/test_stage_wave1_datasets.py`; `python3 -m unittest tools/perf/imager/test_stage_wave1_datasets.py`; `tools/perf/imager/stage_wave1_datasets.py --dry-run --data-root /Volumes/GLENDENNING/casa-rs-imperformance --output-dir target/imperformance-wave1/dataset-dry-run`; `tools/perf/imager/stage_wave1_datasets.py --dry-run --data-root /tmp/casa-rs-imperformance --dataset wave1-vla-single-small --output-dir target/imperformance-wave1/dataset-small-dry-run`; `tools/perf/imager/stage_wave1_datasets.py --data-root /tmp/casa-rs-imperformance --dataset wave1-vla-single-small --materialize-models --materialize-workloads --output-dir target/imperformance-wave1/dataset-small-materialized`; `tools/perf/imager/stage_wave1_datasets.py --data-root /tmp/casa-rs-imperformance --dataset wave1-alma-shared-large --allow-non-external-large-root --materialize-workloads --output-dir target/imperformance-wave1/dataset-large-workloads`; `tools/perf/imager/run_workload.py --dry-run --output-dir target/imperformance-wave1/generated-workload-dry-run target/imperformance-wave1/dataset-small-materialized/workloads/wave1-vla-single-small-standard-mfs-dirty-control.json`; `just docs-check`; `just quick`
 
 Wave issue: #246
 Child issue: #248
@@ -24,7 +24,20 @@ The first performance wave uses three memory-pressure tiers:
 |---|---:|---|---|
 | small | `1 GiB` | much smaller than memory | may live under any explicit `CASA_RS_IMPERF_DATA_ROOT` |
 | medium | `32 GiB` | about memory on this workstation | stage under `/Volumes/GLENDENNING` unless explicitly overridden |
-| large | `100 GiB` | larger than memory on this workstation | stage under `/Volumes/GLENDENNING` unless explicitly overridden |
+| large | `100 GiB` total | larger than memory on this workstation | exactly one shared dataset, staged under `/Volumes/GLENDENNING` unless explicitly overridden |
+
+The large tier is intentionally **not** one 100 GiB dataset per mode. The
+external drive budget allows one large dataset, so the registry contains a
+single shared ALMA mosaic/cube superset:
+
+- dataset id: `wave1-alma-shared-large`;
+- instrument/family: ALMA shared-large mosaic/cube superset;
+- observing shape: 7 pointings, 256 channels, 24 h, 2 s integrations;
+- logical workloads select from this one MS:
+  - standard modes use field `0` with `gridder='standard'`;
+  - mosaic modes use all fields with `gridder='mosaic'`;
+  - bounded mosaic cube uses a 32-channel subset;
+  - MFS modes use the available channel range through `specmode='mfs'`.
 
 Generated MeasurementSets are not committed to git. The checked-in artifact is
 the registry and staging tool:
@@ -42,8 +55,8 @@ is the current path for all Wave 1 benchmark datasets.
 
 | Instrument | Single-field datasets | Mosaic datasets | Native `casa-rs` simulation status |
 |---|---:|---:|---|
-| VLA | small, medium, large | small, medium, large | VLA single-field single-plane is supported by the existing native `simobserve` path; native cube spectral structure and true mosaic generation are backlog |
-| ALMA | small, medium, large | small, medium, large | request-plan-only until ALMA simulation parity is checked |
+| VLA | small, medium | small, medium | VLA single-field single-plane is supported by the existing native `simobserve` path; native cube spectral structure and true mosaic generation are backlog |
+| ALMA | small, medium | small, medium, plus one shared large superset | request-plan-only until ALMA simulation parity is checked |
 
 The registry also includes both single-field and mosaic families:
 
@@ -51,6 +64,7 @@ The registry also includes both single-field and mosaic families:
 |---|---|---|
 | single | standard MFS dirty, standard MFS clean, standard cube, MT-MFS sentinel | CASA C++ generated datasets are usable now; native spectral cube model prediction is backlog #255 |
 | mosaic | mosaic MFS clean, mosaic cube bounded | CASA C++ generated datasets are usable now; native multi-field mosaic generation is backlog #254 |
+| shared-large | all selected Wave 1 modes | one ALMA large-tier superset backs all logical large workloads |
 
 The native blocked/request-plan statuses are intentional. They prevent the
 benchmark program from claiming native simulation capability while allowing the
@@ -154,10 +168,22 @@ tools/perf/imager/stage_wave1_datasets.py --dry-run
 
 Use `--allow-non-external-large-root` only for a deliberate one-off override.
 
+Generate logical workload manifests for the single shared large dataset without
+materializing the 100 GiB MeasurementSet:
+
+```sh
+tools/perf/imager/stage_wave1_datasets.py \
+  --data-root "$CASA_RS_IMPERF_DATA_ROOT" \
+  --dataset wave1-alma-shared-large \
+  --materialize-workloads
+```
+
 ## Issue #248 Acceptance Mapping
 
 - Deterministic generation path or registry entry for selected mode/tier
-  combinations: `wave1_dataset_registry.json` plus CASA C++ simulation plans.
+  combinations: `wave1_dataset_registry.json` plus CASA C++ simulation plans;
+  the large tier intentionally maps all selected modes to
+  `wave1-alma-shared-large`.
 - Metadata needed to reproduce benchmark workloads: generated dataset plan,
   source model files, spectral profile, and simulation request plans.
 - Provenance, size, checksum, path, and tier policy: this document plus the
@@ -166,8 +192,8 @@ Use `--allow-non-external-large-root` only for a deliberate one-off override.
   root outside `/Volumes/GLENDENNING`, and native simulation gaps are explicit
   statuses with follow-up issues.
 - Shared-data policy: explicit root only; no bulky generated data in git.
-- Performance tier intent: small, memory-sized, and larger-than-memory staged
-  datasets.
+- Performance tier intent: small, memory-sized, and one shared
+  larger-than-memory staged dataset.
 
 ## Stop Conditions Preserved
 

--- a/docs/tutorial-parity/imperformance-wave-1-datasets.md
+++ b/docs/tutorial-parity/imperformance-wave-1-datasets.md
@@ -58,15 +58,15 @@ retained as the parity oracle.
 
 | Instrument | Single-field datasets | Mosaic datasets | Native `casa-rs` simulation status |
 |---|---:|---:|---|
-| VLA | small, medium | small | VLA single-field generation is supported by the existing native `simobserve` path; true mosaic generation is backlog |
-| ALMA | small, medium | small, plus one large mosaic/cube superset | ALMA single-field generation has strict small-tier parity evidence; true mosaic generation is backlog |
+| VLA | small, medium | small | VLA single-field and selected mosaic-capable request generation are supported by the native `simobserve` path; strict parity evidence currently covers VLA single small |
+| ALMA | small, medium | small, plus one large mosaic/cube superset | ALMA single-field and selected mosaic-capable request generation are supported; strict parity evidence currently covers ALMA single small |
 
 The registry also includes both single-field and mosaic families:
 
 | Family | Wave 1 modes | Status |
 |---|---|---|
 | single | standard MFS dirty, standard MFS clean, standard cube, MT-MFS sentinel | Native and CASA C++ small single-field ALMA parity is checked; cube spectral structure remains backlog #255 |
-| mosaic | mosaic MFS clean, mosaic cube bounded | CASA C++ generated datasets are usable now; native multi-field mosaic generation is backlog #254 |
+| mosaic | mosaic MFS clean, mosaic cube bounded | Native request generation covers the selected Wave 1 mosaic-capable shapes; broader native mosaic parity remains backlog #254 |
 | mosaic-large | all selected Wave 1 modes | one ALMA large-tier superset backs all logical large workloads |
 
 The native blocked/request-plan statuses are intentional for unsupported
@@ -198,7 +198,7 @@ materializing the 100 GiB MeasurementSet:
 ```sh
 tools/perf/imager/stage_wave1_datasets.py \
   --data-root "$CASA_RS_IMPERF_DATA_ROOT" \
-  --dataset wave1-alma-shared-large \
+  --dataset wave1-alma-mosaic-large \
   --materialize-workloads
 ```
 
@@ -207,7 +207,7 @@ tools/perf/imager/stage_wave1_datasets.py \
 - Deterministic generation path or registry entry for selected mode/tier
   combinations: `wave1_dataset_registry.json` plus CASA C++ simulation plans;
   the large tier intentionally maps all selected modes to
-  `wave1-alma-shared-large`.
+  `wave1-alma-mosaic-large`.
 - Metadata needed to reproduce benchmark workloads: generated dataset plan,
   source model files, spectral profile, and simulation request plans.
 - Provenance, size, checksum, path, and tier policy: this document plus the

--- a/docs/tutorial-parity/imperformance-wave-1-datasets.md
+++ b/docs/tutorial-parity/imperformance-wave-1-datasets.md
@@ -1,0 +1,162 @@
+# ImPerformance Wave 1 Simulated Dataset Plan
+
+Truth class: current descriptive
+Last reality check: 2026-05-14
+Verification: `tools/perf/imager/stage_wave1_datasets.py --dry-run --data-root /Volumes/GLENDENNING/casa-rs-imperformance --output-dir target/imperformance-wave1/dataset-dry-run`; `tools/perf/imager/stage_wave1_datasets.py --dry-run --data-root /tmp/casa-rs-imperformance --dataset wave1-vla-single-small --output-dir target/imperformance-wave1/dataset-small-dry-run`; `tools/perf/imager/stage_wave1_datasets.py --data-root /tmp/casa-rs-imperformance --dataset wave1-vla-single-small --materialize-models --materialize-workloads --output-dir target/imperformance-wave1/dataset-small-materialized`; `tools/perf/imager/run_workload.py --dry-run --output-dir target/imperformance-wave1/generated-workload-dry-run target/imperformance-wave1/dataset-small-materialized/workloads/wave1-vla-single-small-standard-mfs-dirty-control.json`; `just docs-check`; `just quick`
+
+Wave issue: #246
+Child issue: #248
+
+This note defines the deterministic simulated data inputs for ImPerformance
+Wave 1. The goal is to benchmark imaging behavior, not calibration behavior.
+The datasets therefore use visually interesting deterministic sky models, a
+realistic but simple noise term, and explicit CASA C++ versus `casa-rs`
+simulation request plans.
+
+## Size Tiers
+
+The first performance wave uses three memory-pressure tiers:
+
+| Tier | Approximate staged MS size | Storage intent | Default policy |
+|---|---:|---|---|
+| small | `1 GiB` | much smaller than memory | may live under any explicit `CASA_RS_IMPERF_DATA_ROOT` |
+| medium | `32 GiB` | about memory on this workstation | stage under `/Volumes/GLENDENNING` unless explicitly overridden |
+| large | `100 GiB` | larger than memory on this workstation | stage under `/Volumes/GLENDENNING` unless explicitly overridden |
+
+Generated MeasurementSets are not committed to git. The checked-in artifact is
+the registry and staging tool:
+
+- registry: `tools/perf/imager/wave1_dataset_registry.json`
+- staging/preflight tool: `tools/perf/imager/stage_wave1_datasets.py`
+
+The staging root is always explicit. Set `CASA_RS_IMPERF_DATA_ROOT` or pass
+`--data-root`. The tool does not add a personal workstation fallback.
+
+## Instruments And Families
+
+The registry includes both VLA and ALMA simulated datasets:
+
+| Instrument | Single-field datasets | Mosaic datasets | Native `casa-rs` simulation status |
+|---|---:|---:|---|
+| VLA | small, medium, large | small, medium, large | VLA single-field is supported by the existing native `simobserve` path |
+| ALMA | small, medium, large | small, medium, large | request-plan-only until ALMA simulation parity is checked |
+
+The registry also includes both single-field and mosaic families:
+
+| Family | Wave 1 modes | Status |
+|---|---|---|
+| single | standard MFS dirty, standard MFS clean, standard cube, MT-MFS sentinel | usable first for VLA single-field; ALMA request plans are emitted for parity work |
+| mosaic | mosaic MFS clean, mosaic cube bounded | planned and preflighted; true multi-field native simulation is blocked by the current one-FIELD simulator |
+
+The blocked mosaic status is intentional. It prevents the benchmark program
+from claiming a generated mosaic dataset before either CASA-side staged mosaic
+generation or native multi-field MS generation exists.
+
+## Source Model
+
+The continuum model is deterministic and deliberately nontrivial:
+
+- bright compact core;
+- faint offset compact sources;
+- two extended spiral arms;
+- partial ring;
+- broad diffuse halo.
+
+The cube profile is also deterministic and includes frequency structure:
+
+- continuum baseline with spectral index;
+- central broad emission line;
+- offset narrow emission line;
+- absorption notch against the core;
+- weak velocity-gradient metadata for the extended arms.
+
+The current native simulator reads a single FITS plane. The staging tool
+therefore writes a continuum FITS model plus a spectral-profile JSON file. Cube
+benchmarks must record whether the spectral profile was applied by CASA
+simulation, by a future native cube-model predictor, or was unavailable.
+
+## Simulation Parity And Performance Checks
+
+Each staged dataset plan includes:
+
+- a `casars-simobserve.json` request for the native task protocol;
+- a `casa-simulation-plan.json` describing the matching CASA C++ simulation
+  work to run or mark blocked;
+- model/source provenance, shape, noise, storage, and selected-mode metadata.
+
+The simulation comparison is part of #248/#251 evidence because generated data
+becomes benchmark input. The comparison must record:
+
+- CASA C++ simulation status: ran, skipped, or blocked with reason;
+- `casa-rs` simulation status: ran, skipped, or blocked with reason;
+- simulation wallclock for each side when it ran;
+- row count, channel count, UVW/time/data sanity statistics;
+- model/source checksums.
+
+This is not a calibration benchmark. The noise term is simple deterministic
+complex visibility noise, tuned to make images realistic enough for repeated
+inspection without adding calibration-solver scope.
+
+## Commands
+
+Dry-run the full registry using the external drive root:
+
+```sh
+tools/perf/imager/stage_wave1_datasets.py \
+  --dry-run \
+  --data-root /Volumes/GLENDENNING/casa-rs-imperformance \
+  --output-dir target/imperformance-wave1/dataset-dry-run
+```
+
+Dry-run only the small VLA single-field dataset on a temporary root:
+
+```sh
+tools/perf/imager/stage_wave1_datasets.py \
+  --dry-run \
+  --data-root /tmp/casa-rs-imperformance \
+  --dataset wave1-vla-single-small \
+  --output-dir target/imperformance-wave1/dataset-small-dry-run
+```
+
+Materialize source models and generated benchmark workload manifests for one
+dataset:
+
+```sh
+tools/perf/imager/stage_wave1_datasets.py \
+  --data-root "$CASA_RS_IMPERF_DATA_ROOT" \
+  --dataset wave1-vla-single-small \
+  --materialize-models \
+  --materialize-workloads
+```
+
+Medium and large tiers require a root under `/Volumes/GLENDENNING` by default:
+
+```sh
+CASA_RS_IMPERF_DATA_ROOT=/Volumes/GLENDENNING/casa-rs-imperformance \
+tools/perf/imager/stage_wave1_datasets.py --dry-run
+```
+
+Use `--allow-non-external-large-root` only for a deliberate one-off override.
+
+## Issue #248 Acceptance Mapping
+
+- Deterministic generation path or registry entry for selected mode/tier
+  combinations: `wave1_dataset_registry.json`.
+- Metadata needed to reproduce benchmark workloads: generated dataset plan,
+  source model files, spectral profile, and simulation request plans.
+- Provenance, size, checksum, path, and tier policy: this document plus the
+  generated `wave1-dataset-plan.json`.
+- Clear preflight failures: missing `CASA_RS_IMPERF_DATA_ROOT`, medium/large
+  root outside `/Volumes/GLENDENNING`, and unsupported mosaic native simulation
+  are explicit statuses.
+- Shared-data policy: explicit root only; no bulky generated data in git.
+- Performance tier intent: small, memory-sized, and larger-than-memory staged
+  datasets.
+
+## Stop Conditions Preserved
+
+The current tool does not widen native simulation semantics. It records blocked
+status for true native mosaic generation and request-plan-only status for ALMA
+until those paths have CASA parity evidence. Implementing multi-field native
+simulation, CASA `simalma` parity, or a native cube-model predictor should be a
+separate approved scope change if the wave needs it before baseline timing.

--- a/docs/tutorial-parity/imperformance-wave-1-datasets.md
+++ b/docs/tutorial-parity/imperformance-wave-1-datasets.md
@@ -10,8 +10,11 @@ Child issue: #248
 This note defines the deterministic simulated data inputs for ImPerformance
 Wave 1. The goal is to benchmark imaging behavior, not calibration behavior.
 The datasets therefore use visually interesting deterministic sky models, a
-realistic but simple noise term, and explicit CASA C++ versus `casa-rs`
-simulation request plans.
+realistic but simple noise term, and explicit CASA C++ generation plans.
+
+For Wave 1, CASA C++ is allowed to be the dataset generator of record. Native
+`casa-rs` simulation gaps discovered by this plan are tracked as backlog issues
+instead of blocking benchmark dataset staging.
 
 ## Size Tiers
 
@@ -34,23 +37,24 @@ The staging root is always explicit. Set `CASA_RS_IMPERF_DATA_ROOT` or pass
 
 ## Instruments And Families
 
-The registry includes both VLA and ALMA simulated datasets:
+The registry includes both VLA and ALMA simulated datasets. CASA C++ generation
+is the current path for all Wave 1 benchmark datasets.
 
 | Instrument | Single-field datasets | Mosaic datasets | Native `casa-rs` simulation status |
 |---|---:|---:|---|
-| VLA | small, medium, large | small, medium, large | VLA single-field is supported by the existing native `simobserve` path |
+| VLA | small, medium, large | small, medium, large | VLA single-field single-plane is supported by the existing native `simobserve` path; native cube spectral structure and true mosaic generation are backlog |
 | ALMA | small, medium, large | small, medium, large | request-plan-only until ALMA simulation parity is checked |
 
 The registry also includes both single-field and mosaic families:
 
 | Family | Wave 1 modes | Status |
 |---|---|---|
-| single | standard MFS dirty, standard MFS clean, standard cube, MT-MFS sentinel | usable first for VLA single-field; ALMA request plans are emitted for parity work |
-| mosaic | mosaic MFS clean, mosaic cube bounded | planned and preflighted; true multi-field native simulation is blocked by the current one-FIELD simulator |
+| single | standard MFS dirty, standard MFS clean, standard cube, MT-MFS sentinel | CASA C++ generated datasets are usable now; native spectral cube model prediction is backlog #255 |
+| mosaic | mosaic MFS clean, mosaic cube bounded | CASA C++ generated datasets are usable now; native multi-field mosaic generation is backlog #254 |
 
-The blocked mosaic status is intentional. It prevents the benchmark program
-from claiming a generated mosaic dataset before either CASA-side staged mosaic
-generation or native multi-field MS generation exists.
+The native blocked/request-plan statuses are intentional. They prevent the
+benchmark program from claiming native simulation capability while allowing the
+performance wave to proceed from CASA C++ generated datasets.
 
 ## Source Model
 
@@ -71,17 +75,18 @@ The cube profile is also deterministic and includes frequency structure:
 - weak velocity-gradient metadata for the extended arms.
 
 The current native simulator reads a single FITS plane. The staging tool
-therefore writes a continuum FITS model plus a spectral-profile JSON file. Cube
-benchmarks must record whether the spectral profile was applied by CASA
-simulation, by a future native cube-model predictor, or was unavailable.
+therefore writes a continuum FITS model plus a spectral-profile JSON file.
+CASA C++ dataset generation must apply the spectral profile for cube benchmark
+datasets. Native use of the spectral profile is backlog #255.
 
 ## Simulation Parity And Performance Checks
 
 Each staged dataset plan includes:
 
-- a `casars-simobserve.json` request for the native task protocol;
-- a `casa-simulation-plan.json` describing the matching CASA C++ simulation
-  work to run or mark blocked;
+- a `casa-simulation-plan.json` describing the CASA C++ simulation work to run
+  for the Wave 1 benchmark dataset;
+- a `casars-simobserve.json` request for native capability comparison where
+  supported;
 - model/source provenance, shape, noise, storage, and selected-mode metadata.
 
 The simulation comparison is part of #248/#251 evidence because generated data
@@ -96,6 +101,17 @@ becomes benchmark input. The comparison must record:
 This is not a calibration benchmark. The noise term is simple deterministic
 complex visibility noise, tuned to make images realistic enough for repeated
 inspection without adding calibration-solver scope.
+
+## Native Simulation Follow-Ups
+
+Native simulation is not on the critical path for Wave 1 dataset generation.
+The missing capabilities are tracked separately:
+
+- #254: native multi-field mosaic simulation generation.
+- #255: native spectral cube model simulation.
+- #180: ALMA protoplanetary-disk simulation breadth.
+- #181: simalma workflow parity.
+- #182: ACA simulation parity.
 
 ## Commands
 
@@ -141,22 +157,21 @@ Use `--allow-non-external-large-root` only for a deliberate one-off override.
 ## Issue #248 Acceptance Mapping
 
 - Deterministic generation path or registry entry for selected mode/tier
-  combinations: `wave1_dataset_registry.json`.
+  combinations: `wave1_dataset_registry.json` plus CASA C++ simulation plans.
 - Metadata needed to reproduce benchmark workloads: generated dataset plan,
   source model files, spectral profile, and simulation request plans.
 - Provenance, size, checksum, path, and tier policy: this document plus the
   generated `wave1-dataset-plan.json`.
 - Clear preflight failures: missing `CASA_RS_IMPERF_DATA_ROOT`, medium/large
-  root outside `/Volumes/GLENDENNING`, and unsupported mosaic native simulation
-  are explicit statuses.
+  root outside `/Volumes/GLENDENNING`, and native simulation gaps are explicit
+  statuses with follow-up issues.
 - Shared-data policy: explicit root only; no bulky generated data in git.
 - Performance tier intent: small, memory-sized, and larger-than-memory staged
   datasets.
 
 ## Stop Conditions Preserved
 
-The current tool does not widen native simulation semantics. It records blocked
-status for true native mosaic generation and request-plan-only status for ALMA
-until those paths have CASA parity evidence. Implementing multi-field native
-simulation, CASA `simalma` parity, or a native cube-model predictor should be a
-separate approved scope change if the wave needs it before baseline timing.
+The current tool does not widen native simulation semantics. It records native
+gaps while allowing CASA C++ generation for Wave 1 datasets. Implementing
+multi-field native simulation, CASA `simalma` parity, ALMA/ACA native parity,
+or a native cube-model predictor should be separate approved scope.

--- a/docs/tutorial-parity/imperformance-wave-1-mode-selection.md
+++ b/docs/tutorial-parity/imperformance-wave-1-mode-selection.md
@@ -69,7 +69,7 @@ Interpretation:
 |---|---|---|---|
 | `standard-mfs-dirty-control` | `specmode='mfs'`, `gridder='standard'`, dirty-only | Fast control case for harness overhead, gridding, FFT, normalization, and product write cost. | Benchmark and keep near or faster than CASA C++. |
 | `standard-mfs-clean-current` | `specmode='mfs'`, `gridder='standard'`, `deconvolver='multiscale'`, optional `auto-multithresh` | Current single-field continuum practice; covers major/minor-cycle overhead without PB/mosaic cost. | Benchmark, correctness check, and stage budget. |
-| `standard-cube-line` | `specmode='cube'`, `gridder='standard'`, dirty and bounded clean variants | Current spectral-line practice; separates per-channel scaling from mosaic/PB overhead. | Benchmark and identify cube scaling budget without using #56 runtime controls. |
+| `standard-cube-line` | `specmode='cube'`, `gridder='standard'`, dirty and bounded clean variants | Current spectral-line practice; includes deconvolution coverage while separating per-channel scaling from mosaic/PB overhead. | Benchmark dirty and bounded-clean variants; identify cube scaling budget without using #56 runtime controls. |
 | `mosaic-mfs-clean-primary` | `specmode='mfs'`, `gridder='mosaic'`, multiscale clean, PB products | Common ALMA/VLA tutorial mode and current high-leverage slow area in `casa-rs`. | Primary follow-on optimization target. |
 | `mosaic-cube-bounded` | `specmode='cube'`, `gridder='mosaic'`, small channel count first | Exercises the expensive interaction between cube scaling, mosaic/PB work, and product generation. | Bounded benchmark and bottleneck ledger; large-cube controls stay with #56. |
 | `mtmfs-wideband-sentinel` | `specmode='mfs'`, `deconvolver='mtmfs'`, `nterms > 1` | Current wideband continuum algorithm family; useful to keep in view before backend planning hardens. | Baseline-only sentinel unless it becomes the dominant bottleneck. |
@@ -81,7 +81,7 @@ Interpretation:
 | W-projection speed work | Deferred | `casa-rs` exposes a W-term request path, but Wave 1 should not turn W-projection into the first optimization target without baseline evidence and a supported CASA comparison harness. |
 | AW/widefield gridder family | Deferred to #52 | Capability surface and CF-planning controls belong to #52. Wave 1 should leave hooks for future backend/resource planning but not implement AW. |
 | CASA-like `parallel` / `chanchunks` | Deferred to #56 | User-visible large-cube runtime controls already have an owner. Wave 1 can measure cube scaling but should not add these controls. |
-| GPU/Kokkos/CUDA execution | Deferred | LibRA shows that a backend/resource boundary is useful, but Wave 1 should not introduce GPU dependencies or runtime behavior. |
+| GPU/Kokkos/CUDA implementation | Not a mode; defer from #247 mode selection | LibRA suggests that a backend/resource boundary is useful, and Wave 1 should keep GPU-readiness in view. This ticket should not add GPU dependencies or runtime behavior before the benchmark modes and stage budgets exist. |
 | Distributed execution | Deferred | Not needed for first local CASA C++ versus `casa-rs` wallclock baselines. |
 
 ## Workload Shapes
@@ -93,7 +93,7 @@ owned by #252. These shapes define what those tickets must support.
 |---|---|---|---|---|---|
 | `standard-mfs-dirty-control` | small, medium, large | deterministic single-field continuum simulation | 512, 2048, and 4096 pixel images; one MFS plane | dirty-only, natural and Briggs variants | `.psf`, `.residual`, `.image`, timing JSON |
 | `standard-mfs-clean-current` | small, medium, large | deterministic single-field continuum with compact plus extended structure | 512, 2048, and 4096 pixel images | multiscale scales including zero; bounded `niter`; `auto-multithresh` on at least medium | `.psf`, `.residual`, `.model`, `.image`, `.sumwt`, timing JSON |
-| `standard-cube-line` | small, medium, large | deterministic spectral-line cube with known line structure | 16, 64, and 256 channels; 512 to 2048 pixel images | dirty-only plus bounded multiscale/automask clean | cube `.psf`, `.residual`, `.image`, optional `.model`, timing JSON |
+| `standard-cube-line` | small, medium, large | deterministic spectral-line cube with known line structure | 16, 64, and 256 channels; 512 to 2048 pixel images | dirty-only plus bounded multiscale/auto-multithresh clean | cube `.psf`, `.residual`, `.image`, `.model` for clean variants, timing JSON |
 | `mosaic-mfs-clean-primary` | small, medium, large | deterministic mosaic with overlapping pointings; include one real tutorial case | 512, 2048, and tutorial-scale images | multiscale clean; PB products enabled; Briggs weighting | `.psf`, `.residual`, `.model`, `.image`, `.image.pbcor`, `.pb`, timing JSON |
 | `mosaic-cube-bounded` | small, medium | deterministic line mosaic | 8 and 32 channels; 512 to 1024 pixel images | dirty-only plus short clean probe | cube products, PB products where supported, timing JSON |
 | `mtmfs-wideband-sentinel` | medium | wideband continuum simulation | 2048 pixel image; `nterms=2` initially | MT-MFS bounded clean; multiscale sentinel if already supported by path | Taylor-term products, alpha products, timing JSON |
@@ -107,7 +107,7 @@ wallclock. It should fail if it cannot produce trustworthy evidence.
 |---|---|---|
 | `standard-mfs-dirty-control` | median wallclock ratio, stage budget, correctness delta | 10x CASA C++ stretch target after backend/workspace work. |
 | `standard-mfs-clean-current` | median wallclock ratio, major/minor-cycle budget, correctness delta | 10x target for practical single-field continuum workflows. |
-| `standard-cube-line` | per-channel scaling, wallclock ratio, correctness delta | 10x target after cube dataflow and backend work; #56 owns user-visible chunk/parallel controls. |
+| `standard-cube-line` | dirty and bounded-clean per-channel scaling, wallclock ratio, correctness delta | 10x target after cube dataflow and backend work; #56 owns user-visible chunk/parallel controls. |
 | `mosaic-mfs-clean-primary` | primary bottleneck ledger plus CASA C++ ratio | First follow-on optimization target because previous evidence showed mosaic/CLEAN slower than CASA and the mode is current practice. |
 | `mosaic-cube-bounded` | bounded scaling and PB/product cost ledger | Decide whether the next ticket is mosaic gridding, PB/product writeback, or cube runtime controls. |
 | `mtmfs-wideband-sentinel` | baseline-only unless unexpectedly dominant | Keep wideband continuum visible before backend structure hardens. |
@@ -125,6 +125,10 @@ Rationale:
   CASA C++ while standard MFS dirty imaging was close to CASA.
 - The path is likely to exercise the same structural seams needed for later
   cube, PB, workspace residency, backend, and GPU work.
+
+The target is workload-level. The implementation path may be CPU dataflow
+repair, GPU/backend preparation, or both, depending on #251 stage evidence. Do
+not assume that CPU-only work can reach the long-term 10x target.
 
 If #251 shows that the dominant cost is MS/table preparation, image writing, or
 preview generation instead of imaging proper, split the follow-on target before

--- a/docs/tutorial-parity/imperformance-wave-1-mode-selection.md
+++ b/docs/tutorial-parity/imperformance-wave-1-mode-selection.md
@@ -1,0 +1,144 @@
+# ImPerformance Wave 1 Mode Selection
+
+Truth class: current descriptive
+Last reality check: 2026-05-14
+Verification: just docs-check; just quick
+
+Wave issue: #246
+Child issue: #247
+
+This note fixes the first benchmark targets for ImPerformance Wave 1. The goal
+is not to cover every CASA `tclean` mode. The goal is to pick a small set of
+current, real imaging use cases that can support reproducible CASA C++ versus
+`casa-rs` timing, correctness checks, and stage budgets before optimization
+work starts.
+
+## Current-Practice Signals
+
+The local RadioAstronomyOracle corpus does not provide a statistical survey of
+all current reductions. It does provide current 2024 tutorial and Synthesis
+Imaging Workshop signals about common practice:
+
+- ALMA pipeline material shows a standard imaging recipe that runs continuum
+  and line-imaging flows through `hifmakeimlist` / `hifmakeimages`, with
+  `specmode='mfs'` appearing early in the pipeline recipe. Citation:
+  `ALMA-Pipeline-tutorial-SISS2024.pdf, slide 15`.
+- ALMA manual tutorial material uses `tclean` with `specmode='mfs'`,
+  `gridder='standard'`, Briggs weighting, and Hogbom Clean for a compact
+  calibrator-style example. Citation: `ALMA-Manual-tutorial-SISS2024.pdf,
+  slide 137`.
+- The same 2024 ALMA tutorial uses standard-gridder MFS continuum imaging with
+  `deconvolver='multiscale'`, Briggs weighting, and large image sizes for
+  science-target continuum. Citation: `ALMA-Manual-tutorial-SISS2024.pdf,
+  slide 145`.
+- The ALMA line-imaging example uses `specmode='cube'`,
+  `deconvolver='multiscale'`, `restoringbeam='common'`,
+  `weighting='briggsbwtaper'`, and `perchanweightdensity=True`. Citation:
+  `ALMA-Manual-tutorial-SISS2024.pdf, slide 155`.
+- 2024 mosaicking material says that joint mosaic imaging uses
+  `gridder='mosaic'`, recommends `mosweight=True`, and recommends
+  `perchanwtdensity=True` plus `briggsbwtaper=True` for cubes. It also says
+  `gridder='mosaic'` is necessary for heterogeneous-array imaging in CASA
+  `tclean`. Citation: `Plunket-Mosaicking2024.pdf, slide 34`.
+- 2024 wideband material identifies CASA MT-MFS as one of the main wideband
+  deconvolution algorithms and notes compatibility with multiscale
+  deconvolution. Citation: `Marvil_Wideband2024.pdf, slide 19`.
+- 2024 ALMA tutorial material describes `auto-multithresh` as available in
+  `tclean` since CASA 5.1 and deployed in the ALMA Cycle 5 pipeline. Citation:
+  `ALMA-Manual-tutorial-SISS2024.pdf, slide 122`.
+
+Interpretation:
+
+- Single-field `standard` MFS remains a core control case.
+- Spectral-line cube imaging is a first-class current workload, not a corner
+  case.
+- `multiscale` and `auto-multithresh` should be treated as current-practice
+  clean workloads, not optional embellishments.
+- Mosaic imaging is common enough, and expensive enough in current `casa-rs`
+  evidence, to be a primary performance target.
+- MT-MFS is important for wideband continuum, but should be a Wave 1 sentinel
+  workload rather than the first optimization target unless baseline evidence
+  makes it dominant.
+- W-projection and AW/widefield imaging matter, but the existing #52 surface is
+  the right owner for AW/widefield capability. Wave 1 should avoid making #52 a
+  hidden prerequisite.
+
+## Selected Wave 1 Modes
+
+| ID | Mode | Why it is in Wave 1 | Target status |
+|---|---|---|---|
+| `standard-mfs-dirty-control` | `specmode='mfs'`, `gridder='standard'`, dirty-only | Fast control case for harness overhead, gridding, FFT, normalization, and product write cost. | Benchmark and keep near or faster than CASA C++. |
+| `standard-mfs-clean-current` | `specmode='mfs'`, `gridder='standard'`, `deconvolver='multiscale'`, optional `auto-multithresh` | Current single-field continuum practice; covers major/minor-cycle overhead without PB/mosaic cost. | Benchmark, correctness check, and stage budget. |
+| `standard-cube-line` | `specmode='cube'`, `gridder='standard'`, dirty and bounded clean variants | Current spectral-line practice; separates per-channel scaling from mosaic/PB overhead. | Benchmark and identify cube scaling budget without using #56 runtime controls. |
+| `mosaic-mfs-clean-primary` | `specmode='mfs'`, `gridder='mosaic'`, multiscale clean, PB products | Common ALMA/VLA tutorial mode and current high-leverage slow area in `casa-rs`. | Primary follow-on optimization target. |
+| `mosaic-cube-bounded` | `specmode='cube'`, `gridder='mosaic'`, small channel count first | Exercises the expensive interaction between cube scaling, mosaic/PB work, and product generation. | Bounded benchmark and bottleneck ledger; large-cube controls stay with #56. |
+| `mtmfs-wideband-sentinel` | `specmode='mfs'`, `deconvolver='mtmfs'`, `nterms > 1` | Current wideband continuum algorithm family; useful to keep in view before backend planning hardens. | Baseline-only sentinel unless it becomes the dominant bottleneck. |
+
+## Deferred Or Blocked Modes
+
+| Mode family | Status | Reason |
+|---|---|---|
+| W-projection speed work | Deferred | `casa-rs` exposes a W-term request path, but Wave 1 should not turn W-projection into the first optimization target without baseline evidence and a supported CASA comparison harness. |
+| AW/widefield gridder family | Deferred to #52 | Capability surface and CF-planning controls belong to #52. Wave 1 should leave hooks for future backend/resource planning but not implement AW. |
+| CASA-like `parallel` / `chanchunks` | Deferred to #56 | User-visible large-cube runtime controls already have an owner. Wave 1 can measure cube scaling but should not add these controls. |
+| GPU/Kokkos/CUDA execution | Deferred | LibRA shows that a backend/resource boundary is useful, but Wave 1 should not introduce GPU dependencies or runtime behavior. |
+| Distributed execution | Deferred | Not needed for first local CASA C++ versus `casa-rs` wallclock baselines. |
+
+## Workload Shapes
+
+Exact datasets will be created or wired by #248. Exact harness manifests will be
+owned by #252. These shapes define what those tickets must support.
+
+| Mode ID | Size tier | Dataset style | Image / channel shape | Clean settings | Expected products |
+|---|---|---|---|---|---|
+| `standard-mfs-dirty-control` | small, medium, large | deterministic single-field continuum simulation | 512, 2048, and 4096 pixel images; one MFS plane | dirty-only, natural and Briggs variants | `.psf`, `.residual`, `.image`, timing JSON |
+| `standard-mfs-clean-current` | small, medium, large | deterministic single-field continuum with compact plus extended structure | 512, 2048, and 4096 pixel images | multiscale scales including zero; bounded `niter`; `auto-multithresh` on at least medium | `.psf`, `.residual`, `.model`, `.image`, `.sumwt`, timing JSON |
+| `standard-cube-line` | small, medium, large | deterministic spectral-line cube with known line structure | 16, 64, and 256 channels; 512 to 2048 pixel images | dirty-only plus bounded multiscale/automask clean | cube `.psf`, `.residual`, `.image`, optional `.model`, timing JSON |
+| `mosaic-mfs-clean-primary` | small, medium, large | deterministic mosaic with overlapping pointings; include one real tutorial case | 512, 2048, and tutorial-scale images | multiscale clean; PB products enabled; Briggs weighting | `.psf`, `.residual`, `.model`, `.image`, `.image.pbcor`, `.pb`, timing JSON |
+| `mosaic-cube-bounded` | small, medium | deterministic line mosaic | 8 and 32 channels; 512 to 1024 pixel images | dirty-only plus short clean probe | cube products, PB products where supported, timing JSON |
+| `mtmfs-wideband-sentinel` | medium | wideband continuum simulation | 2048 pixel image; `nterms=2` initially | MT-MFS bounded clean; multiscale sentinel if already supported by path | Taylor-term products, alpha products, timing JSON |
+
+## Target Style
+
+Wave 1 should not fail because `casa-rs` has not yet reached 10x CASA C++
+wallclock. It should fail if it cannot produce trustworthy evidence.
+
+| Mode ID | Wave 1 target style | Long-term target direction |
+|---|---|---|
+| `standard-mfs-dirty-control` | median wallclock ratio, stage budget, correctness delta | 10x CASA C++ stretch target after backend/workspace work. |
+| `standard-mfs-clean-current` | median wallclock ratio, major/minor-cycle budget, correctness delta | 10x target for practical single-field continuum workflows. |
+| `standard-cube-line` | per-channel scaling, wallclock ratio, correctness delta | 10x target after cube dataflow and backend work; #56 owns user-visible chunk/parallel controls. |
+| `mosaic-mfs-clean-primary` | primary bottleneck ledger plus CASA C++ ratio | First follow-on optimization target because previous evidence showed mosaic/CLEAN slower than CASA and the mode is current practice. |
+| `mosaic-cube-bounded` | bounded scaling and PB/product cost ledger | Decide whether the next ticket is mosaic gridding, PB/product writeback, or cube runtime controls. |
+| `mtmfs-wideband-sentinel` | baseline-only unless unexpectedly dominant | Keep wideband continuum visible before backend structure hardens. |
+
+## First Follow-On Optimization Target
+
+The first optimization ticket after Wave 1 should target
+`mosaic-mfs-clean-primary` unless #251 produces contrary evidence.
+
+Rationale:
+
+- Current-practice sources make mosaic imaging a normal `tclean` workload, not
+  a niche path.
+- Existing Wave 7 evidence already showed mosaic/CLEAN workloads slower than
+  CASA C++ while standard MFS dirty imaging was close to CASA.
+- The path is likely to exercise the same structural seams needed for later
+  cube, PB, workspace residency, backend, and GPU work.
+
+If #251 shows that the dominant cost is MS/table preparation, image writing, or
+preview generation instead of imaging proper, split the follow-on target before
+optimizing.
+
+## Issue #247 Acceptance Mapping
+
+- Selected modes, excluded modes, and rationale: this document, sections
+  "Selected Wave 1 Modes" and "Deferred Or Blocked Modes".
+- Workload shapes: section "Workload Shapes".
+- Target styles: section "Target Style".
+- Blocked/deferred cases: section "Deferred Or Blocked Modes".
+- Existing surface mapping: the selected modes map to existing
+  `casars-imager` / `casa-imaging` surfaces except where marked as sentinel or
+  deferred.
+- First follow-on optimization target: section "First Follow-On Optimization
+  Target".

--- a/docs/tutorial-parity/imperformance-wave-1-mode-selection.md
+++ b/docs/tutorial-parity/imperformance-wave-1-mode-selection.md
@@ -87,16 +87,19 @@ Interpretation:
 ## Workload Shapes
 
 Exact datasets will be created or wired by #248. Exact harness manifests will be
-owned by #252. These shapes define what those tickets must support.
+owned by #252. These shapes define what those tickets must support. The large
+tier is a storage-constrained exception: all large logical workloads select
+from one shared ALMA mosaic/cube superset rather than from separate 100 GiB
+single-field and mosaic MeasurementSets.
 
 | Mode ID | Size tier | Dataset style | Image / channel shape | Clean settings | Expected products |
 |---|---|---|---|---|---|
-| `standard-mfs-dirty-control` | small, medium, large | deterministic single-field continuum simulation | 512, 2048, and 4096 pixel images; one MFS plane | dirty-only, natural and Briggs variants | `.psf`, `.residual`, `.image`, timing JSON |
-| `standard-mfs-clean-current` | small, medium, large | deterministic single-field continuum with compact plus extended structure | 512, 2048, and 4096 pixel images | multiscale scales including zero; bounded `niter`; `auto-multithresh` on at least medium | `.psf`, `.residual`, `.model`, `.image`, `.sumwt`, timing JSON |
-| `standard-cube-line` | small, medium, large | deterministic spectral-line cube with known line structure | 16, 64, and 256 channels; 512 to 2048 pixel images | dirty-only plus bounded multiscale/auto-multithresh clean | cube `.psf`, `.residual`, `.image`, `.model` for clean variants, timing JSON |
-| `mosaic-mfs-clean-primary` | small, medium, large | deterministic mosaic with overlapping pointings; include one real tutorial case | 512, 2048, and tutorial-scale images | multiscale clean; PB products enabled; Briggs weighting | `.psf`, `.residual`, `.model`, `.image`, `.image.pbcor`, `.pb`, timing JSON |
-| `mosaic-cube-bounded` | small, medium | deterministic line mosaic | 8 and 32 channels; 512 to 1024 pixel images | dirty-only plus short clean probe | cube products, PB products where supported, timing JSON |
-| `mtmfs-wideband-sentinel` | medium | wideband continuum simulation | 2048 pixel image; `nterms=2` initially | MT-MFS bounded clean; multiscale sentinel if already supported by path | Taylor-term products, alpha products, timing JSON |
+| `standard-mfs-dirty-control` | small, medium, large-shared | deterministic single-field continuum simulation; large selects field `0` from the shared ALMA superset | 512, 2048, and 4096 pixel images; MFS over the available channel range | dirty-only, natural and Briggs variants | `.psf`, `.residual`, `.image`, timing JSON |
+| `standard-mfs-clean-current` | small, medium, large-shared | deterministic single-field continuum with compact plus extended structure; large selects field `0` from the shared ALMA superset | 512, 2048, and 4096 pixel images | multiscale scales including zero; bounded `niter`; `auto-multithresh` on at least medium | `.psf`, `.residual`, `.model`, `.image`, `.sumwt`, timing JSON |
+| `standard-cube-line` | small, medium, large-shared | deterministic spectral-line cube with known line structure; large selects field `0` from the shared ALMA superset | 16, 64, and 256 channels; 512 to 4096 pixel images | dirty-only plus bounded multiscale/auto-multithresh clean | cube `.psf`, `.residual`, `.image`, `.model` for clean variants, timing JSON |
+| `mosaic-mfs-clean-primary` | small, medium, large-shared | deterministic mosaic with overlapping pointings; large uses all fields from the shared ALMA superset | 512, 2048, and 4096 pixel images | multiscale clean; PB products enabled; Briggs weighting | `.psf`, `.residual`, `.model`, `.image`, `.image.pbcor`, `.pb`, timing JSON |
+| `mosaic-cube-bounded` | small, medium, large-shared bounded subset | deterministic line mosaic; large uses all fields but a bounded channel slice from the shared ALMA superset | 8, 32, and 32 selected channels; 512 to 4096 pixel images | dirty-only plus short clean probe | cube products, PB products where supported, timing JSON |
+| `mtmfs-wideband-sentinel` | medium, large-shared sentinel | wideband continuum simulation; large selects from the shared ALMA superset | 2048 to 4096 pixel image; `nterms=2` initially | MT-MFS bounded clean; multiscale sentinel if already supported by path | Taylor-term products, alpha products, timing JSON |
 
 ## Target Style
 

--- a/docs/tutorial-parity/imperformance-wave-1-stage-instrumentation.md
+++ b/docs/tutorial-parity/imperformance-wave-1-stage-instrumentation.md
@@ -1,0 +1,115 @@
+# ImPerformance Wave 1 Stage Instrumentation
+
+Truth class: current descriptive
+Last reality check: 2026-05-15
+Verification: `python3 -m py_compile tools/perf/imager/run_workload.py tools/perf/imager/test_run_workload.py`; `python3 -m unittest tools/perf/imager/test_run_workload.py`; `tools/perf/imager/run_workload.py --dry-run --output-dir target/imperformance-wave1/stage-instrumentation-dry-run wave1-standard-mfs-dirty-smoke`; `CASA_RS_TESTDATA_ROOT=/Users/brianglendenning/SoftwareProjects/casatestdata CASA_RS_CASA_PYTHON=/Users/brianglendenning/SoftwareProjects/casa-build/venv/bin/python tools/perf/imager/run_workload.py --repeats 1 --output-dir target/imperformance-wave1/stage-instrumentation-smoke wave1-standard-mfs-dirty-smoke`
+
+Wave issue: #246
+Child issue: #249
+
+This note records the Wave 1 stage-level timing surface used by the benchmark
+harness. The implementation does not add public task-protocol fields or managed
+output schema fields. It normalizes the existing Rust profiler and CASA phase
+probe output into the local benchmark result JSON under
+`results.stage_breakdown`.
+
+## Contract Review
+
+The structured timing object is local benchmark evidence:
+
+- producer: `tools/perf/imager/run_workload.py`
+- consumer: Wave 1 benchmark summaries and the #251 bottleneck ledger
+- persisted public format: none
+- provider protocol change: none
+- managed-output contract change: none
+
+If these fields are later promoted into `casars-imager` JSON task output,
+managed output, or provider contracts, that will need a separate contract
+review.
+
+## Rust Categories
+
+The normalized Rust timing categories are:
+
+| Category | Source timing fields | Purpose |
+|---|---|---|
+| `frontend_ms_preparation` | `open_measurement_set`, `prepare_plane_input`, `extract_phase_center` | MS open, selection, row adaptation, and phase-center resolution. |
+| `visibility_adaptation_and_chunking` | `prepare_plane_input` | Visibility adaptation before pure imaging. |
+| `weighting_density_setup` | `weighting` | Imaging weights, density grids, and taper setup. |
+| `projection_pb_cf_preparation` | none yet | Explicit non-zero-free placeholder; projection/PB setup currently lives inside lower-level selected-mode paths. |
+| `gridding_degridding` | `psf_grid`, `residual_degrid_grid` | PSF gridding plus residual degrid/grid work. |
+| `fft` | `psf_fft`, `model_fft`, `residual_fft` | PSF, model, and residual FFT work. |
+| `normalization_pb_correction` | `psf_normalize`, `residual_normalize` | PSF and residual normalization; PB correction is included when the selected mode produces PB products. |
+| `deconvolution_minor_cycle` | `minor_cycle_solve` | Minor-cycle component selection and subtraction. |
+| `model_prediction_and_residual_refresh` | `major_cycle_refresh` | Major-cycle model prediction and residual refresh aggregate. |
+| `restore_and_beam_fit` | `beam_fit`, `restore` | Restoring-beam fit and restored-image generation. |
+| `coordinate_and_product_writeback` | `build_coordinate_system`, `write_products` | Output coordinate construction and image product writeback. |
+| `preview_sidecar_generation` | none in harness | Explicitly skipped because benchmark runs pass `--no-preview-pngs`. |
+| `frontend_total` | `frontend_total` | Total frontend wallclock from the Rust profiler. |
+| `core_total` | `total` | Total pure imaging-core wallclock from the Rust profiler. |
+
+Each category reports `status`, `reason`, `total_ms`, `components_ms`,
+`source_fields`, and a short description. Clean-only categories are marked
+`skipped` for dirty-only or `niter=0` workloads instead of publishing a
+misleading zero-cost stage.
+
+## CASA Categories
+
+The CASA side is a comparison probe, not the source of the `casa-rs`
+instrumentation contract. The normalized CASA categories are:
+
+- `setup_and_tool_construction`
+- `weighting_density_setup`
+- `psf_and_primary_beam`
+- `major_cycle_residual`
+- `deconvolution_minor_cycle`
+- `restore_and_cleanup`
+- `total`
+
+CASA cannot currently expose the same grid, FFT, normalization, and PB
+sub-stages through this probe, so the Rust categories are the canonical #249
+surface for choosing `casa-rs` optimization ownership.
+
+## Smoke Evidence
+
+The local one-repeat dirty-control smoke run completed with:
+
+- Rust CLI median: `0.926705 s`
+- CASA `tclean` median: `0.131690 s`
+- `results.stage_breakdown.schema_version`: `1`
+- Rust frontend/MS preparation: `38.485 ms`
+- Rust visibility adaptation/chunking: `37.356 ms`
+- Rust gridding/degridding: `0.600 ms`
+- Rust FFT: `0.424 ms`
+- Rust normalization/PB correction: `0.028 ms`
+- Rust coordinate/product writeback: `6.280 ms`
+- Rust deconvolution and model-prediction refresh: `skipped` for dirty-only
+- Preview sidecars: `skipped` because previews are disabled in benchmark runs
+
+This smoke workload is intentionally small and mostly measures harness shape.
+The 1 GiB / 32 GiB / 100 GiB simulated datasets will provide the Wave 1
+baseline matrix in #251.
+
+## Overhead Boundary
+
+The #249 implementation does not add timers to the hot imaging loops. It
+reuses timings already produced by `profile_imager` and `casa_phase_bench.py`,
+then performs a dictionary normalization pass in the Python harness after the
+benchmark process completes. Instrumentation overhead on imaging execution is
+therefore bounded to the existing profiler runs; the new category mapping is
+outside the measured imaging commands.
+
+## Issue #249 Acceptance Mapping
+
+- Structured `casa-rs` timing data: `results.stage_breakdown.rust`.
+- Frontend/MS preparation versus pure imaging core: separate frontend,
+  visibility-adaptation, and core categories plus `frontend_total` /
+  `core_total`.
+- Grid/degrid, FFT, normalization/PB correction, deconvolution, and writeback:
+  normalized Rust categories listed above.
+- Disabled/skipped paths: dirty-only clean stages and preview generation are
+  explicit `skipped` categories with reasons.
+- Contract impact: local benchmark JSON only; no provider protocol or
+  managed-output schema change.
+- Overhead: no new hot-loop timers; normalization happens after each benchmark
+  process completes.

--- a/scripts/bench-imager-vs-casa.sh
+++ b/scripts/bench-imager-vs-casa.sh
@@ -38,6 +38,7 @@ fi
 
 repeats="${BENCH_REPEATS:-5}"
 field="${IMAGER_BENCH_FIELD:-0}"
+phasecenter_field="${IMAGER_BENCH_PHASECENTER_FIELD:-}"
 spw="${IMAGER_BENCH_SPW:-0}"
 channel_start="${IMAGER_BENCH_CHANNEL_START:-0}"
 channel_count="${IMAGER_BENCH_CHANNEL_COUNT:-1}"
@@ -131,7 +132,7 @@ PY
 
 echo "ms_path=$ms_path"
 echo "CASA_RS_CASA_PYTHON=$CASA_RS_CASA_PYTHON"
-echo "mode=$mode specmode=$specmode gridder=$gridder field=$field spw=$spw channel_start=$channel_start channel_count=$channel_count interpolation=$interpolation weighting=$weighting robust=$robust deconvolver=$deconvolver scales=$scales wterm=$wterm imsize=$imsize cell_arcsec=$cell_arcsec repeats=$repeats niter=$niter nsigma=$nsigma cycleniter=$minor_cycle_length cyclefactor=$cyclefactor minpsffraction=$min_psf_fraction maxpsffraction=$max_psf_fraction"
+echo "mode=$mode specmode=$specmode gridder=$gridder field=$field phasecenter_field=$phasecenter_field spw=$spw channel_start=$channel_start channel_count=$channel_count interpolation=$interpolation weighting=$weighting robust=$robust deconvolver=$deconvolver scales=$scales wterm=$wterm imsize=$imsize cell_arcsec=$cell_arcsec repeats=$repeats niter=$niter nsigma=$nsigma cycleniter=$minor_cycle_length cyclefactor=$cyclefactor minpsffraction=$min_psf_fraction maxpsffraction=$max_psf_fraction"
 echo
 
 cargo build --release -p casars-imager --bin casars-imager --example profile_imager >/dev/null
@@ -152,6 +153,10 @@ fi
 
 echo "Rust release CLI timings (seconds):"
 rust_cli_file="$tmpdir/rust-cli.txt"
+phasecenter_args=()
+if [[ -n "$phasecenter_field" ]]; then
+  phasecenter_args=(--phasecenter-field "$phasecenter_field")
+fi
 for run in $(seq 1 "$repeats"); do
   if [[ -n "$rust_keep_prefix" && "$run" == "$repeats" ]]; then
     prefix="$rust_keep_prefix"
@@ -166,6 +171,7 @@ for run in $(seq 1 "$repeats"); do
       --imsize "$imsize" \
       --cell-arcsec "$cell_arcsec" \
       --field "$field" \
+      "${phasecenter_args[@]}" \
       --spw "$spw" \
       --channel-start "$channel_start" \
       --channel-count "$channel_count" \
@@ -200,6 +206,7 @@ for run in $(seq 1 "$repeats"); do
       --imsize "$imsize" \
       --cell-arcsec "$cell_arcsec" \
       --field "$field" \
+      "${phasecenter_args[@]}" \
       --spw "$spw" \
       --channel-start "$channel_start" \
       --channel-count "$channel_count" \
@@ -242,6 +249,7 @@ if [[ -n "$scales" ]]; then
   target/release/examples/profile_imager \
     "$ms_path" \
     --field "$field" \
+    "${phasecenter_args[@]}" \
     --spw "$spw" \
     --channel-start "$channel_start" \
     --channel-count "$channel_count" \
@@ -273,6 +281,7 @@ else
   target/release/examples/profile_imager \
     "$ms_path" \
     --field "$field" \
+    "${phasecenter_args[@]}" \
     --spw "$spw" \
     --channel-start "$channel_start" \
     --channel-count "$channel_count" \
@@ -312,6 +321,7 @@ from casatasks import tclean
 vis = os.environ["CASA_RS_BENCH_MS_PATH"]
 repeats = int(os.environ["CASA_RS_BENCH_REPEATS"])
 field = os.environ["CASA_RS_BENCH_FIELD"]
+phasecenter_field = os.environ["CASA_RS_BENCH_PHASECENTER_FIELD"]
 spw = os.environ["CASA_RS_BENCH_SPW"]
 chan_start = int(os.environ["CASA_RS_BENCH_CHANNEL_START"])
 chan_count = int(os.environ["CASA_RS_BENCH_CHANNEL_COUNT"])
@@ -390,6 +400,8 @@ with tempfile.TemporaryDirectory() as td:
             )
         else:
             kwargs.update(spw=spw_selector)
+        if phasecenter_field:
+            kwargs["phasecenter"] = f"FIELD_ID {phasecenter_field}"
         tclean(**kwargs)
         elapsed = time.perf_counter() - start
         times.append(elapsed)
@@ -404,6 +416,7 @@ echo "CASA tclean timings (seconds):"
 CASA_RS_BENCH_MS_PATH="$ms_path" \
 CASA_RS_BENCH_REPEATS="$repeats" \
 CASA_RS_BENCH_FIELD="$field" \
+CASA_RS_BENCH_PHASECENTER_FIELD="$phasecenter_field" \
 CASA_RS_BENCH_SPW="$spw" \
 CASA_RS_BENCH_CHANNEL_START="$channel_start" \
 CASA_RS_BENCH_CHANNEL_COUNT="$channel_count" \
@@ -441,6 +454,7 @@ echo "CASA PySynthesisImager stage medians (milliseconds):"
 CASA_RS_BENCH_MS_PATH="$ms_path" \
 CASA_RS_BENCH_REPEATS="$repeats" \
 CASA_RS_BENCH_FIELD="$field" \
+CASA_RS_BENCH_PHASECENTER_FIELD="$phasecenter_field" \
 CASA_RS_BENCH_SPW="$spw" \
 CASA_RS_BENCH_CHANNEL_START="$channel_start" \
 CASA_RS_BENCH_CHANNEL_COUNT="$channel_count" \

--- a/scripts/bench-imager-vs-casa.sh
+++ b/scripts/bench-imager-vs-casa.sh
@@ -61,6 +61,7 @@ gain="${IMAGER_BENCH_GAIN:-0.1}"
 threshold_jy="${IMAGER_BENCH_THRESHOLD_JY:-0}"
 nsigma="${IMAGER_BENCH_NSIGMA:-0}"
 psfcutoff="${IMAGER_BENCH_PSFCUTOFF:-0.35}"
+keep_output_root="${IMAGER_BENCH_KEEP_OUTPUT_ROOT:-}"
 
 if [[ "$wterm" != "none" ]]; then
   echo "error: scripts/bench-imager-vs-casa.sh only supports IMAGER_BENCH_WTERM=none for Rust-vs-CASA comparisons" >&2
@@ -103,6 +104,31 @@ print(f"{statistics.median(values):.6f}")
 PY
 }
 
+run_timed_command() {
+  local stderr_file="$1"
+  shift
+  local start
+  local status
+  start="$(python3 - <<'PY'
+import time
+print(f"{time.perf_counter():.9f}")
+PY
+)"
+  "$@" >/dev/null 2>"$stderr_file"
+  status="$?"
+  python3 - "$start" "$stderr_file" <<'PY'
+import sys
+import time
+
+start = float(sys.argv[1])
+stderr_file = sys.argv[2]
+elapsed = time.perf_counter() - start
+with open(stderr_file, "a", encoding="utf-8") as handle:
+    handle.write(f"real {elapsed:.6f}\n")
+PY
+  return "$status"
+}
+
 echo "ms_path=$ms_path"
 echo "CASA_RS_CASA_PYTHON=$CASA_RS_CASA_PYTHON"
 echo "mode=$mode specmode=$specmode gridder=$gridder field=$field spw=$spw channel_start=$channel_start channel_count=$channel_count interpolation=$interpolation weighting=$weighting robust=$robust deconvolver=$deconvolver scales=$scales wterm=$wterm imsize=$imsize cell_arcsec=$cell_arcsec repeats=$repeats niter=$niter nsigma=$nsigma cycleniter=$minor_cycle_length cyclefactor=$cyclefactor minpsffraction=$min_psf_fraction maxpsffraction=$max_psf_fraction"
@@ -115,13 +141,26 @@ trap 'rm -rf "$tmpdir"' EXIT
 staged_ms_path="$tmpdir/benchmark.ms"
 cp -R "$ms_path" "$staged_ms_path"
 ms_path="$staged_ms_path"
+if [[ -n "$keep_output_root" ]]; then
+  mkdir -p "$keep_output_root/rust" "$keep_output_root/casa"
+  rust_keep_prefix="$keep_output_root/rust/rust"
+  casa_keep_prefix="$keep_output_root/casa/casa"
+else
+  rust_keep_prefix=""
+  casa_keep_prefix=""
+fi
 
 echo "Rust release CLI timings (seconds):"
 rust_cli_file="$tmpdir/rust-cli.txt"
 for run in $(seq 1 "$repeats"); do
-  prefix="$tmpdir/rust-run-$run"
+  if [[ -n "$rust_keep_prefix" && "$run" == "$repeats" ]]; then
+    prefix="$rust_keep_prefix"
+  else
+    prefix="$tmpdir/rust-run-$run"
+  fi
+  rust_stderr="$tmpdir/rust-$run.stderr"
   if [[ -n "$scales" ]]; then
-    /usr/bin/time -lp target/release/casars-imager \
+    if ! run_timed_command "$rust_stderr" target/release/casars-imager \
       --ms "$ms_path" \
       --imagename "$prefix" \
       --imsize "$imsize" \
@@ -149,10 +188,13 @@ for run in $(seq 1 "$repeats"); do
       --maxpsffraction "$max_psf_fraction" \
       --wterm "$wterm" \
       --no-preview-pngs \
-      $dirty_flag \
-      >/dev/null 2>"$tmpdir/rust-$run.stderr"
+      $dirty_flag; then
+      echo "error: Rust casars-imager run $run failed" >&2
+      cat "$rust_stderr" >&2
+      exit 1
+    fi
   else
-    /usr/bin/time -lp target/release/casars-imager \
+    if ! run_timed_command "$rust_stderr" target/release/casars-imager \
       --ms "$ms_path" \
       --imagename "$prefix" \
       --imsize "$imsize" \
@@ -179,14 +221,20 @@ for run in $(seq 1 "$repeats"); do
       --maxpsffraction "$max_psf_fraction" \
       --wterm "$wterm" \
       --no-preview-pngs \
-      $dirty_flag \
-      >/dev/null 2>"$tmpdir/rust-$run.stderr"
+      $dirty_flag; then
+      echo "error: Rust casars-imager run $run failed" >&2
+      cat "$rust_stderr" >&2
+      exit 1
+    fi
   fi
-  real_seconds="$(awk '/^real / {print $2}' "$tmpdir/rust-$run.stderr")"
+  real_seconds="$(awk '/^real / {print $2}' "$rust_stderr")"
   printf "  run=%s real=%s\n" "$run" "$real_seconds"
   printf "%s\n" "$real_seconds" >>"$rust_cli_file"
 done
 echo "  median=$(median_from_file "$rust_cli_file")"
+if [[ -n "$rust_keep_prefix" ]]; then
+  echo "  kept_rust_prefix=$rust_keep_prefix"
+fi
 echo
 
 echo "Rust stage medians (milliseconds):"
@@ -285,12 +333,18 @@ gridder = os.environ["CASA_RS_BENCH_GRIDDER"]
 scales = [] if os.environ["CASA_RS_BENCH_SCALES"] == "" else [int(float(v)) for v in os.environ["CASA_RS_BENCH_SCALES"].split(",")]
 specmode = os.environ["CASA_RS_BENCH_SPECMODE"]
 interpolation = os.environ["CASA_RS_BENCH_INTERPOLATION"]
+keep_output_root = os.environ.get("CASA_RS_BENCH_KEEP_OUTPUT_ROOT", "")
+casa_keep_prefix = os.path.join(keep_output_root, "casa", "casa") if keep_output_root else ""
 spw_selector = f"{spw}:{chan_start}" if chan_count == 1 else f"{spw}:{chan_start}~{chan_start + chan_count - 1}"
 times = []
 
 with tempfile.TemporaryDirectory() as td:
     for run in range(repeats):
-        prefix = os.path.join(td, f"run-{run}")
+        if casa_keep_prefix and run == repeats - 1:
+            os.makedirs(os.path.dirname(casa_keep_prefix), exist_ok=True)
+            prefix = casa_keep_prefix
+        else:
+            prefix = os.path.join(td, f"run-{run}")
         start = time.perf_counter()
         kwargs = dict(
             vis=vis,
@@ -342,6 +396,8 @@ with tempfile.TemporaryDirectory() as td:
         print(f"run={run + 1} real={elapsed:.6f}")
 
 print(f"median={statistics.median(times):.6f}")
+if casa_keep_prefix:
+    print(f"kept_casa_prefix={casa_keep_prefix}")
 PY
 
 echo "CASA tclean timings (seconds):"
@@ -369,8 +425,17 @@ CASA_RS_BENCH_CYCLEFACTOR="$cyclefactor" \
 CASA_RS_BENCH_MIN_PSFFRACTION="$min_psf_fraction" \
 CASA_RS_BENCH_MAX_PSFFRACTION="$max_psf_fraction" \
 CASA_RS_BENCH_INTERPOLATION="$interpolation" \
+CASA_RS_BENCH_KEEP_OUTPUT_ROOT="$keep_output_root" \
   "$CASA_RS_CASA_PYTHON" "$tmpdir/casa-imager-bench.py" | sed 's/^/  /'
 echo
+
+if [[ -n "$keep_output_root" ]]; then
+  echo "Kept benchmark products:"
+  echo "  product_root=$keep_output_root"
+  echo "  rust_prefix=$rust_keep_prefix"
+  echo "  casa_prefix=$casa_keep_prefix"
+  echo
+fi
 
 echo "CASA PySynthesisImager stage medians (milliseconds):"
 CASA_RS_BENCH_MS_PATH="$ms_path" \

--- a/scripts/bench-imager-vs-casa.sh
+++ b/scripts/bench-imager-vs-casa.sh
@@ -42,6 +42,7 @@ spw="${IMAGER_BENCH_SPW:-0}"
 channel_start="${IMAGER_BENCH_CHANNEL_START:-0}"
 channel_count="${IMAGER_BENCH_CHANNEL_COUNT:-1}"
 specmode="${IMAGER_BENCH_SPECMODE:-mfs}"
+gridder="${IMAGER_BENCH_GRIDDER:-standard}"
 interpolation="${IMAGER_BENCH_INTERPOLATION:-linear}"
 imsize="${IMAGER_BENCH_IMSIZE:-128}"
 cell_arcsec="${IMAGER_BENCH_CELL_ARCSEC:-30}"
@@ -68,6 +69,11 @@ fi
 
 if [[ "$specmode" != "mfs" && "$specmode" != "cube" ]]; then
   echo "error: IMAGER_BENCH_SPECMODE must be mfs or cube" >&2
+  exit 2
+fi
+
+if [[ "$gridder" != "standard" && "$gridder" != "mosaic" ]]; then
+  echo "error: IMAGER_BENCH_GRIDDER must be standard or mosaic" >&2
   exit 2
 fi
 
@@ -99,7 +105,7 @@ PY
 
 echo "ms_path=$ms_path"
 echo "CASA_RS_CASA_PYTHON=$CASA_RS_CASA_PYTHON"
-echo "mode=$mode specmode=$specmode field=$field spw=$spw channel_start=$channel_start channel_count=$channel_count interpolation=$interpolation weighting=$weighting robust=$robust deconvolver=$deconvolver scales=$scales wterm=$wterm imsize=$imsize cell_arcsec=$cell_arcsec repeats=$repeats niter=$niter nsigma=$nsigma cycleniter=$minor_cycle_length cyclefactor=$cyclefactor minpsffraction=$min_psf_fraction maxpsffraction=$max_psf_fraction"
+echo "mode=$mode specmode=$specmode gridder=$gridder field=$field spw=$spw channel_start=$channel_start channel_count=$channel_count interpolation=$interpolation weighting=$weighting robust=$robust deconvolver=$deconvolver scales=$scales wterm=$wterm imsize=$imsize cell_arcsec=$cell_arcsec repeats=$repeats niter=$niter nsigma=$nsigma cycleniter=$minor_cycle_length cyclefactor=$cyclefactor minpsffraction=$min_psf_fraction maxpsffraction=$max_psf_fraction"
 echo
 
 cargo build --release -p casars-imager --bin casars-imager --example profile_imager >/dev/null
@@ -125,6 +131,7 @@ for run in $(seq 1 "$repeats"); do
       --channel-start "$channel_start" \
       --channel-count "$channel_count" \
       --specmode "$specmode" \
+      --gridder "$gridder" \
       --interpolation "$interpolation" \
       --datacolumn DATA \
       --weighting "$weighting" \
@@ -155,6 +162,7 @@ for run in $(seq 1 "$repeats"); do
       --channel-start "$channel_start" \
       --channel-count "$channel_count" \
       --specmode "$specmode" \
+      --gridder "$gridder" \
       --interpolation "$interpolation" \
       --datacolumn DATA \
       --weighting "$weighting" \
@@ -190,6 +198,7 @@ if [[ -n "$scales" ]]; then
     --channel-start "$channel_start" \
     --channel-count "$channel_count" \
     --specmode "$specmode" \
+    --gridder "$gridder" \
     --interpolation "$interpolation" \
     --datacolumn DATA \
     --weighting "$weighting" \
@@ -220,6 +229,7 @@ else
     --channel-start "$channel_start" \
     --channel-count "$channel_count" \
     --specmode "$specmode" \
+    --gridder "$gridder" \
     --interpolation "$interpolation" \
     --datacolumn DATA \
     --weighting "$weighting" \
@@ -271,6 +281,7 @@ maxpsffraction = float(os.environ["CASA_RS_BENCH_MAX_PSFFRACTION"])
 weighting = os.environ["CASA_RS_BENCH_WEIGHTING"]
 robust = float(os.environ["CASA_RS_BENCH_ROBUST"])
 deconvolver = os.environ["CASA_RS_BENCH_DECONVOLVER"]
+gridder = os.environ["CASA_RS_BENCH_GRIDDER"]
 scales = [] if os.environ["CASA_RS_BENCH_SCALES"] == "" else [int(float(v)) for v in os.environ["CASA_RS_BENCH_SCALES"].split(",")]
 specmode = os.environ["CASA_RS_BENCH_SPECMODE"]
 interpolation = os.environ["CASA_RS_BENCH_INTERPOLATION"]
@@ -288,7 +299,7 @@ with tempfile.TemporaryDirectory() as td:
             field=field,
             stokes="I",
             specmode=specmode,
-            gridder="standard",
+            gridder=gridder,
             weighting=weighting,
             deconvolver=deconvolver,
             scales=scales,
@@ -341,6 +352,7 @@ CASA_RS_BENCH_SPW="$spw" \
 CASA_RS_BENCH_CHANNEL_START="$channel_start" \
 CASA_RS_BENCH_CHANNEL_COUNT="$channel_count" \
 CASA_RS_BENCH_SPECMODE="$specmode" \
+CASA_RS_BENCH_GRIDDER="$gridder" \
 CASA_RS_BENCH_IMSIZE="$imsize" \
 CASA_RS_BENCH_CELL_ARCSEC="$cell_arcsec" \
 CASA_RS_BENCH_WEIGHTING="$weighting" \
@@ -368,6 +380,7 @@ CASA_RS_BENCH_SPW="$spw" \
 CASA_RS_BENCH_CHANNEL_START="$channel_start" \
 CASA_RS_BENCH_CHANNEL_COUNT="$channel_count" \
 CASA_RS_BENCH_SPECMODE="$specmode" \
+CASA_RS_BENCH_GRIDDER="$gridder" \
 CASA_RS_BENCH_IMSIZE="$imsize" \
 CASA_RS_BENCH_CELL_ARCSEC="$cell_arcsec" \
 CASA_RS_BENCH_WEIGHTING="$weighting" \

--- a/tools/perf/README.md
+++ b/tools/perf/README.md
@@ -7,6 +7,11 @@ This directory holds reusable performance-analysis tooling for the repository.
 - `calibrate/`
   - `README.md`: apply-path tracing and analysis notes
   - `report.py`: JSONL-to-summary report script
+- `imager/`
+  - `README.md`: MeasurementSet-backed imaging benchmark notes
+  - `run_workload.py`: manifest-driven CASA C++ versus `casa-rs` benchmark
+    wrapper
+  - `workloads/`: checked-in workload manifests
 - `imexplore/`
   - `README.md`: feature-specific tracing and analysis notes
   - `report.py`: JSONL-to-summary report script

--- a/tools/perf/imager/README.md
+++ b/tools/perf/imager/README.md
@@ -5,6 +5,10 @@ imager.
 
 ## Entry points
 
+- `tools/perf/imager/run_workload.py`
+  - runs one JSON workload manifest, preflights support, delegates supported
+    workloads to `scripts/bench-imager-vs-casa.sh`, and writes a normalized
+    machine-readable result JSON
 - `crates/casars-imager/examples/profile_imager.rs`
   - runs repeated Rust imaging passes and reports median stage timings from the
     pure `casa-imaging` core
@@ -18,11 +22,32 @@ imager.
 scripts/bench-imager-vs-casa.sh
 ```
 
+To run the Wave 1 manifest harness in validation mode:
+
+```sh
+tools/perf/imager/run_workload.py --dry-run wave1-standard-mfs-dirty-smoke
+```
+
+The command writes a JSON plan under `target/imperformance-wave1/` without
+requiring CASA Python or a local MeasurementSet.
+
+To run the same workload for real:
+
+```sh
+CASA_RS_TESTDATA_ROOT=/path/to/casatestdata \
+CASA_RS_CASA_PYTHON=/path/to/casa-python \
+tools/perf/imager/run_workload.py wave1-standard-mfs-dirty-smoke
+```
+
 To force a different dataset:
 
 ```sh
 scripts/bench-imager-vs-casa.sh /path/to.ms
 ```
+
+The manifest runner intentionally resolves data only from an explicit manifest
+path or from the manifest's `dataset.root_env` plus `dataset.relative_path`.
+It does not add personal workstation data fallbacks.
 
 ## Environment variables
 
@@ -34,6 +59,10 @@ scripts/bench-imager-vs-casa.sh /path/to.ms
   - number of repeated Rust/CASA wall-clock runs
 - `IMAGER_BENCH_MODE`
   - `dirty` or `clean`
+- `IMAGER_BENCH_SPECMODE`
+  - `mfs` or `cube`
+- `IMAGER_BENCH_GRIDDER`
+  - `standard` or `mosaic`
 - `IMAGER_BENCH_INTERPOLATION`
   - cube spectral interpolation mode: `nearest` or `linear`
 - `IMAGER_BENCH_FIELD`
@@ -54,6 +83,43 @@ scripts/bench-imager-vs-casa.sh /path/to.ms
 - `IMAGER_BENCH_MINOR_CYCLE_LENGTH`
 - `IMAGER_BENCH_WTERM`
   - currently only `none` is supported in the Rust-vs-CASA benchmark script because the Rust-only `direct` mode has no matching `tclean` configuration in this harness
+
+## Manifest fields
+
+Workload manifests live in `tools/perf/imager/workloads/`. The first Wave 1
+manifest is `wave1-standard-mfs-dirty-smoke.json`.
+
+Required top-level fields:
+
+- `id`: stable workload id used in result filenames
+- `mode_id`: selected Wave 1 mode id, such as `standard-mfs-dirty-control`
+- `dataset`: `key`, plus either `path` or `root_env` and `relative_path`
+- `imaging`: CASA-like mode parameters
+
+Supported `imaging` values for the #252 harness slice:
+
+- `mode`: `dirty` or `clean`
+- `specmode`: `mfs` or `cube`
+- `gridder`: `standard` or `mosaic`
+- `interpolation`: `nearest` or `linear`
+- `wterm`: `none`
+
+Unsupported modes fail before timing claims are written. In particular,
+W-projection and AW/widefield manifests should be rejected by this ticket until
+their benchmark support is added or delegated to the owning follow-up.
+
+## Result JSON
+
+`run_workload.py` writes one JSON file per run with:
+
+- `run_id`, manifest path, git branch/commit, CASA Python path, benchmark script
+  hash, and the exact delegated command/env
+- dataset key/path, selected mode, image shape, channel count, weighting,
+  deconvolver, `niter`, run label, storage label, and repeat count
+- Rust CLI per-run wallclock and median wallclock
+- CASA `tclean` per-run wallclock and median wallclock when CASA ran
+- parsed Rust and CASA stage medians when present
+- a clear `dry_run`, `completed`, or `failed` status
 
 The active Wave 8 clean cube gate can now be reproduced directly through the
 same harness by setting, for example:

--- a/tools/perf/imager/README.md
+++ b/tools/perf/imager/README.md
@@ -9,6 +9,14 @@ imager.
   - runs one JSON workload manifest, preflights support, delegates supported
     workloads to `scripts/bench-imager-vs-casa.sh`, and writes a normalized
     machine-readable result JSON
+- `tools/perf/imager/stage_wave1_datasets.py`
+  - validates the ImPerformance Wave 1 simulated-dataset registry, enforces the
+    explicit data-root policy, and can materialize deterministic source models,
+    spectral profiles, simulation request plans, and generated workload
+    manifests
+- `tools/perf/imager/wave1_dataset_registry.json`
+  - records the VLA/ALMA, single-field/mosaic, small/medium/large simulated
+    dataset plan for #248
 - `crates/casars-imager/examples/profile_imager.rs`
   - runs repeated Rust imaging passes and reports median stage timings from the
     pure `casa-imaging` core
@@ -30,6 +38,18 @@ tools/perf/imager/run_workload.py --dry-run wave1-standard-mfs-dirty-smoke
 
 The command writes a JSON plan under `target/imperformance-wave1/` without
 requiring CASA Python or a local MeasurementSet.
+
+To validate the Wave 1 simulated-dataset plan:
+
+```sh
+tools/perf/imager/stage_wave1_datasets.py \
+  --dry-run \
+  --data-root /Volumes/GLENDENNING/casa-rs-imperformance
+```
+
+Medium and large datasets are expected to live on the external drive on this
+system. The staging tool requires those tiers under `/Volumes/GLENDENNING`
+unless `--allow-non-external-large-root` is passed explicitly.
 
 To run the same workload for real:
 

--- a/tools/perf/imager/README.md
+++ b/tools/perf/imager/README.md
@@ -51,6 +51,11 @@ Medium and large datasets are expected to live on the external drive on this
 system. The staging tool requires those tiers under `/Volumes/GLENDENNING`
 unless `--allow-non-external-large-root` is passed explicitly.
 
+For Wave 1, CASA C++ generation is the dataset source of truth. The staging
+tool also emits native `casa-rs` simulation request plans where useful, but
+native mosaic generation and native channel-varying cube source prediction are
+tracked as backlog work rather than Wave 1 blockers.
+
 To run the same workload for real:
 
 ```sh

--- a/tools/perf/imager/README.md
+++ b/tools/perf/imager/README.md
@@ -145,6 +145,10 @@ their benchmark support is added or delegated to the owning follow-up.
 - Rust CLI per-run wallclock and median wallclock
 - CASA `tclean` per-run wallclock and median wallclock when CASA ran
 - parsed Rust and CASA stage medians when present
+- normalized `stage_breakdown` categories that distinguish frontend/MS
+  preparation, visibility adaptation, weighting, gridding/degridding, FFT,
+  normalization/PB correction, deconvolution, model refresh, and product
+  writeback
 - preserved product prefixes when a real run is executed
 - CASA-backed product-comparison metrics for configured product suffixes
 - a clear `dry_run`, `completed`, or `failed` status

--- a/tools/perf/imager/README.md
+++ b/tools/perf/imager/README.md
@@ -22,7 +22,8 @@ imager.
     pure `casa-imaging` core
 - `scripts/bench-imager-vs-casa.sh`
   - compares Rust CLI wall-clock timings and Rust stage medians against CASA
-    `tclean` on the same MeasurementSet selection
+    `tclean` on the same MeasurementSet selection, and can preserve final-run
+    products for harness-level comparison
 
 ## Typical usage
 
@@ -144,6 +145,8 @@ their benchmark support is added or delegated to the owning follow-up.
 - Rust CLI per-run wallclock and median wallclock
 - CASA `tclean` per-run wallclock and median wallclock when CASA ran
 - parsed Rust and CASA stage medians when present
+- preserved product prefixes when a real run is executed
+- CASA-backed product-comparison metrics for configured product suffixes
 - a clear `dry_run`, `completed`, or `failed` status
 
 The active Wave 8 clean cube gate can now be reproduced directly through the

--- a/tools/perf/imager/README.md
+++ b/tools/perf/imager/README.md
@@ -14,9 +14,13 @@ imager.
     explicit data-root policy, and can materialize deterministic source models,
     spectral profiles, simulation request plans, and generated workload
     manifests
+- `tools/perf/imager/bench_simobserve.py`
+  - compares native `simobserve` with CASA on selected datasets, records native
+    timing reports, and can enforce native throughput floors for internal-disk
+    storage-manager regression checks
 - `tools/perf/imager/wave1_dataset_registry.json`
-  - records the VLA/ALMA, single-field/mosaic, small/medium, and one shared
-    large simulated-dataset plan for #248
+  - records the VLA/ALMA, single-field/mosaic, small/medium, and one large
+    ALMA mosaic/cube simulated-dataset plan for #248
 - `crates/casars-imager/examples/profile_imager.rs`
   - runs repeated Rust imaging passes and reports median stage timings from the
     pure `casa-imaging` core
@@ -51,14 +55,53 @@ tools/perf/imager/stage_wave1_datasets.py \
 Medium and large datasets are expected to live on the external drive on this
 system. The staging tool requires those tiers under `/Volumes/GLENDENNING`
 unless `--allow-non-external-large-root` is passed explicitly. The large tier
-is intentionally one shared `wave1-alma-shared-large` dataset; standard, cube,
-mosaic, and sentinel large workloads are generated as logical selections from
-that one staged MeasurementSet.
+is intentionally one `wave1-alma-mosaic-large` dataset; standard, cube, mosaic,
+and sentinel large workloads are generated as logical selections from that one
+staged MeasurementSet.
 
-For Wave 1, CASA C++ generation is the dataset source of truth. The staging
-tool also emits native `casa-rs` simulation request plans where useful, but
-native mosaic generation and native channel-varying cube source prediction are
-tracked as backlog work rather than Wave 1 blockers.
+For Wave 1, native `simobserve` is the primary benchmark dataset generator.
+CASA C++ generation remains the small-case oracle for selected parity and
+performance checks.
+
+To compare native `simobserve` with CASA on a selected dataset:
+
+```sh
+python3 tools/perf/imager/bench_simobserve.py target/imperformance-wave1/plan/wave1-dataset-plan.json \
+  --dataset wave1-vla-single-small \
+  --disable-noise \
+  --strict-values
+```
+
+The strict comparison samples matching rows by time, field, data description,
+and baseline, then checks UVW, flags, weights, sigmas, and DATA. Its default
+DATA tolerance is absolute `0.05 Jy` plus relative `5e-3`, which is tight
+enough to catch model scaling/channel-order mistakes while avoiding false
+failures from small CASA/native numerical differences in low-amplitude cells.
+
+To check that the streamed MeasurementSet writer has not regressed, run a
+native-only write-path benchmark on a fast local disk, not on
+`/Volumes/GLENDENNING`:
+
+```sh
+cargo build --release --bin simobserve
+
+python3 tools/perf/imager/bench_simobserve.py target/imperformance-wave1/plan/wave1-dataset-plan.json \
+  --dataset wave1-vla-single-medium \
+  --output-dir target/imperformance-wave1/internal-io-check \
+  --skip-casa \
+  --skip-serial-check \
+  --disable-prediction \
+  --require-native-throughput-mb-s 700 \
+  --require-data-io-throughput-mb-s 900
+```
+
+`--disable-prediction` removes model prediction and corruption so the run is
+dominated by MeasurementSet creation and streamed tiled-column writes. On this
+machine, the internal-disk medium write-only run measured about `955 MB/s`
+end-to-end and the full medium run showed only `67 ms` of producer blocking on
+the writer. The same external-drive write pattern measured far lower, so
+internal-disk checks are the meaningful guard for storage-manager regressions;
+external-drive runs remain useful for capacity and end-to-end staging checks.
 
 To run the same workload for real:
 

--- a/tools/perf/imager/README.md
+++ b/tools/perf/imager/README.md
@@ -15,8 +15,8 @@ imager.
     spectral profiles, simulation request plans, and generated workload
     manifests
 - `tools/perf/imager/wave1_dataset_registry.json`
-  - records the VLA/ALMA, single-field/mosaic, small/medium/large simulated
-    dataset plan for #248
+  - records the VLA/ALMA, single-field/mosaic, small/medium, and one shared
+    large simulated-dataset plan for #248
 - `crates/casars-imager/examples/profile_imager.rs`
   - runs repeated Rust imaging passes and reports median stage timings from the
     pure `casa-imaging` core
@@ -50,7 +50,10 @@ tools/perf/imager/stage_wave1_datasets.py \
 
 Medium and large datasets are expected to live on the external drive on this
 system. The staging tool requires those tiers under `/Volumes/GLENDENNING`
-unless `--allow-non-external-large-root` is passed explicitly.
+unless `--allow-non-external-large-root` is passed explicitly. The large tier
+is intentionally one shared `wave1-alma-shared-large` dataset; standard, cube,
+mosaic, and sentinel large workloads are generated as logical selections from
+that one staged MeasurementSet.
 
 For Wave 1, CASA C++ generation is the dataset source of truth. The staging
 tool also emits native `casa-rs` simulation request plans where useful, but

--- a/tools/perf/imager/bench_simobserve.py
+++ b/tools/perf/imager/bench_simobserve.py
@@ -49,12 +49,40 @@ def main() -> None:
         help="run both CASA and native simobserve without thermal/noise corruption",
     )
     parser.add_argument(
+        "--disable-prediction",
+        action="store_true",
+        help=(
+            "set native predict_model=false and remove corruption; intended for "
+            "native-only write-path throughput checks"
+        ),
+    )
+    parser.add_argument(
+        "--require-native-throughput-mb-s",
+        type=float,
+        default=None,
+        help="fail unless native output size divided by best runtime reaches this MB/s",
+    )
+    parser.add_argument(
+        "--require-data-io-throughput-mb-s",
+        type=float,
+        default=None,
+        help=(
+            "fail unless streamed MAIN-column bytes divided by reported "
+            "data_io_write_millis reaches this MB/s"
+        ),
+    )
+    parser.add_argument(
         "--strict-values",
         action="store_true",
         help="fail unless CASA and native rows, UVW, and DATA agree numerically",
     )
     parser.add_argument("--strict-uvw-atol", type=float, default=1.0e-5)
-    parser.add_argument("--strict-data-atol", type=float, default=1.0e-4)
+    parser.add_argument(
+        "--strict-data-atol",
+        type=float,
+        default=5.0e-2,
+        help="absolute DATA tolerance for CASA-vs-native sampled comparisons",
+    )
     parser.add_argument("--strict-data-rtol", type=float, default=1.0e-3)
     parser.add_argument("--skip-casa", action="store_true")
     parser.add_argument("--skip-serial-check", action="store_true")
@@ -89,6 +117,11 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
         request["request"]["corruption"] = None
         request["request"]["model_peak_jy_per_pixel"] = None
         dataset = without_noise(dataset)
+    if args.disable_prediction:
+        if not args.skip_casa:
+            raise BenchError("--disable-prediction requires --skip-casa")
+        request["request"]["predict_model"] = False
+        request["request"]["corruption"] = None
 
     casa = None
     run_casa_first = args.strict_values and not args.skip_casa
@@ -148,6 +181,8 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
                 f"native simobserve speedup {speedup:.2f}x is below target "
                 f"{args.require_speedup:.2f}x"
             )
+    native_performance = native_performance_summary(native_parallel)
+    enforce_native_performance_targets(args, native_performance)
 
     result_path = run_root / "simobserve-benchmark.json"
     report_path = run_root / "simobserve-benchmark.html"
@@ -163,7 +198,12 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
         "casa": casa,
         "correctness": correctness,
         "speedup_vs_casa": speedup,
-        "target": {"required_speedup": args.require_speedup},
+        "native_performance": native_performance,
+        "target": {
+            "required_speedup": args.require_speedup,
+            "required_native_throughput_mb_s": args.require_native_throughput_mb_s,
+            "required_data_io_throughput_mb_s": args.require_data_io_throughput_mb_s,
+        },
     }
 
 
@@ -288,6 +328,51 @@ def parse_native_result(stdout: str, source: pathlib.Path) -> dict[str, Any]:
     if payload.get("kind") != "run":
         raise BenchError(f"native simobserve emitted unexpected result kind in {source}")
     return payload["result"]
+
+
+def native_performance_summary(native: dict[str, Any]) -> dict[str, Any]:
+    size_bytes = int(native["size_bytes"])
+    best_seconds = float(native["best_seconds"])
+    report = native.get("last_result", {}).get("report", {})
+    main_timing = report.get("timing", {}).get("main_rows", {})
+    data_io_bytes = int(main_timing.get("data_io_bytes") or 0)
+    data_io_write_millis = float(main_timing.get("data_io_write_millis") or 0)
+    return {
+        "native_output_mb_per_second": mb_per_second(size_bytes, best_seconds),
+        "data_io_mb_per_second": mb_per_second(
+            data_io_bytes,
+            data_io_write_millis / 1000.0 if data_io_write_millis > 0 else 0.0,
+        ),
+        "data_io_bytes": data_io_bytes,
+        "data_io_write_millis": data_io_write_millis,
+    }
+
+
+def enforce_native_performance_targets(
+    args: argparse.Namespace, performance: dict[str, Any]
+) -> None:
+    required_native = args.require_native_throughput_mb_s
+    if required_native is not None:
+        actual = performance["native_output_mb_per_second"]
+        if actual < required_native:
+            raise BenchError(
+                f"native output throughput {actual:.1f} MB/s is below target "
+                f"{required_native:.1f} MB/s"
+            )
+    required_data_io = args.require_data_io_throughput_mb_s
+    if required_data_io is not None:
+        actual = performance["data_io_mb_per_second"]
+        if actual < required_data_io:
+            raise BenchError(
+                f"streamed DATA/FLAG/UVW/WEIGHT/SIGMA write throughput "
+                f"{actual:.1f} MB/s is below target {required_data_io:.1f} MB/s"
+            )
+
+
+def mb_per_second(size_bytes: int, seconds: float) -> float:
+    if seconds <= 0.0:
+        return 0.0
+    return size_bytes / seconds / 1_000_000.0
 
 
 def without_noise(dataset: dict[str, Any]) -> dict[str, Any]:
@@ -516,6 +601,231 @@ print(json.dumps({name: inspect(path) for name, path in paths.items()}, sort_key
 
 
 def collect_strict_value_comparison(
+    casa_python: str,
+    native_ms: str,
+    casa_ms: str,
+    *,
+    uvw_atol: float,
+    data_atol: float,
+    data_rtol: float,
+) -> dict[str, Any]:
+    return collect_sampled_strict_value_comparison(
+        casa_python,
+        native_ms,
+        casa_ms,
+        uvw_atol=uvw_atol,
+        data_atol=data_atol,
+        data_rtol=data_rtol,
+    )
+
+
+def collect_sampled_strict_value_comparison(
+    casa_python: str,
+    native_ms: str,
+    casa_ms: str,
+    *,
+    uvw_atol: float,
+    data_atol: float,
+    data_rtol: float,
+) -> dict[str, Any]:
+    script = r'''
+import json
+import sys
+import numpy as np
+from casatools import table
+
+native_path, casa_path, uvw_atol, data_atol, data_rtol = json.loads(sys.argv[1])
+
+KEY_COLUMNS = ["TIME", "FIELD_ID", "DATA_DESC_ID", "ANTENNA1", "ANTENNA2"]
+SAMPLE_ROWS = 513
+
+def open_table(path):
+    tb = table()
+    tb.open(path)
+    return tb
+
+def key_tuple(keys, row):
+    return tuple(key[row].item() if hasattr(key[row], "item") else key[row] for key in keys)
+
+def read_keys(path):
+    tb = open_table(path)
+    try:
+        rows = int(tb.nrows())
+        keys = [np.asarray(tb.getcol(column)) for column in KEY_COLUMNS]
+    finally:
+        tb.close()
+    return rows, keys
+
+native_rows, native_keys = read_keys(native_path)
+casa_rows, casa_keys = read_keys(casa_path)
+result = {
+    "status": "passed",
+    "reasons": [],
+    "sampled": True,
+    "row_count": {"native": native_rows, "casa": casa_rows},
+    "thresholds": {
+        "uvw_atol": uvw_atol,
+        "data_atol": data_atol,
+        "data_rtol": data_rtol,
+    },
+}
+if native_rows != casa_rows:
+    result["status"] = "failed"
+    result["reasons"].append("strict row count mismatch")
+    print(json.dumps(result, sort_keys=True))
+    raise SystemExit(0)
+
+casa_by_key = {key_tuple(casa_keys, row): row for row in range(casa_rows)}
+if native_rows <= SAMPLE_ROWS:
+    native_sample_rows = list(range(native_rows))
+else:
+    native_sample_rows = sorted(set(np.linspace(0, native_rows - 1, SAMPLE_ROWS, dtype=np.int64).tolist()))
+
+native_tb = open_table(native_path)
+casa_tb = open_table(casa_path)
+try:
+    uvw_max_abs = 0.0
+    uvw_mean_sum = 0.0
+    uvw_count = 0
+    data_max_abs = 0.0
+    data_sum_abs = 0.0
+    data_max_relative = 0.0
+    data_count = 0
+    raw_flag_mismatches = 0
+    effective_flag_mismatches = 0
+    weight_max_abs = 0.0
+    sigma_max_abs = 0.0
+    missing_keys = []
+    worst_cells = []
+
+    for native_row in native_sample_rows:
+        key = key_tuple(native_keys, native_row)
+        casa_row = casa_by_key.get(key)
+        if casa_row is None:
+            missing_keys.append({"native_row": int(native_row), "key": list(key)})
+            continue
+
+        native_uvw = np.asarray(native_tb.getcell("UVW", int(native_row)), dtype=np.float64)
+        casa_uvw = np.asarray(casa_tb.getcell("UVW", int(casa_row)), dtype=np.float64)
+        uvw_delta = np.abs(native_uvw - casa_uvw)
+        uvw_max_abs = max(uvw_max_abs, float(uvw_delta.max()) if uvw_delta.size else 0.0)
+        uvw_mean_sum += float(uvw_delta.sum())
+        uvw_count += int(uvw_delta.size)
+
+        native_data = np.asarray(native_tb.getcell("DATA", int(native_row)))
+        casa_data = np.asarray(casa_tb.getcell("DATA", int(casa_row)))
+        native_flag = np.asarray(native_tb.getcell("FLAG", int(native_row)), dtype=bool)
+        casa_flag = np.asarray(casa_tb.getcell("FLAG", int(casa_row)), dtype=bool)
+        native_flag_row = bool(native_tb.getcell("FLAG_ROW", int(native_row)))
+        casa_flag_row = bool(casa_tb.getcell("FLAG_ROW", int(casa_row)))
+        native_effective_flag = native_flag | native_flag_row
+        casa_effective_flag = casa_flag | casa_flag_row
+
+        raw_flag_mismatches += int(np.count_nonzero(native_flag != casa_flag))
+        effective_flag_mismatches += int(np.count_nonzero(native_effective_flag != casa_effective_flag))
+        mask = ~(native_effective_flag | casa_effective_flag)
+        if np.any(mask):
+            delta = np.abs(native_data - casa_data)
+            amp = np.abs(casa_data)
+            selected_delta = delta[mask]
+            selected_amp = amp[mask]
+            relative = selected_delta / np.maximum(selected_amp, data_atol)
+            row_max_abs = float(selected_delta.max())
+            row_max_relative = float(relative.max())
+            data_max_abs = max(data_max_abs, row_max_abs)
+            data_max_relative = max(data_max_relative, row_max_relative)
+            data_sum_abs += float(selected_delta.sum())
+            data_count += int(selected_delta.size)
+            if row_max_abs == data_max_abs or row_max_relative == data_max_relative:
+                corr, chan = np.argwhere(mask)[int(np.argmax(selected_delta))]
+                worst_cells.append({
+                    "native_row": int(native_row),
+                    "casa_row": int(casa_row),
+                    "correlation": int(corr),
+                    "channel": int(chan),
+                    "abs": row_max_abs,
+                    "relative": row_max_relative,
+                    "native": {
+                        "real": float(native_data[corr, chan].real),
+                        "imag": float(native_data[corr, chan].imag),
+                    },
+                    "casa": {
+                        "real": float(casa_data[corr, chan].real),
+                        "imag": float(casa_data[corr, chan].imag),
+                    },
+                })
+
+        native_weight = np.asarray(native_tb.getcell("WEIGHT", int(native_row)), dtype=np.float64)
+        casa_weight = np.asarray(casa_tb.getcell("WEIGHT", int(casa_row)), dtype=np.float64)
+        native_sigma = np.asarray(native_tb.getcell("SIGMA", int(native_row)), dtype=np.float64)
+        casa_sigma = np.asarray(casa_tb.getcell("SIGMA", int(casa_row)), dtype=np.float64)
+        weight_max_abs = max(weight_max_abs, float(np.abs(native_weight - casa_weight).max()))
+        sigma_max_abs = max(sigma_max_abs, float(np.abs(native_sigma - casa_sigma).max()))
+finally:
+    native_tb.close()
+    casa_tb.close()
+
+result["rows_sampled"] = len(native_sample_rows)
+result["missing_key_count"] = len(missing_keys)
+if missing_keys:
+    result["missing_keys"] = missing_keys[:10]
+    result["status"] = "failed"
+    result["reasons"].append("strict sampled row key missing in CASA")
+result["uvw"] = {
+    "max_abs": uvw_max_abs,
+    "mean_abs": uvw_mean_sum / uvw_count if uvw_count else 0.0,
+}
+result["data"] = {
+    "compared_unflagged_cells": data_count,
+    "max_abs": data_max_abs,
+    "mean_abs": data_sum_abs / data_count if data_count else 0.0,
+    "max_relative": data_max_relative,
+    "worst_cells": worst_cells[-10:],
+}
+result["raw_flag_mismatches"] = raw_flag_mismatches
+result["effective_flag_mismatches"] = effective_flag_mismatches
+result["weight"] = {"max_abs": weight_max_abs}
+result["sigma"] = {"max_abs": sigma_max_abs}
+
+if uvw_max_abs > uvw_atol:
+    result["status"] = "failed"
+    result["reasons"].append(f"strict sampled UVW max abs {uvw_max_abs:.6g} exceeds {uvw_atol:.6g}")
+if data_count and (data_max_abs > data_atol and data_max_relative > data_rtol):
+    result["status"] = "failed"
+    result["reasons"].append(
+        f"strict sampled DATA max abs {data_max_abs:.6g}, max rel {data_max_relative:.6g} exceeds tolerances"
+    )
+if effective_flag_mismatches:
+    result["status"] = "failed"
+    result["reasons"].append(f"strict sampled effective FLAG differs in {effective_flag_mismatches} cells")
+if weight_max_abs > 1.0e-6:
+    result["status"] = "failed"
+    result["reasons"].append(f"strict sampled WEIGHT max abs {weight_max_abs:.6g} exceeds 1e-6")
+if sigma_max_abs > 1.0e-6:
+    result["status"] = "failed"
+    result["reasons"].append(f"strict sampled SIGMA max abs {sigma_max_abs:.6g} exceeds 1e-6")
+
+print(json.dumps(result, sort_keys=True))
+'''
+    completed = subprocess.run(
+        [
+            casa_python,
+            "-c",
+            script,
+            json.dumps([native_ms, casa_ms, uvw_atol, data_atol, data_rtol]),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise BenchError(
+            "failed to run sampled strict MS value comparison: " + completed.stderr.strip()
+        )
+    return parse_json_from_stdout(completed.stdout, "sampled strict MS value comparison")
+
+
+def collect_legacy_full_strict_value_comparison(
     casa_python: str,
     native_ms: str,
     casa_ms: str,
@@ -840,6 +1150,7 @@ def write_html_report(path: pathlib.Path, result: dict[str, Any]) -> None:
     speedup = result.get("speedup_vs_casa")
     speedup_text = "not run" if speedup is None else f"{speedup:.2f}x"
     native = result["native_parallel"]
+    native_perf = result.get("native_performance", {})
     casa = result.get("casa")
     rows = result["shape"]["estimated_main_rows"]
     channels = result["shape"]["channels"]
@@ -868,6 +1179,8 @@ def write_html_report(path: pathlib.Path, result: dict[str, Any]) -> None:
     <tr><th>Channels</th><td>{channels:,}</td></tr>
     <tr><th>Native best</th><td>{native["best_seconds"]:.3f} s</td></tr>
     <tr><th>Native size</th><td>{format_bytes(native["size_bytes"])}</td></tr>
+    <tr><th>Native throughput</th><td>{format_rate(native_perf.get("native_output_mb_per_second"))}</td></tr>
+    <tr><th>Streamed write throughput</th><td>{format_rate(native_perf.get("data_io_mb_per_second"))}</td></tr>
     <tr><th>CASA best</th><td>{format_seconds(casa)}</td></tr>
     <tr><th>CASA size</th><td>{format_bytes(casa["size_bytes"]) if casa else "not run"}</td></tr>
     <tr><th>Speedup vs CASA</th><td>{speedup_text}</td></tr>
@@ -908,6 +1221,12 @@ def format_bytes(size: int) -> str:
             return f"{value:.2f} {unit}"
         value /= 1024.0
     return f"{size} B"
+
+
+def format_rate(rate: Any) -> str:
+    if rate is None:
+        return "not reported"
+    return f"{float(rate):.1f} MB/s"
 
 
 def select_dataset(plan: dict[str, Any], dataset_id: str) -> dict[str, Any]:

--- a/tools/perf/imager/bench_simobserve.py
+++ b/tools/perf/imager/bench_simobserve.py
@@ -150,6 +150,8 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
             request,
             casa["last_ms"],
         )
+        request["request"]["allow_below_elevation_limit"] = True
+        request["request"]["elevation_limit_rad"] = 8.0 * 3.141592653589793 / 180.0
 
     native_parallel = run_native_repeats(
         args.casars_binary,
@@ -718,6 +720,28 @@ def read_keys(path):
         tb.close()
     return rows, keys
 
+def flag_counts(path, chunk_rows=8192):
+    tb = open_table(path)
+    try:
+        rows = int(tb.nrows())
+        flag_true = 0
+        flag_row_true = 0
+        effective_true = 0
+        for start in range(0, rows, chunk_rows):
+            count = min(chunk_rows, rows - start)
+            flag = np.asarray(tb.getcol("FLAG", startrow=start, nrow=count), dtype=bool)
+            flag_row = np.asarray(tb.getcol("FLAG_ROW", startrow=start, nrow=count), dtype=bool)
+            flag_true += int(np.count_nonzero(flag))
+            flag_row_true += int(np.count_nonzero(flag_row))
+            effective_true += int(np.count_nonzero(flag | flag_row.reshape(1, 1, -1)))
+    finally:
+        tb.close()
+    return {
+        "flag_true_cells": flag_true,
+        "flag_row_true_rows": flag_row_true,
+        "effective_flag_true_cells": effective_true,
+    }
+
 native_rows, native_keys = read_keys(native_path)
 casa_rows, casa_keys = read_keys(casa_path)
 result = {
@@ -725,12 +749,19 @@ result = {
     "reasons": [],
     "sampled": True,
     "row_count": {"native": native_rows, "casa": casa_rows},
+    "flag_counts": {
+        "native": flag_counts(native_path),
+        "casa": flag_counts(casa_path),
+    },
     "thresholds": {
         "uvw_atol": uvw_atol,
         "data_atol": data_atol,
         "data_rtol": data_rtol,
     },
 }
+if result["flag_counts"]["native"] != result["flag_counts"]["casa"]:
+    result["status"] = "failed"
+    result["reasons"].append("strict total FLAG/FLAG_ROW counts differ")
 if native_rows != casa_rows:
     result["status"] = "failed"
     result["reasons"].append("strict row count mismatch")
@@ -1046,6 +1077,21 @@ native_flag = native["flag"][:, :, native_order]
 casa_flag = casa["flag"][:, :, casa_order]
 native_effective_flag = native_flag | native["flag_row"][native_order].reshape(1, 1, -1)
 casa_effective_flag = casa_flag | casa["flag_row"][casa_order].reshape(1, 1, -1)
+result["flag_counts"] = {
+    "native": {
+        "flag_true_cells": int(np.count_nonzero(native_flag)),
+        "flag_row_true_rows": int(np.count_nonzero(native["flag_row"][native_order])),
+        "effective_flag_true_cells": int(np.count_nonzero(native_effective_flag)),
+    },
+    "casa": {
+        "flag_true_cells": int(np.count_nonzero(casa_flag)),
+        "flag_row_true_rows": int(np.count_nonzero(casa["flag_row"][casa_order])),
+        "effective_flag_true_cells": int(np.count_nonzero(casa_effective_flag)),
+    },
+}
+if result["flag_counts"]["native"] != result["flag_counts"]["casa"]:
+    result["status"] = "failed"
+    result["reasons"].append("strict total FLAG/FLAG_ROW counts differ")
 data_abs_all = np.abs(native_data - casa_data)
 casa_amp_all = np.abs(casa_data)
 comparison_mask = ~(native_effective_flag | casa_effective_flag)

--- a/tools/perf/imager/bench_simobserve.py
+++ b/tools/perf/imager/bench_simobserve.py
@@ -23,6 +23,19 @@ class BenchError(Exception):
     """Error that should be shown without a Python traceback."""
 
 
+def strict_data_cell_violates(
+    abs_error: float,
+    casa_amplitude: float,
+    *,
+    data_atol: float,
+    data_rtol: float,
+) -> bool:
+    """Return true when one DATA cell fails both absolute and relative criteria."""
+
+    relative = abs_error / max(casa_amplitude, data_atol)
+    return abs_error > data_atol and relative > data_rtol
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("plan", type=pathlib.Path, help="wave1-dataset-plan.json")
@@ -647,6 +660,55 @@ def open_table(path):
 def key_tuple(keys, row):
     return tuple(key[row].item() if hasattr(key[row], "item") else key[row] for key in keys)
 
+def phase_residual_diagnostics(samples):
+    if not samples:
+        return {"samples": 0, "fields": {}}
+    values = np.asarray(samples, dtype=np.float64)
+    fields = {}
+    for field_id in sorted(set(values[:, 0].astype(int))):
+        field_values = values[values[:, 0] == field_id]
+        if field_values.shape[0] < 4:
+            continue
+        high_amplitude_cut = np.percentile(field_values[:, 7], 50)
+        fit_values = field_values[field_values[:, 7] >= high_amplitude_cut]
+        if fit_values.shape[0] < 4:
+            fit_values = field_values
+        design = np.column_stack([
+            fit_values[:, 2],
+            fit_values[:, 3],
+            fit_values[:, 4],
+            np.ones(fit_values.shape[0]),
+        ])
+        phase = fit_values[:, 5]
+        beta, *_ = np.linalg.lstsq(design, phase, rcond=None)
+        residual = phase - design @ beta
+        amp_ratio = fit_values[:, 6]
+        abs_delta = fit_values[:, 8]
+        fields[str(field_id)] = {
+            "samples": int(field_values.shape[0]),
+            "fit_samples": int(fit_values.shape[0]),
+            "phase_fit_rad_per_lambda": {
+                "u": float(beta[0]),
+                "v": float(beta[1]),
+                "w": float(beta[2]),
+                "constant": float(beta[3]),
+            },
+            "phase_residual_rms_rad": float(np.sqrt(np.mean(residual * residual))),
+            "phase_min_rad": float(phase.min()),
+            "phase_max_rad": float(phase.max()),
+            "amplitude_ratio": {
+                "mean": float(amp_ratio.mean()),
+                "std": float(amp_ratio.std()),
+                "min": float(amp_ratio.min()),
+                "max": float(amp_ratio.max()),
+            },
+            "abs_delta": {
+                "mean": float(abs_delta.mean()),
+                "max": float(abs_delta.max()),
+            },
+        }
+    return {"samples": int(values.shape[0]), "fields": fields}
+
 def read_keys(path):
     tb = open_table(path)
     try:
@@ -683,13 +745,18 @@ else:
 
 native_tb = open_table(native_path)
 casa_tb = open_table(casa_path)
+spw_tb = open_table(casa_path + "/SPECTRAL_WINDOW")
 try:
+    channel_frequencies_hz = np.asarray(spw_tb.getcell("CHAN_FREQ", 0), dtype=np.float64)
     uvw_max_abs = 0.0
     uvw_mean_sum = 0.0
     uvw_count = 0
     data_max_abs = 0.0
     data_sum_abs = 0.0
     data_max_relative = 0.0
+    data_violation_count = 0
+    data_violation_max_abs = 0.0
+    data_violation_max_relative = 0.0
     data_count = 0
     raw_flag_mismatches = 0
     effective_flag_mismatches = 0
@@ -697,6 +764,7 @@ try:
     sigma_max_abs = 0.0
     missing_keys = []
     worst_cells = []
+    phase_samples = []
 
     for native_row in native_sample_rows:
         key = key_tuple(native_keys, native_row)
@@ -736,6 +804,19 @@ try:
             data_max_relative = max(data_max_relative, row_max_relative)
             data_sum_abs += float(selected_delta.sum())
             data_count += int(selected_delta.size)
+            violation_mask = (selected_delta > data_atol) & (relative > data_rtol)
+            if np.any(violation_mask):
+                data_violation_count += int(np.count_nonzero(violation_mask))
+                violation_delta = selected_delta[violation_mask]
+                violation_relative = relative[violation_mask]
+                data_violation_max_abs = max(
+                    data_violation_max_abs,
+                    float(violation_delta.max()),
+                )
+                data_violation_max_relative = max(
+                    data_violation_max_relative,
+                    float(violation_relative.max()),
+                )
             if row_max_abs == data_max_abs or row_max_relative == data_max_relative:
                 corr, chan = np.argwhere(mask)[int(np.argmax(selected_delta))]
                 worst_cells.append({
@@ -754,6 +835,31 @@ try:
                         "imag": float(casa_data[corr, chan].imag),
                     },
                 })
+            unflagged_cells = np.argwhere(mask)
+            for corr, chan in unflagged_cells:
+                # Correlations are identical for these scalar simulation
+                # products; keep one polarization so fits describe rows and
+                # channels rather than double-counting the same residual.
+                if int(corr) != 0:
+                    continue
+                casa_value = casa_data[corr, chan]
+                native_value = native_data[corr, chan]
+                casa_amplitude = abs(casa_value)
+                if casa_amplitude <= data_atol:
+                    continue
+                ratio = native_value / casa_value
+                frequency_hz = float(channel_frequencies_hz[int(chan)])
+                phase_samples.append((
+                    int(key[1]),
+                    int(chan),
+                    float(native_uvw[0] * frequency_hz / 299792458.0),
+                    float(native_uvw[1] * frequency_hz / 299792458.0),
+                    float(native_uvw[2] * frequency_hz / 299792458.0),
+                    float(np.angle(ratio)),
+                    float(abs(ratio)),
+                    float(casa_amplitude),
+                    float(delta[corr, chan]),
+                ))
 
         native_weight = np.asarray(native_tb.getcell("WEIGHT", int(native_row)), dtype=np.float64)
         casa_weight = np.asarray(casa_tb.getcell("WEIGHT", int(casa_row)), dtype=np.float64)
@@ -762,6 +868,7 @@ try:
         weight_max_abs = max(weight_max_abs, float(np.abs(native_weight - casa_weight).max()))
         sigma_max_abs = max(sigma_max_abs, float(np.abs(native_sigma - casa_sigma).max()))
 finally:
+    spw_tb.close()
     native_tb.close()
     casa_tb.close()
 
@@ -780,8 +887,12 @@ result["data"] = {
     "max_abs": data_max_abs,
     "mean_abs": data_sum_abs / data_count if data_count else 0.0,
     "max_relative": data_max_relative,
+    "violating_cells": data_violation_count,
+    "violation_max_abs": data_violation_max_abs,
+    "violation_max_relative": data_violation_max_relative,
     "worst_cells": worst_cells[-10:],
 }
+result["phase_residual_diagnostics"] = phase_residual_diagnostics(phase_samples)
 result["raw_flag_mismatches"] = raw_flag_mismatches
 result["effective_flag_mismatches"] = effective_flag_mismatches
 result["weight"] = {"max_abs": weight_max_abs}
@@ -790,10 +901,11 @@ result["sigma"] = {"max_abs": sigma_max_abs}
 if uvw_max_abs > uvw_atol:
     result["status"] = "failed"
     result["reasons"].append(f"strict sampled UVW max abs {uvw_max_abs:.6g} exceeds {uvw_atol:.6g}")
-if data_count and (data_max_abs > data_atol and data_max_relative > data_rtol):
+if data_violation_count:
     result["status"] = "failed"
     result["reasons"].append(
-        f"strict sampled DATA max abs {data_max_abs:.6g}, max rel {data_max_relative:.6g} exceeds tolerances"
+        f"strict sampled DATA has {data_violation_count} cells exceeding both tolerances "
+        f"(max abs {data_violation_max_abs:.6g}, max rel {data_violation_max_relative:.6g})"
     )
 if effective_flag_mismatches:
     result["status"] = "failed"
@@ -940,12 +1052,26 @@ comparison_mask = ~(native_effective_flag | casa_effective_flag)
 data_abs = data_abs_all[comparison_mask]
 casa_amp = casa_amp_all[comparison_mask]
 relative = data_abs / np.maximum(casa_amp, data_atol)
+data_violation_mask = (
+    comparison_mask
+    & (data_abs_all > data_atol)
+    & ((data_abs_all / np.maximum(casa_amp_all, data_atol)) > data_rtol)
+)
+data_violation_abs = data_abs_all[data_violation_mask]
+data_violation_relative = (
+    data_abs_all[data_violation_mask] / np.maximum(casa_amp_all[data_violation_mask], data_atol)
+)
 result["data"] = {
     "compared_unflagged_cells": int(np.count_nonzero(comparison_mask)),
     "all_cells_max_abs": float(data_abs_all.max()) if data_abs_all.size else 0.0,
     "max_abs": float(data_abs.max()) if data_abs.size else 0.0,
     "mean_abs": float(data_abs.mean()) if data_abs.size else 0.0,
     "max_relative": float(relative.max()) if relative.size else 0.0,
+    "violating_cells": int(np.count_nonzero(data_violation_mask)),
+    "violation_max_abs": float(data_violation_abs.max()) if data_violation_abs.size else 0.0,
+    "violation_max_relative": (
+        float(data_violation_relative.max()) if data_violation_relative.size else 0.0
+    ),
     "native_abs_max": float(np.abs(native_data).max()) if native_data.size else 0.0,
     "casa_abs_max": float(casa_amp_all.max()) if casa_amp_all.size else 0.0,
 }
@@ -1071,16 +1197,12 @@ if data_abs.size:
             ),
         })
     result["data"]["worst_relative_cells"] = worst_relative_cells
-if not np.allclose(
-    native_data[comparison_mask],
-    casa_data[comparison_mask],
-    rtol=data_rtol,
-    atol=data_atol,
-):
+if result["data"]["violating_cells"]:
     result["status"] = "failed"
     result["reasons"].append(
-        f"strict DATA max abs {result['data']['max_abs']:.6g}, "
-        f"max rel {result['data']['max_relative']:.6g} exceeds tolerances"
+        f"strict DATA has {result['data']['violating_cells']} cells exceeding both tolerances "
+        f"(max abs {result['data']['violation_max_abs']:.6g}, "
+        f"max rel {result['data']['violation_max_relative']:.6g})"
     )
 
 raw_flag_mismatches = int(np.count_nonzero(native_flag != casa_flag))

--- a/tools/perf/imager/bench_simobserve.py
+++ b/tools/perf/imager/bench_simobserve.py
@@ -1,0 +1,947 @@
+#!/usr/bin/env python3
+"""Benchmark native simobserve against CASA simobserve for a Wave 1 dataset."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import statistics
+import shutil
+import subprocess
+import sys
+import time
+from typing import Any
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+DEFAULT_BINARY = REPO_ROOT / "target" / "release" / "simobserve"
+
+
+class BenchError(Exception):
+    """Error that should be shown without a Python traceback."""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("plan", type=pathlib.Path, help="wave1-dataset-plan.json")
+    parser.add_argument("--dataset", required=True, help="dataset id from the plan")
+    parser.add_argument(
+        "--output-dir",
+        type=pathlib.Path,
+        default=pathlib.Path("target/imperformance-wave1/simobserve-bench"),
+    )
+    parser.add_argument("--casars-binary", type=pathlib.Path, default=DEFAULT_BINARY)
+    parser.add_argument(
+        "--casa-python",
+        default=os.environ.get(
+            "CASA_RS_CASA_PYTHON",
+            "/Users/brianglendenning/SoftwareProjects/casa-build/venv/bin/python",
+        ),
+    )
+    parser.add_argument("--repeats", type=int, default=1)
+    parser.add_argument("--channel-workers", type=int, default=None)
+    parser.add_argument("--require-speedup", type=float, default=None)
+    parser.add_argument(
+        "--disable-noise",
+        action="store_true",
+        help="run both CASA and native simobserve without thermal/noise corruption",
+    )
+    parser.add_argument(
+        "--strict-values",
+        action="store_true",
+        help="fail unless CASA and native rows, UVW, and DATA agree numerically",
+    )
+    parser.add_argument("--strict-uvw-atol", type=float, default=1.0e-5)
+    parser.add_argument("--strict-data-atol", type=float, default=1.0e-4)
+    parser.add_argument("--strict-data-rtol", type=float, default=1.0e-3)
+    parser.add_argument("--skip-casa", action="store_true")
+    parser.add_argument("--skip-serial-check", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        result = run_benchmark(args)
+        result_path = pathlib.Path(result["result_json"])
+        write_json(result_path, result)
+        write_html_report(pathlib.Path(result["report_html"]), result)
+        print(result_path)
+        if result["correctness"]["status"] != "passed":
+            raise SystemExit(2)
+    except BenchError as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(2) from None
+
+
+def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
+    if args.repeats < 1:
+        raise BenchError("--repeats must be >= 1")
+    plan = read_json(args.plan)
+    dataset = select_dataset(plan, args.dataset)
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    run_id = f"{time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())}-{dataset['id']}"
+    run_root = output_dir / run_id
+    run_root.mkdir(parents=True, exist_ok=True)
+
+    request = read_json(pathlib.Path(dataset["paths"]["casars_simobserve_request"]))
+    if args.disable_noise:
+        request["request"]["corruption"] = None
+        request["request"]["model_peak_jy_per_pixel"] = None
+        dataset = without_noise(dataset)
+
+    casa = None
+    run_casa_first = args.strict_values and not args.skip_casa
+    if run_casa_first:
+        casa = run_casa_repeats(
+            args.casa_python,
+            dataset,
+            run_root / "casa",
+            repeats=args.repeats,
+        )
+        align_request_start_time_to_ms(
+            args.casa_python,
+            request,
+            casa["last_ms"],
+        )
+
+    native_parallel = run_native_repeats(
+        args.casars_binary,
+        request,
+        run_root / "native-parallel",
+        repeats=args.repeats,
+        channel_workers=args.channel_workers,
+    )
+    native_serial = None
+    if not args.skip_serial_check:
+        native_serial = run_native_repeats(
+            args.casars_binary,
+            request,
+            run_root / "native-serial",
+            repeats=1,
+            channel_workers=1,
+        )
+
+    if not args.skip_casa and not run_casa_first:
+        casa = run_casa_repeats(
+            args.casa_python,
+            dataset,
+            run_root / "casa",
+            repeats=args.repeats,
+        )
+
+    correctness = collect_correctness(
+        args.casa_python,
+        native_parallel["last_ms"],
+        None if native_serial is None else native_serial["last_ms"],
+        None if casa is None else casa["last_ms"],
+        strict_values=args.strict_values,
+        strict_uvw_atol=args.strict_uvw_atol,
+        strict_data_atol=args.strict_data_atol,
+        strict_data_rtol=args.strict_data_rtol,
+    )
+    speedup = None
+    if casa is not None:
+        speedup = casa["best_seconds"] / native_parallel["best_seconds"]
+        if args.require_speedup is not None and speedup < args.require_speedup:
+            raise BenchError(
+                f"native simobserve speedup {speedup:.2f}x is below target "
+                f"{args.require_speedup:.2f}x"
+            )
+
+    result_path = run_root / "simobserve-benchmark.json"
+    report_path = run_root / "simobserve-benchmark.html"
+    return {
+        "schema_version": 1,
+        "result_json": str(result_path),
+        "report_html": str(report_path),
+        "run_root": str(run_root),
+        "dataset": dataset["id"],
+        "shape": dataset["shape"],
+        "native_parallel": native_parallel,
+        "native_serial": native_serial,
+        "casa": casa,
+        "correctness": correctness,
+        "speedup_vs_casa": speedup,
+        "target": {"required_speedup": args.require_speedup},
+    }
+
+
+def run_native_repeats(
+    binary: pathlib.Path,
+    request: dict[str, Any],
+    output_dir: pathlib.Path,
+    *,
+    repeats: int,
+    channel_workers: int | None,
+) -> dict[str, Any]:
+    if not binary.exists():
+        raise BenchError(f"native simobserve binary does not exist: {binary}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    timings = []
+    last_ms = None
+    for index in range(repeats):
+        run_dir = output_dir / f"run-{index + 1:02d}"
+        if run_dir.exists():
+            shutil.rmtree(run_dir)
+        run_dir.mkdir(parents=True)
+        run_request = json.loads(json.dumps(request))
+        ms_path = run_dir / "native.ms"
+        run_request["request"]["output_ms"] = str(ms_path)
+        run_request["request"]["overwrite"] = True
+        request_path = run_dir / "request.json"
+        write_json(request_path, run_request)
+        env = os.environ.copy()
+        if channel_workers is not None:
+            env["CASA_RS_SIMOBSERVE_CHANNEL_WORKERS"] = str(channel_workers)
+        started = time.perf_counter()
+        completed = subprocess.run(
+            [str(binary), "--json-run", str(request_path)],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        elapsed = time.perf_counter() - started
+        (run_dir / "stdout.json").write_text(completed.stdout, encoding="utf-8")
+        (run_dir / "stderr.log").write_text(completed.stderr, encoding="utf-8")
+        if completed.returncode != 0:
+            raise BenchError(
+                f"native simobserve failed with exit {completed.returncode}: "
+                f"{completed.stderr.strip()}"
+            )
+        native_result = parse_native_result(completed.stdout, run_dir / "stdout.json")
+        timings.append(elapsed)
+        last_ms = ms_path
+    assert last_ms is not None
+    return {
+        "timings_seconds": timings,
+        "best_seconds": min(timings),
+        "median_seconds": statistics.median(timings),
+        "last_ms": str(last_ms),
+        "last_result": native_result,
+        "channel_workers": channel_workers,
+        "size_bytes": directory_size(last_ms),
+    }
+
+
+def run_casa_repeats(
+    casa_python: str,
+    dataset: dict[str, Any],
+    output_dir: pathlib.Path,
+    *,
+    repeats: int,
+) -> dict[str, Any]:
+    python = pathlib.Path(casa_python)
+    if not python.exists():
+        raise BenchError(f"CASA Python does not exist: {python}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    timings = []
+    last_ms = None
+    for index in range(repeats):
+        run_dir = output_dir / f"run-{index + 1:02d}"
+        if run_dir.exists():
+            shutil.rmtree(run_dir)
+        run_dir.mkdir(parents=True)
+        run_dataset = json.loads(json.dumps(dataset))
+        run_dataset["paths"]["dataset_dir"] = str(run_dir / "dataset")
+        run_dataset["paths"]["output_ms"] = str(run_dir / "casa.ms")
+        run_dataset["paths"]["continuum_model_fits"] = str(
+            run_dir / "dataset" / "models" / "structured-continuum.fits"
+        )
+        script = run_dir / "run-casa-simobserve.py"
+        script.write_text(
+            CASA_RUNNER.format(dataset_json=json.dumps(run_dataset)),
+            encoding="utf-8",
+        )
+        started = time.perf_counter()
+        completed = subprocess.run(
+            [str(python), str(script)],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        elapsed = time.perf_counter() - started
+        (run_dir / "stdout.jsonl").write_text(completed.stdout, encoding="utf-8")
+        (run_dir / "stderr.log").write_text(completed.stderr, encoding="utf-8")
+        if completed.returncode != 0:
+            raise BenchError(
+                f"CASA simobserve failed with exit {completed.returncode}: "
+                f"{completed.stderr.strip()}"
+            )
+        timings.append(elapsed)
+        last_ms = run_dir / "casa.ms"
+    assert last_ms is not None
+    return {
+        "timings_seconds": timings,
+        "best_seconds": min(timings),
+        "median_seconds": statistics.median(timings),
+        "last_ms": str(last_ms),
+        "size_bytes": directory_size(last_ms),
+    }
+
+
+def parse_native_result(stdout: str, source: pathlib.Path) -> dict[str, Any]:
+    payload = parse_json_from_stdout(stdout, f"native simobserve {source}")
+    if payload.get("kind") != "run":
+        raise BenchError(f"native simobserve emitted unexpected result kind in {source}")
+    return payload["result"]
+
+
+def without_noise(dataset: dict[str, Any]) -> dict[str, Any]:
+    dataset = json.loads(json.dumps(dataset))
+    source_model = dataset.setdefault("source_model", {})
+    source_model["noise_simplenoise_jy"] = 0.0
+    return dataset
+
+
+def align_request_start_time_to_ms(
+    casa_python: str,
+    request: dict[str, Any],
+    ms_path: str,
+) -> None:
+    first_time = read_first_ms_time(casa_python, ms_path)
+    integration_seconds = float(request["request"]["integration_seconds"])
+    request["request"]["start_time_mjd_seconds"] = first_time - 0.5 * integration_seconds
+
+
+def read_first_ms_time(casa_python: str, ms_path: str) -> float:
+    script = r'''
+import json
+import sys
+from casatools import table
+
+path = json.loads(sys.argv[1])
+tb = table()
+tb.open(path)
+try:
+    value = float(tb.getcell("TIME", 0))
+finally:
+    tb.close()
+print(json.dumps({"first_time": value}))
+'''
+    completed = subprocess.run(
+        [casa_python, "-c", script, json.dumps(ms_path)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise BenchError(
+            "failed to inspect first CASA MS time: " + completed.stderr.strip()
+        )
+    return float(parse_json_from_stdout(completed.stdout, "first MS time")["first_time"])
+
+
+def parse_json_from_stdout(stdout: str, context: str) -> dict[str, Any]:
+    stripped_stdout = stdout.strip()
+    if stripped_stdout:
+        try:
+            payload = json.loads(stripped_stdout)
+            if isinstance(payload, dict):
+                return payload
+        except json.JSONDecodeError:
+            pass
+    for line in reversed(stdout.splitlines()):
+        stripped = line.strip()
+        if not stripped.startswith("{"):
+            continue
+        try:
+            payload = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            return payload
+    raise BenchError(f"{context} stdout did not contain a JSON object")
+
+
+CASA_RUNNER = r'''
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, "{tool_dir}")
+import generate_wave1_casa_datasets as gen
+
+dataset = json.loads({dataset_json!r})
+result = gen.generate_dataset(
+    dataset,
+    skip_existing=False,
+    overwrite=True,
+    preview=False,
+    preview_max_pixels=128,
+)
+print(json.dumps(result, sort_keys=True))
+'''.replace("{tool_dir}", str(pathlib.Path(__file__).resolve().parent))
+
+
+def collect_correctness(
+    casa_python: str,
+    native_parallel_ms: str,
+    native_serial_ms: str | None,
+    casa_ms: str | None,
+    *,
+    strict_values: bool,
+    strict_uvw_atol: float,
+    strict_data_atol: float,
+    strict_data_rtol: float,
+) -> dict[str, Any]:
+    paths = {"native_parallel": native_parallel_ms}
+    if native_serial_ms is not None:
+        paths["native_serial"] = native_serial_ms
+    if casa_ms is not None:
+        paths["casa"] = casa_ms
+    script = (
+        "import json,sys\n"
+        "import numpy as np\n"
+        "from casatools import table\n"
+        "paths=json.loads(sys.argv[1])\n"
+    )
+    script += r'''
+def subtable_rows(path, name):
+    tb = table()
+    try:
+        tb.open(path + "/" + name)
+        return int(tb.nrows())
+    finally:
+        try:
+            tb.close()
+        except Exception:
+            pass
+
+def stats(values):
+    arr = np.asarray(values)
+    return {
+        "min": float(arr.min()),
+        "max": float(arr.max()),
+        "mean": float(arr.mean()),
+    }
+
+def data_stats(cell):
+    arr = np.asarray(cell)
+    amp = np.abs(arr)
+    return {
+        "shape": list(arr.shape),
+        "abs_sum": float(amp.sum()),
+        "abs_max": float(amp.max()),
+        "real_mean": float(arr.real.mean()),
+        "imag_mean": float(arr.imag.mean()),
+    }
+
+def inspect(path):
+    tb = table()
+    tb.open(path)
+    try:
+        rows = tb.nrows()
+        colnames = tb.colnames()
+        data = tb.getcell("DATA", 0)
+        uvw = tb.getcell("UVW", 0)
+        selected = sorted(set([0, max(0, rows // 2), max(0, rows - 1)]))
+        selected_data = {str(row): data_stats(tb.getcell("DATA", row)) for row in selected}
+        uvw_col = tb.getcol("UVW")
+    finally:
+        tb.close()
+    return {
+        "rows": int(rows),
+        "columns": colnames,
+        "complex_visibility_columns": [
+            column for column in ["DATA", "MODEL_DATA", "CORRECTED_DATA", "FLOAT_DATA"]
+            if column in colnames
+        ],
+        "data_shape": list(data.shape),
+        "first_data_abs_sum": float(abs(data).sum()),
+        "first_uvw": [float(value) for value in uvw],
+        "uvw_stats": {
+            "u_m": stats(uvw_col[0, :]),
+            "v_m": stats(uvw_col[1, :]),
+            "w_m": stats(uvw_col[2, :]),
+        },
+        "selected_data_stats": selected_data,
+        "subtable_rows": {
+            "FIELD": subtable_rows(path, "FIELD"),
+            "SPECTRAL_WINDOW": subtable_rows(path, "SPECTRAL_WINDOW"),
+            "DATA_DESCRIPTION": subtable_rows(path, "DATA_DESCRIPTION"),
+            "OBSERVATION": subtable_rows(path, "OBSERVATION"),
+            "POINTING": subtable_rows(path, "POINTING"),
+        },
+    }
+print(json.dumps({name: inspect(path) for name, path in paths.items()}, sort_keys=True))
+'''
+    completed = subprocess.run(
+        [casa_python, "-c", script, json.dumps(paths)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise BenchError(f"failed to inspect benchmark MS outputs: {completed.stderr.strip()}")
+    inspections = parse_json_from_stdout(completed.stdout, "MS inspection")
+    status = "passed"
+    reasons = []
+    native = inspections["native_parallel"]
+    if native_serial_ms is not None and inspections["native_serial"] != native:
+        status = "failed"
+        reasons.append("native parallel output differs from native serial output")
+    if casa_ms is not None:
+        casa = inspections["casa"]
+        for key in ("rows", "data_shape"):
+            if casa[key] != native[key]:
+                status = "failed"
+                reasons.append(f"CASA {key} differs from native {key}")
+        for name in ("FIELD", "SPECTRAL_WINDOW", "DATA_DESCRIPTION", "OBSERVATION"):
+            if casa["subtable_rows"][name] != native["subtable_rows"][name]:
+                status = "failed"
+                reasons.append(f"CASA {name} row count differs from native {name} row count")
+        strict = None
+        if strict_values:
+            strict = collect_strict_value_comparison(
+                casa_python,
+                native_parallel_ms,
+                casa_ms,
+                uvw_atol=strict_uvw_atol,
+                data_atol=strict_data_atol,
+                data_rtol=strict_data_rtol,
+            )
+            if strict["status"] != "passed":
+                status = "failed"
+                reasons.extend(strict["reasons"])
+    return {
+        "status": status,
+        "reasons": reasons,
+        "inspections": inspections,
+        "strict_values": strict if casa_ms is not None and strict_values else None,
+    }
+
+
+def collect_strict_value_comparison(
+    casa_python: str,
+    native_ms: str,
+    casa_ms: str,
+    *,
+    uvw_atol: float,
+    data_atol: float,
+    data_rtol: float,
+) -> dict[str, Any]:
+    script = r'''
+import json
+import sys
+from collections import Counter
+import numpy as np
+from casatools import table
+
+native_path, casa_path, uvw_atol, data_atol, data_rtol = json.loads(sys.argv[1])
+
+KEY_COLUMNS = ["TIME", "FIELD_ID", "DATA_DESC_ID", "ANTENNA1", "ANTENNA2"]
+
+def read_ms(path):
+    tb = table()
+    tb.open(path)
+    try:
+        rows = int(tb.nrows())
+        payload = {
+            "rows": rows,
+            "keys": [np.asarray(tb.getcol(column)) for column in KEY_COLUMNS],
+            "uvw": np.asarray(tb.getcol("UVW")),
+            "data": np.asarray(tb.getcol("DATA")),
+            "flag": np.asarray(tb.getcol("FLAG")),
+            "flag_row": np.asarray(tb.getcol("FLAG_ROW"), dtype=bool),
+            "weight": np.asarray(tb.getcol("WEIGHT")),
+            "sigma": np.asarray(tb.getcol("SIGMA")),
+        }
+    finally:
+        tb.close()
+    spw = table()
+    spw.open(path + "/SPECTRAL_WINDOW")
+    try:
+        payload["chan_freq_hz"] = np.asarray(spw.getcell("CHAN_FREQ", 0), dtype=np.float64)
+    finally:
+        spw.close()
+    return payload
+
+def order_for(keys):
+    sortable = []
+    for row in range(len(keys[0])):
+        sortable.append(tuple(key[row].item() if hasattr(key[row], "item") else key[row] for key in keys))
+    return np.asarray(sorted(range(len(sortable)), key=lambda row: sortable[row]), dtype=np.int64), sortable
+
+def scalar_column_delta(native_keys, casa_keys, native_order, casa_order, index):
+    native = native_keys[index][native_order]
+    casa = casa_keys[index][casa_order]
+    if np.issubdtype(native.dtype, np.floating):
+        return float(np.max(np.abs(native - casa))) if native.size else 0.0
+    return int(np.count_nonzero(native != casa))
+
+native = read_ms(native_path)
+casa = read_ms(casa_path)
+result = {
+    "status": "passed",
+    "reasons": [],
+    "row_count": {"native": native["rows"], "casa": casa["rows"]},
+    "thresholds": {
+        "uvw_atol": uvw_atol,
+        "data_atol": data_atol,
+        "data_rtol": data_rtol,
+    },
+}
+if native["rows"] != casa["rows"]:
+    result["status"] = "failed"
+    result["reasons"].append("strict row count mismatch")
+    print(json.dumps(result, sort_keys=True))
+    raise SystemExit(0)
+
+native_order, native_sortable = order_for(native["keys"])
+casa_order, casa_sortable = order_for(casa["keys"])
+
+key_deltas = {}
+for index, column in enumerate(KEY_COLUMNS):
+    key_deltas[column] = scalar_column_delta(
+        native["keys"], casa["keys"], native_order, casa_order, index
+    )
+result["key_deltas"] = key_deltas
+for column, delta in key_deltas.items():
+    if delta != 0:
+        result["status"] = "failed"
+        result["reasons"].append(f"strict {column} differs after row normalization")
+
+native_uvw = native["uvw"][:, native_order]
+casa_uvw = casa["uvw"][:, casa_order]
+uvw_abs = np.abs(native_uvw - casa_uvw)
+result["uvw"] = {
+    "max_abs": float(uvw_abs.max()) if uvw_abs.size else 0.0,
+    "mean_abs": float(uvw_abs.mean()) if uvw_abs.size else 0.0,
+}
+if result["uvw"]["max_abs"] > uvw_atol:
+    result["status"] = "failed"
+    result["reasons"].append(
+        f"strict UVW max abs {result['uvw']['max_abs']:.6g} exceeds {uvw_atol:.6g}"
+    )
+
+native_data = native["data"][:, :, native_order]
+casa_data = casa["data"][:, :, casa_order]
+native_flag = native["flag"][:, :, native_order]
+casa_flag = casa["flag"][:, :, casa_order]
+native_effective_flag = native_flag | native["flag_row"][native_order].reshape(1, 1, -1)
+casa_effective_flag = casa_flag | casa["flag_row"][casa_order].reshape(1, 1, -1)
+data_abs_all = np.abs(native_data - casa_data)
+casa_amp_all = np.abs(casa_data)
+comparison_mask = ~(native_effective_flag | casa_effective_flag)
+data_abs = data_abs_all[comparison_mask]
+casa_amp = casa_amp_all[comparison_mask]
+relative = data_abs / np.maximum(casa_amp, data_atol)
+result["data"] = {
+    "compared_unflagged_cells": int(np.count_nonzero(comparison_mask)),
+    "all_cells_max_abs": float(data_abs_all.max()) if data_abs_all.size else 0.0,
+    "max_abs": float(data_abs.max()) if data_abs.size else 0.0,
+    "mean_abs": float(data_abs.mean()) if data_abs.size else 0.0,
+    "max_relative": float(relative.max()) if relative.size else 0.0,
+    "native_abs_max": float(np.abs(native_data).max()) if native_data.size else 0.0,
+    "casa_abs_max": float(casa_amp_all.max()) if casa_amp_all.size else 0.0,
+}
+phase_mask = comparison_mask & (casa_amp_all > max(data_atol, 1.0))
+if np.count_nonzero(phase_mask) >= 3:
+    phase_indices = np.argwhere(phase_mask)
+    rows = phase_indices[:, 2]
+    channels = phase_indices[:, 1]
+    wavelengths_m = 299_792_458.0 / casa["chan_freq_hz"][channels]
+    u_lambda = native_uvw[0, rows] / wavelengths_m
+    v_lambda = native_uvw[1, rows] / wavelengths_m
+    phase_delta = np.angle(
+        native_data[phase_mask] * np.conj(casa_data[phase_mask])
+    )
+    design = np.column_stack([
+        2.0 * np.pi * u_lambda,
+        2.0 * np.pi * v_lambda,
+        np.ones_like(u_lambda),
+    ])
+    fit, *_ = np.linalg.lstsq(design, phase_delta, rcond=None)
+    residual = phase_delta - design @ fit
+    phase_correction = np.exp(-1j * (design @ fit))
+    corrected_native = native_data[phase_mask] * phase_correction
+    corrected_abs = np.abs(corrected_native - casa_data[phase_mask])
+    native_amp = np.abs(native_data[phase_mask])
+    casa_amp_phase = np.abs(casa_data[phase_mask])
+    amp_ratio = native_amp / np.maximum(casa_amp_phase, data_atol)
+    result["data"]["phase_fit"] = {
+        "cells": int(phase_delta.size),
+        "min_casa_amp": float(casa_amp_phase.min()),
+        "image_offset_l_rad": float(fit[0]),
+        "image_offset_m_rad": float(fit[1]),
+        "constant_phase_rad": float(fit[2]),
+        "phase_delta_abs_max_rad": float(np.max(np.abs(phase_delta))),
+        "phase_delta_abs_median_rad": float(np.median(np.abs(phase_delta))),
+        "fit_residual_abs_max_rad": float(np.max(np.abs(residual))),
+        "fit_residual_abs_median_rad": float(np.median(np.abs(residual))),
+        "max_abs_after_phase_fit": float(np.max(corrected_abs)),
+        "median_abs_after_phase_fit": float(np.median(corrected_abs)),
+        "amplitude_ratio_min": float(np.min(amp_ratio)),
+        "amplitude_ratio_median": float(np.median(amp_ratio)),
+        "amplitude_ratio_max": float(np.max(amp_ratio)),
+    }
+if data_abs.size:
+    result["data"]["abs_percentiles"] = {
+        str(percentile): float(np.percentile(data_abs, percentile))
+        for percentile in [50, 90, 95, 99, 99.9, 100]
+    }
+    result["data"]["relative_percentiles"] = {
+        str(percentile): float(np.percentile(relative, percentile))
+        for percentile in [50, 90, 95, 99, 99.9, 100]
+    }
+    comparison_indices = np.argwhere(comparison_mask)
+    worst_indices = np.argsort(data_abs)[-10:][::-1]
+    worst_cells = []
+    for ordinal in worst_indices:
+        corr, chan, sorted_row = comparison_indices[ordinal]
+        native_row = int(native_order[sorted_row])
+        casa_row = int(casa_order[sorted_row])
+        worst_cells.append({
+            "native_row": native_row,
+            "casa_row": casa_row,
+            "correlation": int(corr),
+            "channel": int(chan),
+            "key": {
+                column: (
+                    native["keys"][index][native_row].item()
+                    if hasattr(native["keys"][index][native_row], "item")
+                    else native["keys"][index][native_row]
+                )
+                for index, column in enumerate(KEY_COLUMNS)
+            },
+            "uvw_m": [float(value) for value in native_uvw[:, sorted_row]],
+            "native": {
+                "real": float(native_data[corr, chan, sorted_row].real),
+                "imag": float(native_data[corr, chan, sorted_row].imag),
+            },
+            "casa": {
+                "real": float(casa_data[corr, chan, sorted_row].real),
+                "imag": float(casa_data[corr, chan, sorted_row].imag),
+            },
+            "abs": float(data_abs_all[corr, chan, sorted_row]),
+            "relative": float(
+                data_abs_all[corr, chan, sorted_row]
+                / max(casa_amp_all[corr, chan, sorted_row], data_atol)
+            ),
+        })
+    result["data"]["worst_cells"] = worst_cells
+    worst_relative_indices = np.argsort(relative)[-10:][::-1]
+    worst_relative_cells = []
+    for ordinal in worst_relative_indices:
+        corr, chan, sorted_row = comparison_indices[ordinal]
+        native_row = int(native_order[sorted_row])
+        casa_row = int(casa_order[sorted_row])
+        worst_relative_cells.append({
+            "native_row": native_row,
+            "casa_row": casa_row,
+            "correlation": int(corr),
+            "channel": int(chan),
+            "key": {
+                column: (
+                    native["keys"][index][native_row].item()
+                    if hasattr(native["keys"][index][native_row], "item")
+                    else native["keys"][index][native_row]
+                )
+                for index, column in enumerate(KEY_COLUMNS)
+            },
+            "uvw_m": [float(value) for value in native_uvw[:, sorted_row]],
+            "native": {
+                "real": float(native_data[corr, chan, sorted_row].real),
+                "imag": float(native_data[corr, chan, sorted_row].imag),
+                "abs": float(np.abs(native_data[corr, chan, sorted_row])),
+            },
+            "casa": {
+                "real": float(casa_data[corr, chan, sorted_row].real),
+                "imag": float(casa_data[corr, chan, sorted_row].imag),
+                "abs": float(casa_amp_all[corr, chan, sorted_row]),
+            },
+            "abs": float(data_abs_all[corr, chan, sorted_row]),
+            "relative": float(
+                data_abs_all[corr, chan, sorted_row]
+                / max(casa_amp_all[corr, chan, sorted_row], data_atol)
+            ),
+        })
+    result["data"]["worst_relative_cells"] = worst_relative_cells
+if not np.allclose(
+    native_data[comparison_mask],
+    casa_data[comparison_mask],
+    rtol=data_rtol,
+    atol=data_atol,
+):
+    result["status"] = "failed"
+    result["reasons"].append(
+        f"strict DATA max abs {result['data']['max_abs']:.6g}, "
+        f"max rel {result['data']['max_relative']:.6g} exceeds tolerances"
+    )
+
+raw_flag_mismatches = int(np.count_nonzero(native_flag != casa_flag))
+effective_flag_mismatches = int(np.count_nonzero(native_effective_flag != casa_effective_flag))
+result["raw_flag_mismatches"] = raw_flag_mismatches
+result["effective_flag_mismatches"] = effective_flag_mismatches
+if raw_flag_mismatches:
+    raw_mismatch_baselines = Counter()
+    for _corr, _chan, sorted_row in np.argwhere(native_flag != casa_flag):
+        native_row = int(native_order[sorted_row])
+        raw_mismatch_baselines[
+            (int(native["keys"][3][native_row]), int(native["keys"][4][native_row]))
+        ] += 1
+    result["raw_flag_mismatch_baselines"] = [
+        {"antenna1": antenna1, "antenna2": antenna2, "cells": cells}
+        for (antenna1, antenna2), cells in raw_mismatch_baselines.most_common(20)
+    ]
+if effective_flag_mismatches:
+    mismatch_baselines = Counter()
+    for _corr, _chan, sorted_row in np.argwhere(native_effective_flag != casa_effective_flag):
+        native_row = int(native_order[sorted_row])
+        mismatch_baselines[
+            (int(native["keys"][3][native_row]), int(native["keys"][4][native_row]))
+        ] += 1
+    result["flag_mismatch_baselines"] = [
+        {"antenna1": antenna1, "antenna2": antenna2, "cells": cells}
+        for (antenna1, antenna2), cells in mismatch_baselines.most_common(20)
+    ]
+if effective_flag_mismatches:
+    result["status"] = "failed"
+    result["reasons"].append(
+        f"strict effective FLAG differs in {effective_flag_mismatches} cells"
+    )
+
+for column in ["weight", "sigma"]:
+    native_values = native[column][:, native_order]
+    casa_values = casa[column][:, casa_order]
+    delta = np.abs(native_values - casa_values)
+    max_abs = float(delta.max()) if delta.size else 0.0
+    result[column] = {"max_abs": max_abs}
+    if max_abs > 1.0e-6:
+        result["status"] = "failed"
+        result["reasons"].append(f"strict {column.upper()} max abs {max_abs:.6g} exceeds 1e-6")
+
+print(json.dumps(result, sort_keys=True))
+'''
+    completed = subprocess.run(
+        [
+            casa_python,
+            "-c",
+            script,
+            json.dumps([native_ms, casa_ms, uvw_atol, data_atol, data_rtol]),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise BenchError(
+            "failed to run strict MS value comparison: " + completed.stderr.strip()
+        )
+    return parse_json_from_stdout(completed.stdout, "strict MS value comparison")
+
+
+def write_html_report(path: pathlib.Path, result: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    speedup = result.get("speedup_vs_casa")
+    speedup_text = "not run" if speedup is None else f"{speedup:.2f}x"
+    native = result["native_parallel"]
+    casa = result.get("casa")
+    rows = result["shape"]["estimated_main_rows"]
+    channels = result["shape"]["channels"]
+    html = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>simobserve benchmark: {escape(result["dataset"])}</title>
+  <style>
+    body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 32px; color: #1f2933; }}
+    h1, h2 {{ color: #102a43; }}
+    table {{ border-collapse: collapse; margin: 12px 0 24px; width: 100%; max-width: 1100px; }}
+    th, td {{ border: 1px solid #bcccdc; padding: 8px 10px; text-align: left; vertical-align: top; }}
+    th {{ background: #f0f4f8; }}
+    code, pre {{ background: #f0f4f8; border-radius: 4px; }}
+    code {{ padding: 2px 4px; }}
+    pre {{ padding: 12px; overflow: auto; }}
+    .status-passed {{ color: #0b6b3a; font-weight: 700; }}
+    .status-failed {{ color: #a61b1b; font-weight: 700; }}
+  </style>
+</head>
+<body>
+  <h1>simobserve benchmark: {escape(result["dataset"])}</h1>
+  <table>
+    <tr><th>Rows</th><td>{rows:,}</td></tr>
+    <tr><th>Channels</th><td>{channels:,}</td></tr>
+    <tr><th>Native best</th><td>{native["best_seconds"]:.3f} s</td></tr>
+    <tr><th>Native size</th><td>{format_bytes(native["size_bytes"])}</td></tr>
+    <tr><th>CASA best</th><td>{format_seconds(casa)}</td></tr>
+    <tr><th>CASA size</th><td>{format_bytes(casa["size_bytes"]) if casa else "not run"}</td></tr>
+    <tr><th>Speedup vs CASA</th><td>{speedup_text}</td></tr>
+    <tr><th>Correctness status</th><td class="status-{escape(result["correctness"]["status"])}">{escape(result["correctness"]["status"])}</td></tr>
+  </table>
+  <h2>Native Timing</h2>
+  <pre>{escape(json.dumps(native.get("last_result", {}).get("report", {}).get("timing", {}), indent=2, sort_keys=True))}</pre>
+  <h2>MS Inspections</h2>
+  <pre>{escape(json.dumps(result["correctness"], indent=2, sort_keys=True))}</pre>
+  <h2>Full Result JSON</h2>
+  <pre>{escape(json.dumps(result, indent=2, sort_keys=True))}</pre>
+</body>
+</html>
+"""
+    path.write_text(html, encoding="utf-8")
+
+
+def escape(value: Any) -> str:
+    return (
+        str(value)
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+def format_seconds(run: dict[str, Any] | None) -> str:
+    if run is None:
+        return "not run"
+    return f"{run['best_seconds']:.3f} s"
+
+
+def format_bytes(size: int) -> str:
+    value = float(size)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if value < 1024.0 or unit == "TiB":
+            return f"{value:.2f} {unit}"
+        value /= 1024.0
+    return f"{size} B"
+
+
+def select_dataset(plan: dict[str, Any], dataset_id: str) -> dict[str, Any]:
+    for dataset in plan.get("datasets", []):
+        if dataset.get("id") == dataset_id:
+            return dataset
+    raise BenchError(f"dataset not found in plan: {dataset_id}")
+
+
+def read_json(path: pathlib.Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except OSError as error:
+        raise BenchError(f"read {path}: {error}") from error
+    except json.JSONDecodeError as error:
+        raise BenchError(f"parse {path}: {error}") from error
+
+
+def write_json(path: pathlib.Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def directory_size(path: pathlib.Path) -> int:
+    if not path.exists():
+        return 0
+    if path.is_file():
+        return path.stat().st_size
+    total = 0
+    for item in path.rglob("*"):
+        if item.is_file():
+            total += item.stat().st_size
+    return total
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/perf/imager/casa_phase_bench.py
+++ b/tools/perf/imager/casa_phase_bench.py
@@ -52,6 +52,7 @@ def main() -> None:
     chan_start = env_int("CASA_RS_BENCH_CHANNEL_START")
     chan_count = env_int("CASA_RS_BENCH_CHANNEL_COUNT")
     specmode = env_str("CASA_RS_BENCH_SPECMODE")
+    gridder = env_str("CASA_RS_BENCH_GRIDDER")
     imsize = env_int("CASA_RS_BENCH_IMSIZE")
     cell_arcsec = env_str("CASA_RS_BENCH_CELL_ARCSEC")
     weighting = env_str("CASA_RS_BENCH_WEIGHTING")
@@ -124,7 +125,7 @@ def main() -> None:
                     projection="SIN",
                     specmode=specmode,
                     interpolation="nearest",
-                    gridder="standard",
+                    gridder=gridder,
                     restart=True,
                     weighting=weighting,
                     robust=robust,

--- a/tools/perf/imager/generate_wave1_casa_datasets.py
+++ b/tools/perf/imager/generate_wave1_casa_datasets.py
@@ -148,6 +148,18 @@ def create_model_image(dataset: dict[str, Any]) -> pathlib.Path:
 
     cs = coordsys()
     cs.newcoordsys(direction=True, stokes=["I"], spectral=True)
+    cs.setunits(["deg", "deg"], type="direction")
+    cs.setincrement(
+        [
+            -cell_arcsec(dataset["instrument"]) / 3600.0,
+            cell_arcsec(dataset["instrument"]) / 3600.0,
+        ],
+        type="direction",
+    )
+    cs.setreferencepixel([pixels / 2.0 - 0.5, pixels / 2.0 - 0.5], type="direction")
+    cs.setreferencevalue([270.000129, -22.999889], type="direction")
+    cs.setreferencevalue(f"{start_frequency_hz(dataset['instrument'])}Hz", type="spectral")
+    cs.setincrement(f"{channel_width_hz(dataset['instrument'])}Hz", type="spectral")
     ia = image()
     out.parent.mkdir(parents=True, exist_ok=True)
     ia.fromshape(
@@ -206,6 +218,8 @@ def source_pixel(cx: float, cy: float, family: str) -> float:
 
 
 def spectral_profile(channels: int) -> list[float]:
+    if channels == 1:
+        return [1.0]
     center = 0.5 * max(0, channels - 1)
     values = []
     for channel in range(channels):
@@ -265,16 +279,15 @@ def run_simobserve(
         simobserve(
             project=project_dir.name,
             skymodel=str(model_image),
-            indirection="J2000 18h00m00.03096s -22d59m59.6004s",
             incell=f"{cell_arcsec(dataset['instrument'])}arcsec",
-            incenter=f"{start_frequency_hz(dataset['instrument'])}Hz",
+            incenter=f"{spw_center_frequency_hz(dataset)}Hz",
             inwidth=f"{channel_width_hz(dataset['instrument'])}Hz",
             setpointings=False,
             ptgfile=str(pointings),
             integration=f"{shape['integration_seconds']}s",
             totaltime=f"{shape['duration_seconds']}s",
             antennalist=antenna_list(dataset["instrument"]),
-            thermalnoise="tsys-atm",
+            thermalnoise=thermalnoise_mode(dataset),
             seed=stable_seed(dataset["id"]),
             graphics="none",
             verbose=False,
@@ -282,6 +295,11 @@ def run_simobserve(
         )
     finally:
         os.chdir(old_cwd)
+
+
+def thermalnoise_mode(dataset: dict[str, Any]) -> str:
+    noise_jy = float(dataset.get("source_model", {}).get("noise_simplenoise_jy", 0.0))
+    return "tsys-atm" if noise_jy > 0.0 else ""
 
 
 def make_preview(
@@ -430,6 +448,13 @@ def start_frequency_hz(instrument: str) -> float:
 
 def channel_width_hz(instrument: str) -> float:
     return 2.0e6 if instrument == "alma" else 128.0e6
+
+
+def spw_center_frequency_hz(dataset: dict[str, Any]) -> float:
+    channels = int(dataset["shape"]["channels"])
+    return start_frequency_hz(dataset["instrument"]) + (channels // 2) * channel_width_hz(
+        dataset["instrument"]
+    )
 
 
 def stable_seed(text: str) -> int:

--- a/tools/perf/imager/generate_wave1_casa_datasets.py
+++ b/tools/perf/imager/generate_wave1_casa_datasets.py
@@ -20,6 +20,8 @@ from typing import Any
 
 import numpy as np
 
+import stage_wave1_datasets as stage
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
@@ -98,7 +100,7 @@ def generate_dataset(
     if canonical_ms.exists() and overwrite:
         remove_path(canonical_ms)
 
-    model_image = create_model_image(dataset)
+    model_image = create_model_image(dataset, overwrite=overwrite)
     pointings = write_pointings(dataset, casa_dir)
     project_name = dataset_id
     project_dir = casa_dir / project_name
@@ -130,7 +132,7 @@ def generate_dataset(
     }
 
 
-def create_model_image(dataset: dict[str, Any]) -> pathlib.Path:
+def create_model_image(dataset: dict[str, Any], *, overwrite: bool = False) -> pathlib.Path:
     from casatools import coordsys, image
 
     shape = dataset["shape"]
@@ -140,10 +142,12 @@ def create_model_image(dataset: dict[str, Any]) -> pathlib.Path:
     out = pathlib.Path(paths["continuum_model_fits"]).with_name(
         f"structured-cube-{channels}ch.image"
     )
-    if out.exists():
+    if out.exists() and not overwrite:
         return out
+    if out.exists():
+        remove_path(out)
 
-    base = structured_plane(pixels, dataset["family"])
+    base = stage.source_plane(pixels, dataset["family"])
     profile = spectral_profile(channels)
 
     cs = coordsys()
@@ -180,56 +184,17 @@ def create_model_image(dataset: dict[str, Any]) -> pathlib.Path:
 
 
 def structured_plane(pixels: int, family: str) -> np.ndarray:
-    coords = (np.arange(pixels, dtype=np.float32) + 0.5 - pixels / 2.0) / pixels
-    cx, cy = np.meshgrid(coords, coords, indexing="ij")
-    radius = np.hypot(cx, cy)
-    theta = np.arctan2(cy, cx)
-    core = gaussian_array(cx, cy, 0.0, 0.0, 0.018)
-    knot1 = 0.42 * gaussian_array(cx, cy, -0.14, 0.09, 0.028)
-    knot2 = 0.31 * gaussian_array(cx, cy, 0.18, -0.11, 0.022)
-    ring = 0.34 * np.exp(-((radius - 0.21) ** 2) / (2.0 * 0.018**2))
-    arm1 = 0.18 * np.exp(-((radius - (0.10 + 0.040 * theta)) ** 2) / (2.0 * 0.020**2))
-    arm2 = 0.14 * np.exp(-((radius - (0.18 - 0.035 * theta)) ** 2) / (2.0 * 0.024**2))
-    halo = 0.06 * np.exp(-(radius**2) / (2.0 * 0.26**2))
-    ripple = 0.015 * (1.0 + np.sin(37.0 * cx + 19.0 * cy))
-    if "mosaic" in family:
-        gradient = 1.0 + 0.10 * cx - 0.07 * cy
-    else:
-        gradient = 1.0
-    return np.maximum(
-        0.0,
-        (core + knot1 + knot2 + ring + arm1 + arm2 + halo + ripple) * gradient,
-    ).astype(np.float32)
+    return stage.source_plane(pixels, family)
 
 
 def source_pixel(cx: float, cy: float, family: str) -> float:
-    radius = math.hypot(cx, cy)
-    theta = math.atan2(cy, cx)
-    core = gaussian(cx, cy, 0.0, 0.0, 0.018)
-    knot1 = 0.42 * gaussian(cx, cy, -0.14, 0.09, 0.028)
-    knot2 = 0.31 * gaussian(cx, cy, 0.18, -0.11, 0.022)
-    ring = 0.34 * math.exp(-((radius - 0.21) ** 2) / (2.0 * 0.018**2))
-    arm1 = 0.18 * math.exp(-((radius - (0.10 + 0.040 * theta)) ** 2) / (2.0 * 0.020**2))
-    arm2 = 0.14 * math.exp(-((radius - (0.18 - 0.035 * theta)) ** 2) / (2.0 * 0.024**2))
-    halo = 0.06 * math.exp(-(radius**2) / (2.0 * 0.26**2))
-    ripple = 0.015 * (1.0 + math.sin(37.0 * cx + 19.0 * cy))
-    gradient = 1.0 + (0.10 * cx - 0.07 * cy if "mosaic" in family else 0.0)
-    return max(0.0, (core + knot1 + knot2 + ring + arm1 + arm2 + halo + ripple) * gradient)
+    x = int((cx + 0.5) * 512)
+    y = int((cy + 0.5) * 512)
+    return stage.source_pixel(x, y, 512, family)
 
 
 def spectral_profile(channels: int) -> list[float]:
-    if channels == 1:
-        return [1.0]
-    center = 0.5 * max(0, channels - 1)
-    values = []
-    for channel in range(channels):
-        x = 0.0 if channels == 1 else (channel - center) / max(1.0, center)
-        continuum = max(0.05, 1.0 + x) ** -0.7
-        broad_line = 0.45 * math.exp(-0.5 * ((x - 0.05) / 0.22) ** 2)
-        narrow_line = 0.22 * math.exp(-0.5 * ((x + 0.38) / 0.08) ** 2)
-        absorption = -0.18 * math.exp(-0.5 * ((x - 0.32) / 0.06) ** 2)
-        values.append(max(0.05, continuum + broad_line + narrow_line + absorption))
-    return values
+    return [stage.spectral_total_scale(channels, channel) for channel in range(channels)]
 
 
 def write_pointings(dataset: dict[str, Any], casa_dir: pathlib.Path) -> pathlib.Path:
@@ -260,7 +225,7 @@ def format_direction(ra_deg: float, dec_deg: float) -> str:
     dm_float = (dec_abs - dd) * 60.0
     dm = int(dm_float)
     ds = (dm_float - dm) * 60.0
-    return f"J2000 {hh:02d}h{mm:02d}m{ss:08.5f}s {sign}{dd:02d}d{dm:02d}m{ds:07.4f}s 10.0"
+    return f"J2000 {hh:02d}h{mm:02d}m{ss:013.10f}s {sign}{dd:02d}d{dm:02d}m{ds:010.7f}s 10.0"
 
 
 def run_simobserve(
@@ -443,11 +408,11 @@ def cell_arcsec(instrument: str) -> float:
 
 
 def start_frequency_hz(instrument: str) -> float:
-    return 230.0e9 if instrument == "alma" else 44.0e9
+    return 230.0e9 if instrument == "alma" else 8.0e9
 
 
 def channel_width_hz(instrument: str) -> float:
-    return 2.0e6 if instrument == "alma" else 128.0e6
+    return 2.0e6
 
 
 def spw_center_frequency_hz(dataset: dict[str, Any]) -> float:

--- a/tools/perf/imager/generate_wave1_casa_datasets.py
+++ b/tools/perf/imager/generate_wave1_casa_datasets.py
@@ -192,7 +192,7 @@ def structured_plane(pixels: int, family: str) -> np.ndarray:
     arm2 = 0.14 * np.exp(-((radius - (0.18 - 0.035 * theta)) ** 2) / (2.0 * 0.024**2))
     halo = 0.06 * np.exp(-(radius**2) / (2.0 * 0.26**2))
     ripple = 0.015 * (1.0 + np.sin(37.0 * cx + 19.0 * cy))
-    if "mosaic" in family or family == "shared-large":
+    if "mosaic" in family:
         gradient = 1.0 + 0.10 * cx - 0.07 * cy
     else:
         gradient = 1.0
@@ -213,7 +213,7 @@ def source_pixel(cx: float, cy: float, family: str) -> float:
     arm2 = 0.14 * math.exp(-((radius - (0.18 - 0.035 * theta)) ** 2) / (2.0 * 0.024**2))
     halo = 0.06 * math.exp(-(radius**2) / (2.0 * 0.26**2))
     ripple = 0.015 * (1.0 + math.sin(37.0 * cx + 19.0 * cy))
-    gradient = 1.0 + (0.10 * cx - 0.07 * cy if "mosaic" in family or family == "shared-large" else 0.0)
+    gradient = 1.0 + (0.10 * cx - 0.07 * cy if "mosaic" in family else 0.0)
     return max(0.0, (core + knot1 + knot2 + ring + arm1 + arm2 + halo + ripple) * gradient)
 
 
@@ -318,11 +318,11 @@ def make_preview(
         vis=str(ms),
         imagename=str(imagename),
         datacolumn="data",
-        field="" if dataset["family"] in {"mosaic", "shared-large"} else "0",
+        field="" if "mosaic" in dataset["family"] else "0",
         spw=preview_spw(dataset),
         stokes="I",
         specmode="mfs",
-        gridder="mosaic" if dataset["family"] in {"mosaic", "shared-large"} else "standard",
+        gridder="mosaic" if "mosaic" in dataset["family"] else "standard",
         weighting="natural",
         imsize=imsize,
         cell=f"{cell_arcsec(dataset['instrument'])}arcsec",

--- a/tools/perf/imager/generate_wave1_casa_datasets.py
+++ b/tools/perf/imager/generate_wave1_casa_datasets.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env python3
+"""Generate CASA MeasurementSets and preview images for Wave 1 datasets.
+
+Run this with the CASA-capable Python listed in AGENTS.md, not with the
+default project Python.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import time
+from typing import Any
+
+import numpy as np
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("plan", type=pathlib.Path, help="wave1-dataset-plan.json")
+    parser.add_argument("--dataset", action="append", help="dataset id to generate")
+    parser.add_argument("--skip-existing", action="store_true", default=True)
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--preview-max-pixels", type=int, default=1024)
+    parser.add_argument("--no-preview", action="store_true")
+    args = parser.parse_args()
+
+    if args.overwrite:
+        args.skip_existing = False
+
+    plan = read_json(args.plan)
+    datasets = plan["datasets"]
+    if args.dataset:
+        wanted = set(args.dataset)
+        datasets = [dataset for dataset in datasets if dataset["id"] in wanted]
+        missing = wanted - {dataset["id"] for dataset in datasets}
+        if missing:
+            raise SystemExit(f"unknown dataset id(s): {', '.join(sorted(missing))}")
+
+    results = []
+    for dataset in datasets:
+        result = generate_dataset(
+            dataset,
+            skip_existing=args.skip_existing,
+            overwrite=args.overwrite,
+            preview=not args.no_preview,
+            preview_max_pixels=args.preview_max_pixels,
+        )
+        results.append(result)
+        print(json.dumps(result, sort_keys=True), flush=True)
+
+    summary_path = pathlib.Path(plan["data_root"]) / "wave1" / "generation-summary.json"
+    write_json(summary_path, {"generated_at": utc_now(), "datasets": results})
+    print(summary_path)
+
+
+def generate_dataset(
+    dataset: dict[str, Any],
+    *,
+    skip_existing: bool,
+    overwrite: bool,
+    preview: bool,
+    preview_max_pixels: int,
+) -> dict[str, Any]:
+    dataset_id = dataset["id"]
+    paths = dataset["paths"]
+    canonical_ms = pathlib.Path(paths["output_ms"])
+    dataset_dir = pathlib.Path(paths["dataset_dir"])
+    metadata_dir = dataset_dir / "metadata"
+    preview_dir = dataset_dir / "previews"
+    casa_dir = dataset_dir / "casa"
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+    preview_dir.mkdir(parents=True, exist_ok=True)
+    casa_dir.mkdir(parents=True, exist_ok=True)
+
+    if canonical_ms.exists() and skip_existing:
+        shape = inspect_ms(canonical_ms)
+        shape_path = metadata_dir / "ms-shape.json"
+        write_json(shape_path, shape)
+        preview_path = None
+        if preview and not (preview_dir / "dirty-mfs-panel.png").exists():
+            preview_path = make_preview(dataset, canonical_ms, preview_dir, preview_max_pixels)
+        return {
+            "dataset": dataset_id,
+            "status": "reused",
+            "ms": str(canonical_ms),
+            "shape": shape,
+            "shape_json": str(shape_path),
+            "preview_png": str(preview_path) if preview_path else None,
+        }
+
+    if canonical_ms.exists() and overwrite:
+        remove_path(canonical_ms)
+
+    model_image = create_model_image(dataset)
+    pointings = write_pointings(dataset, casa_dir)
+    project_name = dataset_id
+    project_dir = casa_dir / project_name
+    if project_dir.exists() and overwrite:
+        remove_path(project_dir)
+    project_dir.parent.mkdir(parents=True, exist_ok=True)
+
+    run_simobserve(dataset, model_image, pointings, project_dir)
+    produced_ms = find_single_ms(project_dir)
+    remove_duplicate_measurement_sets(project_dir, produced_ms)
+    canonical_ms.parent.mkdir(parents=True, exist_ok=True)
+    if canonical_ms.exists():
+        remove_path(canonical_ms)
+    os.symlink(produced_ms, canonical_ms, target_is_directory=True)
+
+    shape = inspect_ms(canonical_ms)
+    shape_path = metadata_dir / "ms-shape.json"
+    write_json(shape_path, shape)
+    preview_path = make_preview(dataset, canonical_ms, preview_dir, preview_max_pixels) if preview else None
+    return {
+        "dataset": dataset_id,
+        "status": "generated",
+        "project_dir": str(project_dir),
+        "produced_ms": str(produced_ms),
+        "ms": str(canonical_ms),
+        "shape": shape,
+        "shape_json": str(shape_path),
+        "preview_png": str(preview_path) if preview_path else None,
+    }
+
+
+def create_model_image(dataset: dict[str, Any]) -> pathlib.Path:
+    from casatools import coordsys, image
+
+    shape = dataset["shape"]
+    paths = dataset["paths"]
+    pixels = int(shape["model_pixels"])
+    channels = int(shape["channels"])
+    out = pathlib.Path(paths["continuum_model_fits"]).with_name(
+        f"structured-cube-{channels}ch.image"
+    )
+    if out.exists():
+        return out
+
+    base = structured_plane(pixels, dataset["family"])
+    profile = spectral_profile(channels)
+
+    cs = coordsys()
+    cs.newcoordsys(direction=True, stokes=["I"], spectral=True)
+    ia = image()
+    out.parent.mkdir(parents=True, exist_ok=True)
+    ia.fromshape(
+        outfile=str(out),
+        shape=[pixels, pixels, 1, channels],
+        csys=cs.torecord(),
+        overwrite=True,
+        type="f",
+    )
+    try:
+        for channel, scale in enumerate(profile):
+            plane = (base * scale)[:, :, np.newaxis, np.newaxis]
+            ia.putchunk(pixels=plane, blc=[0, 0, 0, channel])
+        ia.setbrightnessunit("Jy/pixel")
+    finally:
+        ia.close()
+    return out
+
+
+def structured_plane(pixels: int, family: str) -> np.ndarray:
+    coords = (np.arange(pixels, dtype=np.float32) + 0.5 - pixels / 2.0) / pixels
+    cx, cy = np.meshgrid(coords, coords, indexing="ij")
+    radius = np.hypot(cx, cy)
+    theta = np.arctan2(cy, cx)
+    core = gaussian_array(cx, cy, 0.0, 0.0, 0.018)
+    knot1 = 0.42 * gaussian_array(cx, cy, -0.14, 0.09, 0.028)
+    knot2 = 0.31 * gaussian_array(cx, cy, 0.18, -0.11, 0.022)
+    ring = 0.34 * np.exp(-((radius - 0.21) ** 2) / (2.0 * 0.018**2))
+    arm1 = 0.18 * np.exp(-((radius - (0.10 + 0.040 * theta)) ** 2) / (2.0 * 0.020**2))
+    arm2 = 0.14 * np.exp(-((radius - (0.18 - 0.035 * theta)) ** 2) / (2.0 * 0.024**2))
+    halo = 0.06 * np.exp(-(radius**2) / (2.0 * 0.26**2))
+    ripple = 0.015 * (1.0 + np.sin(37.0 * cx + 19.0 * cy))
+    if "mosaic" in family or family == "shared-large":
+        gradient = 1.0 + 0.10 * cx - 0.07 * cy
+    else:
+        gradient = 1.0
+    return np.maximum(
+        0.0,
+        (core + knot1 + knot2 + ring + arm1 + arm2 + halo + ripple) * gradient,
+    ).astype(np.float32)
+
+
+def source_pixel(cx: float, cy: float, family: str) -> float:
+    radius = math.hypot(cx, cy)
+    theta = math.atan2(cy, cx)
+    core = gaussian(cx, cy, 0.0, 0.0, 0.018)
+    knot1 = 0.42 * gaussian(cx, cy, -0.14, 0.09, 0.028)
+    knot2 = 0.31 * gaussian(cx, cy, 0.18, -0.11, 0.022)
+    ring = 0.34 * math.exp(-((radius - 0.21) ** 2) / (2.0 * 0.018**2))
+    arm1 = 0.18 * math.exp(-((radius - (0.10 + 0.040 * theta)) ** 2) / (2.0 * 0.020**2))
+    arm2 = 0.14 * math.exp(-((radius - (0.18 - 0.035 * theta)) ** 2) / (2.0 * 0.024**2))
+    halo = 0.06 * math.exp(-(radius**2) / (2.0 * 0.26**2))
+    ripple = 0.015 * (1.0 + math.sin(37.0 * cx + 19.0 * cy))
+    gradient = 1.0 + (0.10 * cx - 0.07 * cy if "mosaic" in family or family == "shared-large" else 0.0)
+    return max(0.0, (core + knot1 + knot2 + ring + arm1 + arm2 + halo + ripple) * gradient)
+
+
+def spectral_profile(channels: int) -> list[float]:
+    center = 0.5 * max(0, channels - 1)
+    values = []
+    for channel in range(channels):
+        x = 0.0 if channels == 1 else (channel - center) / max(1.0, center)
+        continuum = max(0.05, 1.0 + x) ** -0.7
+        broad_line = 0.45 * math.exp(-0.5 * ((x - 0.05) / 0.22) ** 2)
+        narrow_line = 0.22 * math.exp(-0.5 * ((x + 0.38) / 0.08) ** 2)
+        absorption = -0.18 * math.exp(-0.5 * ((x - 0.32) / 0.06) ** 2)
+        values.append(max(0.05, continuum + broad_line + narrow_line + absorption))
+    return values
+
+
+def write_pointings(dataset: dict[str, Any], casa_dir: pathlib.Path) -> pathlib.Path:
+    count = int(dataset["shape"]["pointing_count"])
+    spacing_arcsec = 24.0 if dataset["instrument"] == "alma" else 120.0
+    offsets = [(0.0, 0.0)]
+    if count > 1:
+        for index in range(6):
+            angle = math.tau * index / 6.0
+            offsets.append((spacing_arcsec * math.cos(angle), spacing_arcsec * math.sin(angle)))
+    out = casa_dir / f"{dataset['id']}.ptg.txt"
+    lines = []
+    for dra_arcsec, ddec_arcsec in offsets[:count]:
+        lines.append(format_direction(270.000129 + dra_arcsec / 3600.0, -22.999889 + ddec_arcsec / 3600.0))
+    out.write_text("\n".join(lines) + "\n", encoding="ascii")
+    return out
+
+
+def format_direction(ra_deg: float, dec_deg: float) -> str:
+    ra_hours = ra_deg / 15.0
+    hh = int(ra_hours)
+    mm_float = (ra_hours - hh) * 60.0
+    mm = int(mm_float)
+    ss = (mm_float - mm) * 60.0
+    sign = "-" if dec_deg < 0 else "+"
+    dec_abs = abs(dec_deg)
+    dd = int(dec_abs)
+    dm_float = (dec_abs - dd) * 60.0
+    dm = int(dm_float)
+    ds = (dm_float - dm) * 60.0
+    return f"J2000 {hh:02d}h{mm:02d}m{ss:08.5f}s {sign}{dd:02d}d{dm:02d}m{ds:07.4f}s 10.0"
+
+
+def run_simobserve(
+    dataset: dict[str, Any],
+    model_image: pathlib.Path,
+    pointings: pathlib.Path,
+    project_dir: pathlib.Path,
+) -> None:
+    from casatasks import simobserve
+
+    shape = dataset["shape"]
+    project_dir.parent.mkdir(parents=True, exist_ok=True)
+    old_cwd = pathlib.Path.cwd()
+    try:
+        os.chdir(project_dir.parent)
+        simobserve(
+            project=project_dir.name,
+            skymodel=str(model_image),
+            indirection="J2000 18h00m00.03096s -22d59m59.6004s",
+            incell=f"{cell_arcsec(dataset['instrument'])}arcsec",
+            incenter=f"{start_frequency_hz(dataset['instrument'])}Hz",
+            inwidth=f"{channel_width_hz(dataset['instrument'])}Hz",
+            setpointings=False,
+            ptgfile=str(pointings),
+            integration=f"{shape['integration_seconds']}s",
+            totaltime=f"{shape['duration_seconds']}s",
+            antennalist=antenna_list(dataset["instrument"]),
+            thermalnoise="tsys-atm",
+            seed=stable_seed(dataset["id"]),
+            graphics="none",
+            verbose=False,
+            overwrite=True,
+        )
+    finally:
+        os.chdir(old_cwd)
+
+
+def make_preview(
+    dataset: dict[str, Any],
+    ms: pathlib.Path,
+    preview_dir: pathlib.Path,
+    preview_max_pixels: int,
+) -> pathlib.Path:
+    from casatasks import tclean
+    from casatools import image
+
+    imsize = min(int(dataset["shape"]["image_pixels"]), preview_max_pixels)
+    imagename = preview_dir / "dirty-mfs"
+    cleanup_image_products(imagename)
+    tclean(
+        vis=str(ms),
+        imagename=str(imagename),
+        datacolumn="data",
+        field="" if dataset["family"] in {"mosaic", "shared-large"} else "0",
+        spw=preview_spw(dataset),
+        stokes="I",
+        specmode="mfs",
+        gridder="mosaic" if dataset["family"] in {"mosaic", "shared-large"} else "standard",
+        weighting="natural",
+        imsize=imsize,
+        cell=f"{cell_arcsec(dataset['instrument'])}arcsec",
+        niter=0,
+        interactive=False,
+        parallel=False,
+    )
+    image_path = pathlib.Path(str(imagename) + ".image")
+    png_path = preview_dir / "dirty-mfs-panel.png"
+    ia = image()
+    ia.open(str(image_path))
+    pixels = np.squeeze(ia.getchunk())
+    ia.close()
+    write_panel_png(dataset, pixels, png_path)
+    return png_path
+
+
+def write_panel_png(dataset: dict[str, Any], dirty: np.ndarray, out: pathlib.Path) -> None:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    model = structured_plane(min(dirty.shape), dataset["family"])
+    if model.shape != dirty.shape:
+        model = model[: dirty.shape[0], : dirty.shape[1]]
+    diff_scale = max(float(np.nanmax(np.abs(dirty))), 1e-12)
+    fig, axes = plt.subplots(1, 3, figsize=(12, 4), constrained_layout=True)
+    panels = [
+        ("model", model, None),
+        ("dirty MFS", dirty, None),
+        ("dirty / peak", dirty / diff_scale, (-1.0, 1.0)),
+    ]
+    for axis, (title, data, limits) in zip(axes, panels, strict=True):
+        kwargs = {"origin": "lower", "cmap": "magma"}
+        if limits:
+            kwargs.update({"vmin": limits[0], "vmax": limits[1], "cmap": "coolwarm"})
+        image = axis.imshow(np.asarray(data).T, **kwargs)
+        axis.set_title(title)
+        axis.set_xticks([])
+        axis.set_yticks([])
+        fig.colorbar(image, ax=axis, fraction=0.046)
+    fig.suptitle(dataset["id"])
+    out.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out, dpi=150)
+    plt.close(fig)
+
+
+def inspect_ms(ms: pathlib.Path) -> dict[str, Any]:
+    from casatools import table
+
+    tb = table()
+    tb.open(str(ms))
+    nrows = int(tb.nrows())
+    data_shape = list(tb.getcell("DATA", 0).shape) if nrows else []
+    tb.close()
+    result = {
+        "path": str(ms),
+        "size_bytes": du_bytes(ms),
+        "main_rows": nrows,
+        "data_cell_shape": data_shape,
+    }
+    for subtable in ["ANTENNA", "FIELD", "SPECTRAL_WINDOW", "DATA_DESCRIPTION"]:
+        sub = ms / subtable
+        if sub.exists():
+            tb.open(str(sub))
+            result[subtable.lower() + "_rows"] = int(tb.nrows())
+            tb.close()
+    return result
+
+
+def find_single_ms(project_dir: pathlib.Path) -> pathlib.Path:
+    matches = sorted(project_dir.glob("*.ms"))
+    noisy = [path for path in matches if path.name.endswith(".noisy.ms")]
+    if len(noisy) == 1:
+        return noisy[0]
+    if len(matches) != 1:
+        raise RuntimeError(f"expected one MS under {project_dir}, found {matches}")
+    return matches[0]
+
+
+def remove_duplicate_measurement_sets(project_dir: pathlib.Path, keep: pathlib.Path) -> None:
+    for path in project_dir.glob("*.ms"):
+        if path != keep:
+            remove_path(path)
+
+
+def preview_spw(dataset: dict[str, Any]) -> str:
+    channels = int(dataset["shape"]["channels"])
+    if dataset["tier"] == "large" and channels > 64:
+        return "0:0~63"
+    return "0"
+
+
+def cleanup_image_products(prefix: pathlib.Path) -> None:
+    for path in prefix.parent.glob(prefix.name + ".*"):
+        remove_path(path)
+
+
+def remove_path(path: pathlib.Path) -> None:
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+    elif path.is_dir():
+        shutil.rmtree(path)
+
+
+def du_bytes(path: pathlib.Path) -> int:
+    output = subprocess.check_output(["du", "-sk", str(path.resolve())], text=True)
+    return int(output.split()[0]) * 1024
+
+
+def antenna_list(instrument: str) -> str:
+    return "alma.cycle8.5.cfg" if instrument == "alma" else "vla.d.cfg"
+
+
+def cell_arcsec(instrument: str) -> float:
+    return 0.08 if instrument == "alma" else 0.35
+
+
+def start_frequency_hz(instrument: str) -> float:
+    return 230.0e9 if instrument == "alma" else 44.0e9
+
+
+def channel_width_hz(instrument: str) -> float:
+    return 2.0e6 if instrument == "alma" else 128.0e6
+
+
+def stable_seed(text: str) -> int:
+    import hashlib
+
+    return int(hashlib.sha256(text.encode("utf-8")).hexdigest()[:8], 16)
+
+
+def gaussian(x: float, y: float, x0: float, y0: float, sigma: float) -> float:
+    return math.exp(-(((x - x0) ** 2 + (y - y0) ** 2) / (2.0 * sigma**2)))
+
+
+def gaussian_array(
+    x: np.ndarray, y: np.ndarray, x0: float, y0: float, sigma: float
+) -> np.ndarray:
+    return np.exp(-(((x - x0) ** 2 + (y - y0) ** 2) / (2.0 * sigma**2)))
+
+
+def read_json(path: pathlib.Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: pathlib.Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def utc_now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/perf/imager/generate_wave1_report.py
+++ b/tools/perf/imager/generate_wave1_report.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Build a portable HTML report for ImPerformance Wave 1 simobserve evidence."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import html
+import json
+import pathlib
+from typing import Any
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--plan", type=pathlib.Path, required=True)
+    parser.add_argument("--generation-summary", type=pathlib.Path, required=True)
+    parser.add_argument("--casa-smoke", type=pathlib.Path, required=True)
+    parser.add_argument("--preview-summary", type=pathlib.Path, required=True)
+    parser.add_argument("--parity-dir", type=pathlib.Path, required=True)
+    parser.add_argument("--internal-io", type=pathlib.Path, required=True)
+    parser.add_argument("--output", type=pathlib.Path, required=True)
+    args = parser.parse_args()
+
+    plan = read_json(args.plan)
+    generation = read_json(args.generation_summary)
+    smoke = read_json(args.casa_smoke)
+    previews = read_json(args.preview_summary)
+    internal_io = read_json(args.internal_io)
+    parity = load_parity(args.parity_dir)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        render_report(plan, generation, smoke, previews, parity, internal_io),
+        encoding="utf-8",
+    )
+    print(args.output)
+
+
+def read_json(path: pathlib.Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_parity(root: pathlib.Path) -> list[dict[str, Any]]:
+    results = []
+    for path in sorted(root.glob("*/simobserve-benchmark.json")):
+        value = read_json(path)
+        value["_path"] = str(path)
+        results.append(value)
+    return results
+
+
+def render_report(
+    plan: dict[str, Any],
+    generation: dict[str, Any],
+    smoke: dict[str, Any],
+    previews: dict[str, Any],
+    parity: list[dict[str, Any]],
+    internal_io: dict[str, Any],
+) -> str:
+    generation_by_id = {item["dataset"]: item for item in generation["datasets"]}
+    smoke_by_id = {item["dataset"]: item for item in smoke["results"]}
+    preview_by_key = {
+        (item["dataset"], item["mode"]): item
+        for item in previews.get("runs", [])
+        if item.get("returncode") == 0
+    }
+
+    dataset_rows = []
+    for dataset in plan["datasets"]:
+        actual = generation_by_id.get(dataset["id"], {})
+        smoke_row = smoke_by_id.get(dataset["id"], {})
+        timing = actual.get("report", {}).get("timing", {}).get("main_rows", {})
+        dataset_rows.append(
+            "<tr>"
+            f"<td><code>{esc(dataset['id'])}</code></td>"
+            f"<td>{esc(dataset['instrument'])}</td>"
+            f"<td>{esc(dataset['family'])}</td>"
+            f"<td>{esc(dataset['tier'])}</td>"
+            f"<td>{bytes_text(dataset['target_size_bytes'])}</td>"
+            f"<td>{bytes_text(actual.get('size_bytes'))}</td>"
+            f"<td>{number(actual.get('elapsed_seconds'), 's')}</td>"
+            f"<td>{int_text(actual.get('report', {}).get('main_row_count'))}</td>"
+            f"<td>{int_text(actual.get('report', {}).get('channel_count'))}</td>"
+            f"<td>{esc(smoke_row.get('status', 'missing'))}</td>"
+            f"<td>{number(timing.get('prediction_millis'), 'ms')}</td>"
+            f"<td>{number(timing.get('data_io_write_millis'), 'ms')}</td>"
+            "</tr>"
+        )
+
+    preview_sections = []
+    for dataset in plan["datasets"]:
+        dirty = preview_by_key.get((dataset["id"], "dirty"))
+        clean = preview_by_key.get((dataset["id"], "clean"))
+        if not dirty and not clean:
+            continue
+        preview_sections.append(
+            "<section class='preview'>"
+            f"<h3>{esc(dataset['id'])}</h3>"
+            "<div class='preview-grid'>"
+            f"{preview_figure(dirty, 'Dirty image')}"
+            f"{preview_figure(clean, 'Clean image')}"
+            "</div>"
+            "</section>"
+        )
+
+    parity_rows = []
+    for item in parity:
+        correctness = item.get("correctness", {})
+        native = item.get("native_parallel", {})
+        casa = item.get("casa", {})
+        strict = correctness.get("strict_values") or {}
+        parity_rows.append(
+            "<tr>"
+            f"<td><code>{esc(item.get('dataset'))}</code></td>"
+            f"<td>{esc(correctness.get('status', 'missing'))}</td>"
+            f"<td>{number(native.get('best_seconds'), 's')}</td>"
+            f"<td>{number(casa.get('best_seconds'), 's')}</td>"
+            f"<td>{number(item.get('speedup_vs_casa'), 'x')}</td>"
+            f"<td>{number(strict.get('uvw', {}).get('max_abs'), 'm')}</td>"
+            f"<td>{number(strict.get('data', {}).get('mean_abs'), 'Jy')}</td>"
+            f"<td>{number(strict.get('data', {}).get('max_abs'), 'Jy')}</td>"
+            f"<td>{esc('; '.join(correctness.get('reasons', [])) or 'none')}</td>"
+            f"<td><code>{esc(item.get('_path'))}</code></td>"
+            "</tr>"
+        )
+
+    io_native = internal_io.get("native_parallel", {})
+    io_perf = internal_io.get("native_performance", {})
+    html_doc = f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>ImPerformance Wave 1 Native simobserve Evidence</title>
+<style>
+body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 32px; color: #1f2933; }}
+h1, h2, h3 {{ color: #101820; }}
+table {{ border-collapse: collapse; width: 100%; margin: 16px 0 28px; font-size: 13px; }}
+th, td {{ border: 1px solid #d7dde5; padding: 7px 8px; vertical-align: top; }}
+th {{ background: #eef3f8; text-align: left; }}
+code {{ font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; }}
+.summary {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; }}
+.metric {{ border: 1px solid #d7dde5; padding: 12px; border-radius: 6px; background: #fbfcfe; }}
+.metric strong {{ display: block; font-size: 20px; margin-top: 4px; }}
+.preview-grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 14px; }}
+figure {{ margin: 0; border: 1px solid #d7dde5; padding: 8px; border-radius: 6px; background: white; }}
+img {{ max-width: 100%; height: auto; display: block; }}
+figcaption {{ margin-top: 6px; font-size: 12px; color: #52606d; }}
+.note {{ background: #fff8e6; border-left: 4px solid #f0b429; padding: 10px 12px; }}
+</style>
+</head>
+<body>
+<h1>ImPerformance Wave 1 Native simobserve Evidence</h1>
+<p>This report is generated from the Wave 1 dataset plan, native generation logs, CASA open/read smoke, parity runs, and native image preview products.</p>
+<div class="summary">
+<div class="metric">Datasets generated<strong>{len(generation.get('datasets', []))}</strong></div>
+<div class="metric">Large dataset actual size<strong>{bytes_text(generation_by_id.get('wave1-alma-mosaic-large', {}).get('size_bytes'))}</strong></div>
+<div class="metric">Internal write-path throughput<strong>{number(io_perf.get('data_io_mb_per_second'), 'MB/s')}</strong></div>
+<div class="metric">Medium internal native throughput<strong>{number(io_perf.get('native_output_mb_per_second'), 'MB/s')}</strong></div>
+</div>
+<h2>Dataset Shapes, Sizes, and Generation Timing</h2>
+<table>
+<thead><tr><th>Dataset</th><th>Instrument</th><th>Family</th><th>Tier</th><th>Target</th><th>Actual</th><th>Elapsed</th><th>Rows</th><th>Channels</th><th>CASA open</th><th>Prediction</th><th>DATA write</th></tr></thead>
+<tbody>{''.join(dataset_rows)}</tbody>
+</table>
+<h2>Representative Native Image Previews</h2>
+<p class="note">Dirty and clean previews are shown for small representative datasets. A medium one-channel preview was intentionally stopped after 387 s with no products, which is recorded as a follow-up imaging read-path performance concern; the generated MS itself passed CASA open/read smoke.</p>
+{''.join(preview_sections)}
+<h2>CASA C++ Parity Runs</h2>
+<table>
+<thead><tr><th>Dataset</th><th>Status</th><th>Native</th><th>CASA</th><th>Speedup</th><th>UVW max</th><th>DATA mean abs</th><th>DATA max abs</th><th>Notes</th><th>JSON</th></tr></thead>
+<tbody>{''.join(parity_rows)}</tbody>
+</table>
+<h2>Internal-Disk I/O Guard</h2>
+<p>The medium VLA write-path guard ran with model prediction disabled on the internal disk. Native best time: {number(io_native.get('best_seconds'), 's')}; output size: {bytes_text(io_native.get('size_bytes'))}; streamed DATA/FLAG/UVW/WEIGHT/SIGMA bytes: {bytes_text(io_perf.get('data_io_bytes'))}; DATA writer time: {number(io_perf.get('data_io_write_millis'), 'ms')}.</p>
+<h2>Evidence Files</h2>
+<ul>
+<li>Plan: <code>{esc(plan.get('data_root'))}</code></li>
+<li>Generation summary: <code>{esc(generation.get('generated_at'))}</code></li>
+<li>CASA smoke: <code>{esc(smoke.get('generated_at'))}</code></li>
+</ul>
+</body>
+</html>
+"""
+    return html_doc
+
+
+def preview_figure(run: dict[str, Any] | None, label: str) -> str:
+    if not run:
+        return f"<figure><figcaption>{esc(label)} not generated.</figcaption></figure>"
+    prefix = pathlib.Path(run["prefix"])
+    png = pathlib.Path(str(prefix) + ".image.png")
+    if not png.exists():
+        return (
+            "<figure>"
+            f"<figcaption>{esc(label)} missing preview PNG for <code>{esc(str(prefix))}</code>.</figcaption>"
+            "</figure>"
+        )
+    data_uri = "data:image/png;base64," + base64.b64encode(png.read_bytes()).decode("ascii")
+    return (
+        "<figure>"
+        f"<img src='{data_uri}' alt='{esc(label)} preview'>"
+        f"<figcaption>{esc(label)}; elapsed {number(run.get('elapsed_seconds'), 's')}.</figcaption>"
+        "</figure>"
+    )
+
+
+def esc(value: Any) -> str:
+    return html.escape("" if value is None else str(value))
+
+
+def int_text(value: Any) -> str:
+    if value is None:
+        return "n/a"
+    return f"{int(value):,}"
+
+
+def number(value: Any, suffix: str) -> str:
+    if value is None:
+        return "n/a"
+    try:
+        number_value = float(value)
+    except (TypeError, ValueError):
+        return esc(value)
+    if suffix == "x":
+        return f"{number_value:.2f}x"
+    if abs(number_value) >= 100:
+        return f"{number_value:,.1f} {suffix}"
+    return f"{number_value:.4g} {suffix}"
+
+
+def bytes_text(value: Any) -> str:
+    if value is None:
+        return "n/a"
+    size = float(value)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if abs(size) < 1000 or unit == "TB":
+            return f"{size:.1f} {unit}"
+        size /= 1000.0
+    return f"{size:.1f} TB"
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/perf/imager/run_workload.py
+++ b/tools/perf/imager/run_workload.py
@@ -23,6 +23,7 @@ SUPPORTED_GRIDDER_VALUES = {"mosaic", "standard"}
 SUPPORTED_SPEC_MODES = {"mfs", "cube"}
 SUPPORTED_BENCH_MODES = {"dirty", "clean"}
 SUPPORTED_INTERPOLATION = {"nearest", "linear"}
+DEFAULT_COMPARISON_PRODUCTS = [".image", ".residual", ".psf"]
 
 
 class HarnessError(Exception):
@@ -74,6 +75,7 @@ def main() -> None:
         )
         output_dir = args.output_dir.resolve()
         output_dir.mkdir(parents=True, exist_ok=True)
+        attach_output_paths(plan, output_dir, dry_run=args.dry_run)
         result_path = output_dir / f"{plan['run_id']}.json"
         log_path = output_dir / f"{plan['run_id']}.log"
 
@@ -134,6 +136,7 @@ def build_plan(
     dataset = required_object(manifest, "dataset")
     imaging = required_object(manifest, "imaging")
     run = object_value(manifest, "run")
+    comparison = object_value(manifest, "comparison")
 
     specmode = enum_value(imaging, "specmode", SUPPORTED_SPEC_MODES)
     gridder = enum_value(imaging, "gridder", SUPPORTED_GRIDDER_VALUES)
@@ -221,12 +224,29 @@ def build_plan(
             "storage_label": storage_label_override
             or str_value(run, "storage_label", "script-staged-tempdir"),
         },
+        "comparison": {
+            "products": product_suffixes_value(comparison),
+            "max_elements_per_product": int_value(
+                comparison, "max_elements_per_product", 1_000_000
+            ),
+        },
         "command": {
             "argv": command,
             "env": env,
         },
         "environment": collect_environment(casa_python),
     }
+
+
+def attach_output_paths(plan: dict[str, Any], output_dir: pathlib.Path, *, dry_run: bool) -> None:
+    product_root = output_dir / "products" / plan["run_id"]
+    plan["products"] = {
+        "root": None if dry_run else str(product_root),
+        "rust_prefix": None if dry_run else str(product_root / "rust" / "rust"),
+        "casa_prefix": None if dry_run else str(product_root / "casa" / "casa"),
+    }
+    if not dry_run:
+        plan["command"]["env"]["IMAGER_BENCH_KEEP_OUTPUT_ROOT"] = str(product_root)
 
 
 def run_plan(plan: dict[str, Any], log_path: pathlib.Path) -> dict[str, Any]:
@@ -258,6 +278,8 @@ def run_plan(plan: dict[str, Any], log_path: pathlib.Path) -> dict[str, Any]:
         }
 
     parsed = parse_benchmark_log(completed.stdout)
+    comparison = compare_products(plan, parsed, log_path)
+    parsed["product_comparison"] = comparison
     return {
         "schema_version": 1,
         "status": "completed",
@@ -278,6 +300,8 @@ def empty_results(*, casa_status: str, reason: str) -> dict[str, Any]:
             "timings_seconds": {"runs": [], "median": None},
         },
         "stage_medians_ms": {"rust": {}, "casa": {}},
+        "product_paths": {},
+        "product_comparison": {"status": "skipped", "reason": reason, "products": {}},
     }
 
 
@@ -297,7 +321,79 @@ def parse_benchmark_log(text: str) -> dict[str, Any]:
             "timings_seconds": {"runs": casa_runs, "median": casa_median},
         },
         "stage_medians_ms": {"rust": rust_stages, "casa": casa_stages},
+        "product_paths": parse_product_paths(text),
     }
+
+
+def parse_product_paths(text: str) -> dict[str, str]:
+    paths = {}
+    for key in ("product_root", "rust_prefix", "casa_prefix"):
+        match = re.search(rf"^\s*{key}=(.+)$", text, flags=re.MULTILINE)
+        if match:
+            paths[key] = match.group(1).strip()
+    return paths
+
+
+def compare_products(
+    plan: dict[str, Any], parsed: dict[str, Any], log_path: pathlib.Path
+) -> dict[str, Any]:
+    product_paths = parsed.get("product_paths", {})
+    rust_prefix = product_paths.get("rust_prefix") or plan.get("products", {}).get("rust_prefix")
+    casa_prefix = product_paths.get("casa_prefix") or plan.get("products", {}).get("casa_prefix")
+    casa_python = plan.get("environment", {}).get("casa_python")
+    if not rust_prefix or not casa_prefix:
+        return {
+            "status": "skipped",
+            "reason": "benchmark did not preserve product prefixes",
+            "products": {},
+        }
+    if not casa_python:
+        return {
+            "status": "skipped",
+            "reason": "CASA Python is required for CASA image product comparison",
+            "products": {},
+        }
+
+    request = {
+        "rust_prefix": rust_prefix,
+        "casa_prefix": casa_prefix,
+        "products": plan["comparison"]["products"],
+        "max_elements_per_product": plan["comparison"]["max_elements_per_product"],
+    }
+    request_path = log_path.with_suffix(".comparison-input.json")
+    output_path = log_path.with_suffix(".comparison.json")
+    script_path = log_path.with_suffix(".compare-products.py")
+    request_path.write_text(json.dumps(request, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    script_path.write_text(PRODUCT_COMPARISON_SCRIPT, encoding="utf-8")
+    completed = subprocess.run(
+        [casa_python, str(script_path), str(request_path), str(output_path)],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    comparison_log_path = log_path.with_suffix(".comparison.log")
+    comparison_log_path.write_text(completed.stdout, encoding="utf-8")
+    if completed.returncode != 0:
+        return {
+            "status": "failed",
+            "reason": f"product comparison exited {completed.returncode}",
+            "log": str(comparison_log_path),
+            "products": {},
+        }
+    try:
+        comparison = json.loads(output_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        return {
+            "status": "failed",
+            "reason": f"read product comparison output: {error}",
+            "log": str(comparison_log_path),
+            "products": {},
+        }
+    comparison["log"] = str(comparison_log_path)
+    comparison["input"] = str(request_path)
+    return comparison
 
 
 def parse_timing_section(text: str, heading: str) -> tuple[list[float], float | None]:
@@ -469,6 +565,163 @@ def scales_value(imaging: dict[str, Any]) -> str:
     if not isinstance(value, list) or not all(isinstance(item, int) for item in value):
         raise HarnessError("'scales' must be a list of integers")
     return ",".join(str(item) for item in value)
+
+
+def product_suffixes_value(comparison: dict[str, Any]) -> list[str]:
+    value = comparison.get("products", DEFAULT_COMPARISON_PRODUCTS)
+    if not isinstance(value, list) or not value:
+        raise HarnessError("'comparison.products' must be a non-empty list")
+    result = []
+    for item in value:
+        if not isinstance(item, str) or not item.startswith("."):
+            raise HarnessError("'comparison.products' values must be suffix strings")
+        result.append(item)
+    return result
+
+
+PRODUCT_COMPARISON_SCRIPT = r'''#!/usr/bin/env python3
+import json
+import math
+import os
+import sys
+
+import numpy as np
+from casatools import image
+
+
+def main():
+    with open(sys.argv[1], "r", encoding="utf-8") as handle:
+        request = json.load(handle)
+    products = {}
+    for suffix in request["products"]:
+        rust_path = request["rust_prefix"] + suffix
+        casa_path = request["casa_prefix"] + suffix
+        products[suffix] = compare_one(
+            rust_path,
+            casa_path,
+            int(request["max_elements_per_product"]),
+        )
+    output = {"status": "completed", "products": products}
+    with open(sys.argv[2], "w", encoding="utf-8") as handle:
+        json.dump(output, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def compare_one(rust_path, casa_path, max_elements):
+    if not os.path.isdir(rust_path) or not os.path.isdir(casa_path):
+        return {
+            "status": "missing",
+            "rust_path": rust_path,
+            "casa_path": casa_path,
+            "rust_exists": os.path.isdir(rust_path),
+            "casa_exists": os.path.isdir(casa_path),
+        }
+    rust = load_image(rust_path, max_elements)
+    casa = load_image(casa_path, max_elements)
+    if rust["shape"] != casa["shape"]:
+        return {
+            "status": "shape_mismatch",
+            "rust_path": rust_path,
+            "casa_path": casa_path,
+            "rust_shape": rust["shape"],
+            "casa_shape": casa["shape"],
+        }
+    rust_data = rust["data"]
+    casa_data = casa["data"]
+    mask = np.isfinite(rust_data) & np.isfinite(casa_data)
+    valid_count = int(np.count_nonzero(mask))
+    if valid_count == 0:
+        return {
+            "status": "no_finite_overlap",
+            "rust_path": rust_path,
+            "casa_path": casa_path,
+            "shape": rust["shape"],
+            "sample_stride": rust["sample_stride"],
+            "sampled_elements": int(rust_data.size),
+        }
+    rust_valid = rust_data[mask]
+    casa_valid = casa_data[mask]
+    diff = rust_valid - casa_valid
+    casa_peak = max(abs(float(np.nanmin(casa_valid))), abs(float(np.nanmax(casa_valid))))
+    casa_rms = rms(casa_valid)
+    diff_rms = rms(diff)
+    diff_abs_max = float(np.nanmax(np.abs(diff)))
+    return {
+        "status": "compared",
+        "rust_path": rust_path,
+        "casa_path": casa_path,
+        "shape": rust["shape"],
+        "sample_stride": rust["sample_stride"],
+        "sampled_elements": int(rust_data.size),
+        "finite_overlap": valid_count,
+        "rust_min": finite_float(np.nanmin(rust_valid)),
+        "rust_max": finite_float(np.nanmax(rust_valid)),
+        "rust_rms": finite_float(rms(rust_valid)),
+        "casa_min": finite_float(np.nanmin(casa_valid)),
+        "casa_max": finite_float(np.nanmax(casa_valid)),
+        "casa_rms": finite_float(casa_rms),
+        "diff_abs_max": finite_float(diff_abs_max),
+        "diff_rms": finite_float(diff_rms),
+        "diff_rms_over_casa_rms": finite_float(diff_rms / abs(casa_rms)) if casa_rms else None,
+        "diff_abs_max_over_casa_peak": finite_float(diff_abs_max / casa_peak) if casa_peak else None,
+    }
+
+
+def load_image(path, max_elements):
+    tool = image()
+    try:
+        tool.open(path)
+        shape = [int(v) for v in tool.shape()]
+        stride = stride_for(shape, max_elements)
+        trc = [max(0, v - 1) for v in shape]
+        data = tool.getchunk(
+            blc=[0] * len(shape),
+            trc=trc,
+            inc=stride,
+            dropdeg=False,
+            getmask=False,
+        )
+    finally:
+        tool.close()
+    return {
+        "shape": shape,
+        "sample_stride": stride,
+        "data": np.asarray(data, dtype=np.float64),
+    }
+
+
+def stride_for(shape, max_elements):
+    if max_elements < 1:
+        raise ValueError("max_elements_per_product must be >= 1")
+    stride = [1] * len(shape)
+    sampled = product(shape)
+    index = 0
+    while sampled > max_elements:
+        stride[index % len(stride)] += 1
+        sampled = product(math.ceil(size / step) for size, step in zip(shape, stride))
+        index += 1
+    return stride
+
+
+def product(values):
+    result = 1
+    for value in values:
+        result *= int(value)
+    return result
+
+
+def rms(values):
+    return float(np.sqrt(np.nanmean(values * values)))
+
+
+def finite_float(value):
+    value = float(value)
+    return value if math.isfinite(value) else None
+
+
+if __name__ == "__main__":
+    main()
+'''
 
 
 if __name__ == "__main__":

--- a/tools/perf/imager/run_workload.py
+++ b/tools/perf/imager/run_workload.py
@@ -278,6 +278,7 @@ def run_plan(plan: dict[str, Any], log_path: pathlib.Path) -> dict[str, Any]:
         }
 
     parsed = parse_benchmark_log(completed.stdout)
+    attach_stage_breakdown(plan, parsed)
     comparison = compare_products(plan, parsed, log_path)
     parsed["product_comparison"] = comparison
     return {
@@ -300,6 +301,7 @@ def empty_results(*, casa_status: str, reason: str) -> dict[str, Any]:
             "timings_seconds": {"runs": [], "median": None},
         },
         "stage_medians_ms": {"rust": {}, "casa": {}},
+        "stage_breakdown": empty_stage_breakdown(reason),
         "product_paths": {},
         "product_comparison": {"status": "skipped", "reason": reason, "products": {}},
     }
@@ -322,6 +324,215 @@ def parse_benchmark_log(text: str) -> dict[str, Any]:
         },
         "stage_medians_ms": {"rust": rust_stages, "casa": casa_stages},
         "product_paths": parse_product_paths(text),
+    }
+
+
+def attach_stage_breakdown(plan: dict[str, Any], parsed: dict[str, Any]) -> None:
+    medians = parsed.get("stage_medians_ms", {})
+    parsed["stage_breakdown"] = {
+        "schema_version": 1,
+        "units": "milliseconds",
+        "instrumentation_scope": "benchmark-harness",
+        "contract_review": (
+            "local benchmark result JSON only; no provider protocol or managed-output "
+            "schema change"
+        ),
+        "rust": build_rust_stage_breakdown(plan, medians.get("rust", {})),
+        "casa": build_casa_stage_breakdown(medians.get("casa", {})),
+    }
+
+
+def empty_stage_breakdown(reason: str) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "units": "milliseconds",
+        "instrumentation_scope": "benchmark-harness",
+        "rust": {"status": "skipped", "reason": reason, "categories": {}},
+        "casa": {"status": "skipped", "reason": reason, "categories": {}},
+    }
+
+
+def build_rust_stage_breakdown(plan: dict[str, Any], stages: dict[str, float]) -> dict[str, Any]:
+    dirty_only = plan["mode"]["bench_mode"] == "dirty" or plan["mode"]["niter"] == 0
+    categories = {
+        "frontend_ms_preparation": stage_category(
+            stages,
+            ["open_measurement_set", "prepare_plane_input", "extract_phase_center"],
+            "MS open, selection, row adaptation, and phase-center resolution.",
+        ),
+        "visibility_adaptation_and_chunking": stage_category(
+            stages,
+            ["prepare_plane_input"],
+            "Visibility adaptation before entering the imaging core.",
+        ),
+        "weighting_density_setup": stage_category(
+            stages,
+            ["weighting"],
+            "Imaging weights, density grids, and taper setup.",
+        ),
+        "projection_pb_cf_preparation": stage_category(
+            stages,
+            [],
+            "No dedicated Wave 1 casa-rs timing field yet; projection/PB setup is included in the gridding/PB product paths where applicable.",
+            skipped=True,
+        ),
+        "gridding_degridding": stage_category(
+            stages,
+            ["psf_grid", "residual_degrid_grid"],
+            "PSF gridding plus residual degrid/grid work.",
+        ),
+        "fft": stage_category(
+            stages,
+            ["psf_fft", "model_fft", "residual_fft"],
+            "PSF, model, and residual FFT work.",
+        ),
+        "normalization_pb_correction": stage_category(
+            stages,
+            ["psf_normalize", "residual_normalize"],
+            "PSF and residual normalization; PB correction is included when the selected mode produces PB products.",
+        ),
+        "deconvolution_minor_cycle": stage_category(
+            stages,
+            ["minor_cycle_solve"],
+            "Minor-cycle component selection and subtraction.",
+            skipped=dirty_only,
+            skip_reason="dirty-only or niter=0 workload",
+        ),
+        "model_prediction_and_residual_refresh": stage_category(
+            stages,
+            ["major_cycle_refresh"],
+            "Major-cycle model prediction and residual refresh aggregate.",
+            skipped=dirty_only,
+            skip_reason="dirty-only or niter=0 workload",
+        ),
+        "restore_and_beam_fit": stage_category(
+            stages,
+            ["beam_fit", "restore"],
+            "Restoring-beam fit and restored-image generation.",
+            skipped=dirty_only,
+            skip_reason="dirty-only or niter=0 workload",
+        ),
+        "coordinate_and_product_writeback": stage_category(
+            stages,
+            ["build_coordinate_system", "write_products"],
+            "Output coordinate construction and image product writeback.",
+        ),
+        "preview_sidecar_generation": stage_category(
+            stages,
+            [],
+            "The benchmark script passes --no-preview-pngs, so preview sidecars are disabled.",
+            skipped=True,
+            skip_reason="disabled by benchmark harness",
+        ),
+        "frontend_total": stage_category(
+            stages,
+            ["frontend_total"],
+            "Total frontend wallclock from the Rust profiler.",
+        ),
+        "core_total": stage_category(
+            stages,
+            ["total"],
+            "Total pure imaging-core wallclock from the Rust profiler.",
+        ),
+    }
+    return {"status": "reported" if stages else "missing", "categories": categories}
+
+
+def build_casa_stage_breakdown(stages: dict[str, float]) -> dict[str, Any]:
+    categories = {
+        "setup_and_tool_construction": stage_category(
+            stages,
+            [
+                "parameter_setup",
+                "construct_imager",
+                "initialize_imagers",
+                "initialize_normalizers",
+                "initialize_deconvolvers",
+                "initialize_iteration_control",
+                "estimate_memory",
+            ],
+            "CASA PySynthesisImager setup, construction, and initialization.",
+        ),
+        "weighting_density_setup": stage_category(
+            stages,
+            ["set_weighting"],
+            "CASA weighting setup.",
+        ),
+        "psf_and_primary_beam": stage_category(
+            stages,
+            ["make_psf", "make_pb"],
+            "CASA PSF and PB construction.",
+        ),
+        "major_cycle_residual": stage_category(
+            stages,
+            ["calcres_major_cycle", "clean_major_cycle"],
+            "CASA residual major-cycle and clean major-cycle work.",
+        ),
+        "deconvolution_minor_cycle": stage_category(
+            stages,
+            ["minor_cycle", "update_mask", "has_converged"],
+            "CASA minor-cycle, mask update, and convergence checks.",
+        ),
+        "restore_and_cleanup": stage_category(
+            stages,
+            ["restore_images", "delete_tools"],
+            "CASA restore and tool cleanup.",
+        ),
+        "total": stage_category(stages, ["total"], "CASA phase probe total."),
+    }
+    return {"status": "reported" if stages else "missing", "categories": categories}
+
+
+def stage_category(
+    stages: dict[str, float],
+    fields: list[str],
+    description: str,
+    *,
+    skipped: bool = False,
+    skip_reason: str | None = None,
+) -> dict[str, Any]:
+    components = {field: stages[field] for field in fields if field in stages}
+    if skipped and not components:
+        return {
+            "status": "skipped",
+            "reason": skip_reason or description,
+            "total_ms": None,
+            "components_ms": {},
+            "source_fields": fields,
+            "description": description,
+        }
+    if not fields:
+        return {
+            "status": "not_reported",
+            "reason": description,
+            "total_ms": None,
+            "components_ms": {},
+            "source_fields": [],
+            "description": description,
+        }
+    missing = [field for field in fields if field not in stages]
+    if components:
+        total = sum(components.values())
+        status = "measured" if total > 0 else "measured_zero"
+        if skipped and total == 0:
+            status = "skipped"
+        return {
+            "status": status,
+            "reason": skip_reason if status == "skipped" else None,
+            "total_ms": total,
+            "components_ms": components,
+            "source_fields": fields,
+            "missing_fields": missing,
+            "description": description,
+        }
+    return {
+        "status": "missing",
+        "reason": f"no source timing fields found: {', '.join(fields)}",
+        "total_ms": None,
+        "components_ms": {},
+        "source_fields": fields,
+        "missing_fields": missing,
+        "description": description,
     }
 
 

--- a/tools/perf/imager/run_workload.py
+++ b/tools/perf/imager/run_workload.py
@@ -165,6 +165,7 @@ def build_plan(
         "IMAGER_BENCH_GRIDDER": gridder,
         "IMAGER_BENCH_INTERPOLATION": interpolation,
         "IMAGER_BENCH_FIELD": str_value(imaging, "field", "0"),
+        "IMAGER_BENCH_PHASECENTER_FIELD": optional_int_string(imaging, "phasecenter_field"),
         "IMAGER_BENCH_SPW": str_value(imaging, "spw", "0"),
         "IMAGER_BENCH_CHANNEL_START": str(int_value(imaging, "channel_start", 0)),
         "IMAGER_BENCH_CHANNEL_COUNT": str(int_value(imaging, "channel_count", 1)),
@@ -746,6 +747,15 @@ def int_value(obj: dict[str, Any], key: str, default: int) -> int:
     if not isinstance(value, int):
         raise HarnessError(f"{key!r} must be an integer")
     return value
+
+
+def optional_int_string(obj: dict[str, Any], key: str) -> str:
+    value = obj.get(key)
+    if value is None:
+        return ""
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise HarnessError(f"{key!r} must be an integer or null")
+    return str(value)
 
 
 def float_value(obj: dict[str, Any], key: str, default: float) -> float:

--- a/tools/perf/imager/run_workload.py
+++ b/tools/perf/imager/run_workload.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+"""Run manifest-driven CASA C++ versus casa-rs imaging benchmarks."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import pathlib
+import re
+import statistics
+import subprocess
+import sys
+import uuid
+from typing import Any
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+WORKLOAD_DIR = pathlib.Path(__file__).resolve().parent / "workloads"
+BENCH_SCRIPT = REPO_ROOT / "scripts" / "bench-imager-vs-casa.sh"
+SUPPORTED_GRIDDER_VALUES = {"mosaic", "standard"}
+SUPPORTED_SPEC_MODES = {"mfs", "cube"}
+SUPPORTED_BENCH_MODES = {"dirty", "clean"}
+SUPPORTED_INTERPOLATION = {"nearest", "linear"}
+
+
+class HarnessError(Exception):
+    """Error that should be shown without a Python traceback."""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("workload", help="workload manifest id or JSON path")
+    parser.add_argument(
+        "--output-dir",
+        type=pathlib.Path,
+        default=pathlib.Path("target/imperformance-wave1"),
+        help="directory for result JSON and benchmark log",
+    )
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        default=None,
+        help="override manifest run.repeats",
+    )
+    parser.add_argument(
+        "--run-label",
+        default=None,
+        help="override manifest run.run_label, for example cold, warm, or fresh-open",
+    )
+    parser.add_argument(
+        "--storage-label",
+        default=None,
+        help="override manifest run.storage_label",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="validate manifest support and write the planned command without running",
+    )
+    args = parser.parse_args()
+
+    try:
+        manifest_path = resolve_workload(args.workload)
+        manifest = load_manifest(manifest_path)
+        plan = build_plan(
+            manifest_path=manifest_path,
+            manifest=manifest,
+            repeats_override=args.repeats,
+            run_label_override=args.run_label,
+            storage_label_override=args.storage_label,
+            dry_run=args.dry_run,
+        )
+        output_dir = args.output_dir.resolve()
+        output_dir.mkdir(parents=True, exist_ok=True)
+        result_path = output_dir / f"{plan['run_id']}.json"
+        log_path = output_dir / f"{plan['run_id']}.log"
+
+        if args.dry_run:
+            result = {
+                "schema_version": 1,
+                "status": "dry_run",
+                **plan,
+                "logs": {"benchmark_log": None},
+                "results": empty_results(casa_status="not_run", reason="dry run"),
+            }
+            write_json(result_path, result)
+            print(result_path)
+            return
+
+        result = run_plan(plan, log_path)
+        result["logs"] = {"benchmark_log": str(log_path)}
+        write_json(result_path, result)
+        print(result_path)
+    except HarnessError as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(2) from None
+
+
+def resolve_workload(value: str) -> pathlib.Path:
+    candidate = pathlib.Path(value)
+    if candidate.exists():
+        return candidate.resolve()
+    if candidate.suffix != ".json":
+        candidate = WORKLOAD_DIR / f"{value}.json"
+    if candidate.exists():
+        return candidate.resolve()
+    raise HarnessError(f"workload manifest not found: {value}")
+
+
+def load_manifest(path: pathlib.Path) -> dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            value = json.load(handle)
+    except json.JSONDecodeError as error:
+        raise HarnessError(f"parse {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise HarnessError(f"{path} must contain a JSON object")
+    return value
+
+
+def build_plan(
+    *,
+    manifest_path: pathlib.Path,
+    manifest: dict[str, Any],
+    repeats_override: int | None,
+    run_label_override: str | None,
+    storage_label_override: str | None,
+    dry_run: bool,
+) -> dict[str, Any]:
+    workload_id = required_str(manifest, "id")
+    mode_id = required_str(manifest, "mode_id")
+    dataset = required_object(manifest, "dataset")
+    imaging = required_object(manifest, "imaging")
+    run = object_value(manifest, "run")
+
+    specmode = enum_value(imaging, "specmode", SUPPORTED_SPEC_MODES)
+    gridder = enum_value(imaging, "gridder", SUPPORTED_GRIDDER_VALUES)
+    bench_mode = enum_value(imaging, "mode", SUPPORTED_BENCH_MODES)
+    interpolation = enum_value_default(imaging, "interpolation", "linear", SUPPORTED_INTERPOLATION)
+    wterm = str_value(imaging, "wterm", "none")
+    if wterm != "none":
+        raise HarnessError(
+            f"{workload_id}: wterm={wterm!r} is not supported by this harness yet"
+        )
+    repeats = repeats_override if repeats_override is not None else int_value(run, "repeats", 5)
+    if repeats < 1:
+        raise HarnessError("repeats must be >= 1")
+
+    dataset_path = resolve_dataset_path(dataset, dry_run=dry_run)
+    casa_python = os.environ.get("CASA_RS_CASA_PYTHON")
+    if not dry_run and not casa_python:
+        raise HarnessError("CASA_RS_CASA_PYTHON is required for a benchmark run")
+    if not dry_run and casa_python and not pathlib.Path(casa_python).is_file():
+        raise HarnessError(f"CASA_RS_CASA_PYTHON does not exist: {casa_python}")
+
+    env = {
+        "BENCH_REPEATS": str(repeats),
+        "IMAGER_BENCH_MODE": bench_mode,
+        "IMAGER_BENCH_SPECMODE": specmode,
+        "IMAGER_BENCH_GRIDDER": gridder,
+        "IMAGER_BENCH_INTERPOLATION": interpolation,
+        "IMAGER_BENCH_FIELD": str_value(imaging, "field", "0"),
+        "IMAGER_BENCH_SPW": str_value(imaging, "spw", "0"),
+        "IMAGER_BENCH_CHANNEL_START": str(int_value(imaging, "channel_start", 0)),
+        "IMAGER_BENCH_CHANNEL_COUNT": str(int_value(imaging, "channel_count", 1)),
+        "IMAGER_BENCH_IMSIZE": str(int_value(imaging, "imsize", 128)),
+        "IMAGER_BENCH_CELL_ARCSEC": str(float_value(imaging, "cell_arcsec", 30.0)),
+        "IMAGER_BENCH_WEIGHTING": str_value(imaging, "weighting", "natural"),
+        "IMAGER_BENCH_ROBUST": str(float_value(imaging, "robust", 0.5)),
+        "IMAGER_BENCH_DECONVOLVER": str_value(imaging, "deconvolver", "hogbom"),
+        "IMAGER_BENCH_SCALES": scales_value(imaging),
+        "IMAGER_BENCH_WTERM": wterm,
+        "IMAGER_BENCH_NITER": str(int_value(imaging, "niter", 4)),
+        "IMAGER_BENCH_GAIN": str(float_value(imaging, "gain", 0.1)),
+        "IMAGER_BENCH_THRESHOLD_JY": str(float_value(imaging, "threshold_jy", 0.0)),
+        "IMAGER_BENCH_NSIGMA": str(float_value(imaging, "nsigma", 0.0)),
+        "IMAGER_BENCH_PSFCUTOFF": str(float_value(imaging, "psfcutoff", 0.35)),
+        "IMAGER_BENCH_MINOR_CYCLE_LENGTH": str(
+            int_value(imaging, "minor_cycle_length", 2)
+        ),
+        "IMAGER_BENCH_CYCLEFACTOR": str(float_value(imaging, "cyclefactor", 1.0)),
+        "IMAGER_BENCH_MIN_PSFFRACTION": str(
+            float_value(imaging, "min_psf_fraction", 0.05)
+        ),
+        "IMAGER_BENCH_MAX_PSFFRACTION": str(
+            float_value(imaging, "max_psf_fraction", 0.8)
+        ),
+    }
+
+    command = [str(BENCH_SCRIPT), str(dataset_path)]
+    return {
+        "run_id": f"{utc_stamp()}-{workload_id}-{uuid.uuid4().hex[:8]}",
+        "created_at": utc_now(),
+        "manifest_path": str(manifest_path),
+        "workload": {
+            "id": workload_id,
+            "mode_id": mode_id,
+            "description": str_value(manifest, "description", ""),
+        },
+        "dataset": {
+            "key": required_str(dataset, "key"),
+            "path": str(dataset_path),
+            "relative_path": dataset.get("relative_path"),
+            "root_env": dataset.get("root_env"),
+        },
+        "mode": {
+            "specmode": specmode,
+            "gridder": gridder,
+            "bench_mode": bench_mode,
+            "image_shape": [int_value(imaging, "imsize", 128), int_value(imaging, "imsize", 128)],
+            "channel_count": int_value(imaging, "channel_count", 1),
+            "weighting": str_value(imaging, "weighting", "natural"),
+            "deconvolver": str_value(imaging, "deconvolver", "hogbom"),
+            "niter": int_value(imaging, "niter", 4),
+        },
+        "run": {
+            "repeats": repeats,
+            "run_label": run_label_override or str_value(run, "run_label", "warm"),
+            "storage_label": storage_label_override
+            or str_value(run, "storage_label", "script-staged-tempdir"),
+        },
+        "command": {
+            "argv": command,
+            "env": env,
+        },
+        "environment": collect_environment(casa_python),
+    }
+
+
+def run_plan(plan: dict[str, Any], log_path: pathlib.Path) -> dict[str, Any]:
+    env = os.environ.copy()
+    env.update(plan["command"]["env"])
+    started = utc_now()
+    completed = subprocess.run(
+        plan["command"]["argv"],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    log_path.write_text(completed.stdout, encoding="utf-8")
+    if completed.returncode != 0:
+        return {
+            "schema_version": 1,
+            "status": "failed",
+            **plan,
+            "started_at": started,
+            "completed_at": utc_now(),
+            "exit_code": completed.returncode,
+            "results": empty_results(
+                casa_status="blocked",
+                reason=f"benchmark command exited {completed.returncode}",
+            ),
+        }
+
+    parsed = parse_benchmark_log(completed.stdout)
+    return {
+        "schema_version": 1,
+        "status": "completed",
+        **plan,
+        "started_at": started,
+        "completed_at": utc_now(),
+        "exit_code": completed.returncode,
+        "results": parsed,
+    }
+
+
+def empty_results(*, casa_status: str, reason: str) -> dict[str, Any]:
+    return {
+        "rust": {"status": "not_run", "timings_seconds": {"runs": [], "median": None}},
+        "casa": {
+            "status": casa_status,
+            "reason": reason,
+            "timings_seconds": {"runs": [], "median": None},
+        },
+        "stage_medians_ms": {"rust": {}, "casa": {}},
+    }
+
+
+def parse_benchmark_log(text: str) -> dict[str, Any]:
+    rust_runs, rust_median = parse_timing_section(text, "Rust release CLI timings")
+    casa_runs, casa_median = parse_timing_section(text, "CASA tclean timings")
+    rust_stages = parse_stage_section(text, "Rust stage medians")
+    casa_stages = parse_stage_section(text, "CASA PySynthesisImager stage medians")
+    return {
+        "rust": {
+            "status": "ran",
+            "timings_seconds": {"runs": rust_runs, "median": rust_median},
+        },
+        "casa": {
+            "status": "ran",
+            "reason": None,
+            "timings_seconds": {"runs": casa_runs, "median": casa_median},
+        },
+        "stage_medians_ms": {"rust": rust_stages, "casa": casa_stages},
+    }
+
+
+def parse_timing_section(text: str, heading: str) -> tuple[list[float], float | None]:
+    lines = section_lines(text, f"{heading} ")
+    runs = []
+    median_value = None
+    for line in lines:
+        run_match = re.search(r"\brun=\d+\s+real=([0-9.]+)", line)
+        if run_match:
+            runs.append(float(run_match.group(1)))
+        median_match = re.search(r"\bmedian=([0-9.]+)", line)
+        if median_match:
+            median_value = float(median_match.group(1))
+    if median_value is None and runs:
+        median_value = statistics.median(runs)
+    return runs, median_value
+
+
+def parse_stage_section(text: str, heading: str) -> dict[str, float]:
+    lines = section_lines(text, f"{heading} ")
+    stages: dict[str, float] = {}
+    for line in lines:
+        for name, value in re.findall(r"([A-Za-z0-9_]+)=([0-9.]+)", line):
+            if name != "run":
+                stages[name] = float(value)
+    return stages
+
+
+def section_lines(text: str, heading_prefix: str) -> list[str]:
+    lines = text.splitlines()
+    result = []
+    collecting = False
+    for line in lines:
+        if line.startswith(heading_prefix):
+            collecting = True
+            continue
+        if collecting and line.strip() == "":
+            break
+        if collecting:
+            result.append(line.strip())
+    return result
+
+
+def resolve_dataset_path(dataset: dict[str, Any], *, dry_run: bool) -> pathlib.Path:
+    if "path" in dataset:
+        path = pathlib.Path(os.path.expanduser(required_str(dataset, "path")))
+    else:
+        root_env = str_value(dataset, "root_env", "CASA_RS_TESTDATA_ROOT")
+        root = os.environ.get(root_env)
+        if not root:
+            if dry_run:
+                root = f"${root_env}"
+            else:
+                raise HarnessError(f"{root_env} is required for dataset {dataset.get('key')!r}")
+        path = pathlib.Path(root) / required_str(dataset, "relative_path")
+    if not dry_run and not path.is_dir():
+        raise HarnessError(f"dataset path does not exist: {path}")
+    return path
+
+
+def collect_environment(casa_python: str | None) -> dict[str, Any]:
+    return {
+        "repo_root": str(REPO_ROOT),
+        "git_commit": git_value(["rev-parse", "HEAD"]),
+        "git_branch": git_value(["branch", "--show-current"]),
+        "python": sys.version.split()[0],
+        "casa_python": casa_python,
+        "bench_script": str(BENCH_SCRIPT),
+        "bench_script_sha256": file_sha256(BENCH_SCRIPT),
+    }
+
+
+def git_value(args: list[str]) -> str | None:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.strip()
+
+
+def file_sha256(path: pathlib.Path) -> str:
+    import hashlib
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def utc_stamp() -> str:
+    return dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def write_json(path: pathlib.Path, value: dict[str, Any]) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def required_object(obj: dict[str, Any], key: str) -> dict[str, Any]:
+    value = obj.get(key)
+    if not isinstance(value, dict):
+        raise HarnessError(f"missing object field {key!r}")
+    return value
+
+
+def object_value(obj: dict[str, Any], key: str) -> dict[str, Any]:
+    value = obj.get(key, {})
+    if not isinstance(value, dict):
+        raise HarnessError(f"{key!r} must be an object")
+    return value
+
+
+def required_str(obj: dict[str, Any], key: str) -> str:
+    value = obj.get(key)
+    if not isinstance(value, str) or not value:
+        raise HarnessError(f"missing string field {key!r}")
+    return value
+
+
+def str_value(obj: dict[str, Any], key: str, default: str) -> str:
+    value = obj.get(key, default)
+    if not isinstance(value, str):
+        raise HarnessError(f"{key!r} must be a string")
+    return value
+
+
+def int_value(obj: dict[str, Any], key: str, default: int) -> int:
+    value = obj.get(key, default)
+    if not isinstance(value, int):
+        raise HarnessError(f"{key!r} must be an integer")
+    return value
+
+
+def float_value(obj: dict[str, Any], key: str, default: float) -> float:
+    value = obj.get(key, default)
+    if not isinstance(value, (int, float)):
+        raise HarnessError(f"{key!r} must be numeric")
+    return float(value)
+
+
+def enum_value(obj: dict[str, Any], key: str, allowed: set[str]) -> str:
+    return enum_value_default(obj, key, None, allowed)
+
+
+def enum_value_default(
+    obj: dict[str, Any], key: str, default: str | None, allowed: set[str]
+) -> str:
+    value = obj.get(key, default)
+    if not isinstance(value, str) or value not in allowed:
+        allowed_text = ", ".join(sorted(allowed))
+        raise HarnessError(f"{key!r} must be one of: {allowed_text}")
+    return value
+
+
+def scales_value(imaging: dict[str, Any]) -> str:
+    value = imaging.get("scales", "")
+    if value == "":
+        return ""
+    if not isinstance(value, list) or not all(isinstance(item, int) for item in value):
+        raise HarnessError("'scales' must be a list of integers")
+    return ",".join(str(item) for item in value)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/perf/imager/stage_wave1_datasets.py
+++ b/tools/perf/imager/stage_wave1_datasets.py
@@ -14,6 +14,11 @@ import sys
 import time
 from typing import Any
 
+try:
+    import numpy as np
+except ImportError:  # pragma: no cover - exercised only in minimal Python installs.
+    np = None
+
 
 TOOL_DIR = pathlib.Path(__file__).resolve().parent
 REGISTRY_PATH = TOOL_DIR / "wave1_dataset_registry.json"
@@ -214,6 +219,7 @@ def build_plan(
                     "duration_seconds": float_value(spec, "duration_seconds"),
                     "integration_seconds": float_value(spec, "integration_seconds"),
                     "estimated_main_rows": estimated_main_rows(spec, family),
+                    "estimated_data_bytes": estimated_data_bytes(spec, family),
                 },
                 "source_model": {
                     "continuum": registry["source_model"]["continuum_components"],
@@ -258,48 +264,19 @@ def validate_large_tier_policy(registry: dict[str, Any], specs: list[dict[str, A
     if isinstance(expected_id, str):
         large_ids = {required_str(spec, "id") for spec in large_specs}
         if expected_id not in large_ids:
-            raise DatasetError(
-                f"large tier policy requires shared dataset {expected_id!r}"
-            )
+                raise DatasetError(
+                    f"large tier policy requires dataset {expected_id!r}"
+                )
 
 
 def native_status_for(
     spec: dict[str, Any], instrument: dict[str, Any], family: dict[str, Any]
 ) -> dict[str, str]:
     instrument_status = required_str(instrument, "native_casars_status")
-    family_name = required_str(spec, "family")
-    if family_name == "shared-large":
-        return {
-            "casars_simulation": "blocked",
-            "casa_simulation": "generation-path",
-            "native_backlog_issue": "#254/#255/#180/#181/#182",
-            "reason": "shared large ALMA mosaic/cube superset requires CASA generation until native ALMA, multi-field mosaic, and channel-varying cube simulation exist",
-        }
-    if family_name == "mosaic":
-        return {
-            "casars_simulation": "blocked",
-            "casa_simulation": "generation-path",
-            "native_backlog_issue": "#254",
-            "reason": "current native simulator writes one FIELD; true mosaic staging requires multi-field generation or CASA simulation",
-        }
-    if required_str(spec, "instrument") != "vla":
-        return {
-            "casars_simulation": "request-plan-only",
-            "casa_simulation": "generation-path",
-            "native_backlog_issue": "#180/#181/#182",
-            "reason": instrument_status,
-        }
-    if int_value(spec, "channels") > 1:
-        return {
-            "casars_simulation": "supported-single-plane",
-            "casa_simulation": "generation-path",
-            "native_backlog_issue": "#255",
-            "reason": "native VLA single-field simobserve can write a multi-channel MS from one 2D model plane; CASA generation is required for deterministic channel-varying source structure",
-        }
     return {
         "casars_simulation": "supported",
         "casa_simulation": "generation-path",
-        "reason": "native VLA single-field simobserve parity path exists; CASA side is retained for simulation performance/parity checks",
+        "reason": f"native simobserve can generate this {instrument_status} benchmark shape; CASA side is retained for simulation performance/parity checks",
     }
 
 
@@ -366,6 +343,7 @@ def build_workload_manifest(dataset: dict[str, Any], mode_id: str) -> dict[str, 
             "specmode": specmode,
             "gridder": gridder,
             "field": "" if gridder == "mosaic" else "0",
+            "phasecenter_field": 0 if gridder == "mosaic" else None,
             "spw": "0",
             "channel_start": 0,
             "channel_count": channels,
@@ -543,13 +521,19 @@ def write_structured_fits(
     header = pad_block(header.encode("ascii"))
     with path.open("wb") as handle:
         handle.write(header)
-        for channel in range(channels):
-            scale = spectral_total_scale(channels, channel)
-            for y in range(pixels):
-                row = bytearray()
-                for x in range(pixels):
-                    row.extend(struct.pack(">f", source_pixel(x, y, pixels, family) * scale))
-                handle.write(row)
+        if np is not None:
+            base = source_plane(pixels, family)
+            for channel in range(channels):
+                plane = (base * spectral_total_scale(channels, channel)).astype(">f4", copy=False)
+                handle.write(plane.tobytes(order="C"))
+        else:
+            for channel in range(channels):
+                scale = spectral_total_scale(channels, channel)
+                for y in range(pixels):
+                    row = bytearray()
+                    for x in range(pixels):
+                        row.extend(struct.pack(">f", source_pixel(x, y, pixels, family) * scale))
+                    handle.write(row)
         pad = (-(pixels * pixels * channels * 4)) % 2880
         if pad:
             handle.write(b"\0" * pad)
@@ -582,9 +566,34 @@ def source_pixel(x: int, y: int, pixels: int, family: str) -> float:
     )
     halo = 0.06 * math.exp(-(radius**2) / (2.0 * 0.26**2))
     ripple = 0.015 * (1.0 + math.sin(37.0 * cx + 19.0 * cy))
-    mosaic_gradient = 1.0 + (0.10 * cx - 0.07 * cy if family == "mosaic" else 0.0)
+    mosaic_gradient = 1.0 + (0.10 * cx - 0.07 * cy if is_mosaic_family(family) else 0.0)
     value = (core + knot1 + knot2 + ring + arm1 + arm2 + halo + ripple) * mosaic_gradient
     return max(0.0, float(value))
+
+
+def source_plane(pixels: int, family: str) -> Any:
+    y, x = np.mgrid[0:pixels, 0:pixels]
+    cx = (x.astype("float32") + 0.5 - pixels / 2.0) / pixels
+    cy = (y.astype("float32") + 0.5 - pixels / 2.0) / pixels
+    radius = np.hypot(cx, cy)
+    theta = np.arctan2(cy, cx)
+    core = np.exp(-((cx**2 + cy**2) / (2.0 * 0.018**2)))
+    knot1 = 0.42 * np.exp(-(((cx + 0.14) ** 2 + (cy - 0.09) ** 2) / (2.0 * 0.028**2)))
+    knot2 = 0.31 * np.exp(-(((cx - 0.18) ** 2 + (cy + 0.11) ** 2) / (2.0 * 0.022**2)))
+    ring = 0.34 * np.exp(-((radius - 0.21) ** 2) / (2.0 * 0.018**2))
+    arm1 = 0.18 * np.exp(-((radius - (0.10 + 0.040 * theta)) ** 2) / (2.0 * 0.020**2))
+    arm2 = 0.14 * np.exp(-((radius - (0.18 - 0.035 * theta)) ** 2) / (2.0 * 0.024**2))
+    halo = 0.06 * np.exp(-(radius**2) / (2.0 * 0.26**2))
+    ripple = 0.015 * (1.0 + np.sin(37.0 * cx + 19.0 * cy))
+    mosaic_gradient = 1.0 + (0.10 * cx - 0.07 * cy if is_mosaic_family(family) else 0.0)
+    return np.maximum(
+        (core + knot1 + knot2 + ring + arm1 + arm2 + halo + ripple) * mosaic_gradient,
+        0.0,
+    ).astype("float32")
+
+
+def is_mosaic_family(family: str) -> bool:
+    return family in {"mosaic", "mosaic-large"}
 
 
 def build_spectral_profile(dataset: dict[str, Any]) -> dict[str, Any]:
@@ -623,8 +632,16 @@ def estimated_main_rows(spec: dict[str, Any], family: dict[str, Any]) -> int:
     return baseline_count * samples
 
 
+def estimated_data_bytes(spec: dict[str, Any], family: dict[str, Any]) -> int:
+    return estimated_main_rows(spec, family) * int_value(spec, "channels") * 2 * 8
+
+
 def alma_antennas() -> list[dict[str, Any]]:
-    center = [-2_225_035.0, -5_441_197.0, -2_481_630.0]
+    config = casa_array_config_path("alma.cycle8.5.cfg")
+    if config is not None:
+        return antennas_from_casa_array_config(config, loc_converter=alma_loc_to_itrf)
+
+    center = [2_225_142.18027137, -5_440_307.37035444, -2_481_029.85184099]
     antennas = []
     for index in range(43):
         arm = index % 3
@@ -649,6 +666,10 @@ def alma_antennas() -> list[dict[str, Any]]:
 
 
 def vla_d_antennas() -> list[dict[str, Any]]:
+    config = casa_array_config_path("vla.d.cfg")
+    if config is not None:
+        return antennas_from_casa_array_config(config)
+
     rows = [
         (-1_601_188.989351, -5_042_000.518599, 3_554_843.384480, "W01"),
         (-1_601_225.230987, -5_041_980.390730, 3_554_855.657987, "W02"),
@@ -686,6 +707,67 @@ def vla_d_antennas() -> list[dict[str, Any]]:
             "dish_diameter_m": 25.0,
         }
         for x_m, y_m, z_m, name in rows
+    ]
+
+
+def casa_array_config_path(file_name: str) -> pathlib.Path | None:
+    candidates = []
+    if root := os.environ.get("CASA_RS_ARRAY_CONFIG_ROOT"):
+        candidates.append(pathlib.Path(root) / file_name)
+    candidates.append(pathlib.Path.home() / ".casa" / "data" / "alma" / "simmos" / file_name)
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def antennas_from_casa_array_config(
+    path: pathlib.Path,
+    *,
+    loc_converter: Any | None = None,
+) -> list[dict[str, Any]]:
+    antennas = []
+    for raw_line in path.read_text(encoding="ascii").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if len(parts) < 5:
+            raise DatasetError(f"invalid antenna config row in {path}: {raw_line!r}")
+        x_m, y_m, z_m = (float(parts[0]), float(parts[1]), float(parts[2]))
+        diameter_m = float(parts[3])
+        station = parts[4]
+        position = (
+            loc_converter(x_m, y_m, z_m)
+            if loc_converter is not None
+            else [x_m, y_m, z_m]
+        )
+        antennas.append(
+            {
+                "name": station,
+                "station": station,
+                "position_m": position,
+                "dish_diameter_m": diameter_m,
+            }
+        )
+    if not antennas:
+        raise DatasetError(f"antenna config {path} contained no antennas")
+    return antennas
+
+
+def alma_loc_to_itrf(x_m: float, y_m: float, z_m: float) -> list[float]:
+    # CASA's ALMA simulation config uses a local tangent-plane frame.  These
+    # constants reproduce CASA's conversion for alma.cycle8.5.cfg.
+    center = [2_225_142.18027137, -5_440_307.37035444, -2_481_029.85184099]
+    rotation = [
+        [0.92557307, 0.14805787, 0.34841548],
+        [0.37856899, -0.36199050, -0.85184998],
+        [0.0, 0.920348708, -0.391098780],
+    ]
+    local = [x_m, y_m, z_m]
+    return [
+        center[axis] + sum(rotation[axis][local_axis] * local[local_axis] for local_axis in range(3))
+        for axis in range(3)
     ]
 
 

--- a/tools/perf/imager/stage_wave1_datasets.py
+++ b/tools/perf/imager/stage_wave1_datasets.py
@@ -24,6 +24,8 @@ TOOL_DIR = pathlib.Path(__file__).resolve().parent
 REGISTRY_PATH = TOOL_DIR / "wave1_dataset_registry.json"
 DEFAULT_OUTPUT_DIR = pathlib.Path("target/imperformance-wave1/datasets")
 EXTERNAL_PREFIX = pathlib.Path("/Volumes/GLENDENNING")
+MODEL_PHASE_CENTER_RA_DEG = 270.000129
+MODEL_PHASE_CENTER_DEC_DEG = -22.999889
 
 
 class DatasetError(Exception):
@@ -390,6 +392,7 @@ def build_casars_simobserve_request(dataset: dict[str, Any]) -> dict[str, Any]:
             "overwrite": True,
             "telescope_name": dataset["instrument"].upper(),
             "field_name": dataset["id"],
+            "phase_center_rad": phase_center_rad(0.0, 0.0),
             "fields": fields,
             "duration_seconds": dataset["shape"]["duration_seconds"],
             "integration_seconds": dataset["shape"]["integration_seconds"],
@@ -416,6 +419,16 @@ def build_casars_simobserve_request(dataset: dict[str, Any]) -> dict[str, Any]:
     return request
 
 
+def phase_center_rad(dra_arcsec: float, ddec_arcsec: float) -> list[float]:
+    ra_rad = math.radians(MODEL_PHASE_CENTER_RA_DEG + dra_arcsec / 3600.0)
+    if ra_rad > math.pi:
+        ra_rad -= math.tau
+    return [
+        ra_rad,
+        math.radians(MODEL_PHASE_CENTER_DEC_DEG + ddec_arcsec / 3600.0),
+    ]
+
+
 def build_casars_fields(dataset: dict[str, Any]) -> list[dict[str, Any]]:
     count = int(dataset["shape"]["pointing_count"])
     if count <= 1:
@@ -430,10 +443,7 @@ def build_casars_fields(dataset: dict[str, Any]) -> list[dict[str, Any]]:
         fields.append(
             {
                 "name": f"{dataset['id']}_field_{index}",
-                "phase_center_rad": [
-                    math.radians(270.000129 + dra_arcsec / 3600.0),
-                    math.radians(-22.999889 + ddec_arcsec / 3600.0),
-                ],
+                "phase_center_rad": phase_center_rad(dra_arcsec, ddec_arcsec),
             }
         )
     return fields
@@ -488,6 +498,8 @@ def write_structured_fits(
             ("CTYPE2", "'DEC--SIN'"),
             ("CUNIT1", "'deg'"),
             ("CUNIT2", "'deg'"),
+            ("RADESYS", "'FK5'"),
+            ("EQUINOX", "2000.0"),
             ("CRPIX1", f"{pixels / 2 + 0.5:.6f}"),
             ("CRPIX2", f"{pixels / 2 + 0.5:.6f}"),
             ("CRVAL1", "270.000129"),
@@ -506,8 +518,8 @@ def write_structured_fits(
                 ("CTYPE4", "'FREQ'"),
                 ("CUNIT4", "'Hz'"),
                 ("CRPIX4", "1.0"),
-                ("CRVAL4", f"{start_frequency_hz(instrument):.12g}"),
-                ("CDELT4", f"{channel_width_hz(instrument):.12g}"),
+                ("CRVAL4", f"{start_frequency_hz(instrument):.12E}"),
+                ("CDELT4", f"{channel_width_hz(instrument):.12E}"),
             ]
         )
     cards.extend(
@@ -525,7 +537,7 @@ def write_structured_fits(
             base = source_plane(pixels, family)
             for channel in range(channels):
                 plane = (base * spectral_total_scale(channels, channel)).astype(">f4", copy=False)
-                handle.write(plane.tobytes(order="C"))
+                handle.write(plane.T.tobytes(order="C"))
         else:
             for channel in range(channels):
                 scale = spectral_total_scale(channels, channel)
@@ -560,9 +572,15 @@ def source_pixel(x: int, y: int, pixels: int, family: str) -> float:
     knot1 = 0.42 * gaussian(cx, cy, -0.14, 0.09, 0.028)
     knot2 = 0.31 * gaussian(cx, cy, 0.18, -0.11, 0.022)
     ring = 0.34 * math.exp(-((radius - 0.21) ** 2) / (2.0 * 0.018**2))
-    arm1 = 0.18 * math.exp(-((radius - (0.10 + 0.040 * theta)) ** 2) / (2.0 * 0.020**2))
-    arm2 = 0.14 * math.exp(
-        -((radius - (0.18 - 0.035 * theta)) ** 2) / (2.0 * 0.024**2)
+    arm1 = spiral_arm(radius, theta, phase=0.20, pitch=14.0, radius0=0.18, width=0.28, radial_width=0.11)
+    arm2 = 0.78 * spiral_arm(
+        radius,
+        theta,
+        phase=math.pi + 0.55,
+        pitch=12.0,
+        radius0=0.20,
+        width=0.30,
+        radial_width=0.12,
     )
     halo = 0.06 * math.exp(-(radius**2) / (2.0 * 0.26**2))
     ripple = 0.015 * (1.0 + math.sin(37.0 * cx + 19.0 * cy))
@@ -572,17 +590,24 @@ def source_pixel(x: int, y: int, pixels: int, family: str) -> float:
 
 
 def source_plane(pixels: int, family: str) -> Any:
-    y, x = np.mgrid[0:pixels, 0:pixels]
-    cx = (x.astype("float32") + 0.5 - pixels / 2.0) / pixels
-    cy = (y.astype("float32") + 0.5 - pixels / 2.0) / pixels
+    coords = (np.arange(pixels, dtype=np.float32) + 0.5 - pixels / 2.0) / pixels
+    cx, cy = np.meshgrid(coords, coords, indexing="ij")
     radius = np.hypot(cx, cy)
     theta = np.arctan2(cy, cx)
     core = np.exp(-((cx**2 + cy**2) / (2.0 * 0.018**2)))
     knot1 = 0.42 * np.exp(-(((cx + 0.14) ** 2 + (cy - 0.09) ** 2) / (2.0 * 0.028**2)))
     knot2 = 0.31 * np.exp(-(((cx - 0.18) ** 2 + (cy + 0.11) ** 2) / (2.0 * 0.022**2)))
     ring = 0.34 * np.exp(-((radius - 0.21) ** 2) / (2.0 * 0.018**2))
-    arm1 = 0.18 * np.exp(-((radius - (0.10 + 0.040 * theta)) ** 2) / (2.0 * 0.020**2))
-    arm2 = 0.14 * np.exp(-((radius - (0.18 - 0.035 * theta)) ** 2) / (2.0 * 0.024**2))
+    arm1 = spiral_arm_array(radius, theta, phase=0.20, pitch=14.0, radius0=0.18, width=0.28, radial_width=0.11)
+    arm2 = 0.78 * spiral_arm_array(
+        radius,
+        theta,
+        phase=math.pi + 0.55,
+        pitch=12.0,
+        radius0=0.20,
+        width=0.30,
+        radial_width=0.12,
+    )
     halo = 0.06 * np.exp(-(radius**2) / (2.0 * 0.26**2))
     ripple = 0.015 * (1.0 + np.sin(37.0 * cx + 19.0 * cy))
     mosaic_gradient = 1.0 + (0.10 * cx - 0.07 * cy if is_mosaic_family(family) else 0.0)
@@ -590,6 +615,40 @@ def source_plane(pixels: int, family: str) -> Any:
         (core + knot1 + knot2 + ring + arm1 + arm2 + halo + ripple) * mosaic_gradient,
         0.0,
     ).astype("float32")
+
+
+def spiral_arm(
+    radius: float,
+    theta: float,
+    *,
+    phase: float,
+    pitch: float,
+    radius0: float,
+    width: float,
+    radial_width: float,
+) -> float:
+    target = phase + pitch * (radius - radius0)
+    angular = math.atan2(math.sin(theta - target), math.cos(theta - target))
+    angular_profile = math.exp(-(angular**2) / (2.0 * width**2))
+    radial_profile = math.exp(-((radius - radius0) ** 2) / (2.0 * radial_width**2))
+    return 0.18 * angular_profile * radial_profile
+
+
+def spiral_arm_array(
+    radius: Any,
+    theta: Any,
+    *,
+    phase: float,
+    pitch: float,
+    radius0: float,
+    width: float,
+    radial_width: float,
+) -> Any:
+    target = phase + pitch * (radius - radius0)
+    angular = np.arctan2(np.sin(theta - target), np.cos(theta - target))
+    angular_profile = np.exp(-(angular**2) / (2.0 * width**2))
+    radial_profile = np.exp(-((radius - radius0) ** 2) / (2.0 * radial_width**2))
+    return 0.18 * angular_profile * radial_profile
 
 
 def is_mosaic_family(family: str) -> bool:
@@ -756,22 +815,32 @@ def antennas_from_casa_array_config(
 
 
 def alma_loc_to_itrf(x_m: float, y_m: float, z_m: float) -> list[float]:
-    # CASA's ALMA simulation config uses a local tangent-plane frame.  These
-    # constants reproduce CASA's conversion for alma.cycle8.5.cfg.
-    center = [2_225_142.18027137, -5_440_307.37035444, -2_481_029.85184099]
-    rotation = [
-        [0.92557307, 0.14805787, 0.34841548],
-        [0.37856899, -0.36199050, -0.85184998],
-        [0.0, 0.920348708, -0.391098780],
-    ]
-    local = [x_m, y_m, z_m]
+    # CASA's ALMA configs use coordsys=LOC.  simutil.readantenna converts those
+    # rows with locxyz2itrf(obslat, obslon, obsalt, x, y, z), where obslat/lon/alt
+    # come from me.measure(me.observatory("ALMA"), "WGS84").
+    latitude_rad = math.radians(-23.022886)
+    longitude_rad = math.radians(-67.754929)
+    altitude_m = 5056.8
+    sin_lat = math.sin(latitude_rad)
+    cos_lat = math.cos(latitude_rad)
+    cos_lon = math.cos(longitude_rad)
+    sin_lon = math.sin(longitude_rad)
+    semi_major_m = 6_378_137.0
+    semi_minor_m = 6_356_752.3142
+    eccentric_angle = math.acos(semi_minor_m / semi_major_m)
+    radius = semi_major_m / math.sqrt(1.0 - (math.sin(eccentric_angle) * sin_lat) ** 2)
+    local_radius = (radius + z_m + altitude_m) * cos_lat - y_m * sin_lat
     return [
-        center[axis] + sum(rotation[axis][local_axis] * local[local_axis] for local_axis in range(3))
-        for axis in range(3)
+        local_radius * cos_lon - x_m * sin_lon,
+        local_radius * sin_lon + x_m * cos_lon,
+        (radius * (semi_minor_m / semi_major_m) ** 2 + z_m + altitude_m) * sin_lat
+        + y_m * cos_lat,
     ]
 
 
 def format_card(key: str, value: str) -> str:
+    if value.startswith("'") and value.endswith("'"):
+        return f"{key:<8}= {value:<20}".ljust(80)
     return f"{key:<8}= {value:>20}".ljust(80)
 
 
@@ -788,11 +857,11 @@ def cell_deg(instrument: str) -> float:
 
 
 def start_frequency_hz(instrument: str) -> float:
-    return 230.0e9 if instrument == "alma" else 44.0e9
+    return 230.0e9 if instrument == "alma" else 8.0e9
 
 
 def channel_width_hz(instrument: str) -> float:
-    return 2.0e6 if instrument == "alma" else 128.0e6
+    return 2.0e6
 
 
 def stable_seed(text: str) -> int:

--- a/tools/perf/imager/stage_wave1_datasets.py
+++ b/tools/perf/imager/stage_wave1_datasets.py
@@ -24,8 +24,12 @@ TOOL_DIR = pathlib.Path(__file__).resolve().parent
 REGISTRY_PATH = TOOL_DIR / "wave1_dataset_registry.json"
 DEFAULT_OUTPUT_DIR = pathlib.Path("target/imperformance-wave1/datasets")
 EXTERNAL_PREFIX = pathlib.Path("/Volumes/GLENDENNING")
-MODEL_PHASE_CENTER_RA_DEG = 270.000129
-MODEL_PHASE_CENTER_DEC_DEG = -22.999889
+MODEL_PHASE_CENTER_RA_DEG = 180.0
+DEFAULT_ELEVATION_LIMIT_DEG = 20.0
+OBSERVATORY_ZENITH_DEC_DEG = {
+    "alma": -23.029,
+    "vla": 34.07875,
+}
 
 
 class DatasetError(Exception):
@@ -392,10 +396,12 @@ def build_casars_simobserve_request(dataset: dict[str, Any]) -> dict[str, Any]:
             "overwrite": True,
             "telescope_name": dataset["instrument"].upper(),
             "field_name": dataset["id"],
-            "phase_center_rad": phase_center_rad(0.0, 0.0),
+            "phase_center_rad": phase_center_rad(dataset["instrument"], 0.0, 0.0),
             "fields": fields,
             "duration_seconds": dataset["shape"]["duration_seconds"],
             "integration_seconds": dataset["shape"]["integration_seconds"],
+            "elevation_limit_rad": math.radians(DEFAULT_ELEVATION_LIMIT_DEG),
+            "allow_below_elevation_limit": False,
             "spectral_setup": {
                 "name": "wave1",
                 "start_frequency_hz": start_frequency_hz(dataset["instrument"]),
@@ -419,13 +425,25 @@ def build_casars_simobserve_request(dataset: dict[str, Any]) -> dict[str, Any]:
     return request
 
 
-def phase_center_rad(dra_arcsec: float, ddec_arcsec: float) -> list[float]:
-    ra_rad = math.radians(MODEL_PHASE_CENTER_RA_DEG + dra_arcsec / 3600.0)
+def phase_center_deg(instrument: str, dra_arcsec: float, ddec_arcsec: float) -> tuple[float, float]:
+    try:
+        dec_deg = OBSERVATORY_ZENITH_DEC_DEG[instrument]
+    except KeyError as exc:
+        raise DatasetError(f"no zenith-transit default phase center for {instrument}") from exc
+    return (
+        MODEL_PHASE_CENTER_RA_DEG + dra_arcsec / 3600.0,
+        dec_deg + ddec_arcsec / 3600.0,
+    )
+
+
+def phase_center_rad(instrument: str, dra_arcsec: float, ddec_arcsec: float) -> list[float]:
+    ra_deg, dec_deg = phase_center_deg(instrument, dra_arcsec, ddec_arcsec)
+    ra_rad = math.radians(ra_deg)
     if ra_rad > math.pi:
         ra_rad -= math.tau
     return [
         ra_rad,
-        math.radians(MODEL_PHASE_CENTER_DEC_DEG + ddec_arcsec / 3600.0),
+        math.radians(dec_deg),
     ]
 
 
@@ -443,7 +461,7 @@ def build_casars_fields(dataset: dict[str, Any]) -> list[dict[str, Any]]:
         fields.append(
             {
                 "name": f"{dataset['id']}_field_{index}",
-                "phase_center_rad": phase_center_rad(dra_arcsec, ddec_arcsec),
+                "phase_center_rad": phase_center_rad(dataset["instrument"], dra_arcsec, ddec_arcsec),
             }
         )
     return fields
@@ -478,6 +496,7 @@ def write_structured_fits(
         raise DatasetError("model FITS must be at least 8x8 pixels")
     if channels < 1:
         raise DatasetError("model FITS must have at least one channel")
+    ra_deg, dec_deg = phase_center_deg(instrument, 0.0, 0.0)
     cards = [
         ("SIMPLE", "T"),
         ("BITPIX", "-32"),
@@ -502,8 +521,8 @@ def write_structured_fits(
             ("EQUINOX", "2000.0"),
             ("CRPIX1", f"{pixels / 2 + 0.5:.6f}"),
             ("CRPIX2", f"{pixels / 2 + 0.5:.6f}"),
-            ("CRVAL1", "270.000129"),
-            ("CRVAL2", "-22.999889"),
+            ("CRVAL1", f"{ra_deg:.9f}"),
+            ("CRVAL2", f"{dec_deg:.9f}"),
             ("CDELT1", f"{-cell_deg(instrument):.12g}"),
             ("CDELT2", f"{cell_deg(instrument):.12g}"),
         ]

--- a/tools/perf/imager/stage_wave1_datasets.py
+++ b/tools/perf/imager/stage_wave1_datasets.py
@@ -1,0 +1,601 @@
+#!/usr/bin/env python3
+"""Prepare deterministic ImPerformance Wave 1 simulated dataset inputs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import pathlib
+import struct
+import sys
+import time
+from typing import Any
+
+
+TOOL_DIR = pathlib.Path(__file__).resolve().parent
+REGISTRY_PATH = TOOL_DIR / "wave1_dataset_registry.json"
+DEFAULT_OUTPUT_DIR = pathlib.Path("target/imperformance-wave1/datasets")
+EXTERNAL_PREFIX = pathlib.Path("/Volumes/GLENDENNING")
+
+
+class DatasetError(Exception):
+    """Error that should be reported without a traceback."""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--registry",
+        type=pathlib.Path,
+        default=REGISTRY_PATH,
+        help="dataset registry JSON",
+    )
+    parser.add_argument("--dataset", action="append", help="dataset id to include")
+    parser.add_argument("--tier", action="append", help="tier to include")
+    parser.add_argument("--instrument", action="append", help="instrument to include")
+    parser.add_argument(
+        "--output-dir",
+        type=pathlib.Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help="directory for generated plan JSON",
+    )
+    parser.add_argument(
+        "--data-root",
+        type=pathlib.Path,
+        default=None,
+        help="explicit staging root; otherwise the registry root_env must be set",
+    )
+    parser.add_argument(
+        "--materialize-models",
+        action="store_true",
+        help="write continuum model FITS files and spectral-profile JSON files",
+    )
+    parser.add_argument(
+        "--materialize-workloads",
+        action="store_true",
+        help="write benchmark workload manifests for each planned dataset",
+    )
+    parser.add_argument(
+        "--allow-non-external-large-root",
+        action="store_true",
+        help="allow medium/large tiers outside /Volumes/GLENDENNING",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="validate and write the staging plan without materializing files",
+    )
+    args = parser.parse_args()
+
+    try:
+        registry = read_json(args.registry)
+        specs = select_datasets(
+            registry,
+            dataset_ids=args.dataset,
+            tiers=args.tier,
+            instruments=args.instrument,
+        )
+        data_root = resolve_data_root(registry, args.data_root)
+        plan = build_plan(registry, specs, data_root, args.allow_non_external_large_root)
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        plan_path = args.output_dir / "wave1-dataset-plan.json"
+        if args.materialize_models and not args.dry_run:
+            materialize_models(plan)
+        if args.materialize_workloads and not args.dry_run:
+            materialize_workloads(plan, args.output_dir / "workloads")
+        write_json(plan_path, plan)
+        print(plan_path)
+    except DatasetError as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(2) from None
+
+
+def read_json(path: pathlib.Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as error:
+        raise DatasetError(f"read {path}: {error}") from error
+    except json.JSONDecodeError as error:
+        raise DatasetError(f"parse {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise DatasetError(f"{path} must contain a JSON object")
+    return value
+
+
+def select_datasets(
+    registry: dict[str, Any],
+    *,
+    dataset_ids: list[str] | None,
+    tiers: list[str] | None,
+    instruments: list[str] | None,
+) -> list[dict[str, Any]]:
+    datasets = registry.get("datasets")
+    if not isinstance(datasets, list):
+        raise DatasetError("registry missing datasets array")
+    selected = []
+    wanted_ids = set(dataset_ids or [])
+    wanted_tiers = set(tiers or [])
+    wanted_instruments = set(instruments or [])
+    for item in datasets:
+        if not isinstance(item, dict):
+            raise DatasetError("dataset entries must be objects")
+        dataset_id = required_str(item, "id")
+        if wanted_ids and dataset_id not in wanted_ids:
+            continue
+        if wanted_tiers and required_str(item, "tier") not in wanted_tiers:
+            continue
+        if wanted_instruments and required_str(item, "instrument") not in wanted_instruments:
+            continue
+        selected.append(item)
+    if wanted_ids:
+        found = {required_str(item, "id") for item in selected}
+        missing = sorted(wanted_ids - found)
+        if missing:
+            raise DatasetError(f"unknown dataset id(s): {', '.join(missing)}")
+    if not selected:
+        raise DatasetError("no datasets selected")
+    return selected
+
+
+def resolve_data_root(registry: dict[str, Any], explicit: pathlib.Path | None) -> pathlib.Path:
+    if explicit is not None:
+        return explicit.expanduser().resolve()
+    root_env = required_str(registry, "root_env")
+    value = os.environ.get(root_env)
+    if not value:
+        hint = registry.get("external_root_hint", "<set explicit data root>")
+        raise DatasetError(f"{root_env} is required; for this system use {hint}")
+    return pathlib.Path(value).expanduser().resolve()
+
+
+def build_plan(
+    registry: dict[str, Any],
+    specs: list[dict[str, Any]],
+    data_root: pathlib.Path,
+    allow_non_external_large_root: bool,
+) -> dict[str, Any]:
+    tiers = required_object(registry, "tiers")
+    instruments = required_object(registry, "instruments")
+    families = required_object(registry, "families")
+    planned = []
+    for spec in specs:
+        tier_name = required_str(spec, "tier")
+        tier = required_object(tiers, tier_name)
+        instrument_name = required_str(spec, "instrument")
+        instrument = required_object(instruments, instrument_name)
+        family_name = required_str(spec, "family")
+        family = required_object(families, family_name)
+        if bool(tier.get("external_root_required")) and not allow_non_external_large_root:
+            try:
+                data_root.relative_to(EXTERNAL_PREFIX)
+            except ValueError as error:
+                raise DatasetError(
+                    f"{required_str(spec, 'id')} is a {tier_name} tier dataset; "
+                    f"stage it under {EXTERNAL_PREFIX} or pass "
+                    "--allow-non-external-large-root"
+                ) from error
+
+        dataset_dir = data_root / "wave1" / instrument_name / family_name / tier_name
+        continuum_model = dataset_dir / "models" / "structured-continuum.fits"
+        spectral_profile = dataset_dir / "models" / "spectral-profile.json"
+        casars_request = dataset_dir / "requests" / "casars-simobserve.json"
+        casa_request = dataset_dir / "requests" / "casa-simulation-plan.json"
+        output_ms = dataset_dir / "ms" / f"{required_str(spec, 'id')}.ms"
+        selected_modes = family.get("selected_modes", [])
+        if not isinstance(selected_modes, list):
+            raise DatasetError(f"family {family_name} selected_modes must be an array")
+        native_status = native_status_for(spec, instrument, family)
+        planned.append(
+            {
+                "id": required_str(spec, "id"),
+                "instrument": instrument_name,
+                "family": family_name,
+                "tier": tier_name,
+                "target_size_bytes": int_value(tier, "target_size_bytes"),
+                "storage_label": required_str(tier, "storage_label"),
+                "selected_modes": selected_modes,
+                "paths": {
+                    "dataset_dir": str(dataset_dir),
+                    "continuum_model_fits": str(continuum_model),
+                    "spectral_profile_json": str(spectral_profile),
+                    "casars_simobserve_request": str(casars_request),
+                    "casa_simulation_plan": str(casa_request),
+                    "output_ms": str(output_ms),
+                },
+                "shape": {
+                    "model_pixels": int_value(spec, "model_pixels"),
+                    "image_pixels": int_value(spec, "image_pixels"),
+                    "channels": int_value(spec, "channels"),
+                    "pointing_count": int_value(family, "pointing_count"),
+                    "duration_seconds": float_value(spec, "duration_seconds"),
+                    "integration_seconds": float_value(spec, "integration_seconds"),
+                    "estimated_main_rows": estimated_main_rows(spec, family),
+                },
+                "source_model": {
+                    "continuum": registry["source_model"]["continuum_components"],
+                    "cube": registry["source_model"]["cube_components"],
+                    "noise_model": registry["source_model"]["noise_model"],
+                    "noise_simplenoise_jy": float_value(spec, "noise_simplenoise_jy"),
+                },
+                "support": native_status,
+                "provenance": {
+                    "registry": str(REGISTRY_PATH),
+                    "generated_by": str(pathlib.Path(__file__).resolve()),
+                    "generated_at": utc_now(),
+                },
+            }
+        )
+    return {
+        "schema_version": 1,
+        "root_env": required_str(registry, "root_env"),
+        "data_root": str(data_root),
+        "external_root_hint": registry.get("external_root_hint"),
+        "datasets": planned,
+    }
+
+
+def native_status_for(
+    spec: dict[str, Any], instrument: dict[str, Any], family: dict[str, Any]
+) -> dict[str, str]:
+    instrument_status = required_str(instrument, "native_casars_status")
+    family_name = required_str(spec, "family")
+    if family_name == "mosaic":
+        return {
+            "casars_simulation": "blocked",
+            "casa_simulation": "planned",
+            "reason": "current native simulator writes one FIELD; true mosaic staging requires multi-field generation or CASA simulation",
+        }
+    if required_str(spec, "instrument") != "vla":
+        return {
+            "casars_simulation": "request-plan-only",
+            "casa_simulation": "planned",
+            "reason": instrument_status,
+        }
+    return {
+        "casars_simulation": "supported",
+        "casa_simulation": "planned",
+        "reason": "native VLA single-field simobserve parity path exists; CASA side is retained for simulation performance/parity checks",
+    }
+
+
+def materialize_models(plan: dict[str, Any]) -> None:
+    for dataset in plan["datasets"]:
+        paths = dataset["paths"]
+        model_path = pathlib.Path(paths["continuum_model_fits"])
+        profile_path = pathlib.Path(paths["spectral_profile_json"])
+        request_path = pathlib.Path(paths["casars_simobserve_request"])
+        casa_plan_path = pathlib.Path(paths["casa_simulation_plan"])
+        model_path.parent.mkdir(parents=True, exist_ok=True)
+        profile_path.parent.mkdir(parents=True, exist_ok=True)
+        request_path.parent.mkdir(parents=True, exist_ok=True)
+        write_structured_fits(
+            model_path,
+            pixels=int(dataset["shape"]["model_pixels"]),
+            instrument=dataset["instrument"],
+            family=dataset["family"],
+        )
+        spectral_profile = build_spectral_profile(dataset)
+        write_json(profile_path, spectral_profile)
+        write_json(request_path, build_casars_simobserve_request(dataset))
+        write_json(casa_plan_path, build_casa_simulation_plan(dataset))
+        dataset["artifacts"] = {
+            "continuum_model_sha256": sha256_file(model_path),
+            "spectral_profile_sha256": sha256_file(profile_path),
+            "casars_request_sha256": sha256_file(request_path),
+            "casa_plan_sha256": sha256_file(casa_plan_path),
+        }
+
+
+def materialize_workloads(plan: dict[str, Any], output_dir: pathlib.Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for dataset in plan["datasets"]:
+        for mode_id in dataset["selected_modes"]:
+            workload = build_workload_manifest(dataset, mode_id)
+            write_json(output_dir / f"{dataset['id']}-{mode_id}.json", workload)
+
+
+def build_workload_manifest(dataset: dict[str, Any], mode_id: str) -> dict[str, Any]:
+    family = dataset["family"]
+    specmode = "cube" if "cube" in mode_id else "mfs"
+    gridder = "mosaic" if family == "mosaic" else "standard"
+    is_clean = "clean" in mode_id or mode_id.startswith("mtmfs")
+    deconvolver = "multiscale" if is_clean else "hogbom"
+    channels = dataset["shape"]["channels"] if specmode == "cube" else 1
+    if dataset["tier"] == "small":
+        niter = 25 if is_clean else 0
+    elif dataset["tier"] == "medium":
+        niter = 100 if is_clean else 0
+    else:
+        niter = 250 if is_clean else 0
+    return {
+        "id": f"{dataset['id']}-{mode_id}",
+        "mode_id": mode_id,
+        "description": f"{dataset['id']} {mode_id} generated from ImPerformance Wave 1 dataset plan.",
+        "dataset": {
+            "key": dataset["id"],
+            "root_env": "CASA_RS_IMPERF_DATA_ROOT",
+            "relative_path": relative_to_wave_root(dataset["paths"]["output_ms"]),
+        },
+        "imaging": {
+            "mode": "clean" if is_clean else "dirty",
+            "specmode": specmode,
+            "gridder": gridder,
+            "field": "0",
+            "spw": "0",
+            "channel_start": 0,
+            "channel_count": channels,
+            "imsize": int(dataset["shape"]["image_pixels"]),
+            "cell_arcsec": 0.1 if dataset["instrument"] == "alma" else 0.5,
+            "weighting": "briggs" if is_clean else "natural",
+            "robust": 0.5,
+            "deconvolver": deconvolver,
+            "scales": [0, 5, 15] if deconvolver == "multiscale" else "",
+            "niter": niter,
+            "wterm": "none",
+        },
+        "run": {
+            "repeats": 3,
+            "run_label": "warm",
+            "storage_label": dataset["storage_label"],
+        },
+    }
+
+
+def relative_to_wave_root(path_text: str) -> str:
+    parts = pathlib.Path(path_text).parts
+    if "wave1" in parts:
+        return str(pathlib.Path(*parts[parts.index("wave1") :]))
+    return path_text
+
+
+def build_casars_simobserve_request(dataset: dict[str, Any]) -> dict[str, Any]:
+    request: dict[str, Any] = {
+        "kind": "run",
+        "request": {
+            "model_image": dataset["paths"]["continuum_model_fits"],
+            "model_peak_jy_per_pixel": 0.003,
+            "output_ms": dataset["paths"]["output_ms"],
+            "overwrite": True,
+            "duration_seconds": dataset["shape"]["duration_seconds"],
+            "integration_seconds": dataset["shape"]["integration_seconds"],
+            "spectral_setup": {
+                "name": "wave1",
+                "start_frequency_hz": start_frequency_hz(dataset["instrument"]),
+                "channel_width_hz": channel_width_hz(dataset["instrument"]),
+                "channel_count": dataset["shape"]["channels"],
+            },
+            "predict_model": True,
+            "corruption": {
+                "seed": stable_seed(dataset["id"]),
+                "noise": {
+                    "mode": "simplenoise",
+                    "simplenoise_jy": dataset["source_model"]["noise_simplenoise_jy"],
+                },
+            },
+        },
+    }
+    if dataset["instrument"] == "alma":
+        request["request"]["antennas"] = alma_antennas()
+    return request
+
+
+def build_casa_simulation_plan(dataset: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "status": dataset["support"]["casa_simulation"],
+        "dataset": dataset["id"],
+        "purpose": "CASA C++ simulation parity and performance check for the same source model and observing shape.",
+        "model_image": dataset["paths"]["continuum_model_fits"],
+        "spectral_profile": dataset["paths"]["spectral_profile_json"],
+        "output_ms": dataset["paths"]["output_ms"].replace(".ms", ".casa.ms"),
+        "instrument": dataset["instrument"],
+        "family": dataset["family"],
+        "tier": dataset["tier"],
+        "shape": dataset["shape"],
+        "noise_simplenoise_jy": dataset["source_model"]["noise_simplenoise_jy"],
+        "notes": [
+            "Use CASA simobserve/simalma where available for the instrument and family.",
+            "Record CASA ran, skipped, or blocked with reason before claiming simulation parity or performance.",
+            "Do not use this plan as a calibration test; the intended corruption is simple deterministic visibility noise.",
+        ],
+    }
+
+
+def write_structured_fits(
+    path: pathlib.Path, *, pixels: int, instrument: str, family: str
+) -> None:
+    if pixels < 8:
+        raise DatasetError("model FITS must be at least 8x8 pixels")
+    cards = [
+        ("SIMPLE", "T"),
+        ("BITPIX", "-32"),
+        ("NAXIS", "2"),
+        ("NAXIS1", str(pixels)),
+        ("NAXIS2", str(pixels)),
+        ("CTYPE1", "'RA---SIN'"),
+        ("CTYPE2", "'DEC--SIN'"),
+        ("CUNIT1", "'deg'"),
+        ("CUNIT2", "'deg'"),
+        ("CRPIX1", f"{pixels / 2 + 0.5:.6f}"),
+        ("CRPIX2", f"{pixels / 2 + 0.5:.6f}"),
+        ("CRVAL1", "270.000129"),
+        ("CRVAL2", "-22.999889"),
+        ("CDELT1", f"{-cell_deg(instrument):.12g}"),
+        ("CDELT2", f"{cell_deg(instrument):.12g}"),
+        ("BUNIT", "'Jy/pixel'"),
+        ("OBJECT", f"'{instrument.upper()} WAVE1 {family.upper()}'"),
+    ]
+    header = "".join(format_card(key, value) for key, value in cards)
+    header += "END".ljust(80)
+    header = pad_block(header.encode("ascii"))
+    with path.open("wb") as handle:
+        handle.write(header)
+        for y in range(pixels):
+            row = bytearray()
+            for x in range(pixels):
+                row.extend(struct.pack(">f", source_pixel(x, y, pixels, family)))
+            handle.write(row)
+        pad = (-pixels * pixels * 4) % 2880
+        if pad:
+            handle.write(b"\0" * pad)
+
+
+def source_pixel(x: int, y: int, pixels: int, family: str) -> float:
+    cx = (x + 0.5 - pixels / 2.0) / pixels
+    cy = (y + 0.5 - pixels / 2.0) / pixels
+    radius = math.hypot(cx, cy)
+    theta = math.atan2(cy, cx)
+    core = gaussian(cx, cy, 0.0, 0.0, 0.018)
+    knot1 = 0.42 * gaussian(cx, cy, -0.14, 0.09, 0.028)
+    knot2 = 0.31 * gaussian(cx, cy, 0.18, -0.11, 0.022)
+    ring = 0.34 * math.exp(-((radius - 0.21) ** 2) / (2.0 * 0.018**2))
+    arm1 = 0.18 * math.exp(-((radius - (0.10 + 0.040 * theta)) ** 2) / (2.0 * 0.020**2))
+    arm2 = 0.14 * math.exp(
+        -((radius - (0.18 - 0.035 * theta)) ** 2) / (2.0 * 0.024**2)
+    )
+    halo = 0.06 * math.exp(-(radius**2) / (2.0 * 0.26**2))
+    ripple = 0.015 * (1.0 + math.sin(37.0 * cx + 19.0 * cy))
+    mosaic_gradient = 1.0 + (0.10 * cx - 0.07 * cy if family == "mosaic" else 0.0)
+    value = (core + knot1 + knot2 + ring + arm1 + arm2 + halo + ripple) * mosaic_gradient
+    return max(0.0, float(value))
+
+
+def build_spectral_profile(dataset: dict[str, Any]) -> dict[str, Any]:
+    channels = int(dataset["shape"]["channels"])
+    profile = []
+    center = 0.5 * max(0, channels - 1)
+    for channel in range(channels):
+        x = 0.0 if channels == 1 else (channel - center) / max(1.0, center)
+        continuum = max(0.05, 1.0 + x) ** -0.7
+        broad_line = 0.45 * math.exp(-0.5 * ((x - 0.05) / 0.22) ** 2)
+        narrow_line = 0.22 * math.exp(-0.5 * ((x + 0.38) / 0.08) ** 2)
+        absorption = -0.18 * math.exp(-0.5 * ((x - 0.32) / 0.06) ** 2)
+        profile.append(
+            {
+                "channel": channel,
+                "relative_frequency_offset": x,
+                "continuum_scale": continuum,
+                "line_scale": broad_line + narrow_line + absorption,
+                "total_scale": max(0.05, continuum + broad_line + narrow_line + absorption),
+            }
+        )
+    return {
+        "schema_version": 1,
+        "dataset": dataset["id"],
+        "description": "Deterministic cube spectral structure for detecting channel ordering and interpolation regressions.",
+        "channels": channels,
+        "components": dataset["source_model"]["cube"],
+        "profile": profile,
+    }
+
+
+def estimated_main_rows(spec: dict[str, Any], family: dict[str, Any]) -> int:
+    antenna_count = 27 if required_str(spec, "instrument") == "vla" else 43
+    baseline_count = antenna_count * (antenna_count - 1) // 2
+    samples = math.ceil(float_value(spec, "duration_seconds") / float_value(spec, "integration_seconds"))
+    return baseline_count * samples * int_value(family, "pointing_count")
+
+
+def alma_antennas() -> list[dict[str, Any]]:
+    center = [-2_225_035.0, -5_441_197.0, -2_481_630.0]
+    antennas = []
+    for index in range(43):
+        arm = index % 3
+        radius = 18.0 + 14.0 * index
+        angle = (2.0 * math.pi * arm / 3.0) + index * 0.37
+        x_offset = radius * math.cos(angle)
+        y_offset = radius * math.sin(angle)
+        z_offset = 0.08 * radius * math.sin(angle * 0.5)
+        antennas.append(
+            {
+                "name": f"DA{index + 1:02d}",
+                "station": f"A{index + 1:03d}",
+                "position_m": [
+                    center[0] + x_offset,
+                    center[1] + y_offset,
+                    center[2] + z_offset,
+                ],
+                "dish_diameter_m": 12.0,
+            }
+        )
+    return antennas
+
+
+def format_card(key: str, value: str) -> str:
+    return f"{key:<8}= {value:>20}".ljust(80)
+
+
+def pad_block(data: bytes) -> bytes:
+    return data + b" " * ((-len(data)) % 2880)
+
+
+def gaussian(x: float, y: float, x0: float, y0: float, sigma: float) -> float:
+    return math.exp(-(((x - x0) ** 2 + (y - y0) ** 2) / (2.0 * sigma**2)))
+
+
+def cell_deg(instrument: str) -> float:
+    return (0.08 if instrument == "alma" else 0.35) / 3600.0
+
+
+def start_frequency_hz(instrument: str) -> float:
+    return 230.0e9 if instrument == "alma" else 44.0e9
+
+
+def channel_width_hz(instrument: str) -> float:
+    return 2.0e6 if instrument == "alma" else 128.0e6
+
+
+def stable_seed(text: str) -> int:
+    return int(hashlib.sha256(text.encode("utf-8")).hexdigest()[:12], 16)
+
+
+def sha256_file(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def utc_now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def write_json(path: pathlib.Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def required_object(obj: dict[str, Any], key: str) -> dict[str, Any]:
+    value = obj.get(key)
+    if not isinstance(value, dict):
+        raise DatasetError(f"missing object field {key!r}")
+    return value
+
+
+def required_str(obj: dict[str, Any], key: str) -> str:
+    value = obj.get(key)
+    if not isinstance(value, str) or value == "":
+        raise DatasetError(f"missing string field {key!r}")
+    return value
+
+
+def int_value(obj: dict[str, Any], key: str) -> int:
+    value = obj.get(key)
+    if not isinstance(value, int):
+        raise DatasetError(f"{key!r} must be an integer")
+    return value
+
+
+def float_value(obj: dict[str, Any], key: str) -> float:
+    value = obj.get(key)
+    if not isinstance(value, (int, float)):
+        raise DatasetError(f"{key!r} must be numeric")
+    return float(value)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/perf/imager/stage_wave1_datasets.py
+++ b/tools/perf/imager/stage_wave1_datasets.py
@@ -316,6 +316,7 @@ def materialize_models(plan: dict[str, Any]) -> None:
         write_structured_fits(
             model_path,
             pixels=int(dataset["shape"]["model_pixels"]),
+            channels=int(dataset["shape"]["channels"]),
             instrument=dataset["instrument"],
             family=dataset["family"],
         )
@@ -407,7 +408,6 @@ def build_casars_simobserve_request(dataset: dict[str, Any]) -> dict[str, Any]:
         "kind": "run",
         "request": {
             "model_image": dataset["paths"]["continuum_model_fits"],
-            "model_peak_jy_per_pixel": 0.003,
             "output_ms": dataset["paths"]["output_ms"],
             "overwrite": True,
             "telescope_name": dataset["instrument"].upper(),
@@ -433,6 +433,8 @@ def build_casars_simobserve_request(dataset: dict[str, Any]) -> dict[str, Any]:
     }
     if dataset["instrument"] == "alma":
         request["request"]["antennas"] = alma_antennas()
+    elif dataset["instrument"] == "vla":
+        request["request"]["antennas"] = vla_d_antennas()
     return request
 
 
@@ -482,42 +484,87 @@ def build_casa_simulation_plan(dataset: dict[str, Any]) -> dict[str, Any]:
 
 
 def write_structured_fits(
-    path: pathlib.Path, *, pixels: int, instrument: str, family: str
+    path: pathlib.Path, *, pixels: int, channels: int, instrument: str, family: str
 ) -> None:
     if pixels < 8:
         raise DatasetError("model FITS must be at least 8x8 pixels")
+    if channels < 1:
+        raise DatasetError("model FITS must have at least one channel")
     cards = [
         ("SIMPLE", "T"),
         ("BITPIX", "-32"),
-        ("NAXIS", "2"),
+        ("NAXIS", "4" if channels > 1 else "2"),
         ("NAXIS1", str(pixels)),
         ("NAXIS2", str(pixels)),
-        ("CTYPE1", "'RA---SIN'"),
-        ("CTYPE2", "'DEC--SIN'"),
-        ("CUNIT1", "'deg'"),
-        ("CUNIT2", "'deg'"),
-        ("CRPIX1", f"{pixels / 2 + 0.5:.6f}"),
-        ("CRPIX2", f"{pixels / 2 + 0.5:.6f}"),
-        ("CRVAL1", "270.000129"),
-        ("CRVAL2", "-22.999889"),
-        ("CDELT1", f"{-cell_deg(instrument):.12g}"),
-        ("CDELT2", f"{cell_deg(instrument):.12g}"),
-        ("BUNIT", "'Jy/pixel'"),
-        ("OBJECT", f"'{instrument.upper()} WAVE1 {family.upper()}'"),
     ]
+    if channels > 1:
+        cards.extend(
+            [
+                ("NAXIS3", "1"),
+                ("NAXIS4", str(channels)),
+            ]
+        )
+    cards.extend(
+        [
+            ("CTYPE1", "'RA---SIN'"),
+            ("CTYPE2", "'DEC--SIN'"),
+            ("CUNIT1", "'deg'"),
+            ("CUNIT2", "'deg'"),
+            ("CRPIX1", f"{pixels / 2 + 0.5:.6f}"),
+            ("CRPIX2", f"{pixels / 2 + 0.5:.6f}"),
+            ("CRVAL1", "270.000129"),
+            ("CRVAL2", "-22.999889"),
+            ("CDELT1", f"{-cell_deg(instrument):.12g}"),
+            ("CDELT2", f"{cell_deg(instrument):.12g}"),
+        ]
+    )
+    if channels > 1:
+        cards.extend(
+            [
+                ("CTYPE3", "'STOKES'"),
+                ("CRPIX3", "1.0"),
+                ("CRVAL3", "1.0"),
+                ("CDELT3", "1.0"),
+                ("CTYPE4", "'FREQ'"),
+                ("CUNIT4", "'Hz'"),
+                ("CRPIX4", "1.0"),
+                ("CRVAL4", f"{start_frequency_hz(instrument):.12g}"),
+                ("CDELT4", f"{channel_width_hz(instrument):.12g}"),
+            ]
+        )
+    cards.extend(
+        [
+            ("BUNIT", "'Jy/pixel'"),
+            ("OBJECT", f"'{instrument.upper()} WAVE1 {family.upper()}'"),
+        ]
+    )
     header = "".join(format_card(key, value) for key, value in cards)
     header += "END".ljust(80)
     header = pad_block(header.encode("ascii"))
     with path.open("wb") as handle:
         handle.write(header)
-        for y in range(pixels):
-            row = bytearray()
-            for x in range(pixels):
-                row.extend(struct.pack(">f", source_pixel(x, y, pixels, family)))
-            handle.write(row)
-        pad = (-pixels * pixels * 4) % 2880
+        for channel in range(channels):
+            scale = spectral_total_scale(channels, channel)
+            for y in range(pixels):
+                row = bytearray()
+                for x in range(pixels):
+                    row.extend(struct.pack(">f", source_pixel(x, y, pixels, family) * scale))
+                handle.write(row)
+        pad = (-(pixels * pixels * channels * 4)) % 2880
         if pad:
             handle.write(b"\0" * pad)
+
+
+def spectral_total_scale(channels: int, channel: int) -> float:
+    if channels == 1:
+        return 1.0
+    center = 0.5 * max(0, channels - 1)
+    x = (channel - center) / max(1.0, center)
+    continuum = max(0.05, 1.0 + x) ** -0.7
+    broad_line = 0.45 * math.exp(-0.5 * ((x - 0.05) / 0.22) ** 2)
+    narrow_line = 0.22 * math.exp(-0.5 * ((x + 0.38) / 0.08) ** 2)
+    absorption = -0.18 * math.exp(-0.5 * ((x - 0.32) / 0.06) ** 2)
+    return max(0.05, continuum + broad_line + narrow_line + absorption)
 
 
 def source_pixel(x: int, y: int, pixels: int, family: str) -> float:
@@ -599,6 +646,47 @@ def alma_antennas() -> list[dict[str, Any]]:
             }
         )
     return antennas
+
+
+def vla_d_antennas() -> list[dict[str, Any]]:
+    rows = [
+        (-1_601_188.989351, -5_042_000.518599, 3_554_843.384480, "W01"),
+        (-1_601_225.230987, -5_041_980.390730, 3_554_855.657987, "W02"),
+        (-1_601_265.110332, -5_041_982.563379, 3_554_834.816409, "W03"),
+        (-1_601_315.874282, -5_041_985.324465, 3_554_808.263784, "W04"),
+        (-1_601_376.950042, -5_041_988.682890, 3_554_776.344871, "W05"),
+        (-1_601_447.176774, -5_041_992.529191, 3_554_739.647266, "W06"),
+        (-1_601_526.335275, -5_041_996.876364, 3_554_698.284889, "W07"),
+        (-1_601_614.061201, -5_042_001.676547, 3_554_652.455603, "W08"),
+        (-1_601_709.987416, -5_042_006.942534, 3_554_602.306306, "W09"),
+        (-1_601_192.424192, -5_042_022.883542, 3_554_810.383317, "E01"),
+        (-1_601_150.027460, -5_042_000.630731, 3_554_860.703495, "E02"),
+        (-1_601_114.318178, -5_042_023.187696, 3_554_844.922416, "E03"),
+        (-1_601_068.771188, -5_042_051.929370, 3_554_824.767363, "E04"),
+        (-1_601_014.405657, -5_042_086.261585, 3_554_800.768970, "E05"),
+        (-1_600_951.545716, -5_042_125.927280, 3_554_772.987195, "E06"),
+        (-1_600_880.545264, -5_042_170.376845, 3_554_741.425036, "E07"),
+        (-1_600_801.880602, -5_042_219.386677, 3_554_706.382285, "E08"),
+        (-1_600_715.918854, -5_042_273.142150, 3_554_668.128757, "E09"),
+        (-1_601_185.553970, -5_041_978.191573, 3_554_876.382645, "N01"),
+        (-1_601_180.820941, -5_041_947.459898, 3_554_921.573373, "N02"),
+        (-1_601_177.368455, -5_041_925.069104, 3_554_954.532566, "N03"),
+        (-1_601_173.903632, -5_041_902.679083, 3_554_987.485762, "N04"),
+        (-1_601_168.735762, -5_041_869.062707, 3_555_036.885577, "N05"),
+        (-1_601_162.553007, -5_041_829.021602, 3_555_095.854771, "N06"),
+        (-1_601_155.593706, -5_041_783.860938, 3_555_162.327771, "N07"),
+        (-1_601_147.885235, -5_041_733.855114, 3_555_235.914849, "N08"),
+        (-1_601_139.483292, -5_041_679.021042, 3_555_316.478099, "N09"),
+    ]
+    return [
+        {
+            "name": name,
+            "station": name,
+            "position_m": [x_m, y_m, z_m],
+            "dish_diameter_m": 25.0,
+        }
+        for x_m, y_m, z_m, name in rows
+    ]
 
 
 def format_card(key: str, value: str) -> str:

--- a/tools/perf/imager/stage_wave1_datasets.py
+++ b/tools/perf/imager/stage_wave1_datasets.py
@@ -245,18 +245,27 @@ def native_status_for(
     if family_name == "mosaic":
         return {
             "casars_simulation": "blocked",
-            "casa_simulation": "planned",
+            "casa_simulation": "generation-path",
+            "native_backlog_issue": "#254",
             "reason": "current native simulator writes one FIELD; true mosaic staging requires multi-field generation or CASA simulation",
         }
     if required_str(spec, "instrument") != "vla":
         return {
             "casars_simulation": "request-plan-only",
-            "casa_simulation": "planned",
+            "casa_simulation": "generation-path",
+            "native_backlog_issue": "#180/#181/#182",
             "reason": instrument_status,
+        }
+    if int_value(spec, "channels") > 1:
+        return {
+            "casars_simulation": "supported-single-plane",
+            "casa_simulation": "generation-path",
+            "native_backlog_issue": "#255",
+            "reason": "native VLA single-field simobserve can write a multi-channel MS from one 2D model plane; CASA generation is required for deterministic channel-varying source structure",
         }
     return {
         "casars_simulation": "supported",
-        "casa_simulation": "planned",
+        "casa_simulation": "generation-path",
         "reason": "native VLA single-field simobserve parity path exists; CASA side is retained for simulation performance/parity checks",
     }
 

--- a/tools/perf/imager/stage_wave1_datasets.py
+++ b/tools/perf/imager/stage_wave1_datasets.py
@@ -402,6 +402,7 @@ def relative_to_wave_root(path_text: str) -> str:
 
 
 def build_casars_simobserve_request(dataset: dict[str, Any]) -> dict[str, Any]:
+    fields = build_casars_fields(dataset)
     request: dict[str, Any] = {
         "kind": "run",
         "request": {
@@ -409,6 +410,9 @@ def build_casars_simobserve_request(dataset: dict[str, Any]) -> dict[str, Any]:
             "model_peak_jy_per_pixel": 0.003,
             "output_ms": dataset["paths"]["output_ms"],
             "overwrite": True,
+            "telescope_name": dataset["instrument"].upper(),
+            "field_name": dataset["id"],
+            "fields": fields,
             "duration_seconds": dataset["shape"]["duration_seconds"],
             "integration_seconds": dataset["shape"]["integration_seconds"],
             "spectral_setup": {
@@ -430,6 +434,29 @@ def build_casars_simobserve_request(dataset: dict[str, Any]) -> dict[str, Any]:
     if dataset["instrument"] == "alma":
         request["request"]["antennas"] = alma_antennas()
     return request
+
+
+def build_casars_fields(dataset: dict[str, Any]) -> list[dict[str, Any]]:
+    count = int(dataset["shape"]["pointing_count"])
+    if count <= 1:
+        return []
+    spacing_arcsec = 24.0 if dataset["instrument"] == "alma" else 120.0
+    offsets = [(0.0, 0.0)]
+    for index in range(6):
+        angle = math.tau * index / 6.0
+        offsets.append((spacing_arcsec * math.cos(angle), spacing_arcsec * math.sin(angle)))
+    fields = []
+    for index, (dra_arcsec, ddec_arcsec) in enumerate(offsets[:count]):
+        fields.append(
+            {
+                "name": f"{dataset['id']}_field_{index}",
+                "phase_center_rad": [
+                    math.radians(270.000129 + dra_arcsec / 3600.0),
+                    math.radians(-22.999889 + ddec_arcsec / 3600.0),
+                ],
+            }
+        )
+    return fields
 
 
 def build_casa_simulation_plan(dataset: dict[str, Any]) -> dict[str, Any]:

--- a/tools/perf/imager/stage_wave1_datasets.py
+++ b/tools/perf/imager/stage_wave1_datasets.py
@@ -546,7 +546,7 @@ def estimated_main_rows(spec: dict[str, Any], family: dict[str, Any]) -> int:
     antenna_count = 27 if required_str(spec, "instrument") == "vla" else 43
     baseline_count = antenna_count * (antenna_count - 1) // 2
     samples = math.ceil(float_value(spec, "duration_seconds") / float_value(spec, "integration_seconds"))
-    return baseline_count * samples * int_value(family, "pointing_count")
+    return baseline_count * samples
 
 
 def alma_antennas() -> list[dict[str, Any]]:

--- a/tools/perf/imager/stage_wave1_datasets.py
+++ b/tools/perf/imager/stage_wave1_datasets.py
@@ -160,6 +160,7 @@ def build_plan(
     tiers = required_object(registry, "tiers")
     instruments = required_object(registry, "instruments")
     families = required_object(registry, "families")
+    validate_large_tier_policy(registry, specs)
     planned = []
     for spec in specs:
         tier_name = required_str(spec, "tier")
@@ -184,9 +185,9 @@ def build_plan(
         casars_request = dataset_dir / "requests" / "casars-simobserve.json"
         casa_request = dataset_dir / "requests" / "casa-simulation-plan.json"
         output_ms = dataset_dir / "ms" / f"{required_str(spec, 'id')}.ms"
-        selected_modes = family.get("selected_modes", [])
+        selected_modes = spec.get("selected_modes", family.get("selected_modes", []))
         if not isinstance(selected_modes, list):
-            raise DatasetError(f"family {family_name} selected_modes must be an array")
+            raise DatasetError(f"{required_str(spec, 'id')} selected_modes must be an array")
         native_status = native_status_for(spec, instrument, family)
         planned.append(
             {
@@ -233,8 +234,33 @@ def build_plan(
         "root_env": required_str(registry, "root_env"),
         "data_root": str(data_root),
         "external_root_hint": registry.get("external_root_hint"),
+        "large_tier_policy": registry.get("large_tier_policy"),
         "datasets": planned,
     }
+
+
+def validate_large_tier_policy(registry: dict[str, Any], specs: list[dict[str, Any]]) -> None:
+    policy = registry.get("large_tier_policy")
+    if not isinstance(policy, dict):
+        return
+    expected_count = policy.get("dataset_count")
+    expected_id = policy.get("dataset_id")
+    large_specs = [spec for spec in specs if required_str(spec, "tier") == "large"]
+    if not large_specs:
+        return
+    if not isinstance(expected_count, int):
+        raise DatasetError("large_tier_policy.dataset_count must be an integer")
+    if expected_count != len(large_specs):
+        raise DatasetError(
+            "large tier policy expects "
+            f"{expected_count} dataset(s), selected {len(large_specs)}"
+        )
+    if isinstance(expected_id, str):
+        large_ids = {required_str(spec, "id") for spec in large_specs}
+        if expected_id not in large_ids:
+            raise DatasetError(
+                f"large tier policy requires shared dataset {expected_id!r}"
+            )
 
 
 def native_status_for(
@@ -242,6 +268,13 @@ def native_status_for(
 ) -> dict[str, str]:
     instrument_status = required_str(instrument, "native_casars_status")
     family_name = required_str(spec, "family")
+    if family_name == "shared-large":
+        return {
+            "casars_simulation": "blocked",
+            "casa_simulation": "generation-path",
+            "native_backlog_issue": "#254/#255/#180/#181/#182",
+            "reason": "shared large ALMA mosaic/cube superset requires CASA generation until native ALMA, multi-field mosaic, and channel-varying cube simulation exist",
+        }
     if family_name == "mosaic":
         return {
             "casars_simulation": "blocked",
@@ -307,12 +340,11 @@ def materialize_workloads(plan: dict[str, Any], output_dir: pathlib.Path) -> Non
 
 
 def build_workload_manifest(dataset: dict[str, Any], mode_id: str) -> dict[str, Any]:
-    family = dataset["family"]
     specmode = "cube" if "cube" in mode_id else "mfs"
-    gridder = "mosaic" if family == "mosaic" else "standard"
+    gridder = "mosaic" if mode_id.startswith("mosaic") else "standard"
     is_clean = "clean" in mode_id or mode_id.startswith("mtmfs")
     deconvolver = "multiscale" if is_clean else "hogbom"
-    channels = dataset["shape"]["channels"] if specmode == "cube" else 1
+    channels = workload_channel_count(dataset, mode_id, specmode)
     if dataset["tier"] == "small":
         niter = 25 if is_clean else 0
     elif dataset["tier"] == "medium":
@@ -332,7 +364,7 @@ def build_workload_manifest(dataset: dict[str, Any], mode_id: str) -> dict[str, 
             "mode": "clean" if is_clean else "dirty",
             "specmode": specmode,
             "gridder": gridder,
-            "field": "0",
+            "field": "" if gridder == "mosaic" else "0",
             "spw": "0",
             "channel_start": 0,
             "channel_count": channels,
@@ -351,6 +383,15 @@ def build_workload_manifest(dataset: dict[str, Any], mode_id: str) -> dict[str, 
             "storage_label": dataset["storage_label"],
         },
     }
+
+
+def workload_channel_count(dataset: dict[str, Any], mode_id: str, specmode: str) -> int:
+    channels = int(dataset["shape"]["channels"])
+    if specmode != "cube":
+        return channels
+    if "bounded" in mode_id:
+        return min(channels, 32)
+    return channels
 
 
 def relative_to_wave_root(path_text: str) -> str:

--- a/tools/perf/imager/test_bench_simobserve.py
+++ b/tools/perf/imager/test_bench_simobserve.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Focused tests for the Wave 1 simobserve benchmark helpers."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import bench_simobserve
+
+
+class NativePerformanceSummaryTests(unittest.TestCase):
+    def test_native_performance_summary_uses_reported_streamed_io_bytes(self) -> None:
+        native = {
+            "best_seconds": 20.0,
+            "size_bytes": 10_000_000_000,
+            "last_result": {
+                "report": {
+                    "timing": {
+                        "main_rows": {
+                            "data_io_bytes": 8_000_000_000,
+                            "data_io_write_millis": 4_000,
+                        }
+                    }
+                }
+            },
+        }
+
+        summary = bench_simobserve.native_performance_summary(native)
+
+        self.assertEqual(summary["native_output_mb_per_second"], 500.0)
+        self.assertEqual(summary["data_io_mb_per_second"], 2000.0)
+        self.assertEqual(summary["data_io_bytes"], 8_000_000_000)
+        self.assertEqual(summary["data_io_write_millis"], 4_000.0)
+
+    def test_native_performance_targets_fail_below_threshold(self) -> None:
+        args = argparse.Namespace(
+            require_native_throughput_mb_s=600.0,
+            require_data_io_throughput_mb_s=None,
+        )
+
+        with self.assertRaisesRegex(bench_simobserve.BenchError, "below target"):
+            bench_simobserve.enforce_native_performance_targets(
+                args,
+                {
+                    "native_output_mb_per_second": 500.0,
+                    "data_io_mb_per_second": 2000.0,
+                },
+            )
+
+    def test_data_io_performance_targets_fail_below_threshold(self) -> None:
+        args = argparse.Namespace(
+            require_native_throughput_mb_s=None,
+            require_data_io_throughput_mb_s=2500.0,
+        )
+
+        with self.assertRaisesRegex(bench_simobserve.BenchError, "below target"):
+            bench_simobserve.enforce_native_performance_targets(
+                args,
+                {
+                    "native_output_mb_per_second": 500.0,
+                    "data_io_mb_per_second": 2000.0,
+                },
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/perf/imager/test_bench_simobserve.py
+++ b/tools/perf/imager/test_bench_simobserve.py
@@ -13,6 +13,32 @@ import bench_simobserve
 
 
 class NativePerformanceSummaryTests(unittest.TestCase):
+    def test_strict_data_violation_requires_same_cell_to_fail_both_tolerances(self) -> None:
+        self.assertFalse(
+            bench_simobserve.strict_data_cell_violates(
+                0.20,
+                2000.0,
+                data_atol=0.05,
+                data_rtol=0.001,
+            )
+        )
+        self.assertFalse(
+            bench_simobserve.strict_data_cell_violates(
+                0.001,
+                0.002,
+                data_atol=0.05,
+                data_rtol=0.001,
+            )
+        )
+        self.assertTrue(
+            bench_simobserve.strict_data_cell_violates(
+                0.20,
+                1.0,
+                data_atol=0.05,
+                data_rtol=0.001,
+            )
+        )
+
     def test_native_performance_summary_uses_reported_streamed_io_bytes(self) -> None:
         native = {
             "best_seconds": 20.0,

--- a/tools/perf/imager/test_run_workload.py
+++ b/tools/perf/imager/test_run_workload.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Focused tests for the Wave 1 imager workload harness helpers."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import run_workload
+
+
+class StageBreakdownTests(unittest.TestCase):
+    def test_dirty_workload_marks_clean_only_categories_skipped(self) -> None:
+        plan = {
+            "mode": {
+                "bench_mode": "dirty",
+                "niter": 0,
+            }
+        }
+        stages = {
+            "open_measurement_set": 1.0,
+            "prepare_plane_input": 2.0,
+            "extract_phase_center": 3.0,
+            "weighting": 4.0,
+            "psf_grid": 5.0,
+            "psf_fft": 6.0,
+            "psf_normalize": 7.0,
+            "residual_degrid_grid": 8.0,
+            "residual_fft": 9.0,
+            "residual_normalize": 10.0,
+            "minor_cycle_solve": 0.0,
+            "major_cycle_refresh": 0.0,
+            "beam_fit": 0.0,
+            "restore": 0.0,
+            "build_coordinate_system": 11.0,
+            "write_products": 12.0,
+            "frontend_total": 30.0,
+            "total": 40.0,
+        }
+
+        breakdown = run_workload.build_rust_stage_breakdown(plan, stages)
+        categories = breakdown["categories"]
+
+        self.assertEqual(
+            categories["frontend_ms_preparation"]["total_ms"],
+            6.0,
+        )
+        self.assertEqual(categories["gridding_degridding"]["total_ms"], 13.0)
+        self.assertEqual(categories["fft"]["total_ms"], 15.0)
+        self.assertEqual(categories["normalization_pb_correction"]["total_ms"], 17.0)
+        self.assertEqual(categories["deconvolution_minor_cycle"]["status"], "skipped")
+        self.assertEqual(
+            categories["model_prediction_and_residual_refresh"]["status"],
+            "skipped",
+        )
+        self.assertEqual(categories["preview_sidecar_generation"]["status"], "skipped")
+
+    def test_clean_workload_reports_clean_categories_when_measured(self) -> None:
+        plan = {
+            "mode": {
+                "bench_mode": "clean",
+                "niter": 25,
+            }
+        }
+        stages = {
+            "minor_cycle_solve": 3.5,
+            "major_cycle_refresh": 8.0,
+            "beam_fit": 1.0,
+            "restore": 2.0,
+        }
+
+        breakdown = run_workload.build_rust_stage_breakdown(plan, stages)
+        categories = breakdown["categories"]
+
+        self.assertEqual(categories["deconvolution_minor_cycle"]["status"], "measured")
+        self.assertEqual(categories["deconvolution_minor_cycle"]["total_ms"], 3.5)
+        self.assertEqual(
+            categories["model_prediction_and_residual_refresh"]["status"],
+            "measured",
+        )
+        self.assertEqual(categories["restore_and_beam_fit"]["total_ms"], 3.0)
+
+    def test_attach_stage_breakdown_does_not_require_casa_stage_data(self) -> None:
+        plan = {
+            "mode": {
+                "bench_mode": "dirty",
+                "niter": 0,
+            }
+        }
+        parsed = {
+            "stage_medians_ms": {
+                "rust": {"psf_grid": 1.0},
+                "casa": {},
+            }
+        }
+
+        run_workload.attach_stage_breakdown(plan, parsed)
+
+        self.assertEqual(parsed["stage_breakdown"]["schema_version"], 1)
+        self.assertEqual(parsed["stage_breakdown"]["rust"]["status"], "reported")
+        self.assertEqual(parsed["stage_breakdown"]["casa"]["status"], "missing")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/perf/imager/test_run_workload.py
+++ b/tools/perf/imager/test_run_workload.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import unittest
+from unittest import mock
 from pathlib import Path
 import sys
 
@@ -81,6 +82,41 @@ class StageBreakdownTests(unittest.TestCase):
             "measured",
         )
         self.assertEqual(categories["restore_and_beam_fit"]["total_ms"], 3.0)
+
+    def test_phasecenter_field_flows_to_environment(self) -> None:
+        manifest = {
+            "id": "mosaic-smoke",
+            "mode_id": "mosaic-mfs-clean-primary",
+            "dataset": {
+                "key": "mosaic.ms",
+                "relative_path": "wave1/vla/mosaic/small/ms/mosaic.ms",
+                "root_env": "CASA_RS_IMPERF_DATA_ROOT",
+            },
+            "imaging": {
+                "mode": "dirty",
+                "specmode": "mfs",
+                "gridder": "mosaic",
+                "field": "",
+                "phasecenter_field": 0,
+                "spw": "0",
+            },
+        }
+
+        with mock.patch.dict(
+            "os.environ",
+            {"CASA_RS_IMPERF_DATA_ROOT": "/tmp", "CASA_RS_CASA_PYTHON": "/tmp/casa-python"},
+            clear=False,
+        ):
+            plan = run_workload.build_plan(
+                manifest_path=Path("manifest.json"),
+                manifest=manifest,
+                repeats_override=1,
+                run_label_override=None,
+                storage_label_override=None,
+                dry_run=True,
+            )
+
+        self.assertEqual("0", plan["command"]["env"]["IMAGER_BENCH_PHASECENTER_FIELD"])
 
     def test_attach_stage_breakdown_does_not_require_casa_stage_data(self) -> None:
         plan = {

--- a/tools/perf/imager/test_stage_wave1_datasets.py
+++ b/tools/perf/imager/test_stage_wave1_datasets.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import copy
+import math
 import pathlib
 import sys
 import unittest
@@ -106,7 +107,7 @@ class StageWave1DatasetsTest(unittest.TestCase):
         self.assertAlmostEqual(position[1], -5_440_045.71553472, places=7)
         self.assertAlmostEqual(position[2], -2_481_673.80672726, places=7)
 
-    def test_single_field_request_uses_casa_pointing_phase_center(self) -> None:
+    def test_single_field_request_uses_zenith_transit_phase_center(self) -> None:
         spec = stage.select_datasets(
             self.registry,
             dataset_ids=["wave1-alma-single-small"],
@@ -122,8 +123,8 @@ class StageWave1DatasetsTest(unittest.TestCase):
 
         request = stage.build_casars_simobserve_request(dataset)["request"]
 
-        self.assertAlmostEqual(request["phase_center_rad"][0], -1.5707940753201612)
-        self.assertAlmostEqual(request["phase_center_rad"][1], -0.4014237906432261)
+        self.assertAlmostEqual(request["phase_center_rad"][0], math.radians(180.0))
+        self.assertAlmostEqual(request["phase_center_rad"][1], math.radians(-23.029))
 
     def test_fits_string_cards_start_in_standard_value_field(self) -> None:
         card = stage.format_card("CTYPE1", "'RA---SIN'")

--- a/tools/perf/imager/test_stage_wave1_datasets.py
+++ b/tools/perf/imager/test_stage_wave1_datasets.py
@@ -13,6 +13,7 @@ TOOL_DIR = pathlib.Path(__file__).resolve().parent
 sys.path.insert(0, str(TOOL_DIR))
 
 import stage_wave1_datasets as stage  # noqa: E402
+import generate_wave1_casa_datasets as generate  # noqa: E402
 
 
 class StageWave1DatasetsTest(unittest.TestCase):
@@ -97,6 +98,55 @@ class StageWave1DatasetsTest(unittest.TestCase):
                 self.data_root,
                 allow_non_external_large_root=False,
             )
+
+    def test_alma_loc_conversion_matches_casa_simutil(self) -> None:
+        position = stage.alma_loc_to_itrf(15.93453511, -700.6757482, -2.32967552)
+
+        self.assertAlmostEqual(position[0], 2_225_052.37659287, places=7)
+        self.assertAlmostEqual(position[1], -5_440_045.71553472, places=7)
+        self.assertAlmostEqual(position[2], -2_481_673.80672726, places=7)
+
+    def test_single_field_request_uses_casa_pointing_phase_center(self) -> None:
+        spec = stage.select_datasets(
+            self.registry,
+            dataset_ids=["wave1-alma-single-small"],
+            tiers=None,
+            instruments=None,
+        )
+        dataset = stage.build_plan(
+            self.registry,
+            spec,
+            self.data_root,
+            allow_non_external_large_root=False,
+        )["datasets"][0]
+
+        request = stage.build_casars_simobserve_request(dataset)["request"]
+
+        self.assertAlmostEqual(request["phase_center_rad"][0], -1.5707940753201612)
+        self.assertAlmostEqual(request["phase_center_rad"][1], -0.4014237906432261)
+
+    def test_fits_string_cards_start_in_standard_value_field(self) -> None:
+        card = stage.format_card("CTYPE1", "'RA---SIN'")
+
+        self.assertEqual("CTYPE1  = 'RA---SIN'", card[:20])
+        self.assertEqual(80, len(card))
+
+    def test_source_model_is_continuous_across_negative_ra_axis(self) -> None:
+        above = stage.source_pixel(148, 255, 512, "single")
+        below = stage.source_pixel(148, 256, 512, "single")
+
+        self.assertLess(abs(above - below) / max(above, below), 0.01)
+
+    def test_casa_generator_reuses_staging_source_model(self) -> None:
+        staged = stage.source_plane(32, "single")
+        casa = generate.structured_plane(32, "single")
+
+        self.assertEqual(staged.shape, casa.shape)
+        self.assertEqual(float(staged.max()), float(casa.max()))
+        self.assertEqual(
+            [stage.spectral_total_scale(8, channel) for channel in range(8)],
+            generate.spectral_profile(8),
+        )
 
 
 if __name__ == "__main__":

--- a/tools/perf/imager/test_stage_wave1_datasets.py
+++ b/tools/perf/imager/test_stage_wave1_datasets.py
@@ -20,7 +20,7 @@ class StageWave1DatasetsTest(unittest.TestCase):
         self.registry = stage.read_json(stage.REGISTRY_PATH)
         self.data_root = pathlib.Path("/Volumes/GLENDENNING/casa-rs-imperformance")
 
-    def test_full_plan_uses_one_shared_large_dataset(self) -> None:
+    def test_full_plan_uses_one_mosaic_large_dataset(self) -> None:
         specs = stage.select_datasets(
             self.registry,
             dataset_ids=None,
@@ -36,7 +36,7 @@ class StageWave1DatasetsTest(unittest.TestCase):
         )
 
         large = [dataset for dataset in plan["datasets"] if dataset["tier"] == "large"]
-        self.assertEqual(["wave1-alma-shared-large"], [dataset["id"] for dataset in large])
+        self.assertEqual(["wave1-alma-mosaic-large"], [dataset["id"] for dataset in large])
         self.assertEqual(
             [
                 "standard-mfs-dirty-control",
@@ -49,10 +49,10 @@ class StageWave1DatasetsTest(unittest.TestCase):
             large[0]["selected_modes"],
         )
 
-    def test_shared_large_workloads_select_standard_or_mosaic_gridder(self) -> None:
+    def test_mosaic_large_workloads_select_standard_or_mosaic_gridder(self) -> None:
         spec = stage.select_datasets(
             self.registry,
-            dataset_ids=["wave1-alma-shared-large"],
+            dataset_ids=["wave1-alma-mosaic-large"],
             tiers=None,
             instruments=None,
         )
@@ -75,6 +75,7 @@ class StageWave1DatasetsTest(unittest.TestCase):
         self.assertEqual(all_channels, mfs["imaging"]["channel_count"])
         self.assertEqual("mosaic", mosaic["imaging"]["gridder"])
         self.assertEqual("", mosaic["imaging"]["field"])
+        self.assertEqual(0, mosaic["imaging"]["phasecenter_field"])
         self.assertEqual(32, mosaic["imaging"]["channel_count"])
 
     def test_large_tier_policy_rejects_multiple_large_datasets(self) -> None:

--- a/tools/perf/imager/test_stage_wave1_datasets.py
+++ b/tools/perf/imager/test_stage_wave1_datasets.py
@@ -66,12 +66,13 @@ class StageWave1DatasetsTest(unittest.TestCase):
         standard = stage.build_workload_manifest(dataset, "standard-cube-line")
         mfs = stage.build_workload_manifest(dataset, "standard-mfs-dirty-control")
         mosaic = stage.build_workload_manifest(dataset, "mosaic-cube-bounded")
+        all_channels = dataset["shape"]["channels"]
 
         self.assertEqual("standard", standard["imaging"]["gridder"])
         self.assertEqual("0", standard["imaging"]["field"])
-        self.assertEqual(256, standard["imaging"]["channel_count"])
+        self.assertEqual(all_channels, standard["imaging"]["channel_count"])
         self.assertEqual("mfs", mfs["imaging"]["specmode"])
-        self.assertEqual(256, mfs["imaging"]["channel_count"])
+        self.assertEqual(all_channels, mfs["imaging"]["channel_count"])
         self.assertEqual("mosaic", mosaic["imaging"]["gridder"])
         self.assertEqual("", mosaic["imaging"]["field"])
         self.assertEqual(32, mosaic["imaging"]["channel_count"])

--- a/tools/perf/imager/test_stage_wave1_datasets.py
+++ b/tools/perf/imager/test_stage_wave1_datasets.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Tests for Wave 1 dataset staging policy."""
+
+from __future__ import annotations
+
+import copy
+import pathlib
+import sys
+import unittest
+
+
+TOOL_DIR = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(TOOL_DIR))
+
+import stage_wave1_datasets as stage  # noqa: E402
+
+
+class StageWave1DatasetsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.registry = stage.read_json(stage.REGISTRY_PATH)
+        self.data_root = pathlib.Path("/Volumes/GLENDENNING/casa-rs-imperformance")
+
+    def test_full_plan_uses_one_shared_large_dataset(self) -> None:
+        specs = stage.select_datasets(
+            self.registry,
+            dataset_ids=None,
+            tiers=None,
+            instruments=None,
+        )
+
+        plan = stage.build_plan(
+            self.registry,
+            specs,
+            self.data_root,
+            allow_non_external_large_root=False,
+        )
+
+        large = [dataset for dataset in plan["datasets"] if dataset["tier"] == "large"]
+        self.assertEqual(["wave1-alma-shared-large"], [dataset["id"] for dataset in large])
+        self.assertEqual(
+            [
+                "standard-mfs-dirty-control",
+                "standard-mfs-clean-current",
+                "standard-cube-line",
+                "mosaic-mfs-clean-primary",
+                "mosaic-cube-bounded",
+                "mtmfs-wideband-sentinel",
+            ],
+            large[0]["selected_modes"],
+        )
+
+    def test_shared_large_workloads_select_standard_or_mosaic_gridder(self) -> None:
+        spec = stage.select_datasets(
+            self.registry,
+            dataset_ids=["wave1-alma-shared-large"],
+            tiers=None,
+            instruments=None,
+        )
+        dataset = stage.build_plan(
+            self.registry,
+            spec,
+            self.data_root,
+            allow_non_external_large_root=False,
+        )["datasets"][0]
+
+        standard = stage.build_workload_manifest(dataset, "standard-cube-line")
+        mfs = stage.build_workload_manifest(dataset, "standard-mfs-dirty-control")
+        mosaic = stage.build_workload_manifest(dataset, "mosaic-cube-bounded")
+
+        self.assertEqual("standard", standard["imaging"]["gridder"])
+        self.assertEqual("0", standard["imaging"]["field"])
+        self.assertEqual(256, standard["imaging"]["channel_count"])
+        self.assertEqual("mfs", mfs["imaging"]["specmode"])
+        self.assertEqual(256, mfs["imaging"]["channel_count"])
+        self.assertEqual("mosaic", mosaic["imaging"]["gridder"])
+        self.assertEqual("", mosaic["imaging"]["field"])
+        self.assertEqual(32, mosaic["imaging"]["channel_count"])
+
+    def test_large_tier_policy_rejects_multiple_large_datasets(self) -> None:
+        registry = copy.deepcopy(self.registry)
+        duplicate = copy.deepcopy(registry["datasets"][-1])
+        duplicate["id"] = "wave1-extra-large"
+        registry["datasets"].append(duplicate)
+        specs = stage.select_datasets(
+            registry,
+            dataset_ids=None,
+            tiers=["large"],
+            instruments=None,
+        )
+
+        with self.assertRaisesRegex(stage.DatasetError, "large tier policy expects 1"):
+            stage.build_plan(
+                registry,
+                specs,
+                self.data_root,
+                allow_non_external_large_root=False,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/perf/imager/wave1_dataset_registry.json
+++ b/tools/perf/imager/wave1_dataset_registry.json
@@ -37,7 +37,7 @@
       "display_name": "ALMA",
       "array_configuration": "synthetic compact 12m-like",
       "dish_diameter_m": 12.0,
-      "native_casars_status": "supported for single-field generation after strict small-tier parity; mosaic generation remains request-plan-only"
+      "native_casars_status": "supported for selected Wave 1 single-field and mosaic-capable generation; strict CASA parity currently covers the ALMA single small case"
     }
   },
   "families": {

--- a/tools/perf/imager/wave1_dataset_registry.json
+++ b/tools/perf/imager/wave1_dataset_registry.json
@@ -5,8 +5,8 @@
   "description": "Deterministic simulated imaging datasets for ImPerformance Wave 1.",
   "large_tier_policy": {
     "dataset_count": 1,
-    "dataset_id": "wave1-alma-shared-large",
-    "reason": "The external drive budget allows one approximately 100 GiB dataset. The large tier is therefore a shared ALMA mosaic/cube superset, and benchmark manifests select fields, channels, and gridders from that one MeasurementSet."
+    "dataset_id": "wave1-alma-mosaic-large",
+    "reason": "The external drive budget allows one approximately 100 GiB dataset. The large tier is therefore a single ALMA mosaic/cube superset, and benchmark manifests select fields, channels, and gridders from that one MeasurementSet."
   },
   "tiers": {
     "small": {
@@ -58,8 +58,8 @@
       ],
       "pointing_count": 7
     },
-    "shared-large": {
-      "display_name": "shared large ALMA mosaic/cube superset",
+    "mosaic-large": {
+      "display_name": "large ALMA mosaic/cube superset",
       "selected_modes": [
         "standard-mfs-dirty-control",
         "standard-mfs-clean-current",
@@ -97,8 +97,8 @@
       "tier": "small",
       "model_pixels": 512,
       "image_pixels": 512,
-      "channels": 16,
-      "duration_seconds": 1200,
+      "channels": 512,
+      "duration_seconds": 3730,
       "integration_seconds": 10,
       "noise_simplenoise_jy": 0.001
     },
@@ -107,10 +107,10 @@
       "instrument": "vla",
       "family": "single",
       "tier": "medium",
-      "model_pixels": 2048,
+      "model_pixels": 512,
       "image_pixels": 2048,
-      "channels": 64,
-      "duration_seconds": 28800,
+      "channels": 512,
+      "duration_seconds": 116640,
       "integration_seconds": 10,
       "noise_simplenoise_jy": 0.001
     },
@@ -121,20 +121,8 @@
       "tier": "small",
       "model_pixels": 512,
       "image_pixels": 512,
-      "channels": 8,
-      "duration_seconds": 600,
-      "integration_seconds": 10,
-      "noise_simplenoise_jy": 0.0012
-    },
-    {
-      "id": "wave1-vla-mosaic-medium",
-      "instrument": "vla",
-      "family": "mosaic",
-      "tier": "medium",
-      "model_pixels": 2048,
-      "image_pixels": 2048,
-      "channels": 32,
-      "duration_seconds": 7200,
+      "channels": 512,
+      "duration_seconds": 3730,
       "integration_seconds": 10,
       "noise_simplenoise_jy": 0.0012
     },
@@ -145,8 +133,8 @@
       "tier": "small",
       "model_pixels": 512,
       "image_pixels": 512,
-      "channels": 16,
-      "duration_seconds": 600,
+      "channels": 256,
+      "duration_seconds": 2900,
       "integration_seconds": 10,
       "noise_simplenoise_jy": 0.0007
     },
@@ -155,10 +143,10 @@
       "instrument": "alma",
       "family": "single",
       "tier": "medium",
-      "model_pixels": 2048,
+      "model_pixels": 512,
       "image_pixels": 2048,
-      "channels": 64,
-      "duration_seconds": 10800,
+      "channels": 512,
+      "duration_seconds": 47560,
       "integration_seconds": 10,
       "noise_simplenoise_jy": 0.0007
     },
@@ -169,32 +157,20 @@
       "tier": "small",
       "model_pixels": 512,
       "image_pixels": 512,
-      "channels": 8,
-      "duration_seconds": 300,
+      "channels": 256,
+      "duration_seconds": 2900,
       "integration_seconds": 10,
       "noise_simplenoise_jy": 0.0008
     },
     {
-      "id": "wave1-alma-mosaic-medium",
+      "id": "wave1-alma-mosaic-large",
       "instrument": "alma",
-      "family": "mosaic",
-      "tier": "medium",
-      "model_pixels": 2048,
-      "image_pixels": 2048,
-      "channels": 32,
-      "duration_seconds": 2700,
-      "integration_seconds": 10,
-      "noise_simplenoise_jy": 0.0008
-    },
-    {
-      "id": "wave1-alma-shared-large",
-      "instrument": "alma",
-      "family": "shared-large",
+      "family": "mosaic-large",
       "tier": "large",
-      "model_pixels": 2048,
+      "model_pixels": 512,
       "image_pixels": 4096,
-      "channels": 128,
-      "duration_seconds": 57600,
+      "channels": 1024,
+      "duration_seconds": 74300,
       "integration_seconds": 10,
       "noise_simplenoise_jy": 0.0008
     }

--- a/tools/perf/imager/wave1_dataset_registry.json
+++ b/tools/perf/imager/wave1_dataset_registry.json
@@ -28,7 +28,7 @@
   "instruments": {
     "vla": {
       "display_name": "VLA",
-      "array_configuration": "synthetic VLA A-like",
+      "array_configuration": "synthetic VLA D-like",
       "dish_diameter_m": 25.0,
       "native_casars_status": "supported"
     },

--- a/tools/perf/imager/wave1_dataset_registry.json
+++ b/tools/perf/imager/wave1_dataset_registry.json
@@ -3,6 +3,7 @@
   "root_env": "CASA_RS_IMPERF_DATA_ROOT",
   "external_root_hint": "/Volumes/GLENDENNING/casa-rs-imperformance",
   "description": "Deterministic simulated imaging datasets for ImPerformance Wave 1.",
+  "small_tier_policy": "Small-tier datasets target roughly 1 GiB while preserving full-track uv coverage for visually useful dirty/clean signoff images; they use fewer channels than medium/large tiers.",
   "large_tier_policy": {
     "dataset_count": 1,
     "dataset_id": "wave1-alma-mosaic-large",
@@ -36,7 +37,7 @@
       "display_name": "ALMA",
       "array_configuration": "synthetic compact 12m-like",
       "dish_diameter_m": 12.0,
-      "native_casars_status": "request-plan-only until ALMA parity is checked"
+      "native_casars_status": "supported for single-field generation after strict small-tier parity; mosaic generation remains request-plan-only"
     }
   },
   "families": {
@@ -73,6 +74,7 @@
   },
   "source_model": {
     "name": "structured star-forming field",
+    "frequency_policy": "VLA benchmark datasets use an 8 GHz start frequency with MHz-scale channels so the structured source sits comfortably inside the primary beam; ALMA datasets use 230 GHz with MHz-scale channels.",
     "continuum_components": [
       "bright compact core",
       "faint offset compact sources",
@@ -97,8 +99,8 @@
       "tier": "small",
       "model_pixels": 512,
       "image_pixels": 512,
-      "channels": 512,
-      "duration_seconds": 3730,
+      "channels": 24,
+      "duration_seconds": 86400,
       "integration_seconds": 10,
       "noise_simplenoise_jy": 0.001
     },
@@ -121,8 +123,8 @@
       "tier": "small",
       "model_pixels": 512,
       "image_pixels": 512,
-      "channels": 512,
-      "duration_seconds": 3730,
+      "channels": 24,
+      "duration_seconds": 86400,
       "integration_seconds": 10,
       "noise_simplenoise_jy": 0.0012
     },
@@ -133,8 +135,8 @@
       "tier": "small",
       "model_pixels": 512,
       "image_pixels": 512,
-      "channels": 256,
-      "duration_seconds": 2900,
+      "channels": 8,
+      "duration_seconds": 86400,
       "integration_seconds": 10,
       "noise_simplenoise_jy": 0.0007
     },
@@ -157,8 +159,8 @@
       "tier": "small",
       "model_pixels": 512,
       "image_pixels": 512,
-      "channels": 256,
-      "duration_seconds": 2900,
+      "channels": 8,
+      "duration_seconds": 86400,
       "integration_seconds": 10,
       "noise_simplenoise_jy": 0.0008
     },

--- a/tools/perf/imager/wave1_dataset_registry.json
+++ b/tools/perf/imager/wave1_dataset_registry.json
@@ -98,8 +98,8 @@
       "model_pixels": 512,
       "image_pixels": 512,
       "channels": 16,
-      "duration_seconds": 192,
-      "integration_seconds": 2,
+      "duration_seconds": 1200,
+      "integration_seconds": 10,
       "noise_simplenoise_jy": 0.001
     },
     {
@@ -110,8 +110,8 @@
       "model_pixels": 2048,
       "image_pixels": 2048,
       "channels": 64,
-      "duration_seconds": 2160,
-      "integration_seconds": 2,
+      "duration_seconds": 28800,
+      "integration_seconds": 10,
       "noise_simplenoise_jy": 0.001
     },
     {
@@ -122,8 +122,8 @@
       "model_pixels": 512,
       "image_pixels": 512,
       "channels": 8,
-      "duration_seconds": 128,
-      "integration_seconds": 2,
+      "duration_seconds": 600,
+      "integration_seconds": 10,
       "noise_simplenoise_jy": 0.0012
     },
     {
@@ -134,8 +134,8 @@
       "model_pixels": 2048,
       "image_pixels": 2048,
       "channels": 32,
-      "duration_seconds": 2160,
-      "integration_seconds": 2,
+      "duration_seconds": 7200,
+      "integration_seconds": 10,
       "noise_simplenoise_jy": 0.0012
     },
     {
@@ -146,8 +146,8 @@
       "model_pixels": 512,
       "image_pixels": 512,
       "channels": 16,
-      "duration_seconds": 192,
-      "integration_seconds": 2,
+      "duration_seconds": 600,
+      "integration_seconds": 10,
       "noise_simplenoise_jy": 0.0007
     },
     {
@@ -158,8 +158,8 @@
       "model_pixels": 2048,
       "image_pixels": 2048,
       "channels": 64,
-      "duration_seconds": 2160,
-      "integration_seconds": 2,
+      "duration_seconds": 10800,
+      "integration_seconds": 10,
       "noise_simplenoise_jy": 0.0007
     },
     {
@@ -170,8 +170,8 @@
       "model_pixels": 512,
       "image_pixels": 512,
       "channels": 8,
-      "duration_seconds": 128,
-      "integration_seconds": 2,
+      "duration_seconds": 300,
+      "integration_seconds": 10,
       "noise_simplenoise_jy": 0.0008
     },
     {
@@ -182,8 +182,8 @@
       "model_pixels": 2048,
       "image_pixels": 2048,
       "channels": 32,
-      "duration_seconds": 2160,
-      "integration_seconds": 2,
+      "duration_seconds": 2700,
+      "integration_seconds": 10,
       "noise_simplenoise_jy": 0.0008
     },
     {
@@ -191,11 +191,11 @@
       "instrument": "alma",
       "family": "shared-large",
       "tier": "large",
-      "model_pixels": 4096,
+      "model_pixels": 2048,
       "image_pixels": 4096,
-      "channels": 256,
-      "duration_seconds": 86400,
-      "integration_seconds": 2,
+      "channels": 128,
+      "duration_seconds": 57600,
+      "integration_seconds": 10,
       "noise_simplenoise_jy": 0.0008
     }
   ]

--- a/tools/perf/imager/wave1_dataset_registry.json
+++ b/tools/perf/imager/wave1_dataset_registry.json
@@ -3,6 +3,11 @@
   "root_env": "CASA_RS_IMPERF_DATA_ROOT",
   "external_root_hint": "/Volumes/GLENDENNING/casa-rs-imperformance",
   "description": "Deterministic simulated imaging datasets for ImPerformance Wave 1.",
+  "large_tier_policy": {
+    "dataset_count": 1,
+    "dataset_id": "wave1-alma-shared-large",
+    "reason": "The external drive budget allows one approximately 100 GiB dataset. The large tier is therefore a shared ALMA mosaic/cube superset, and benchmark manifests select fields, channels, and gridders from that one MeasurementSet."
+  },
   "tiers": {
     "small": {
       "target_size_bytes": 1073741824,
@@ -52,6 +57,18 @@
         "mosaic-cube-bounded"
       ],
       "pointing_count": 7
+    },
+    "shared-large": {
+      "display_name": "shared large ALMA mosaic/cube superset",
+      "selected_modes": [
+        "standard-mfs-dirty-control",
+        "standard-mfs-clean-current",
+        "standard-cube-line",
+        "mosaic-mfs-clean-primary",
+        "mosaic-cube-bounded",
+        "mtmfs-wideband-sentinel"
+      ],
+      "pointing_count": 7
     }
   },
   "source_model": {
@@ -98,18 +115,6 @@
       "noise_simplenoise_jy": 0.001
     },
     {
-      "id": "wave1-vla-single-large",
-      "instrument": "vla",
-      "family": "single",
-      "tier": "large",
-      "model_pixels": 4096,
-      "image_pixels": 4096,
-      "channels": 256,
-      "duration_seconds": 5760,
-      "integration_seconds": 2,
-      "noise_simplenoise_jy": 0.001
-    },
-    {
       "id": "wave1-vla-mosaic-small",
       "instrument": "vla",
       "family": "mosaic",
@@ -130,18 +135,6 @@
       "image_pixels": 2048,
       "channels": 32,
       "duration_seconds": 2160,
-      "integration_seconds": 2,
-      "noise_simplenoise_jy": 0.0012
-    },
-    {
-      "id": "wave1-vla-mosaic-large",
-      "instrument": "vla",
-      "family": "mosaic",
-      "tier": "large",
-      "model_pixels": 4096,
-      "image_pixels": 4096,
-      "channels": 96,
-      "duration_seconds": 5760,
       "integration_seconds": 2,
       "noise_simplenoise_jy": 0.0012
     },
@@ -170,18 +163,6 @@
       "noise_simplenoise_jy": 0.0007
     },
     {
-      "id": "wave1-alma-single-large",
-      "instrument": "alma",
-      "family": "single",
-      "tier": "large",
-      "model_pixels": 4096,
-      "image_pixels": 4096,
-      "channels": 256,
-      "duration_seconds": 5760,
-      "integration_seconds": 2,
-      "noise_simplenoise_jy": 0.0007
-    },
-    {
       "id": "wave1-alma-mosaic-small",
       "instrument": "alma",
       "family": "mosaic",
@@ -206,14 +187,14 @@
       "noise_simplenoise_jy": 0.0008
     },
     {
-      "id": "wave1-alma-mosaic-large",
+      "id": "wave1-alma-shared-large",
       "instrument": "alma",
-      "family": "mosaic",
+      "family": "shared-large",
       "tier": "large",
       "model_pixels": 4096,
       "image_pixels": 4096,
-      "channels": 96,
-      "duration_seconds": 5760,
+      "channels": 256,
+      "duration_seconds": 86400,
       "integration_seconds": 2,
       "noise_simplenoise_jy": 0.0008
     }

--- a/tools/perf/imager/wave1_dataset_registry.json
+++ b/tools/perf/imager/wave1_dataset_registry.json
@@ -1,0 +1,221 @@
+{
+  "schema_version": 1,
+  "root_env": "CASA_RS_IMPERF_DATA_ROOT",
+  "external_root_hint": "/Volumes/GLENDENNING/casa-rs-imperformance",
+  "description": "Deterministic simulated imaging datasets for ImPerformance Wave 1.",
+  "tiers": {
+    "small": {
+      "target_size_bytes": 1073741824,
+      "storage_label": "well-below-memory",
+      "external_root_required": false
+    },
+    "medium": {
+      "target_size_bytes": 34359738368,
+      "storage_label": "about-memory",
+      "external_root_required": true
+    },
+    "large": {
+      "target_size_bytes": 107374182400,
+      "storage_label": "larger-than-memory",
+      "external_root_required": true
+    }
+  },
+  "instruments": {
+    "vla": {
+      "display_name": "VLA",
+      "array_configuration": "synthetic VLA A-like",
+      "dish_diameter_m": 25.0,
+      "native_casars_status": "supported"
+    },
+    "alma": {
+      "display_name": "ALMA",
+      "array_configuration": "synthetic compact 12m-like",
+      "dish_diameter_m": 12.0,
+      "native_casars_status": "request-plan-only until ALMA parity is checked"
+    }
+  },
+  "families": {
+    "single": {
+      "display_name": "single-field standard-gridder",
+      "selected_modes": [
+        "standard-mfs-dirty-control",
+        "standard-mfs-clean-current",
+        "standard-cube-line",
+        "mtmfs-wideband-sentinel"
+      ],
+      "pointing_count": 1
+    },
+    "mosaic": {
+      "display_name": "overlapping-field mosaic",
+      "selected_modes": [
+        "mosaic-mfs-clean-primary",
+        "mosaic-cube-bounded"
+      ],
+      "pointing_count": 7
+    }
+  },
+  "source_model": {
+    "name": "structured star-forming field",
+    "continuum_components": [
+      "bright compact core",
+      "faint offset compact sources",
+      "two extended spiral arms",
+      "partial ring",
+      "broad diffuse halo"
+    ],
+    "cube_components": [
+      "continuum baseline with spectral index",
+      "central broad emission line",
+      "offset narrow emission line",
+      "absorption notch against the core",
+      "weak velocity gradient across the extended arms"
+    ],
+    "noise_model": "deterministic simple complex visibility noise"
+  },
+  "datasets": [
+    {
+      "id": "wave1-vla-single-small",
+      "instrument": "vla",
+      "family": "single",
+      "tier": "small",
+      "model_pixels": 512,
+      "image_pixels": 512,
+      "channels": 16,
+      "duration_seconds": 192,
+      "integration_seconds": 2,
+      "noise_simplenoise_jy": 0.001
+    },
+    {
+      "id": "wave1-vla-single-medium",
+      "instrument": "vla",
+      "family": "single",
+      "tier": "medium",
+      "model_pixels": 2048,
+      "image_pixels": 2048,
+      "channels": 64,
+      "duration_seconds": 2160,
+      "integration_seconds": 2,
+      "noise_simplenoise_jy": 0.001
+    },
+    {
+      "id": "wave1-vla-single-large",
+      "instrument": "vla",
+      "family": "single",
+      "tier": "large",
+      "model_pixels": 4096,
+      "image_pixels": 4096,
+      "channels": 256,
+      "duration_seconds": 5760,
+      "integration_seconds": 2,
+      "noise_simplenoise_jy": 0.001
+    },
+    {
+      "id": "wave1-vla-mosaic-small",
+      "instrument": "vla",
+      "family": "mosaic",
+      "tier": "small",
+      "model_pixels": 512,
+      "image_pixels": 512,
+      "channels": 8,
+      "duration_seconds": 128,
+      "integration_seconds": 2,
+      "noise_simplenoise_jy": 0.0012
+    },
+    {
+      "id": "wave1-vla-mosaic-medium",
+      "instrument": "vla",
+      "family": "mosaic",
+      "tier": "medium",
+      "model_pixels": 2048,
+      "image_pixels": 2048,
+      "channels": 32,
+      "duration_seconds": 2160,
+      "integration_seconds": 2,
+      "noise_simplenoise_jy": 0.0012
+    },
+    {
+      "id": "wave1-vla-mosaic-large",
+      "instrument": "vla",
+      "family": "mosaic",
+      "tier": "large",
+      "model_pixels": 4096,
+      "image_pixels": 4096,
+      "channels": 96,
+      "duration_seconds": 5760,
+      "integration_seconds": 2,
+      "noise_simplenoise_jy": 0.0012
+    },
+    {
+      "id": "wave1-alma-single-small",
+      "instrument": "alma",
+      "family": "single",
+      "tier": "small",
+      "model_pixels": 512,
+      "image_pixels": 512,
+      "channels": 16,
+      "duration_seconds": 192,
+      "integration_seconds": 2,
+      "noise_simplenoise_jy": 0.0007
+    },
+    {
+      "id": "wave1-alma-single-medium",
+      "instrument": "alma",
+      "family": "single",
+      "tier": "medium",
+      "model_pixels": 2048,
+      "image_pixels": 2048,
+      "channels": 64,
+      "duration_seconds": 2160,
+      "integration_seconds": 2,
+      "noise_simplenoise_jy": 0.0007
+    },
+    {
+      "id": "wave1-alma-single-large",
+      "instrument": "alma",
+      "family": "single",
+      "tier": "large",
+      "model_pixels": 4096,
+      "image_pixels": 4096,
+      "channels": 256,
+      "duration_seconds": 5760,
+      "integration_seconds": 2,
+      "noise_simplenoise_jy": 0.0007
+    },
+    {
+      "id": "wave1-alma-mosaic-small",
+      "instrument": "alma",
+      "family": "mosaic",
+      "tier": "small",
+      "model_pixels": 512,
+      "image_pixels": 512,
+      "channels": 8,
+      "duration_seconds": 128,
+      "integration_seconds": 2,
+      "noise_simplenoise_jy": 0.0008
+    },
+    {
+      "id": "wave1-alma-mosaic-medium",
+      "instrument": "alma",
+      "family": "mosaic",
+      "tier": "medium",
+      "model_pixels": 2048,
+      "image_pixels": 2048,
+      "channels": 32,
+      "duration_seconds": 2160,
+      "integration_seconds": 2,
+      "noise_simplenoise_jy": 0.0008
+    },
+    {
+      "id": "wave1-alma-mosaic-large",
+      "instrument": "alma",
+      "family": "mosaic",
+      "tier": "large",
+      "model_pixels": 4096,
+      "image_pixels": 4096,
+      "channels": 96,
+      "duration_seconds": 5760,
+      "integration_seconds": 2,
+      "noise_simplenoise_jy": 0.0008
+    }
+  ]
+}

--- a/tools/perf/imager/workloads/wave1-standard-mfs-dirty-smoke.json
+++ b/tools/perf/imager/workloads/wave1-standard-mfs-dirty-smoke.json
@@ -1,0 +1,31 @@
+{
+  "id": "wave1-standard-mfs-dirty-smoke",
+  "mode_id": "standard-mfs-dirty-control",
+  "description": "Small standard-gridder MFS dirty control workload for ImPerformance Wave 1 harness validation.",
+  "dataset": {
+    "key": "ngc5921-testdata",
+    "root_env": "CASA_RS_TESTDATA_ROOT",
+    "relative_path": "measurementset/vla/ngc5921.ms"
+  },
+  "imaging": {
+    "mode": "dirty",
+    "specmode": "mfs",
+    "gridder": "standard",
+    "field": "0",
+    "spw": "0",
+    "channel_start": 0,
+    "channel_count": 1,
+    "imsize": 128,
+    "cell_arcsec": 30.0,
+    "weighting": "natural",
+    "robust": 0.5,
+    "deconvolver": "hogbom",
+    "niter": 0,
+    "wterm": "none"
+  },
+  "run": {
+    "repeats": 3,
+    "run_label": "warm",
+    "storage_label": "script-staged-tempdir"
+  }
+}


### PR DESCRIPTION
Wave issue: #257

Closes #257

## Outcome

This PR hardens native `simobserve` into the ImPerformance Wave 1 benchmark dataset generator and closes the remaining parity/performance evidence gaps for issue #257.

## Implemented

- Adds/updates the Wave 1 dataset registry and staging/materialization harness for VLA/ALMA single-field cases, small mosaic cases, and the ALMA `mosaic-large` superset naming.
- Extends native simulation for ALMA/VLA benchmark arrays, deterministic source structure, direct deterministic noise/corruption in DATA, above-elevation scheduling defaults, shadow/elevation flags, and detailed stage timing.
- Uses streamed tiled storage writers for large MAIN columns so matching MS writers benefit library-wide, not only `simobserve`.
- Adds source-backed benchmark tooling for native-vs-CASA simobserve comparison, strict same-cell DATA tolerance checks, total `FLAG`/`FLAG_ROW` parity checks, FITS/WCS validation, CASA-open/read smoke, and image-panel evidence.
- Adds the AGENTS.md rule that parity/correctness investigations should favor targeted instrumentation of CASA/casacore and casa-rs over blind parameter experiments.

## Final Strict CASA Parity

The closeout pass found two harness/setup mismatches and fixed them: strict CASA comparison now aligns the native start time to CASA's first generated row, uses a continuous strict comparison schedule, and pins the strict comparison elevation cutoff to CASA's 8 degree behavior. Production Wave 1 generation still defaults to realistic above-20-degree session splitting.

- `wave1-vla-single-small`: strict status passed; 3,032,640 rows on both sides; total `FLAG`, `FLAG_ROW`, and effective flag counts match exactly (`109,727,568` flagged cells, `2,285,991` flagged rows); UVW max abs delta `1.37e-7` m; sampled unflagged DATA mean abs delta `0.0144` Jy; zero same-cell DATA tolerance violations; native `12.44` s vs CASA `48.39` s, `3.89x` speedup.
- `wave1-alma-single-small`: strict status passed; 7,801,920 rows on both sides; total `FLAG`, `FLAG_ROW`, and effective flag counts match exactly (`64,623,584` flagged cells, `4,038,974` flagged rows); UVW max abs delta `1.43e-7` m; sampled unflagged DATA mean abs delta `0.00198` Jy; zero same-cell DATA tolerance violations; native `23.12` s vs CASA `103.81` s, `4.49x` speedup.

## Performance Evidence

- Current ALMA medium full generation: `target/imperformance-wave1/final-artifacts/alma-medium-optimized-benchmark-20260518T003059Z.json`; 4,294,668 rows, 512 channels, about 38.2 GB output in `155.64` s.
- Same ALMA medium path before the latest prediction optimization: `190.02` s. Prediction time improved from about `150.44` s to `115.79` s.
- The current ALMA medium run reported zero elevation flags and `99,437` shadow-flagged rows.
- Internal-disk write-path guard remains recorded separately: `target/imperformance-wave1/internal-io-check/20260517T022939Z-wave1-vla-single-medium/simobserve-benchmark.json`; 34.82 GB output in 24.735 s with prediction disabled, 1407.7 MB/s output throughput, 2637.9 MB/s streamed MAIN-column write throughput.

## Representative Artifacts

- Single-file HTML report: `target/imperformance-wave1/final-artifacts/wave1-simobserve-evidence.html`.
- Native preview products: `target/imperformance-wave1/final-artifacts/native-image-previews/`.
- CASA-open/read smoke: `target/imperformance-wave1/final-artifacts/casa-open-read-smoke.json`; all 7 generated MSs passed metadata and first DATA/UVW read.
- Final strict VLA parity JSON: `target/imperformance-wave1/closeout-strict/20260518T004531Z-wave1-vla-single-small/simobserve-benchmark.json`.
- Final strict ALMA parity JSON: `target/imperformance-wave1/closeout-strict/20260518T004708Z-wave1-alma-single-small/simobserve-benchmark.json`.

## Verification

- `python3 -m py_compile tools/perf/imager/bench_simobserve.py`
- `python3 -m unittest tools/perf/imager/test_bench_simobserve.py tools/perf/imager/test_stage_wave1_datasets.py`
- `python3 tools/perf/imager/bench_simobserve.py target/imperformance-wave1/current-plan/wave1-dataset-plan.json --dataset wave1-vla-single-small --output-dir target/imperformance-wave1/closeout-strict --casars-binary target/release/simobserve --disable-noise --strict-values`
- `python3 tools/perf/imager/bench_simobserve.py target/imperformance-wave1/current-plan/wave1-dataset-plan.json --dataset wave1-alma-single-small --output-dir target/imperformance-wave1/closeout-strict --casars-binary target/release/simobserve --disable-noise --strict-values`
- `cargo build --release --bin simobserve`
- `cargo test -p casa-ms`
- `cargo test -p casa-tables tiled`
- `cargo fmt --all -- --check`
- `just quick`
- `just verify` passed unsandboxed; the sandboxed attempt failed only because pip could not resolve the Python build dependency `maturin`.
