### PR TITLE
Fix imager parity CliConfig defaults

### DIFF
--- a/crates/casars-imager/tests/imager_casa_parity.rs
+++ b/crates/casars-imager/tests/imager_casa_parity.rs
@@ -25,8 +25,9 @@ use casa_test_support::{
 use casa_types::measures::frequency::FrequencyRef;
 use casa_types::{ArrayValue, ScalarValue};
 use casars_imager::{
-    CliConfig, ImagerRunTaskRequest, RunSummary, build_prepare_plane_trace_from_config,
-    run_from_config, trace_cube_channel_residual_refresh_from_config,
+    CliConfig, ImagerRunTaskRequest, RunSummary, StandardMfsAccelerationPolicy,
+    build_prepare_plane_trace_from_config, run_from_config,
+    trace_cube_channel_residual_refresh_from_config,
     trace_cube_channel_residual_refresh_from_config_with_model_cube,
     trace_cube_channel_residual_refresh_from_config_with_model_cube_model_channel_lambda,
 };
@@ -723,6 +724,13 @@ fn hogbom_mfs_nmajor_fullsummary_task_return_tracks_casa_on_refim_twochan() {
         w_term_mode: WTermMode::None,
         w_project_planes: None,
         dirty_only: false,
+        standard_mfs_acceleration: StandardMfsAccelerationPolicy::Auto,
+        standard_mfs_backend: None,
+        standard_mfs_grid_threads: None,
+        standard_mfs_tile_anchor: None,
+        standard_mfs_residual_backend: None,
+        standard_mfs_initial_dirty_backend: None,
+        standard_mfs_metal_grouped_input_cache: None,
         write_preview_pngs: false,
     };
 
@@ -5841,6 +5849,13 @@ fn hogbom_cube_nsigma_late_block_inputs_track_casa_minor_cycle_snapshots() {
         w_term_mode: WTermMode::None,
         w_project_planes: None,
         dirty_only: false,
+        standard_mfs_acceleration: StandardMfsAccelerationPolicy::Auto,
+        standard_mfs_backend: None,
+        standard_mfs_grid_threads: None,
+        standard_mfs_tile_anchor: None,
+        standard_mfs_residual_backend: None,
+        standard_mfs_initial_dirty_backend: None,
+        standard_mfs_metal_grouped_input_cache: None,
         write_preview_pngs: false,
     };
 
@@ -6080,6 +6095,13 @@ fn hogbom_cube_nsigma_same_model_residual_refresh_tracks_casa_restart() {
         w_term_mode: WTermMode::None,
         w_project_planes: None,
         dirty_only: false,
+        standard_mfs_acceleration: StandardMfsAccelerationPolicy::Auto,
+        standard_mfs_backend: None,
+        standard_mfs_grid_threads: None,
+        standard_mfs_tile_anchor: None,
+        standard_mfs_residual_backend: None,
+        standard_mfs_initial_dirty_backend: None,
+        standard_mfs_metal_grouped_input_cache: None,
         write_preview_pngs: false,
     };
 
@@ -6214,6 +6236,13 @@ fn hogbom_cube_nsigma_internal_model_residual_refresh_matches_captured_state() {
         w_term_mode: WTermMode::None,
         w_project_planes: None,
         dirty_only: false,
+        standard_mfs_acceleration: StandardMfsAccelerationPolicy::Auto,
+        standard_mfs_backend: None,
+        standard_mfs_grid_threads: None,
+        standard_mfs_tile_anchor: None,
+        standard_mfs_residual_backend: None,
+        standard_mfs_initial_dirty_backend: None,
+        standard_mfs_metal_grouped_input_cache: None,
         write_preview_pngs: false,
     };
 
@@ -6367,6 +6396,13 @@ fn hogbom_cube_nsigma_full_cube_model_context_explains_late_restart_gap() {
         w_term_mode: WTermMode::None,
         w_project_planes: None,
         dirty_only: false,
+        standard_mfs_acceleration: StandardMfsAccelerationPolicy::Auto,
+        standard_mfs_backend: None,
+        standard_mfs_grid_threads: None,
+        standard_mfs_tile_anchor: None,
+        standard_mfs_residual_backend: None,
+        standard_mfs_initial_dirty_backend: None,
+        standard_mfs_metal_grouped_input_cache: None,
         write_preview_pngs: false,
     };
 
@@ -6606,6 +6642,13 @@ fn hogbom_cube_nsigma_block0_channel9_nearest_vs_linear_dirty_against_casa() {
             w_term_mode: WTermMode::None,
             w_project_planes: None,
             dirty_only: true,
+            standard_mfs_acceleration: StandardMfsAccelerationPolicy::Auto,
+            standard_mfs_backend: None,
+            standard_mfs_grid_threads: None,
+            standard_mfs_tile_anchor: None,
+            standard_mfs_residual_backend: None,
+            standard_mfs_initial_dirty_backend: None,
+            standard_mfs_metal_grouped_input_cache: None,
             write_preview_pngs: false,
         }
     };
