### PR TITLE
Fix slow imager parity config literal

### DIFF
--- a/crates/casars-imager/tests/imager_casa_parity.rs
+++ b/crates/casars-imager/tests/imager_casa_parity.rs
@@ -9922,6 +9922,7 @@ fn run_rust_imager_cube_case_with_solver_and_w_term_mode(
         psf_cutoff: 0.35,
         mosaic_pb_limit: 0.1,
         pbcor: false,
+        write_pb: false,
         minor_cycle_length,
         cyclefactor: 1.0,
         min_psf_fraction: 0.1,


### PR DESCRIPTION
## Root cause

The slow `casars-imager` parity test helper manually constructs a `CliConfig` value and had not been updated after `write_pb` was added to the struct. The normal workspace test target did not catch this because the failing literal only compiled in the slow parity test path.

## Files changed

- `crates/casars-imager/tests/imager_casa_parity.rs`

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p casars-imager --test imager_casa_parity --no-run`
- `scripts/test-slow.sh`
- `scripts/run-coverage.sh --ci-like`

Final CI-like coverage: 81.97% line coverage.

## Residual risks / follow-up

- Slow parity used the local shared test data root selected by preflight: `/Volumes/home/casatestdata`.
- Existing ignored diagnostic parity tests remain unchanged.
- No release versions or tags were modified.

Wave source: automation long-gates-pr-fixer
