### PR TITLE
Fix long-gate parity regressions

### DIFF
--- a/crates/casa-ms/tests/msexplore_casa_parity.rs
+++ b/crates/casa-ms/tests/msexplore_casa_parity.rs
@@ -2015,6 +2015,8 @@ fn run_casa_plotms_sequence_png(calls: &[CasaPlotmsCall<'_>]) -> Result<CasaPlot
     let casa = discover_casa_python().ok_or_else(|| skip_reason(false))?;
     let ms_path = ngc5921_ms_path().ok_or_else(|| skip_reason(true))?;
     let temp = tempdir().map_err(|error| format!("tempdir: {error}"))?;
+    let local_ms_path = temp.path().join("casa-plotms-input.ms");
+    copy_measurement_set(&ms_path, &local_ms_path)?;
     let output = temp.path().join("casa-plotms.png");
 
     let mut script = String::from(
@@ -2049,7 +2051,7 @@ except Exception:
         .current_dir(temp.path())
         .arg("-c")
         .arg(&script)
-        .env("CASA_VIS", &ms_path)
+        .env("CASA_VIS", &local_ms_path)
         .env("CASA_OUT", &output)
         .env(
             "DISPLAY",
@@ -2090,6 +2092,8 @@ fn run_casa_plotms_export_on_with_expr(
     let _guard = casa_plotms_lock().lock().expect("lock CASA plotms");
     let casa = discover_casa_python().ok_or_else(|| skip_reason(false))?;
     let temp = tempdir().map_err(|error| format!("tempdir: {error}"))?;
+    let local_ms_path = temp.path().join("casa-plotms-input.ms");
+    copy_measurement_set(ms_path, &local_ms_path)?;
     let output = temp.path().join(match expformat {
         "png" => "casa-plotms.png",
         _ => "casa-plotms.txt",
@@ -2128,7 +2132,7 @@ kwargs = {
         .current_dir(temp.path())
         .arg("-c")
         .arg(&script)
-        .env("CASA_VIS", ms_path)
+        .env("CASA_VIS", &local_ms_path)
         .env("CASA_OUT", &output)
         .env("CASA_EXPFORMAT", expformat)
         // `casaplotms` checks only for the presence of DISPLAY, even when

--- a/crates/casars-imager/src/lib.rs
+++ b/crates/casars-imager/src/lib.rs
@@ -2345,7 +2345,7 @@ fn can_run_standard_mfs_fixed_tile_streaming_clean(
         && config.deconvolver != Deconvolver::Mtmfs
         && config.field_ids.as_ref().is_none_or(|ids| ids.len() <= 1)
         && config.phasecenter.is_none()
-        && config.phasecenter_field.is_none()
+        && phasecenter_field_matches_single_selected_field(config)
         && config.save_model == SaveModelMode::None
         && config.outlier_file.is_none()
         && config.use_mask == CleanMaskMode::User
@@ -2367,7 +2367,7 @@ fn can_run_standard_mfs_dirty_streaming(
         && !config.use_pointing
         && config.field_ids.as_ref().is_none_or(|ids| ids.len() <= 1)
         && config.phasecenter.is_none()
-        && config.phasecenter_field.is_none()
+        && phasecenter_field_matches_single_selected_field(config)
         && config.save_model == SaveModelMode::None
         && config.start_model.is_none()
         && config.outlier_file.is_none()
@@ -2376,6 +2376,16 @@ fn can_run_standard_mfs_dirty_streaming(
         && matches!(config.w_term_mode, WTermMode::None | WTermMode::WProject)
         && !needs_single_field_primary_beam_products(config)
         && (config.dirty_only || config.niter == 0)
+}
+
+fn phasecenter_field_matches_single_selected_field(config: &CliConfig) -> bool {
+    match config.phasecenter_field {
+        None => true,
+        Some(phasecenter_field) => config
+            .field_ids
+            .as_ref()
+            .is_some_and(|field_ids| field_ids.as_slice() == [phasecenter_field]),
+    }
 }
 
 fn can_run_mfs_mosaic_from_single_plane_stream(


### PR DESCRIPTION
Wave source: automation Long Gates PR Fixer

## Root causes

- CASA `plotms` TXT exports were empty when the slow msexplore parity tests read `ngc5921.ms` directly from `/Volumes/home/casatestdata`; CASA logged a table-lock failure on the shared-volume MeasurementSet and wrote header-only TXT files.
- Standard MFS dispatch rejected otherwise valid single-field requests when `phasecenter_field` matched the only selected field, causing those requests to fall into the mosaic stream path and fail its row-selection guard.

## Files changed

- `crates/casa-ms/tests/msexplore_casa_parity.rs`: copy the CASA plotms input MeasurementSet into the oracle tempdir before invoking `plotms`, so CASA locks a local filesystem path.
- `crates/casars-imager/src/lib.rs`: allow standard-MFS streaming when `phasecenter_field` is the same as the sole selected field.

## Validation run

- `cargo fmt --all -- --check` passed.
- `cargo clippy --workspace --all-targets -- -D warnings` passed.
- `cargo test --workspace` passed before the patch; touched-code validation after the patch is below.
- `cargo test -p casa-ms --test msexplore_casa_parity amplitude_vs_time_txt_manifest_tracks_casa_plotms_line_count --features slow-tests -- --exact --nocapture` failed before the plotms local-copy fix, then passed after it.
- `scripts/test-slow.sh` initially failed in `msexplore_casa_parity` with 28 empty CASA TXT export failures. After the local-copy fix, the msexplore suite passed: `36 passed; 0 failed`.
- `cargo test -p casars-imager --test imager_casa_parity dirty_products_track_casa_headers_and_pixels --features slow-tests -- --exact --nocapture` failed before the standard-MFS dispatch fix, then passed after it.
- `cargo test -p casars-imager --features slow-tests --test imager_casa_parity` improved from `3 passed; 74 failed; 21 ignored` to `30 passed; 47 failed; 21 ignored`.
- `cargo test -p casars-imager --lib` passed: `250 passed; 0 failed; 9 ignored`.

## Coverage

CI-like coverage was not reached. The ordered gate is still blocked at `scripts/test-slow.sh` by the remaining `casars-imager --test imager_casa_parity` failures, so there is no final coverage percentage for this run.

## Residual risks / follow-up

- The repo is not green yet. Remaining failures are concentrated in unsupported bounded-stream consumers after retained MS materialization was removed: multi-channel cube/cubedata, MT-MFS, outlier-file, `savemodel=modelcolumn`, some W-projection multifield/cube paths, and one mosaic Metal coordinate guard.
- Those remaining failures need a separate imaging bounded-stream implementation pass rather than a small automation repair.