@@ -6772,6 +6815,13 @@ fn hogbom_cube_nsigma_block0_channel9_casa_regridded_ms_isolates_spectral_seam()
         w_term_mode: WTermMode::None,
         w_project_planes: None,
         dirty_only: true,
+        standard_mfs_acceleration: StandardMfsAccelerationPolicy::Auto,
+        standard_mfs_backend: None,
+        standard_mfs_grid_threads: None,
+        standard_mfs_tile_anchor: None,
+        standard_mfs_residual_backend: None,
+        standard_mfs_initial_dirty_backend: None,
+        standard_mfs_metal_grouped_input_cache: None,
         write_preview_pngs: false,
     };
     let _ = run_from_config(&cubedata_config).expect("run rust cubedata dirty cube");
@@ -9217,6 +9267,13 @@ fn run_rust_imager(ms_path: &Path, prefix: &Path, dirty_only: bool) -> Result<()
         w_term_mode: WTermMode::None,
         w_project_planes: None,
         dirty_only,
+        standard_mfs_acceleration: StandardMfsAccelerationPolicy::Auto,
+        standard_mfs_backend: None,
+        standard_mfs_grid_threads: None,
+        standard_mfs_tile_anchor: None,
+        standard_mfs_residual_backend: None,
+        standard_mfs_initial_dirty_backend: None,
+        standard_mfs_metal_grouped_input_cache: None,
         write_preview_pngs: false,
     })
     .map(|_| ())
@@ -9296,6 +9353,13 @@ fn run_rust_imager_outlierfile_with_niter(
         w_term_mode: WTermMode::None,
         w_project_planes: None,
         dirty_only: false,
+        standard_mfs_acceleration: StandardMfsAccelerationPolicy::Auto,
+        standard_mfs_backend: None,
+        standard_mfs_grid_threads: None,
+        standard_mfs_tile_anchor: None,
+        standard_mfs_residual_backend: None,
+        standard_mfs_initial_dirty_backend: None,
+        standard_mfs_metal_grouped_input_cache: None,
         write_preview_pngs: false,
     })
 }
@@ -9354,6 +9418,13 @@ fn run_rust_imager_savemodel(ms_path: &Path, prefix: &Path) -> Result<(), String
         w_term_mode: WTermMode::None,
         w_project_planes: None,
         dirty_only: false,
+        standard_mfs_acceleration: StandardMfsAccelerationPolicy::Auto,
+        standard_mfs_backend: None,
+        standard_mfs_grid_threads: None,
+        standard_mfs_tile_anchor: None,
+        standard_mfs_residual_backend: None,
+        standard_mfs_initial_dirty_backend: None,
+        standard_mfs_metal_grouped_input_cache: None,
         write_preview_pngs: false,
     })
     .map(|_| ())
@@ -9418,6 +9489,13 @@ fn run_rust_imager_startmodel(
         w_term_mode: WTermMode::None,
         w_project_planes: None,
         dirty_only: false,
+        standard_mfs_acceleration: StandardMfsAccelerationPolicy::Auto,
+        standard_mfs_backend: None,
+        standard_mfs_grid_threads: None,
+        standard_mfs_tile_anchor: None,
+        standard_mfs_residual_backend: None,
+        standard_mfs_initial_dirty_backend: None,
+        standard_mfs_metal_grouped_input_cache: None,
         write_preview_pngs: false,
     })
     .map(|_| ())
@@ -9559,6 +9637,13 @@ fn run_rust_imager_case_with_explicit_phasecenter_and_w_term_mode(
         w_term_mode,
         w_project_planes,
         dirty_only,
+        standard_mfs_acceleration: StandardMfsAccelerationPolicy::Auto,
+        standard_mfs_backend: None,
+        standard_mfs_grid_threads: None,
+        standard_mfs_tile_anchor: None,
+        standard_mfs_residual_backend: None,
+        standard_mfs_initial_dirty_backend: None,
+        standard_mfs_metal_grouped_input_cache: None,
         write_preview_pngs: false,
     })
     .map(|_| ())
