### PR TITLE
Fix slow oracle CliConfig defaults

### DIFF
--- a/crates/casars-imager/tests/prepare_geometry_casa_oracle.rs
+++ b/crates/casars-imager/tests/prepare_geometry_casa_oracle.rs
@@ -303,6 +303,7 @@ fn base_config(ms_path: PathBuf, spectral_mode: SpectralMode) -> CliConfig {
         standard_mfs_tile_anchor: None,
         standard_mfs_residual_backend: None,
         standard_mfs_initial_dirty_backend: None,
+        standard_mfs_metal_minor_cycle_chunk: None,
         standard_mfs_metal_grouped_input_cache: None,
         standard_mfs_memory_target_mb: None,
         standard_mfs_prepare_buffer_mb: None,

--- a/crates/casars-imager/tests/prepare_spectral_casa_oracle.rs
+++ b/crates/casars-imager/tests/prepare_spectral_casa_oracle.rs
@@ -523,6 +523,7 @@ fn base_config(ms_path: PathBuf, spectral_mode: SpectralMode) -> CliConfig {
         standard_mfs_tile_anchor: None,
         standard_mfs_residual_backend: None,
         standard_mfs_initial_dirty_backend: None,
+        standard_mfs_metal_minor_cycle_chunk: None,
         standard_mfs_metal_grouped_input_cache: None,
         standard_mfs_memory_target_mb: None,
         standard_mfs_prepare_buffer_mb: None,


### PR DESCRIPTION
Wave source: automation long-gates-pr-fixer

## Root Cause

The CI-like coverage gate builds slow `casars-imager` CASA oracle tests with `casars-imager/slow-tests`. Two slow oracle test `CliConfig` base builders had not been updated after `standard_mfs_metal_minor_cycle_chunk` became a required `CliConfig` field, so `scripts/run-coverage.sh --ci-like` failed at compile time with `E0063: missing field standard_mfs_metal_minor_cycle_chunk`.

## Files Changed

- `crates/casars-imager/tests/prepare_geometry_casa_oracle.rs`
- `crates/casars-imager/tests/prepare_spectral_casa_oracle.rs`

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `scripts/test-slow.sh`
- `cargo test -p casars-imager --features slow-tests --test prepare_geometry_casa_oracle --test prepare_spectral_casa_oracle --no-run`
- `scripts/run-coverage.sh --ci-like`

Final CI-like coverage: line coverage 79.12%, satisfying the 78.0% automation threshold.

## Residual Risk / Follow-up

- No version or tag changes were made.
- This is a narrow compile-fix for slow oracle test configuration defaults; CI should confirm the pushed branch in GitHub Actions.