@@ -9628,6 +9713,13 @@ fn run_rust_imager_case_with_solver_and_w_term_mode(
         w_term_mode,
         w_project_planes,
         dirty_only,
+        standard_mfs_acceleration: StandardMfsAccelerationPolicy::Auto,
+        standard_mfs_backend: None,
+        standard_mfs_grid_threads: None,
+        standard_mfs_tile_anchor: None,
+        standard_mfs_residual_backend: None,
+        standard_mfs_initial_dirty_backend: None,
+        standard_mfs_metal_grouped_input_cache: None,
         write_preview_pngs: false,
     })
     .map(|_| ())
@@ -9694,6 +9786,13 @@ fn run_rust_imager_case_with_mtmfs(
         w_term_mode: WTermMode::None,
         w_project_planes: None,
         dirty_only,
+        standard_mfs_acceleration: StandardMfsAccelerationPolicy::Auto,
+        standard_mfs_backend: None,
+        standard_mfs_grid_threads: None,
+        standard_mfs_tile_anchor: None,
+        standard_mfs_residual_backend: None,
+        standard_mfs_initial_dirty_backend: None,
+        standard_mfs_metal_grouped_input_cache: None,
         write_preview_pngs: false,
     })
     .map(|_| ())
@@ -9835,6 +9934,13 @@ fn run_rust_imager_cube_task_default_case_with_clean_controls(
         w_term_mode: WTermMode::None,
         w_project_planes: None,
         dirty_only,
+        standard_mfs_acceleration: StandardMfsAccelerationPolicy::Auto,
+        standard_mfs_backend: None,
+        standard_mfs_grid_threads: None,
+        standard_mfs_tile_anchor: None,
+        standard_mfs_residual_backend: None,
+        standard_mfs_initial_dirty_backend: None,
+        standard_mfs_metal_grouped_input_cache: None,
         write_preview_pngs: false,
     })
 }
@@ -9951,6 +10057,13 @@ fn run_rust_imager_cube_case_with_solver_and_w_term_mode(
         w_term_mode,
         w_project_planes,
         dirty_only,
+        standard_mfs_acceleration: StandardMfsAccelerationPolicy::Auto,
+        standard_mfs_backend: None,
+        standard_mfs_grid_threads: None,
+        standard_mfs_tile_anchor: None,
+        standard_mfs_residual_backend: None,
+        standard_mfs_initial_dirty_backend: None,
+        standard_mfs_metal_grouped_input_cache: None,
         write_preview_pngs: false,
     })
 }
@@ -10117,6 +10230,13 @@ fn run_rust_imager_spectral_cube_case_with_options_and_weighting(
         w_term_mode: WTermMode::None,
         w_project_planes: None,
         dirty_only,
+        standard_mfs_acceleration: StandardMfsAccelerationPolicy::Auto,
+        standard_mfs_backend: None,
+        standard_mfs_grid_threads: None,
+        standard_mfs_tile_anchor: None,
+        standard_mfs_residual_backend: None,
+        standard_mfs_initial_dirty_backend: None,
+        standard_mfs_metal_grouped_input_cache: None,
         write_preview_pngs: false,
     })
 }


### PR DESCRIPTION
## Root cause

- `scripts/test-slow.sh` compiled the slow-only `casars-imager` CASA parity test target and found stale direct `CliConfig` literals.
- The standard-MFS acceleration/runtime fields had been added to `CliConfig`, but the slow parity fixtures were not updated because they are behind `cfg(slow-tests)` and are not compiled by `cargo test --workspace`.

## Files changed

- `crates/casars-imager/tests/imager_casa_parity.rs`: imports `StandardMfsAccelerationPolicy` and fills the standard-MFS fields on direct `CliConfig` literals with the normal CLI defaults.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p casars-imager --test imager_casa_parity --no-run`
- `scripts/test-slow.sh`
- `scripts/run-coverage.sh --ci-like`

Final CI-like coverage: 78.09%.

## Residual risks / follow-up

- The fix keeps parity-test construction aligned with current defaults. Future `CliConfig` field additions can still require updating these direct literals unless the tests are later refactored around a shared default constructor.

Wave source: automation Long Gates PR Fixer
